### PR TITLE
Collection tree in API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -15,7 +15,7 @@ sealed trait QueryParams
 
 case class SingleWorkParams(
   include: Option[V2WorksIncludes],
-  expandPaths: Option[List[String]],
+  _expandPaths: Option[List[String]],
   _index: Option[String],
 ) extends QueryParams
 
@@ -30,7 +30,7 @@ object SingleWorkParams extends QueryParamsUtils {
     parameter(
       (
         "include".as[V2WorksIncludes].?,
-        "expandPaths".as[List[String]].?,
+        "_expandPaths".as[List[String]].?,
         "_index".as[String].?
       )
     ).tmap((SingleWorkParams.apply _).tupled(_))

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/QueryParams.scala
@@ -15,6 +15,7 @@ sealed trait QueryParams
 
 case class SingleWorkParams(
   include: Option[V2WorksIncludes],
+  expandPaths: Option[List[String]],
   _index: Option[String],
 ) extends QueryParams
 
@@ -29,9 +30,13 @@ object SingleWorkParams extends QueryParamsUtils {
     parameter(
       (
         "include".as[V2WorksIncludes].?,
+        "expandPaths".as[List[String]].?,
         "_index".as[String].?
       )
     ).tmap((SingleWorkParams.apply _).tupled(_))
+
+  implicit val decodePaths: Decoder[List[String]] =
+    decodeCommaSeparated
 }
 
 case class MultipleWorksParams(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -247,8 +247,8 @@ class Router(elasticClient: ElasticClient,
     work.data.collection
       .map {
         case Collection(_, path) =>
-          val paths = path :: expandedPaths
-          collectionService.retrieveTree(index, paths).map {
+          val allPaths = path :: expandedPaths
+          collectionService.retrieveTree(index, allPaths).map {
             case Left(err) =>
               // We just log this here rather than raising so as not to bring down
               // the work API when tree retrieval fails
@@ -259,7 +259,7 @@ class Router(elasticClient: ElasticClient,
                 logger.error(s"Ancestors to ${tree.path} not found")
                 None
               } else
-                Some((tree, paths))
+                Some((tree, allPaths))
           }
       }
       .getOrElse(Future.successful(None))

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -116,7 +116,7 @@ class Router(elasticClient: ElasticClient,
         .findWorkById(id)(index)
         .flatMap {
           case Right(Some(work: IdentifiedWork)) =>
-            val expandedPaths = params.expandPaths.getOrElse(Nil)
+            val expandedPaths = params._expandPaths.getOrElse(Nil)
             retrieveTree(index, work, expandedPaths).map {
               workFound(work, _, includes)
             }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -116,7 +116,8 @@ class Router(elasticClient: ElasticClient,
         .findWorkById(id)(index)
         .flatMap {
           case Right(Some(work: IdentifiedWork)) =>
-            retrieveTree(index, work, Nil).map {
+            val expandedPaths = params.expandPaths.getOrElse(Nil)
+            retrieveTree(index, work, expandedPaths).map {
               workFound(work, _, includes)
             }
           case Right(Some(work: IdentifiedRedirectedWork)) =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -14,7 +14,13 @@ import akka.http.scaladsl.server.{
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
 import io.circe.Printer
-import uk.ac.wellcome.platform.api.services.{ElasticsearchService, WorksService}
+import grizzled.slf4j.Logger
+
+import uk.ac.wellcome.platform.api.services.{
+  CollectionService,
+  ElasticsearchService,
+  WorksService
+}
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
 import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
@@ -108,20 +114,31 @@ class Router(elasticClient: ElasticClient,
       val includes = params.include.getOrElse(V2WorksIncludes())
       worksService
         .findWorkById(id)(index)
-        .map {
-          case Right(Some(work: IdentifiedWork))           => workFound(work, includes)
-          case Right(Some(work: IdentifiedRedirectedWork)) => workRedirect(work)
-          case Right(Some(_))                              => workGone
-          case Right(None)                                 => workNotFound(id)
-          case Left(err)                                   => elasticError(err)
+        .flatMap {
+          case Right(Some(work: IdentifiedWork)) =>
+            retrieveTree(index, work, Nil).map {
+              workFound(work, _, includes)
+            }
+          case Right(Some(work: IdentifiedRedirectedWork)) =>
+            Future.successful(workRedirect(work))
+          case Right(Some(_)) => Future.successful(workGone)
+          case Right(None)    => Future.successful(workNotFound(id))
+          case Left(err)      => Future.successful(elasticError(err))
         }
     })
 
-  def workFound(work: IdentifiedWork, includes: V2WorksIncludes): Route =
+  def workFound(work: IdentifiedWork,
+                tree: Option[(CollectionTree, List[String])],
+                includes: V2WorksIncludes): Route =
     complete(
       ResultResponse(
         context = contextUri,
-        result = DisplayWorkV2(work, includes)
+        result = DisplayWorkV2(work, includes).copy(
+          collectionTree = tree.map {
+            case (tree, expandedPaths) =>
+              DisplayCollectionTree(tree, expandedPaths)
+          }
+        )
       )
     )
 
@@ -222,6 +239,30 @@ class Router(elasticClient: ElasticClient,
       }
     }
 
+  def retrieveTree(index: Index,
+                   work: IdentifiedWork,
+                   expandedPaths: List[String])
+    : Future[Option[(CollectionTree, List[String])]] =
+    work.data.collection
+      .map {
+        case Collection(_, path) =>
+          val paths = path :: expandedPaths
+          collectionService.retrieveTree(index, paths).map {
+            case Left(err) =>
+              // We just log this here rather than raising so as not to bring down
+              // the work API when tree retrieval fails
+              logger.error("Error retrieving collection tree", err)
+              None
+            case Right(tree) =>
+              if (!tree.isRoot) {
+                logger.error(s"Ancestors to ${tree.path} not found")
+                None
+              } else
+                Some((tree, paths))
+          }
+      }
+      .getOrElse(Future.successful(None))
+
   // Directive for getting public URI of the current request, using the host
   // and scheme as per the config.
   // (without this URIs end up looking like https://localhost:8888/..., rather
@@ -245,6 +286,11 @@ class Router(elasticClient: ElasticClient,
 
   lazy val worksService =
     new WorksService(new ElasticsearchService(elasticClient))
+
+  lazy val collectionService =
+    new CollectionService(elasticClient)
+
+  lazy val logger = Logger(this.getClass.getName)
 
   implicit val jsonPrinter: Printer = DisplayJsonUtil.printer
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionRequestBuilder.scala
@@ -12,13 +12,22 @@ case class CollectionRequestBuilder(index: Index,
                                     expandedPaths: List[String],
                                     maxNodes: Int = 1000) {
 
-  val excludeFields = List(
-    "data.items",
-    "data.notes",
-    "data.production",
-    "data.subjects",
-    "data.genres",
-    "data.images",
+  // To reduce response size and improve Elasticsearch performance we only
+  // return core fields for works in the tree.
+  val fieldWhitelist = List(
+    "canonicalId",
+    "version",
+    "ontologyType",
+    "sourceIdentifier.identifierType.id",
+    "sourceIdentifier.identifierType.label",
+    "sourceIdentifier.identifierType.ontologyType",
+    "sourceIdentifier.value",
+    "sourceIdentifier.ontologyType",
+    "data.title",
+    "data.alternativeTitles",
+    "data.collection.label",
+    "data.collection.path",
+    "data.ontologyType",
   )
 
   lazy val request: SearchRequest =
@@ -26,7 +35,7 @@ case class CollectionRequestBuilder(index: Index,
       .query(query)
       .from(0)
       .limit(maxNodes)
-      .sourceExclude(excludeFields)
+      .sourceInclude(fieldWhitelist)
 
   lazy val query: Query =
     should(expandedPaths.map(expandPathQuery))

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
@@ -41,8 +41,9 @@ class CollectionService(elasticClient: ElasticClient, index: Index)(
     extends Tracing {
 
   def retrieveTree(
+    index: Index,
     expandedPaths: List[String]): Future[Result[CollectionTree]] =
-    makeEsRequest(expandedPaths)
+    makeEsRequest(index, expandedPaths)
       .map { result =>
         result.left
           .map(_.asException)
@@ -53,6 +54,7 @@ class CollectionService(elasticClient: ElasticClient, index: Index)(
       }
 
   private def makeEsRequest(
+    index: Index,
     paths: List[String]): Future[Either[ElasticError, SearchResponse]] =
     withActiveTrace(elasticClient.execute {
       CollectionRequestBuilder(index, paths).request

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
@@ -36,7 +36,7 @@ import uk.ac.wellcome.platform.api.Tracing
   * incremental exploration of the data (akin to exploring a filesystem), due to
   * the fact the whole tree may be rather large.
   */
-class CollectionService(elasticClient: ElasticClient, index: Index)(
+class CollectionService(elasticClient: ElasticClient)(
   implicit ec: ExecutionContext)
     extends Tracing {
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/CollectionService.scala
@@ -61,6 +61,8 @@ class CollectionService(elasticClient: ElasticClient, index: Index)(
       case resp                 => Right(resp.result)
     }
 
+  // Note that the search request should only return work with type
+  // IdentifiedWork due to the fact that we are filtering on data.collection
   private def toWork(hit: SearchHit): Result[IdentifiedWork] =
     fromJson[IdentifiedWork](hit.sourceAsString).toEither
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -81,7 +81,7 @@ trait SingleWorkSwagger {
         required = false,
       ),
       new Parameter(
-        name = "expandPaths",
+        name = "_expandPaths",
         in = ParameterIn.QUERY,
         description =
           "A comma-separated list of extra paths in the collection hierarchy to expand",

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -80,6 +80,13 @@ trait SingleWorkSwagger {
             "collection")),
         required = false,
       ),
+      new Parameter(
+        name = "expandPaths",
+        in = ParameterIn.QUERY,
+        description =
+          "A comma-separated list of extra paths in the collection hierarchy to expand",
+        required = false,
+      )
     )
   )
   @ApiResponse(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiWorkCollectionTreeTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiWorkCollectionTreeTest.scala
@@ -78,7 +78,7 @@ class ApiWorkCollectionTreeTest extends ApiV2WorksTestBase {
         insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
         assertJsonResponse(
           routes,
-          s"/$apiPrefix/works/${workB.canonicalId}?include=collection&expandPaths=a/d,a/b/c") {
+          s"/$apiPrefix/works/${workB.canonicalId}?include=collection&_expandPaths=a/d,a/b/c") {
           Status.OK -> s"""
             {
               ${singleWorkResult(apiPrefix)},

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiWorkCollectionTreeTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiWorkCollectionTreeTest.scala
@@ -1,0 +1,207 @@
+package uk.ac.wellcome.platform.api.works.v2
+
+import uk.ac.wellcome.models.work.internal._
+
+class ApiWorkCollectionTreeTest extends ApiV2WorksTestBase {
+
+  def work(path: String) =
+    createIdentifiedWorkWith(
+      collection = Some(Collection(path = path)),
+      title = Some(path),
+      sourceIdentifier = createSourceIdentifierWith(value = path)
+    )
+
+  val workA = work("a")
+  val workB = work("a/b")
+  val workC = work("a/b/c")
+  val workD = work("a/d")
+  val workE = work("a/d/e")
+
+  def workJson(work: IdentifiedWork) =
+    s"""
+      {
+        "id": "${work.canonicalId}",
+        "alternativeTitles": [],
+        "type": "Work",
+        "title": "${work.data.title.get}"
+      }
+    """
+
+  it("includes collection tree when requested") {
+    withApi {
+      case (index, routes) =>
+        insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works/${workC.canonicalId}?include=collection") {
+          Status.OK -> s"""
+            {
+              ${singleWorkResult(apiPrefix)},
+              "id": "${workC.canonicalId}",
+              "title": "a/b/c",
+              "alternativeTitles": [],
+              "collection": {
+                "path": "a/b/c",
+                "type": "Collection"
+              },
+              "collectionTree": {
+                "path": "a",
+                "work": ${workJson(workA)},
+                "children": [
+                  {
+                    "path": "a/b",
+                    "work": ${workJson(workB)},
+                    "children": [
+                      {
+                        "path": "a/b/c",
+                        "work": ${workJson(workC)},
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "path": "a/d",
+                    "work": ${workJson(workD)}
+                  }
+                ]
+              }
+            }
+          """
+        }
+    }
+  }
+
+  it(
+    "includes collection tree and additional multiple expanded paths when requested ") {
+    withApi {
+      case (index, routes) =>
+        insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works/${workB.canonicalId}?include=collection&expandPaths=a/d,a/b/c") {
+          Status.OK -> s"""
+            {
+              ${singleWorkResult(apiPrefix)},
+              "id": "${workB.canonicalId}",
+              "title": "a/b",
+              "alternativeTitles": [],
+              "collection": {
+                "path": "a/b",
+                "type": "Collection"
+              },
+              "collectionTree": {
+                "path": "a",
+                "work": ${workJson(workA)},
+                "children": [
+                  {
+                    "path": "a/b",
+                    "work": ${workJson(workB)},
+                    "children": [
+                      {
+                        "path": "a/b/c",
+                        "work": ${workJson(workC)},
+                        "children": []
+                      }
+                    ]
+                  },
+                  {
+                    "path": "a/d",
+                    "work": ${workJson(workD)},
+                    "children": [
+                      {
+                        "path": "a/d/e",
+                        "work": ${workJson(workE)}
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          """
+        }
+    }
+  }
+
+  it("does not expand tree more than one level deep") {
+    withApi {
+      case (index, routes) =>
+        insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works/${workA.canonicalId}?include=collection") {
+          Status.OK -> s"""
+            {
+              ${singleWorkResult(apiPrefix)},
+              "id": "${workA.canonicalId}",
+              "title": "a",
+              "alternativeTitles": [],
+              "collection": {
+                "path": "a",
+                "type": "Collection"
+              },
+              "collectionTree": {
+                "path": "a",
+                "work": ${workJson(workA)},
+                "children": [
+                  {
+                    "path": "a/b",
+                    "work": ${workJson(workB)}
+                  },
+                  {
+                    "path": "a/d",
+                    "work": ${workJson(workD)}
+                  }
+                ]
+              }
+            }
+          """
+        }
+    }
+  }
+
+  it("still returns the work when the collection tree cannot be generated") {
+    withApi {
+      case (index, routes) =>
+        insertIntoElasticsearch(index, workA, workC, workD, workE)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works/${workC.canonicalId}?include=collection") {
+          Status.OK -> s"""
+            {
+              ${singleWorkResult(apiPrefix)},
+              "id": "${workC.canonicalId}",
+              "title": "a/b/c",
+              "alternativeTitles": [],
+              "collection": {
+                "path": "a/b/c",
+                "type": "Collection"
+              }
+            }
+          """
+        }
+    }
+  }
+
+  it("does not include the collection tree when the root node is non existent") {
+    withApi {
+      case (index, routes) =>
+        insertIntoElasticsearch(index, workB, workC, workD, workE)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works/${workE.canonicalId}?include=collection") {
+          Status.OK -> s"""
+            {
+              ${singleWorkResult(apiPrefix)},
+              "id": "${workE.canonicalId}",
+              "title": "a/d/e",
+              "alternativeTitles": [],
+              "collection": {
+                "path": "a/d/e",
+                "type": "Collection"
+              }
+            }
+          """
+        }
+    }
+  }
+}

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayCollectionTree.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayCollectionTree.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.display.models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.display.models.v2.DisplayWorkV2
+
+@Schema(
+  name = "CollectionTree",
+  description = "A hierarchical collection of works."
+)
+case class DisplayCollectionTree(
+  @Schema(
+    description =
+      "A slash separated path containing the position within the hierarchy."
+  ) path: String,
+  @Schema(
+    description =
+      "The work. This only contains a limited set of fields, regardless of the includes."
+  ) work: DisplayWorkV2,
+  @Schema(
+    description =
+      "An array containing any children. This value is null when a given node has not been expanded."
+  ) children: Option[List[DisplayCollectionTree]],
+)
+
+object DisplayCollectionTree {
+
+  def apply(tree: CollectionTree,
+            expandedPaths: List[String]): DisplayCollectionTree =
+    DisplayCollectionTree(
+      path = tree.path,
+      work = DisplayWorkV2(tree.work),
+      children =
+        if (isExpanded(tree.path, expandedPaths))
+          Some(tree.children.map(DisplayCollectionTree(_, expandedPaths)))
+        else
+          None
+    )
+
+  private def isExpanded(path: String, expandedPaths: List[String]): Boolean =
+    expandedPaths.exists(_.startsWith(path))
+}

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayWorkV2.scala
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal.IdentifiedWork
+import uk.ac.wellcome.display.models.DisplayCollectionTree
 
 @Schema(
   name = "Work",
@@ -94,6 +95,10 @@ case class DisplayWorkV2(
     `type` = "Collection",
     description = "The collection a work is part of."
   ) collection: Option[DisplayCollection] = None,
+  @Schema(
+    `type` = "CollectionTree",
+    description = "The partially expanded collection tree for this work."
+  ) collectionTree: Option[DisplayCollectionTree] = None,
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Work"
 ) extends DisplayWork
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
@@ -1,0 +1,166 @@
+package uk.ac.wellcome.display.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.display.models.v2.DisplayWorkV2
+import uk.ac.wellcome.models.work.generators.WorksGenerators
+
+class DisplayCollectionTreeTest
+    extends FunSpec
+    with Matchers
+    with WorksGenerators {
+
+  def work(path: String) =
+    createIdentifiedWorkWith(collection = Some(Collection(path = path)))
+
+  it("creates a display tree with a path expanded") {
+    val a = work("a")
+    val b = work("a/b")
+    val c = work("a/b/c")
+    val tree = CollectionTree(List(a, b, c)).right.get
+    DisplayCollectionTree(tree, List("a/b/c")) shouldBe
+      DisplayCollectionTree(
+        path = "a",
+        work = DisplayWorkV2(a),
+        children = Some(
+          List(
+            DisplayCollectionTree(
+              path = "a/b",
+              work = DisplayWorkV2(b),
+              children = Some(
+                List(
+                  DisplayCollectionTree(
+                    path = "a/b/c",
+                    work = DisplayWorkV2(c),
+                    children = Some(Nil)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+  }
+
+  it("creates a display tree with multiple paths expanded") {
+    val a = work("a")
+    val b = work("a/b")
+    val c = work("a/b/c")
+    val d = work("a/d")
+    val e = work("a/d/e")
+    val tree = CollectionTree(List(a, b, c, d, e)).right.get
+    DisplayCollectionTree(tree, List("a/b/c", "a/d/e")) shouldBe
+      DisplayCollectionTree(
+        path = "a",
+        work = DisplayWorkV2(a),
+        children = Some(
+          List(
+            DisplayCollectionTree(
+              path = "a/b",
+              work = DisplayWorkV2(b),
+              children = Some(
+                List(
+                  DisplayCollectionTree(
+                    path = "a/b/c",
+                    work = DisplayWorkV2(c),
+                    children = Some(Nil)
+                  )
+                )
+              )
+            ),
+            DisplayCollectionTree(
+              path = "a/d",
+              work = DisplayWorkV2(d),
+              children = Some(
+                List(
+                  DisplayCollectionTree(
+                    path = "a/d/e",
+                    work = DisplayWorkV2(e),
+                    children = Some(Nil)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+  }
+
+  it("creates a display tree with ancestor paths also expanded") {
+    val a = work("a")
+    val b = work("a/b")
+    val c = work("a/b/c")
+    val d = work("a/d")
+    val e = work("a/b/e")
+    val tree = CollectionTree(List(a, b, c, d, e)).right.get
+    DisplayCollectionTree(tree, List("a/b/c")) shouldBe
+      DisplayCollectionTree(
+        path = "a",
+        work = DisplayWorkV2(a),
+        children = Some(
+          List(
+            DisplayCollectionTree(
+              path = "a/b",
+              work = DisplayWorkV2(b),
+              children = Some(
+                List(
+                  DisplayCollectionTree(
+                    path = "a/b/c",
+                    work = DisplayWorkV2(c),
+                    children = Some(Nil)
+                  ),
+                  DisplayCollectionTree(
+                    path = "a/b/e",
+                    work = DisplayWorkV2(e),
+                    children = None
+                  ),
+                )
+              )
+            ),
+            DisplayCollectionTree(
+              path = "a/d",
+              work = DisplayWorkV2(d),
+              children = None
+            )
+          )
+        )
+      )
+  }
+
+  it("creates a display tree non expanded paths None rather than empty list") {
+    val a = work("a")
+    val b = work("a/b")
+    val c = work("a/b/c")
+    val d = work("a/d")
+    val e = work("a/d/e")
+    val tree = CollectionTree(List(a, b, c, d, e)).right.get
+    DisplayCollectionTree(tree, List("a/b")) shouldBe
+      DisplayCollectionTree(
+        path = "a",
+        work = DisplayWorkV2(a),
+        children = Some(
+          List(
+            DisplayCollectionTree(
+              path = "a/b",
+              work = DisplayWorkV2(b),
+              children = Some(
+                List(
+                  DisplayCollectionTree(
+                    path = "a/b/c",
+                    work = DisplayWorkV2(c),
+                    children = None
+                  )
+                )
+              )
+            ),
+            DisplayCollectionTree(
+              path = "a/d",
+              work = DisplayWorkV2(d),
+              children = None
+            )
+          )
+        )
+      )
+  }
+}

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
@@ -128,7 +128,7 @@ class DisplayCollectionTreeTest
       )
   }
 
-  it("creates a display tree non expanded paths None rather than empty list") {
+  it("sets non-expanded paths as None rather than empty list") {
     val a = work("a")
     val b = work("a/b")
     val c = work("a/b/c")

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/CollectionTree.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/CollectionTree.scala
@@ -21,6 +21,9 @@ case class CollectionTree(
 
   def pathList: List[String] =
     path :: children.flatMap(_.pathList)
+
+  def isRoot: Boolean =
+    !path.contains("/")
 }
 
 object CollectionTree {


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4378

## Description

Displays the collection tree when requested under the `collectionTree` field in the `works/{id}` endpoint.