### PR TITLE
Fix duplicate locations when merging METS and Sierra

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -48,7 +48,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
       val metsUrls = metsItems.flatMap(_.locations).collect {
         case DigitalLocation(url, _, _, _, _, _) => url
       }
-      info(s"Merging METS items from ${describeWorks(sources)}")
+      debug(s"Merging METS items from ${describeWorks(sources)}")
       sierraItems match {
         case List(sierraItem) =>
           List(

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.platform.merger.rules
 
 import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
   Item,
+  Location,
   TransformedBaseWork,
   UnidentifiedWork,
   Unminted
@@ -43,15 +45,21 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
              sources: Seq[TransformedBaseWork]): FieldData = {
       val sierraItems = target.data.items
       val metsItems = sources.flatMap(_.data.items)
+      val metsUrls = metsItems.flatMap(_.locations).collect {
+        case DigitalLocation(url, _, _, _, _, _) => url
+      }
       info(s"Merging METS items from ${describeWorks(sources)}")
       sierraItems match {
         case List(sierraItem) =>
           List(
             sierraItem.copy(
-              locations = sierraItem.locations ++ metsItems.flatMap(_.locations)
+              locations = sierraItem.locations.filterNot(hasUrl(metsUrls)) ++
+                metsItems.flatMap(_.locations)
             )
           )
-        case _ => sierraItems ++ metsItems
+        case _ =>
+          sierraItems.filterNot(_.locations.exists(hasUrl(metsUrls))) ++
+            metsItems
       }
     }
   }
@@ -77,4 +85,11 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
           multipleSierraItems ++ sierraSources.flatMap(_.data.items)
       }
   }
+
+  private def hasUrl(matchUrls: Seq[String])(location: Location) =
+    location match {
+      case DigitalLocation(url, _, _, _, _, _) if matchUrls.contains(url) =>
+        true
+      case _ => false
+    }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -43,7 +43,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     override def rule(
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): List[SourceIdentifier] = {
-      info(s"Merging Miro IDs from ${describeWorks(sources)}")
+      debug(s"Merging Miro IDs from ${describeWorks(sources)}")
       target.data.otherIdentifiers ++ sources.flatMap(
         _.identifiers.filterNot(sourceIdentifier =>
           unmergeableMiroIdTypes.contains(sourceIdentifier.identifierType.id)))
@@ -57,7 +57,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     override def rule(
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): List[SourceIdentifier] = {
-      info(s"Merging physical and digital IDs from ${describeWorks(sources)}")
+      debug(s"Merging physical and digital IDs from ${describeWorks(sources)}")
       target.data.otherIdentifiers ++ sources.flatMap(_.identifiers)
     }
   }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -34,7 +34,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
 
       def rule(target: UnidentifiedWork,
                sources: Seq[TransformedBaseWork]): FieldData = {
-        info(s"Choosing METS thumbnail from ${describeWorks(sources)}")
+        debug(s"Choosing METS thumbnail from ${describeWorks(sources)}")
         sources.headOption.flatMap(_.data.thumbnail)
       }
     }
@@ -48,7 +48,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
                sources: Seq[TransformedBaseWork]): FieldData = {
         val minMiroSource = Try(sources.min(MiroIdOrdering)).toOption
         minMiroSource.foreach { source =>
-          info(s"Choosing METS thumbnail from ${describeWork(source)}")
+          debug(s"Choosing METS thumbnail from ${describeWork(source)}")
         }
         minMiroSource.flatMap(_.data.thumbnail)
       }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.merger.rules
 
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, License}
 
 class ItemsRuleTest
     extends FunSpec
@@ -12,6 +13,19 @@ class ItemsRuleTest
   val multiItemPhysicalSierra = createSierraWorkWithTwoPhysicalItems
   val digitalSierra = createSierraDigitalWork
   val metsWork = createUnidentifiedInvisibleMetsWork
+  val metsWorkWithSierraUrl = createUnidentifiedInvisibleMetsWorkWith(
+    items = List(
+      createDigitalItemWith(
+        locations = List(
+          createDigitalLocationWith(
+            url = digitalSierra.data.items.head.locations.head
+              .asInstanceOf[DigitalLocation]
+              .url,
+            license = Some(License.InCopyright)
+          ))
+      )
+    )
+  )
   val miroWork = createMiroWork
 
   it(
@@ -45,11 +59,11 @@ class ItemsRuleTest
 
   it(
     "merges non-duplicate-URL locations from METS items into single-item Sierra works") {
-    inside(ItemsRule.merge(physicalSierra, List(metsWork))) {
+    inside(ItemsRule.merge(digitalSierra, List(metsWorkWithSierraUrl))) {
       case MergeResult(items, _) =>
         items should have size 1
         items.head.locations should contain theSameElementsAs
-          physicalSierra.data.items.head.locations ++ metsWork.data.items.head.locations
+          metsWorkWithSierraUrl.data.items.head.locations
     }
   }
 


### PR DESCRIPTION
It turns out that we missed a subtlety when simplifying the METS merging logic - if the Sierra work has an item location with the same URL as the METS item, that should be filtered out (see [here](https://github.com/wellcomecollection/catalogue/blob/3e3ccbc3134b2aaff0b3f906335f26ad97ba60a2/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/sierramets/SierraMetsWorkPairMerger.scala#L85)).