### PR TITLE
Speed up METS transformer by a factor of 30

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXml.scala
@@ -169,9 +169,10 @@ case class MetsXml(root: Elem) {
     * file IDs in the (normalised) fileObjects mapping
     */
   def physicalFileReferences(bnumber: String): List[FileReference] =
-    physicalFileIds
+    physicalFileIds.par
       .flatMap(getFileReference)
       .map(normaliseLocation(bnumber))
+      .toList
 
   /** Returns the first href to a manifestation in the logical structMap
     */

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -18,7 +18,7 @@ class MetsXmlTransformerTest extends FunSpec with Matchers with MetsGenerators {
         accessConditionDz = Some("CC-BY-NC"),
         accessConditionStatus = Some("Open"),
         accessConditionUsage = Some("Some terms"),
-        fileReferences = List(createFileReferences(6, "b30246039").head)
+        fileReferences = createFileReferences(6, "b30246039")
       )
     )
   }
@@ -38,8 +38,7 @@ class MetsXmlTransformerTest extends FunSpec with Matchers with MetsGenerators {
         recordIdentifier = "b22012692",
         accessConditionDz = Some("PDM"),
         accessConditionStatus = Some("Open"),
-        fileReferences =
-          List(createFileReferences(2, "b22012692", Some(1)).head)
+        fileReferences = createFileReferences(2, "b22012692", Some(1))
       )
     )
   }
@@ -62,7 +61,7 @@ class MetsXmlTransformerTest extends FunSpec with Matchers with MetsGenerators {
         recordIdentifier = "b30246039",
         accessConditionDz = Some("INC"),
         accessConditionStatus = None,
-        fileReferences = List(createFileReferences(2, "b30246039").head)
+        fileReferences = createFileReferences(2, "b30246039")
       )
     )
   }


### PR DESCRIPTION
In https://github.com/wellcomecollection/catalogue/pull/450, we had to stop the METS transformer from extracting all of the images from METS files because it was too slow, and because having that many images caused issues in the ID minter. _This PR solves the first problem_.

Using the [new profiler in IntelliJ](https://blog.jetbrains.com/idea/2019/06/intellij-idea-2019-2-eap-4-profiling-tools-structural-search-preview-and-more/), I saw the construction of a `ListMap` for `fileReferences` was the bottleneck: addition to a `ListMap` has linear time complexity, and it's constructed by adding each element in turn (I think that means the construction goes as `O(n log n)`? Not sure).

This PR removes that `ListMap` and instead looks up `FileReference`s lazily when it parallel-maps over the (ordered) list of physical IDs, the generation of which I also simplified.

***

The figure of 30x improvement comes from running `MetsXmlTransformer.transform(..).toWork` on the enormous METS file, `b21465071`. This has 640 assets in its first manifestation and 1094 in its second.

Over a sample of 100 transformations, the transformation averaged 4.36s before this PR, and 0.140s after 🎉.

***

**This PR should not be merged until we've worked out how to get the ID minter to handle this many images**.