### PR TITLE
Make the Sierra progress reporter be less spammy

### DIFF
--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -43,9 +43,9 @@ def get_missing_windows(report):
     # We're missing any records created between the *end* of window_1
     # and the *start* of window_2, so we use these as the basis for
     # our new window.
-    for (window_1, _), (window_2, _) in sliding_window(report):
-        missing_start = window_1.end - dt.timedelta(seconds=1)
-        missing_end = window_2.start + dt.timedelta(seconds=1)
+    for interval_1, interval_2 in sliding_window(report):
+        missing_start = interval_1.end - dt.timedelta(seconds=1)
+        missing_end = interval_2.start + dt.timedelta(seconds=1)
 
         yield from generate_windows(start=missing_start, end=missing_end, minutes=2)
 

--- a/sierra_adapter/sierra_progress_reporter/README.md
+++ b/sierra_adapter/sierra_progress_reporter/README.md
@@ -1,0 +1,24 @@
+# sierra_progress_reporter
+
+We harvest records from Sierra every 15 minutes, grabbing the last 30 minutes of updates.
+When the Sierra reader is done, it writes a marker into S3 to say "I got these updates":
+
+```
+s3://wc-platform-adapters-sierra
+  └── windows_bibs_complete
+        ├── 2020-03-16T00-00-00__2020-03-16T00-30-00
+        ├── 2020-03-16T00-15-00__2020-03-16T00-45-00
+        └── 2020-03-16T00-30-00__2020-03-16T01-00-00
+```
+
+The Sierra progress reporter goes through the objects in this bucket, and consolidates overlapping markers them into a single marker, for example:
+
+```
+s3://wc-platform-adapters-sierra
+  └── windows_bibs_complete
+        └── 2020-03-16T00-00-00__2020-03-16T01-00-00
+```
+
+This gives us a crude reporting mechanism to see whether we missed any updates.
+
+If it spots a gap in the windows, it sends a message to a Slack channel.

--- a/sierra_adapter/sierra_progress_reporter/src/interval_arithmetic.py
+++ b/sierra_adapter/sierra_progress_reporter/src/interval_arithmetic.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8
-
 import datetime as dt
 import os
 


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4372

The Sierra reader writes a marker to S3 to say “I got all the updates from 00:00–00:30”. The Sierra progress reporter consolidates overlapping markers, so we can see if we've got complete coverage of the Sierra updates. Recently it’s been timing out and spamming our Slack channel with errors, because there were more markers in the bucket than it could deal with.

Previously it would list *all* the markers before doing any consolidation – so if there were millions of markers, it would hit the Lambda timeout just from calling the ListObject API.

This patch changes the behaviour – for every 1000 objects it gets from the ListObject API (a single page of results), it consolidates those into a single marker. It will likely still time out if there are millions of markers, but gradually it will reduce the number over consecutive runs, so the timeouts will eventually go away.

I also added a bit of logging for every call to the ListObjects API, so it’ll be easier to see if it’s hanging, crashing or just very busy the next time it has an error.