### PR TITLE
Split the data_api into its own terraform stack

### DIFF
--- a/api/terraform/config.tf
+++ b/api/terraform/config.tf
@@ -1,7 +1,0 @@
-data "aws_ssm_parameter" "infra_bucket" {
-  name = "/api/config/prod/infra_bucket"
-}
-
-locals {
-  infra_bucket = "${data.aws_ssm_parameter.infra_bucket.value}"
-}

--- a/api/terraform/data_api/domain.tf
+++ b/api/terraform/data_api/domain.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "data_page" {
-  provider          = "aws.us_e1"
+  provider          = "aws.us_east_1"
   domain_name       = "${var.data_page_url}"
   validation_method = "DNS"
 
@@ -12,20 +12,20 @@ resource "aws_route53_record" "cert_validation" {
   provider = "aws.routemaster"
   name     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_name}"
   type     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_type}"
-  zone_id  = "${var.route_zone_id}"
+  zone_id  = "${local.route53_zone_id}"
   records  = ["${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_value}"]
   ttl      = 60
 }
 
 resource "aws_acm_certificate_validation" "catalogue_api_validation" {
-  provider                = "aws.us_e1"
+  provider                = "aws.us_east_1"
   certificate_arn         = "${aws_acm_certificate.data_page.arn}"
   validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 
 resource "aws_route53_record" "data_page" {
   provider = "aws.routemaster"
-  zone_id  = "${var.route_zone_id}"
+  zone_id  = "${local.route53_zone_id}"
   name     = "${var.data_page_url}"
   type     = "A"
 

--- a/api/terraform/data_api/ecr.tf
+++ b/api/terraform/data_api/ecr.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "allow_snapshot_generator_access" {
 }
 
 resource "aws_ecr_repository_policy" "snapshot_generator_access_policy" {
-  provider   = "aws.platform_account"
+  provider   = "aws.platform"
   repository = "uk.ac.wellcome/snapshot_generator"
   policy     = "${data.aws_iam_policy_document.allow_snapshot_generator_access.json}"
 }

--- a/api/terraform/data_api/lambda_snapshot_slack_alarms.tf
+++ b/api/terraform/data_api/lambda_snapshot_slack_alarms.tf
@@ -1,7 +1,7 @@
 module "lambda_snapshot_slack_alarms" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
 
-  s3_bucket = "${var.infra_bucket}"
+  s3_bucket = "${local.infra_bucket}"
   s3_key    = "lambdas/data_api/snapshot_slack_alarms.zip"
 
   name        = "snapshot_slack_alarms"

--- a/api/terraform/data_api/locals.tf
+++ b/api/terraform/data_api/locals.tf
@@ -2,4 +2,14 @@ locals {
   lambda_error_alarm_arn      = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
   dlq_alarm_arn               = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
   service_discovery_namespace = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+
+  vpc_id          = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
+  private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_vpc_private_subnets}"
+
+  infra_bucket = "wellcomecollection-catalogue-infra-delta"
+
+  # This is the Zone ID for wellcomecollection.org in the routemaster account.
+  # We can't look this up programatically because the role we use doesn't have
+  # the right permissions in that account.
+  route53_zone_id = "Z3THRVQ5VDYDMC"
 }

--- a/api/terraform/data_api/main.tf
+++ b/api/terraform/data_api/main.tf
@@ -1,3 +1,9 @@
+data "aws_ssm_parameter" "snapshot_generator_image" {
+  provider = "aws.platform"
+
+  name = "/catalogue_api/images/latest/snapshot_generator"
+}
+
 module "snapshot_generator" {
   source = "git::https://github.com/wellcometrust/terraform.git//ecs/prebuilt/scaling?ref=v19.7.2"
 
@@ -5,10 +11,10 @@ module "snapshot_generator" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   cluster_name = "${aws_ecs_cluster.cluster.name}"
 
-  subnets = "${var.private_subnets}"
+  subnets = "${local.private_subnets}"
 
   namespace_id    = "${local.service_discovery_namespace}"
-  container_image = "${var.snapshot_generator_release_uri}"
+  container_image = "${data.aws_ssm_parameter.snapshot_generator_image.value}"
 
   env_vars_length = 3
 
@@ -40,7 +46,7 @@ module "snapshot_scheduler" {
   source = "./snapshot_scheduler"
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
-  infra_bucket           = "${var.infra_bucket}"
+  infra_bucket           = "${local.infra_bucket}"
 
   public_bucket_name = "${aws_s3_bucket.public_data.id}"
 

--- a/api/terraform/data_api/network.tf
+++ b/api/terraform/data_api/network.tf
@@ -1,4 +1,4 @@
 resource "aws_service_discovery_private_dns_namespace" "namespace" {
   name = "${var.namespace}"
-  vpc  = "${var.vpc_id}"
+  vpc  = "${local.vpc_id}"
 }

--- a/api/terraform/data_api/provider.tf
+++ b/api/terraform/data_api/provider.tf
@@ -1,13 +1,43 @@
 data "aws_caller_identity" "current" {}
 
 provider "aws" {
-  alias = "us_e1"
+  region  = "${var.aws_region}"
+  version = "1.57.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
+  }
 }
 
 provider "aws" {
-  alias = "platform_account"
+  alias   = "us_east_1"
+  region  = "us-east-1"
+  version = "1.57.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
+  }
+}
+
+// Given the tangle of resources in this repo, the lightest touch
+// approach to having the API in the `catalogue` VPC is to allow access
+// to select resources in the `platform` account.
+provider "aws" {
+  alias   = "platform"
+  region  = "${var.aws_region}"
+  version = "1.57.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  }
 }
 
 provider "aws" {
-  alias = "routemaster"
+  version = "1.57.0"
+  region  = "eu-west-1"
+  alias   = "routemaster"
+
+  assume_role {
+    role_arn = "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
 }

--- a/api/terraform/data_api/security_groups.tf
+++ b/api/terraform/data_api/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "service_egress_security_group" {
   name        = "${var.namespace}-service_egress_security_group"
   description = "Allow traffic between services"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = "${local.vpc_id}"
 
   egress {
     from_port   = 0

--- a/api/terraform/data_api/terraform.tf
+++ b/api/terraform/data_api/terraform.tf
@@ -11,23 +11,11 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "catalogue_pipeline_data" {
-  backend = "s3"
-
-  config {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
-
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/catalogue_pipeline_data.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"

--- a/api/terraform/data_api/terraform.tf
+++ b/api/terraform/data_api/terraform.tf
@@ -2,10 +2,10 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
 
-    bucket         = "wellcomecollection-platform-infra"
-    key            = "terraform/data_api.tfstate"
+    bucket         = "wellcomecollection-catalogue-infra-delta"
+    key            = "terraform/catalogue/api/data_api.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
   }

--- a/api/terraform/data_api/terraform.tf
+++ b/api/terraform/data_api/terraform.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 0.9"
-
   backend "s3" {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
 

--- a/api/terraform/data_api/variables.tf
+++ b/api/terraform/data_api/variables.tf
@@ -2,24 +2,14 @@ variable "aws_region" {
   default = "eu-west-1"
 }
 
-variable "infra_bucket" {}
-
 variable "namespace" {
   default = "data_api"
 }
 
-variable "snapshot_generator_release_uri" {}
-
-variable "critical_slack_webhook" {}
-
-variable "vpc_id" {}
-
-variable "private_subnets" {
-  type = "list"
+variable "critical_slack_webhook" {
+  default = ""
 }
 
 variable "data_page_url" {
   default = "data.wellcomecollection.org"
 }
-
-variable "route_zone_id" {}

--- a/api/terraform/main.tf
+++ b/api/terraform/main.tf
@@ -53,24 +53,3 @@ module "catalogue_api_staging" {
 
   interservice_sg_id = "${aws_security_group.interservice.id}"
 }
-
-module "data_api" {
-  source = "./data_api"
-
-  aws_region   = "${var.aws_region}"
-  infra_bucket = "${local.infra_bucket}"
-
-  snapshot_generator_release_uri = "${module.latest_images.services["snapshot_generator"]}"
-
-  critical_slack_webhook = ""
-
-  vpc_id          = "${local.vpc_id}"
-  private_subnets = ["${local.private_subnets}"]
-  route_zone_id   = "${local.routemaster_router53_zone_id}"
-
-  providers = {
-    aws.us_e1            = "aws.us_e1"
-    aws.routemaster      = "aws.routemaster"
-    aws.platform_account = "aws.platform_account"
-  }
-}

--- a/api/terraform/outputs.tf
+++ b/api/terraform/outputs.tf
@@ -1,7 +1,3 @@
-output "snapshots_bucket_arn" {
-  value = "${module.data_api.snapshots_bucket_arn}"
-}
-
 output "catalogue_api_nlb_arn" {
   value = "${module.nlb.arn}"
 }

--- a/api/terraform/provider.tf
+++ b/api/terraform/provider.tf
@@ -7,16 +7,6 @@ provider "aws" {
   }
 }
 
-provider "aws" {
-  alias   = "us_e1"
-  region  = "us-east-1"
-  version = "1.57.0"
-
-  assume_role {
-    role_arn = "${local.catalogue_developer_role_arn}"
-  }
-}
-
 // Given the tangle of resources in this repo, the lightest touch
 // approach to having the API in the `catalogue` VPC is to allow access
 // to select resources in the `platform` account.

--- a/api/terraform/release_uris.tf
+++ b/api/terraform/release_uris.tf
@@ -23,16 +23,3 @@ module "staging_images" {
     aws = "aws.platform_account"
   }
 }
-
-module "latest_images" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/images?ref=v19.8.0"
-
-  project = "catalogue_api"
-  label   = "latest"
-
-  services = "${local.service_repositories}"
-
-  providers = {
-    aws = "aws.platform_account"
-  }
-}


### PR DESCRIPTION
This means we can make changes to the snapshot service with less risk of affecting the production catalogue API. (In particular, in a later pull request we can upgrade it to terraform 0.12!)

Follows https://github.com/wellcomecollection/catalogue/pull/491; another step towards https://github.com/wellcomecollection/platform/issues/4386

The eventual plan is to have the following folder structure in the `terraform` directory:

- catalogue_api_shared (API Gateway, ECR repositories, ECS cluster, etc.)
- catalogue_api_prod (ECS services for the prod API, alarms)
- catalogue_api_staging (ECS services for the staging API)
- data_api (snapshots service)
- update_api_docs
- modules (for shared pieces)

And then each of those can be rolled to terraform 0.12 independently (and in particular, the first time I hit apply I won't be affecting the production API!).
