### PR TITLE
add collection.depth filter

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -155,7 +155,7 @@ object MultipleWorksParams extends QueryParamsUtils {
     decodeCommaSeparated.emap(strs => Right(LicenseFilter(strs)))
 
   implicit val collectionsDepthFilter: Decoder[CollectionDepthFilter] =
-    decodeInt map CollectionDepthFilter
+    decodeInt map (CollectionDepthFilter(_))
 
   implicit val aggregationsDecoder: Decoder[List[AggregationRequest]] =
     decodeOneOfCommaSeparated(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -50,6 +50,7 @@ case class MultipleWorksParams(
   sort: Option[List[SortRequest]],
   sortOrder: Option[SortingOrder],
   query: Option[String],
+  `collection.depth`: Option[CollectionDepthFilter],
   _queryType: Option[SearchQueryType],
   _index: Option[String],
 ) extends QueryParams {
@@ -85,6 +86,7 @@ case class MultipleWorksParams(
       language,
       `genres.label`,
       `subjects.label`,
+      `collection.depth`,
       license
     ).flatten
 
@@ -120,6 +122,7 @@ object MultipleWorksParams extends QueryParamsUtils {
         "sort".as[List[SortRequest]].?,
         "sortOrder".as[SortingOrder].?,
         "query".as[String].?,
+        "collection.depth".as[CollectionDepthFilter].?,
         "_queryType".as[SearchQueryType].?,
         "_index".as[String].?,
       )
@@ -150,6 +153,9 @@ object MultipleWorksParams extends QueryParamsUtils {
 
   implicit val licenseFilter: Decoder[LicenseFilter] =
     decodeCommaSeparated.emap(strs => Right(LicenseFilter(strs)))
+
+  implicit val collectionsDepthFilter: Decoder[CollectionDepthFilter] =
+    decodeInt map CollectionDepthFilter
 
   implicit val aggregationsDecoder: Decoder[List[AggregationRequest]] =
     decodeOneOfCommaSeparated(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkFilter.scala
@@ -22,3 +22,5 @@ case class GenreFilter(genreQuery: String) extends WorkFilter
 case class SubjectFilter(subjectQuery: String) extends WorkFilter
 
 case class LicenseFilter(licenseIds: Seq[String]) extends WorkFilter
+
+case class CollectionDepthFilter(depth: Int) extends WorkFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
@@ -142,6 +142,8 @@ case class ElasticsearchRequestBuilder(
         termsQuery(
           field = "data.items.locations.license.id",
           values = licenseIds)
+      case CollectionDepthFilter(depth) =>
+        termQuery(field = "data.collection.depth", value = depth)
     }
 
   implicit class EnhancedTermsAggregation(agg: TermsAggregation) {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -87,6 +87,7 @@ class FiltersAndAggregationsBuilder(
     case _: GenreFilter            => Some(AggregationRequest.Genre)
     case _: SubjectFilter          => Some(AggregationRequest.Subject)
     case _: LicenseFilter          => Some(AggregationRequest.License)
+    case _: CollectionDepthFilter  => None
   }
 
   private sealed trait FilterCategory

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -259,6 +259,12 @@ trait MultipleWorksSwagger {
         required = false
       ),
       new Parameter(
+        name = "collection.depth",
+        in = ParameterIn.QUERY,
+        description = "Testing. Considered Unstable.",
+        required = false
+      ),
+      new Parameter(
         name = "_queryType",
         in = ParameterIn.QUERY,
         description =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/QueryParamsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/QueryParamsTest.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.api
+
+import org.scalatest.FunSuite
+
+class QueryParamsTest extends FunSuite {}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/QueryParamsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/QueryParamsTest.scala
@@ -1,5 +1,0 @@
-package uk.ac.wellcome.platform.api
-
-import org.scalatest.FunSuite
-
-class QueryParamsTest extends FunSuite {}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2ErrorsTest.scala
@@ -97,6 +97,13 @@ class ApiV2ErrorsTest extends ApiV2WorksTestBase with ApiErrorsTestBase {
           "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
       )
     }
+
+    it("400s on a non-int-able value for collection.depth") {
+      assertIsBadRequest(
+        "/works?collection.depth=challenger-deep",
+        description = "collection.depth: must be a valid Integer"
+      )
+    }
   }
 
   // This is expected as it's transient parameter that will have valid values changing over time


### PR DESCRIPTION
Adding a filter that allows you to get works with a specified collection depth.

This is not intended to cover all bases of what we _might_ want to do, but allow us to start surfacing stuff to the `www` so we can expose it to people who can tell us how they expect to use it.


## 👁 forward
This _might_ be more useful as a range, and I imagine that we might use something like `collection.depth.from` & `collection.depth.till`.