### PR TITLE
Update the data API to terraform 0.12

### DIFF
--- a/api/terraform/data_api/cloudfront.tf
+++ b/api/terraform/data_api/cloudfront.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_distribution" "data_api" {
   origin {
-    domain_name = "${aws_s3_bucket.public_data.bucket_domain_name}"
+    domain_name = aws_s3_bucket.public_data.bucket_domain_name
     origin_id   = "data_api"
 
     custom_origin_config {
@@ -16,7 +16,7 @@ resource "aws_cloudfront_distribution" "data_api" {
 
   default_root_object = "index.html"
 
-  aliases = ["${var.data_page_url}"]
+  aliases = [var.data_page_url]
 
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
@@ -43,7 +43,7 @@ resource "aws_cloudfront_distribution" "data_api" {
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    acm_certificate_arn      = "${aws_acm_certificate_validation.catalogue_api_validation.certificate_arn}"
+    acm_certificate_arn      = aws_acm_certificate_validation.catalogue_api_validation.certificate_arn
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }

--- a/api/terraform/data_api/cluster.tf
+++ b/api/terraform/data_api/cluster.tf
@@ -1,3 +1,3 @@
-resource "aws_ecs_cluster" "cluster" {
-  name = "${replace(var.namespace, "_", "-")}"
+resource "aws_ecs_cluster" "data_api" {
+  name = replace(var.namespace, "_", "-")
 }

--- a/api/terraform/data_api/domain.tf
+++ b/api/terraform/data_api/domain.tf
@@ -1,7 +1,11 @@
-data "aws_route53_zone" "dotorg" {
+/*data "aws_route53_zone" "dotorg" {
   provider = "aws.routemaster"
 
   name = "wellcomecollection.org."
+}*/
+
+locals {
+  route53_zone_id = "Z3THRVQ5VDYDMC"
 }
 
 resource "aws_acm_certificate" "data_page" {
@@ -18,7 +22,7 @@ resource "aws_route53_record" "cert_validation" {
   provider = "aws.routemaster"
   name     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_name}"
   type     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_type}"
-  zone_id  = "${data.aws_route53_zone.dotorg.id}"
+  zone_id  = "${local.route53_zone_id}"
   records  = ["${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_value}"]
   ttl      = 60
 }
@@ -31,7 +35,7 @@ resource "aws_acm_certificate_validation" "catalogue_api_validation" {
 
 resource "aws_route53_record" "data_page" {
   provider = "aws.routemaster"
-  zone_id  = "${data.aws_route53_zone.dotorg.id}"
+  zone_id  = "${local.route53_zone_id}"
   name     = "${var.data_page_url}"
   type     = "A"
 

--- a/api/terraform/data_api/domain.tf
+++ b/api/terraform/data_api/domain.tf
@@ -1,10 +1,13 @@
 /*data "aws_route53_zone" "dotorg" {
-  provider = "aws.routemaster"
+  provider = aws.routemaster
 
   name = "wellcomecollection.org."
 }*/
 
 locals {
+  # This is the Zone ID for wellcomecollection.org in the routemaster account.
+  # We can't look this up programatically because the role we use doesn't have
+  # the right permissions in that account.
   route53_zone_id = "Z3THRVQ5VDYDMC"
 }
 

--- a/api/terraform/data_api/domain.tf
+++ b/api/terraform/data_api/domain.tf
@@ -9,8 +9,9 @@ locals {
 }
 
 resource "aws_acm_certificate" "data_page" {
-  provider          = "aws.us_east_1"
-  domain_name       = "${var.data_page_url}"
+  provider = aws.us_east_1
+
+  domain_name       = var.data_page_url
   validation_method = "DNS"
 
   lifecycle {
@@ -19,29 +20,32 @@ resource "aws_acm_certificate" "data_page" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  provider = "aws.routemaster"
-  name     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_name}"
-  type     = "${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_type}"
-  zone_id  = "${local.route53_zone_id}"
-  records  = ["${aws_acm_certificate.data_page.domain_validation_options.0.resource_record_value}"]
-  ttl      = 60
+  provider = aws.routemaster
+
+  name    = aws_acm_certificate.data_page.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.data_page.domain_validation_options.0.resource_record_type
+  zone_id = local.route53_zone_id
+  records = [aws_acm_certificate.data_page.domain_validation_options.0.resource_record_value]
+  ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "catalogue_api_validation" {
-  provider                = "aws.us_east_1"
-  certificate_arn         = "${aws_acm_certificate.data_page.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.data_page.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }
 
 resource "aws_route53_record" "data_page" {
-  provider = "aws.routemaster"
-  zone_id  = "${local.route53_zone_id}"
-  name     = "${var.data_page_url}"
-  type     = "A"
+  provider = aws.routemaster
+
+  zone_id = local.route53_zone_id
+  name    = var.data_page_url
+  type    = "A"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.data_api.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.data_api.hosted_zone_id}"
+    name                   = aws_cloudfront_distribution.data_api.domain_name
+    zone_id                = aws_cloudfront_distribution.data_api.hosted_zone_id
     evaluate_target_health = false
   }
 }

--- a/api/terraform/data_api/iam.tf
+++ b/api/terraform/data_api/iam.tf
@@ -1,39 +1,26 @@
 # Role policies for the snapshot_generator
 
 resource "aws_iam_role_policy" "ecs_snapshot_generator_task_sns" {
-  role   = "${module.snapshot_generator.task_role_name}"
-  policy = "${module.snapshot_complete_topic.publish_policy}"
+  role   = module.snapshot_generator.task_role_name
+  policy = module.snapshot_complete_topic.publish_policy
 }
 
 resource "aws_iam_role_policy" "ecs_snapshot_generator_task_s3_public" {
-  role   = "${module.snapshot_generator.task_role_name}"
-  policy = "${data.aws_iam_policy_document.public_data_bucket_full_access_policy.json}"
+  role   = module.snapshot_generator.task_role_name
+  policy = data.aws_iam_policy_document.public_data_bucket_full_access_policy.json
 }
 
 resource "aws_iam_role_policy" "snapshot_generator_cloudwatch" {
-  role   = "${module.snapshot_generator.task_role_name}"
-  policy = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
+  role   = module.snapshot_generator.task_role_name
+  policy = data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json
 }
 
 resource "aws_iam_role_policy" "snapshot_generator_read_from_q" {
-  role   = "${module.snapshot_generator.task_role_name}"
-  policy = "${data.aws_iam_policy_document.snapshot_generator_read_from_q.json}"
+  role   = module.snapshot_generator.task_role_name
+  policy = module.snapshot_generator_queue.read_policy
 }
 
 # Policy documents
-
-data "aws_iam_policy_document" "snapshot_generator_read_from_q" {
-  statement {
-    actions = [
-      "sqs:DeleteMessage",
-      "sqs:ReceiveMessage",
-    ]
-
-    resources = [
-      "${module.snapshot_generator_queue.arn}",
-    ]
-  }
-}
 
 data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
   statement {
@@ -50,29 +37,11 @@ data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
 data "aws_iam_policy_document" "public_data_bucket_full_access_policy" {
   statement {
     actions = [
-      "s3:*",
+      "s3:Put*",
     ]
 
     resources = [
-      "${aws_s3_bucket.public_data.arn}/",
-      "${aws_s3_bucket.public_data.arn}/*",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "public_data_bucket_get_access_policy" {
-  statement {
-    actions = [
-      "s3:GetObject",
-    ]
-
-    principals {
-      identifiers = ["*"]
-      type        = "AWS"
-    }
-
-    resources = [
-      "arn:aws:s3:::${local.public_data_bucket_name}/*",
+      "${aws_s3_bucket.public_data.arn}/catalogue/*",
     ]
   }
 }

--- a/api/terraform/data_api/lambda_snapshot_slack_alarms.tf
+++ b/api/terraform/data_api/lambda_snapshot_slack_alarms.tf
@@ -1,18 +1,18 @@
 module "lambda_snapshot_slack_alarms" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
+  source = "../modules/lambda"
 
-  s3_bucket = "${local.infra_bucket}"
+  s3_bucket = local.infra_bucket
   s3_key    = "lambdas/data_api/snapshot_slack_alarms.zip"
 
   name        = "snapshot_slack_alarms"
   description = "Post a notification to Slack when a snapshot fails"
   timeout     = 10
 
-  environment_variables = {
-    CRITICAL_SLACK_WEBHOOK = "${var.critical_slack_webhook}"
+  env_vars = {
+    CRITICAL_SLACK_WEBHOOK = var.critical_slack_webhook
   }
 
-  alarm_topic_arn = "${local.lambda_error_alarm_arn}"
+  alarm_topic_arn = local.lambda_error_alarm_arn
 
   log_retention_in_days = 30
 }
@@ -32,14 +32,14 @@ data "aws_iam_policy_document" "read_from_snapshots_bucket" {
 }
 
 resource "aws_iam_role_policy" "snapshot_alarms_read_from_bucket" {
-  role   = "${module.lambda_snapshot_slack_alarms.role_name}"
-  policy = "${data.aws_iam_policy_document.read_from_snapshots_bucket.json}"
+  role   = module.lambda_snapshot_slack_alarms.role_name
+  policy = data.aws_iam_policy_document.read_from_snapshots_bucket.json
 }
 
 module "trigger_post_to_slack_dlqs_not_empty" {
   source = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_sns?ref=v1.0.0"
 
-  lambda_function_name = "${module.lambda_snapshot_slack_alarms.function_name}"
-  lambda_function_arn  = "${module.lambda_snapshot_slack_alarms.arn}"
-  sns_trigger_arn      = "${module.snapshot_alarm_topic.arn}"
+  lambda_function_name = module.lambda_snapshot_slack_alarms.function_name
+  lambda_function_arn  = module.lambda_snapshot_slack_alarms.arn
+  sns_trigger_arn      = module.snapshot_alarm_topic.arn
 }

--- a/api/terraform/data_api/locals.tf
+++ b/api/terraform/data_api/locals.tf
@@ -1,10 +1,11 @@
 locals {
-  lambda_error_alarm_arn      = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
-  dlq_alarm_arn               = "${data.terraform_remote_state.shared_infra.dlq_alarm_arn}"
-  service_discovery_namespace = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+  service_discovery_namespace = aws_service_discovery_private_dns_namespace.namespace.id
 
-  vpc_id          = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
-  private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_vpc_private_subnets}"
+  lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
+  dlq_alarm_arn          = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+
+  vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_id
+  private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_private_subnets
 
   infra_bucket = "wellcomecollection-catalogue-infra-delta"
 }

--- a/api/terraform/data_api/main.tf
+++ b/api/terraform/data_api/main.tf
@@ -5,8 +5,8 @@ module "snapshot_generator" {
   input_queue_url  = module.snapshot_generator_queue.url
   output_topic_arn = module.snapshot_complete_topic.arn
 
-  cluster_arn  = aws_ecs_cluster.cluster.arn
-  cluster_name = aws_ecs_cluster.cluster.name
+  cluster_arn  = aws_ecs_cluster.data_api.arn
+  cluster_name = aws_ecs_cluster.data_api.name
 
   subnets = local.private_subnets
 

--- a/api/terraform/data_api/main.tf
+++ b/api/terraform/data_api/main.tf
@@ -2,7 +2,7 @@ module "snapshot_generator" {
   source = "./snapshot_generator"
 
   input_queue_name = module.snapshot_generator_queue.name
-  input_queue_url  = module.snapshot_generator_queue.id
+  input_queue_url  = module.snapshot_generator_queue.url
   output_topic_arn = module.snapshot_complete_topic.arn
 
   cluster_arn  = aws_ecs_cluster.cluster.arn

--- a/api/terraform/data_api/main.tf
+++ b/api/terraform/data_api/main.tf
@@ -13,7 +13,7 @@ module "snapshot_generator" {
   namespace_id = local.service_discovery_namespace
 
   security_group_ids = [
-    aws_security_group.service_egress_security_group.id,
+    aws_security_group.egress_security_group.id,
   ]
 
   aws_region = var.aws_region

--- a/api/terraform/data_api/network.tf
+++ b/api/terraform/data_api/network.tf
@@ -1,4 +1,4 @@
 resource "aws_service_discovery_private_dns_namespace" "namespace" {
-  name = "${var.namespace}"
-  vpc  = "${local.vpc_id}"
+  name = var.namespace
+  vpc  = local.vpc_id
 }

--- a/api/terraform/data_api/outputs.tf
+++ b/api/terraform/data_api/outputs.tf
@@ -1,3 +1,3 @@
 output "snapshots_bucket_arn" {
-  value = "${aws_s3_bucket.public_data.arn}"
+  value = aws_s3_bucket.public_data.arn
 }

--- a/api/terraform/data_api/provider.tf
+++ b/api/terraform/data_api/provider.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 provider "aws" {
   region  = var.aws_region
   version = "~> 2.7"

--- a/api/terraform/data_api/provider.tf
+++ b/api/terraform/data_api/provider.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 provider "aws" {
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
@@ -10,22 +10,21 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias   = "us_east_1"
+  alias = "us_east_1"
+
   region  = "us-east-1"
-  version = "1.57.0"
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
   }
 }
 
-// Given the tangle of resources in this repo, the lightest touch
-// approach to having the API in the `catalogue` VPC is to allow access
-// to select resources in the `platform` account.
 provider "aws" {
-  alias   = "platform"
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  alias = "platform"
+
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -33,9 +32,10 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "1.57.0"
+  alias = "routemaster"
+
   region  = "eu-west-1"
-  alias   = "routemaster"
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update"

--- a/api/terraform/data_api/s3_data_public.tf
+++ b/api/terraform/data_api/s3_data_public.tf
@@ -3,22 +3,39 @@ locals {
 }
 
 resource "aws_s3_bucket" "public_data" {
-  bucket = "${local.public_data_bucket_name}"
+  bucket = local.public_data_bucket_name
   acl    = "private"
 
   lifecycle {
     prevent_destroy = true
   }
 
-  policy = "${data.aws_iam_policy_document.public_data_bucket_get_access_policy.json}"
+  policy = data.aws_iam_policy_document.public_data_bucket_get_access_policy.json
+}
+
+data "aws_iam_policy_document" "public_data_bucket_get_access_policy" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+
+    resources = [
+      "arn:aws:s3:::${local.public_data_bucket_name}/*",
+    ]
+  }
 }
 
 # This file is served from the root of data.wellcomecollection.org.
 resource "aws_s3_bucket_object" "index_page" {
-  bucket  = "${aws_s3_bucket.public_data.id}"
+  bucket  = aws_s3_bucket.public_data.id
   key     = "index.html"
-  content = "${file("${path.module}/data_wc_index.html")}"
-  etag    = "${md5(file("${path.module}/data_wc_index.html"))}"
+  content = file("${path.module}/data_wc_index.html")
+  etag    = md5(file("${path.module}/data_wc_index.html"))
 
   content_type = "text/html"
 }

--- a/api/terraform/data_api/security_groups.tf
+++ b/api/terraform/data_api/security_groups.tf
@@ -1,7 +1,7 @@
-resource "aws_security_group" "service_egress_security_group" {
-  name        = "${var.namespace}-service_egress_security_group"
-  description = "Allow traffic between services"
-  vpc_id      = "${local.vpc_id}"
+resource "aws_security_group" "egress_security_group" {
+  name        = "${var.namespace}-egress_security_group"
+  description = "Allow outbound traffic to the Internet"
+  vpc_id      = local.vpc_id
 
   egress {
     from_port   = 0
@@ -10,7 +10,7 @@ resource "aws_security_group" "service_egress_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.namespace}-egress"
   }
 }

--- a/api/terraform/data_api/snapshot_generator/main.tf
+++ b/api/terraform/data_api/snapshot_generator/main.tf
@@ -1,0 +1,71 @@
+data "aws_ssm_parameter" "snapshot_generator_image" {
+  provider = "aws.platform"
+
+  name = "/catalogue_api/images/latest/snapshot_generator"
+}
+
+module "task_definition" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.5.2"
+
+  task_name = "snapshot_generator"
+
+  container_image = data.aws_ssm_parameter.snapshot_generator_image.value
+
+  cpu    = 512
+  memory = 1024
+
+  env_vars = {
+    queue_url        = var.input_queue_url
+    topic_arn        = var.output_topic_arn
+    metric_namespace = "snapshot_generator"
+  }
+
+  secret_env_vars = {
+    es_host     = "catalogue/api/es_host"
+    es_port     = "catalogue/api/es_port"
+    es_protocol = "catalogue/api/es_protocol"
+    es_username = "catalogue/api/es_username"
+    es_password = "catalogue/api/es_password"
+  }
+
+  aws_region = var.aws_region
+}
+
+module "service" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.5.2"
+
+  service_name = "snapshot_generator"
+  cluster_arn  = var.cluster_arn
+
+  task_definition_arn = module.task_definition.arn
+
+  subnets = var.subnets
+
+  namespace_id = var.namespace_id
+
+  security_group_ids = var.security_group_ids
+
+  use_fargate_spot = true
+}
+
+module "autoscaling_actions" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//autoscaling?ref=v1.5.2"
+
+  name         = "snapshot_generator"
+  cluster_name = var.cluster_name
+  service_name = module.service.name
+}
+
+module "autoscaling_queue" {
+  source = "github.com/wellcomecollection/terraform-aws-sqs.git//autoscaling?ref=v1.1.2"
+
+  queue_name = var.input_queue_name
+
+  queue_low_actions = [
+    module.autoscaling_actions.scale_down_arn,
+  ]
+
+  queue_high_actions = [
+    module.autoscaling_actions.scale_up_arn,
+  ]
+}

--- a/api/terraform/data_api/snapshot_generator/main.tf
+++ b/api/terraform/data_api/snapshot_generator/main.tf
@@ -1,5 +1,5 @@
 data "aws_ssm_parameter" "snapshot_generator_image" {
-  provider = "aws.platform"
+  provider = aws.platform
 
   name = "/catalogue_api/images/latest/snapshot_generator"
 }
@@ -11,8 +11,8 @@ module "task_definition" {
 
   container_image = data.aws_ssm_parameter.snapshot_generator_image.value
 
-  cpu    = 512
-  memory = 1024
+  cpu    = 1024
+  memory = 4096
 
   env_vars = {
     queue_url        = var.input_queue_url

--- a/api/terraform/data_api/snapshot_generator/outputs.tf
+++ b/api/terraform/data_api/snapshot_generator/outputs.tf
@@ -1,0 +1,3 @@
+output "task_role_name" {
+  value = module.task_definition.task_role_name
+}

--- a/api/terraform/data_api/snapshot_generator/provider.tf
+++ b/api/terraform/data_api/snapshot_generator/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  alias = "platform"
+}

--- a/api/terraform/data_api/snapshot_generator/variables.tf
+++ b/api/terraform/data_api/snapshot_generator/variables.tf
@@ -1,0 +1,18 @@
+variable "input_queue_name" {}
+variable "input_queue_url" {}
+variable "output_topic_arn" {}
+
+variable "cluster_arn" {}
+variable "cluster_name" {}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "namespace_id" {}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "aws_region" {}

--- a/api/terraform/data_api/snapshot_scheduler/iam_role_policy.tf
+++ b/api/terraform/data_api/snapshot_scheduler/iam_role_policy.tf
@@ -1,4 +1,4 @@
 resource "aws_iam_role_policy" "snapshot_scheduler_sns_publish" {
-  role   = "${module.snapshot_scheduler_lambda.role_name}"
-  policy = "${module.scheduler_topic.publish_policy}"
+  role   = module.snapshot_scheduler_lambda.role_name
+  policy = module.scheduler_topic.publish_policy
 }

--- a/api/terraform/data_api/snapshot_scheduler/lambdas.tf
+++ b/api/terraform/data_api/snapshot_scheduler/lambdas.tf
@@ -1,21 +1,19 @@
 module "snapshot_scheduler_lambda" {
-  source = "git::https://github.com/wellcometrust/terraform.git//lambda?ref=v10.2.2"
+  source = "../../modules/lambda"
 
   name = "snapshot_scheduler"
 
-  s3_bucket = "${var.infra_bucket}"
+  s3_bucket = var.infra_bucket
   s3_key    = "lambdas/data_api/snapshot_scheduler.zip"
 
   description     = "Send snapshot schedules to an SNS topic"
-  alarm_topic_arn = "${var.lambda_error_alarm_arn}"
+  alarm_topic_arn = var.lambda_error_alarm_arn
   timeout         = 10
 
-  environment_variables = {
-    TOPIC_ARN = "${module.scheduler_topic.arn}"
-
-    PUBLIC_BUCKET_NAME = "${var.public_bucket_name}"
-
-    PUBLIC_OBJECT_KEY_V2 = "${var.public_object_key_v2}"
+  env_vars = {
+    TOPIC_ARN            = module.scheduler_topic.arn
+    PUBLIC_BUCKET_NAME   = var.public_bucket_name
+    PUBLIC_OBJECT_KEY_V2 = var.public_object_key_v2
   }
 
   log_retention_in_days = 30
@@ -23,8 +21,8 @@ module "snapshot_scheduler_lambda" {
 
 module "trigger_snapshot_scheduler_lambda" {
   source                  = "git::https://github.com/wellcometrust/terraform.git//lambda/trigger_cloudwatch?ref=v1.0.0"
-  lambda_function_name    = "${module.snapshot_scheduler_lambda.function_name}"
-  lambda_function_arn     = "${module.snapshot_scheduler_lambda.arn}"
-  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.snapshot_scheduler_rule.arn}"
-  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.snapshot_scheduler_rule.id}"
+  lambda_function_name    = module.snapshot_scheduler_lambda.function_name
+  lambda_function_arn     = module.snapshot_scheduler_lambda.arn
+  cloudwatch_trigger_arn  = aws_cloudwatch_event_rule.snapshot_scheduler_rule.arn
+  cloudwatch_trigger_name = aws_cloudwatch_event_rule.snapshot_scheduler_rule.id
 }

--- a/api/terraform/data_api/snapshot_scheduler/lambdas.tf
+++ b/api/terraform/data_api/snapshot_scheduler/lambdas.tf
@@ -19,13 +19,7 @@ module "snapshot_scheduler_lambda" {
   log_retention_in_days = 30
 }
 
-resource "random_id" "cloudwatch_trigger_name" {
-  byte_length = 8
-  prefix      = "AllowExecutionFromCloudWatch_${module.snapshot_scheduler_lambda.function_name}_"
-}
-
 resource "aws_lambda_permission" "allow_cloudwatch_trigger" {
-  statement_id  = random_id.cloudwatch_trigger_name.id
   action        = "lambda:InvokeFunction"
   function_name = module.snapshot_scheduler_lambda.function_name
   principal     = "events.amazonaws.com"

--- a/api/terraform/data_api/snapshot_scheduler/outputs.tf
+++ b/api/terraform/data_api/snapshot_scheduler/outputs.tf
@@ -1,3 +1,3 @@
-output "topic_name" {
-  value = "${module.scheduler_topic.name}"
+output "topic_arn" {
+  value = module.scheduler_topic.arn
 }

--- a/api/terraform/data_api/snapshot_scheduler/topics.tf
+++ b/api/terraform/data_api/snapshot_scheduler/topics.tf
@@ -1,4 +1,4 @@
 module "scheduler_topic" {
-  source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v1.0.0"
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"
   name   = "snapshot_schedule"
 }

--- a/api/terraform/data_api/terraform.tf
+++ b/api/terraform/data_api/terraform.tf
@@ -12,7 +12,7 @@ terraform {
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
-  config {
+  config = {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"

--- a/api/terraform/modules/lambda/cloudwatch_log_group.tf
+++ b/api/terraform/modules/lambda/cloudwatch_log_group.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
+  name = "/aws/lambda/${var.name}"
+
+  retention_in_days = var.log_retention_in_days
+}
+
+resource "aws_iam_role_policy" "cloudwatch_logs" {
+  name   = "${aws_iam_role.iam_role.name}_lambda_cloudwatch_logs"
+  role   = aws_iam_role.iam_role.name
+  policy = data.aws_iam_policy_document.cloudwatch_logs.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_logs" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.cloudwatch_log_group.arn,
+    ]
+  }
+}

--- a/api/terraform/modules/lambda/dlq.tf
+++ b/api/terraform/modules/lambda/dlq.tf
@@ -1,0 +1,21 @@
+resource "aws_sqs_queue" "lambda_dlq" {
+  name = "lambda-${var.name}_dlq"
+}
+
+resource "aws_iam_role_policy" "lambda_dlq" {
+  name   = "${aws_iam_role.iam_role.name}_lambda_dlq"
+  role   = aws_iam_role.iam_role.name
+  policy = data.aws_iam_policy_document.lambda_dlq.json
+}
+
+data "aws_iam_policy_document" "lambda_dlq" {
+  statement {
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = [
+      aws_sqs_queue.lambda_dlq.arn,
+    ]
+  }
+}

--- a/api/terraform/modules/lambda/lambda_function.tf
+++ b/api/terraform/modules/lambda/lambda_function.tf
@@ -1,0 +1,44 @@
+data "aws_s3_bucket_object" "package" {
+  bucket = var.s3_bucket
+  key    = var.s3_key
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  description   = var.description
+  function_name = var.name
+
+  s3_bucket         = var.s3_bucket
+  s3_key            = var.s3_key
+  s3_object_version = data.aws_s3_bucket_object.package.version_id
+
+  role    = aws_iam_role.iam_role.arn
+  handler = "${var.name}.main"
+  runtime = "python3.6"
+  timeout = var.timeout
+
+  dead_letter_config {
+    target_arn = aws_sqs_queue.lambda_dlq.arn
+  }
+
+  environment {
+    variables = var.env_vars
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_alarm" {
+  alarm_name          = "lambda-${var.name}-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+
+  dimensions = {
+    FunctionName = var.name
+  }
+
+  alarm_description = "This metric monitors lambda errors for function: ${var.name}"
+  alarm_actions     = [var.alarm_topic_arn]
+}

--- a/api/terraform/modules/lambda/outputs.tf
+++ b/api/terraform/modules/lambda/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "ARN of the Lambda function"
+  value       = aws_lambda_function.lambda_function.arn
+}
+
+output "function_name" {
+  description = "Name of the Lambda function"
+  value       = aws_lambda_function.lambda_function.function_name
+}
+
+output "role_name" {
+  description = "Name of the IAM role for this Lambda"
+  value       = aws_iam_role.iam_role.name
+}

--- a/api/terraform/modules/lambda/role.tf
+++ b/api/terraform/modules/lambda/role.tf
@@ -1,0 +1,17 @@
+resource "aws_iam_role" "iam_role" {
+  name               = "lambda_${var.name}_iam_role"
+  assume_role_policy = data.aws_iam_policy_document.assume_lambda_role.json
+}
+
+data "aws_iam_policy_document" "assume_lambda_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}

--- a/api/terraform/modules/lambda/variables.tf
+++ b/api/terraform/modules/lambda/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "Name of the Lambda"
+}
+
+variable "description" {
+  description = "Description of the Lambda function"
+}
+
+variable "env_vars" {
+  description = "Environment variables to pass to the Lambda"
+  type        = map(string)
+}
+
+variable "timeout" {
+  description = "The amount of time your Lambda function has to run in seconds"
+}
+
+variable "alarm_topic_arn" {
+  description = "ARN of the topic where to send notification for lambda errors"
+}
+
+variable "s3_bucket" {
+  description = "The S3 bucket containing the function's deployment package"
+}
+
+variable "s3_key" {
+  description = "The S3 key of the function's deployment package"
+}
+
+variable "log_retention_in_days" {
+  description = "The number of days to keep CloudWatch logs"
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4250

I inlined a few Lambda-related modules and increased the memory in the snapshot generator; previously 1GB, now 4GB – if you look at the logs, it keeps dropping out-of-memory exceptions.