### PR TITLE
Add result relevance information 

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ResultList.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.platform.api.models
 
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
 
+case class WorkResult(work: IdentifiedWork, score: Int, queryName: String)
+
 case class ResultList(
-  results: List[IdentifiedWork],
+  results: List[WorkResult],
   totalResults: Int,
   aggregations: Option[Aggregations]
 )


### PR DESCRIPTION
For testing, and _probably_ for features in the future, you might want to attach some metadata to a result that contextualised it within the set of results.

An example of this would be score (for testing, I need to compare) where we might want to flag how relevant we think something is. While order is an indicator of this, if you have say 5 results, 2 might be highly relevant, while the other three might be loosely relevant.

Another piece of information might be what we matched (the title, publisher etc), the highlighted piece of content etc.

This __draft PR__ starts with the model and if it feels like that is the right direction?

The rendering might unpack this into something along the lines of:
```JS
GET /works?include=results.relevance&query=spain
{
  "results": [
    {
      "type": "Work",
      "title": "The rain in Maine is plainly not in Spain",
      "description": "This is not really a rhymme from Spain",
      "relevance": {
        "matched": ["title" ,"description"],
        "score": {
          "value": "1.6",
          "label": "Highly relevant"
        }
      }
    },
    {
      "type": "Work",
      "title": "The rain in spain",
      "description": "Fell mainly on the plain",
      "relevance": {
        "matched": ["title"],
        "score": {
          "value": "1.2",
          "label": "Relevant"
        }
      }
    }
  ]
}
```