### PR TITLE
Rename calm sourcedata VHS to be consistant

### DIFF
--- a/calm_adapter/terraform/vhs.tf
+++ b/calm_adapter/terraform/vhs.tf
@@ -2,7 +2,7 @@ module "vhs" {
   source             = "git::github.com/wellcomecollection/terraform-aws-vhs.git//hash-store?ref=f62e0544687a7361810a14ef78a5e198cfc5d365"
   bucket_name_prefix = "wellcomecollection-vhs-"
   table_name_prefix  = "vhs-"
-  name               = local.namespace
+  name               = "sourcedata-calm"
 }
 
 resource "aws_iam_role_policy" "vhs_readwrite" {

--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -17,6 +17,7 @@ SOURCES = {
     "sierra": "vhs-sourcedata-sierra",
     "sierra-items": "vhs-sourcedata-sierra-items",
     "mets": "mets-adapter-store",
+    "calm": "vhs-sourcedata-calm",
 }
 
 DESTINATIONS = ["catalogue", "reporting"]


### PR DESCRIPTION
Sorry for the revert nonsense, committed straight into master.

Changing the name as it is annoying to have to dig around thinking why it was named differently and realising it doesn't matter.

