### PR TITLE
Fix calm window generator

### DIFF
--- a/calm_adapter/calm_window_generator/src/window_generator.py
+++ b/calm_adapter/calm_window_generator/src/window_generator.py
@@ -27,9 +27,7 @@ class WindowGenerator:
 
     def send_window_to_sns(self, window):
         msg = json.dumps({"date": window.isoformat()})
-        self.client.publish(
-            TopicArn=self.topic_arn, Message=msg, Subject=f"Window sent by {__file__}"
-        )
+        self.client.publish(TopicArn=self.topic_arn, Message=msg)
 
     def get_sns_client(self):
         sts = boto3.client("sts")


### PR DESCRIPTION
The `boto3` SNS client no longer appears to accept the `Subject` argument, so remove it.