### PR TITLE
use 1 calm adapter

### DIFF
--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -10,12 +10,13 @@ locals {
   vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
   private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
 
+  vhs_read_policy = data.terraform_remote_state.critical_infra.outputs.vhs_calm_read_policy
   env_vars = {
     calm_api_url = "https://wt-calm.wellcome.ac.uk/CalmAPI/ContentService.asmx"
     calm_sqs_url = module.calm_windows_queue.url
     calm_sns_topic = aws_sns_topic.calm_adapter_topic.arn
-    vhs_dynamo_table_name = module.vhs.table_name
-    vhs_bucket_name = module.vhs.bucket_name
+    vhs_dynamo_table_name = data.terraform_remote_state.critical_infra.outputs.vhs_calm_table_name
+    vhs_bucket_name = data.terraform_remote_state.critical_infra.outputs.vhs_calm_bucket_name
   }
   secret_env_vars = {
     calm_api_username = "calm_adapter/calm_api/username"

--- a/calm_adapter/terraform/provider.tf
+++ b/calm_adapter/terraform/provider.tf
@@ -6,3 +6,7 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "template" {
+  version = "~> 2.1"
+}

--- a/calm_adapter/terraform/terraform.tf
+++ b/calm_adapter/terraform/terraform.tf
@@ -21,4 +21,16 @@ data "terraform_remote_state" "shared_infra" {
   }
 }
 
+data "terraform_remote_state" "critical_infra" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue/infrastructure/critical.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "aws_caller_identity" "current" {}

--- a/calm_adapter/terraform/vhs.tf
+++ b/calm_adapter/terraform/vhs.tf
@@ -1,11 +1,4 @@
-module "vhs" {
-  source             = "git::github.com/wellcomecollection/terraform-aws-vhs.git//hash-store?ref=f62e0544687a7361810a14ef78a5e198cfc5d365"
-  bucket_name_prefix = "wellcomecollection-vhs-"
-  table_name_prefix  = "vhs-"
-  name               = local.namespace
-}
-
 resource "aws_iam_role_policy" "vhs_readwrite" {
   role   = module.task_definition.task_role_name
-  policy = module.vhs.full_access_policy
+  policy = local.vhs_read_policy
 }


### PR DESCRIPTION
Agreeing with @warrd that it feels better with the project, but I would rather have 1 place and naming convention for the source data for now so I don't have to remember we did it partially correctly later on.