### PR TITLE
remove fixed fields query and add additive score query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -175,7 +175,7 @@ object MultipleWorksParams extends QueryParamsUtils {
   implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
     decodeOneWithDefaultOf(
       SearchQueryType.default,
-      "FixedFields" -> SearchQueryType.FixedFields
+      "AdditiveScore" -> SearchQueryType.AdditiveScore
     )
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchQueryType.scala
@@ -7,11 +7,11 @@ sealed trait SearchQueryType {
   final val name = this.getClass.getSimpleName.split("\\$").last
 }
 object SearchQueryType {
-  val default = FixedFields
+  val default = IdSearch
   // These are the queries that we are surfacing to the frontend to be able to select which one they want to run.
   // You'll need to change the `allowableValues` in `uk.ac.wellcome.platform.api.swagger.SwaggerDocs`
   // when changing these as they can't be read there as they need to be constant.
-  val allowed = List(IdSearch, FixedFields)
+  val allowed = List(IdSearch, AdditiveScore)
   final case object IdSearch extends SearchQueryType
-  final case object FixedFields extends SearchQueryType
+  final case object AdditiveScore extends SearchQueryType
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -265,7 +265,7 @@ trait MultipleWorksSwagger {
           "Which query should we use search the works? Used predominantly for internal testing of relevancy. Considered Unstable.",
         schema = new Schema(
           `type` = "enum",
-          allowableValues = Array("IdSearch", "FixedFields"),
+          allowableValues = Array("IdSearch", "AdditiveScore"),
         ),
         required = false
       )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.generators.{
 }
 import uk.ac.wellcome.models.work.internal.IdentifiedBaseWork
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
-import uk.ac.wellcome.platform.api.models.{SearchQuery, SearchQueryType}
+import uk.ac.wellcome.platform.api.models.SearchQuery
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchQueryOptions,
   ElasticsearchService
@@ -36,7 +36,58 @@ class ElasticsearchQueryTest
     elasticClient = elasticClient
   )
 
-  describe("ScoringTiers") {
+  describe("default") {
+    it("returns all results in a tiered order") {
+      withLocalWorksIndex { index =>
+        // Longer text used to ensure signal in TF/IDF
+        val titledWorks = List(
+          "Gray's Inn.",
+          "Loose Lychee",
+          "Gray, John",
+          "Gray's Inn Hall.",
+          "Poems by Mr. Gray.",
+          "A brief history of 'Gray's anatomy'",
+          "H. Gray, Anatomy descriptive and surgical",
+          "Gray's anatomy, descriptive and applied.",
+          "Gray's anatomy.",
+        ).map { t =>
+          createIdentifiedWorkWith(canonicalId = t, title = Some(t))
+        }
+
+        val subjectedWorks = List(
+          ("exact match subject", "Gray's Anatomy"),
+          ("partial match subject", "Anatomy"),
+        ).map {
+          case (id, subject) =>
+            createIdentifiedWorkWith(
+              canonicalId = id,
+              title = Some(s"subjected $subject"),
+              subjects = List(createSubjectWithConcept(subject)))
+        }
+        val insertedWorks = titledWorks ++ subjectedWorks
+        insertIntoElasticsearch(index, insertedWorks: _*)
+
+        val results =
+          searchResults(
+            index = index,
+            queryOptions = createElasticsearchQueryOptionsWith(
+              searchQuery = Some(SearchQuery("Gray's anatomy"))))
+
+        withClue(
+          "a MUST query is used on the base query so as not to match everything") {
+          (results.size < insertedWorks.size) should be(true)
+        }
+
+        withClue("the exact title should be first") {
+          results.head should be(getWorkWithId("Gray's anatomy.", results))
+        }
+
+        withClue(
+          "should find only subjects matching on AND operator and order it highly") {
+          results(1) should be(getWorkWithId("exact match subject", results))
+        }
+      }
+    }
     it("returns all results in a tiered order") {
       withLocalWorksIndex { index =>
         // Longer text used to ensure signal in TF/IDF
@@ -89,118 +140,63 @@ class ElasticsearchQueryTest
       }
     }
 
-    describe("FixedFields") {
-      it("returns all results in a tiered order") {
-        withLocalWorksIndex { index =>
-          // Longer text used to ensure signal in TF/IDF
-          val titledWorks = List(
-            "Gray's Inn.",
-            "Loose Lychee",
-            "Gray, John",
-            "Gray's Inn Hall.",
-            "Poems by Mr. Gray.",
-            "A brief history of 'Gray's anatomy'",
-            "H. Gray, Anatomy descriptive and surgical",
-            "Gray's anatomy, descriptive and applied.",
-            "Gray's anatomy.",
-          ).map { t =>
-            createIdentifiedWorkWith(canonicalId = t, title = Some(t))
-          }
-
-          val subjectedWorks = List(
-            ("exact match subject", "Gray's Anatomy"),
-            ("partial match subject", "Anatomy"),
-          ).map {
-            case (id, subject) =>
-              createIdentifiedWorkWith(
-                canonicalId = id,
-                title = Some(s"subjected $subject"),
-                subjects = List(createSubjectWithConcept(subject)))
-          }
-          val insertedWorks = titledWorks ++ subjectedWorks
-          insertIntoElasticsearch(index, insertedWorks: _*)
-
-          val results =
-            searchResults(
-              index = index,
-              queryOptions = createElasticsearchQueryOptionsWith(
-                searchQuery = Some(SearchQuery("Gray's anatomy"))))
-
-          withClue(
-            "a MUST query is used on the base query so as not to match everything") {
-            (results.size < insertedWorks.size) should be(true)
-          }
-
-          withClue("the exact title should be first") {
-            results.head should be(getWorkWithId("Gray's anatomy.", results))
-          }
-
-          withClue(
-            "should find only subjects matching on AND operator and order it highly") {
-            results(1) should be(getWorkWithId("exact match subject", results))
-          }
+    it("should use the english analyser in the base query") {
+      withLocalWorksIndex { index =>
+        val works = List(
+          "Vlad the impaler",
+          "Dad the impala",
+        ).map { t =>
+          createIdentifiedWorkWith(title = Some(t))
         }
+
+        insertIntoElasticsearch(index, works: _*)
+
+        // If we search the non-english analysed fields with the base query
+        // `the` would in the search as we're using the `OR` operator
+        // and would be matched in both examples above as the root field
+        // (not `field` rather than `field.english`, see `WorksIndex.scala`)
+        // does not use the english analyser.
+
+        // We wouldn't want to use the english analyser at query time though
+        // as we would lose detail used in other where we use exact matching
+        val results =
+          searchResults(
+            index = index,
+            queryOptions = createElasticsearchQueryOptionsWith(
+              searchQuery = Some(SearchQuery("vlad the impaler")))
+          )
+
+        results should contain theSameElementsAs List(works.head)
       }
+    }
 
-      it("should use the english analyser in the base query") {
-        withLocalWorksIndex { index =>
-          val works = List(
-            "Vlad the impaler",
-            "Dad the impala",
-          ).map { t =>
-            createIdentifiedWorkWith(title = Some(t))
-          }
-
-          insertIntoElasticsearch(index, works: _*)
-
-          // If we search the non-english analysed fields with the base query
-          // `the` would in the search as we're using the `OR` operator
-          // and would be matched in both examples above as the root field
-          // (not `field` rather than `field.english`, see `WorksIndex.scala`)
-          // does not use the english analyser.
-
-          // We wouldn't want to use the english analyser at query time though
-          // as we would lose detail used in other where we use exact matching
-          val results =
-            searchResults(
-              index = index,
-              queryOptions = createElasticsearchQueryOptionsWith(
-                searchQuery = Some(
-                  SearchQuery("vlad the impaler", SearchQueryType.FixedFields)))
-            )
-
-          results should contain theSameElementsAs List(works.head)
-        }
-      }
-
-      it("AND scores heavily on the contributors field") {
-        withLocalWorksIndex { index =>
-          val workWithExactMatchingContributors =
-            createIdentifiedWorkWith(
-              contributors = List(
-                createPersonContributorWith("Alice Stewart"),
-                createPersonContributorWith("Honor Fell"),
-              ))
-
-          val workWithPartialMatchingContributors = createIdentifiedWorkWith(
+    it("AND scores heavily on the contributors field") {
+      withLocalWorksIndex { index =>
+        val workWithExactMatchingContributors =
+          createIdentifiedWorkWith(
             contributors = List(
-              createPersonContributorWith("Alice Fell"),
+              createPersonContributorWith("Alice Stewart"),
+              createPersonContributorWith("Honor Fell"),
             ))
 
-          insertIntoElasticsearch(
-            index,
-            workWithPartialMatchingContributors,
-            workWithExactMatchingContributors)
-          val results =
-            searchResults(
-              index = index,
-              queryOptions = createElasticsearchQueryOptionsWith(searchQuery =
-                Some(SearchQuery("Alice Stewart", SearchQueryType.FixedFields)))
-            )
+        val workWithPartialMatchingContributors = createIdentifiedWorkWith(
+          contributors = List(
+            createPersonContributorWith("Alice Fell"),
+          ))
 
-          results.head should be(workWithExactMatchingContributors)
-          results.last should be(workWithPartialMatchingContributors)
-        }
+        insertIntoElasticsearch(
+          index,
+          workWithPartialMatchingContributors,
+          workWithExactMatchingContributors)
+        val results =
+          searchResults(
+            index = index,
+            queryOptions = createElasticsearchQueryOptionsWith(
+              searchQuery = Some(SearchQuery("Alice Stewart")))
+          )
+
+        results.head should be(workWithExactMatchingContributors)
+        results.last should be(workWithPartialMatchingContributors)
       }
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchSearchQueryTest.scala
@@ -1,3 +1,5 @@
+package uk.ac.wellcome.platform.api.services
+
 import com.sksamuel.elastic4s.{ElasticError, Index}
 import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
 import org.scalatest.{FunSpec, Matchers}
@@ -21,7 +23,7 @@ import uk.ac.wellcome.json.JsonUtil._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ElasticsearchQueryTest
+class ElasticsearchSearchQueryTest
     extends FunSpec
     with Matchers
     with ElasticsearchFixtures


### PR DESCRIPTION
Focusing on e.g. The title part of the query

We will boost anything that matches that query `1000` as it's wrapped in the `contant_score`. Problem being we loose the scoring within that query as it's a filter.

We thus loose the ordering within that match, so if there are multiple matches, it just returns back ordered by ID as everything has scored `1000`. 

This now takes the score and multiplies it.


```JS
PUT test/_doc/1
{
  "title": "The spain in spain falls spain on the spain"
}

PUT test/_doc/2
{
  "title": "The rain in spain falls mainly on the plain"
}

// <= Returns [id: 2, id: 1]
// because of standard tf/idf
GET test/_search
{
  "query": {
    "match": {
      "title": "spain"
    }
  }
}

// returns [id: 1, id: 2]
// this is our current implementation
// as much as it will return the wrapped function higher than everything,
// it looses the nuance of the score in that query as contant_score uses a filter
GET test/_search
{
  "query": {
    "constant_score": {
      "filter": {
        "match": {
          "title": "spain"
        }
      },
      "boost": 10
    }
  }
}

// Returns [id: 2, id: 1]
// This will being everything in this part of the query up, and multiply the score by the boost
GET test/_search
{
  "query": {
    "constant_score": {
      "filter": {
        "match": {
          "title": "spain"
        }
      },
      "boost": 10
    }
  }
}
```

## TODO
- [ ] Write a better description - maybe with a diagram, add to docs
- [ ] Write tests, probably a refactor of the tests as we'll need to start reading the scores, but saying that we might want to start surfacing things like that (and QueryName) for reporting.