### PR TITLE
Bump the catalogue API to terraform 0.12

### DIFF
--- a/api/terraform/catalogue_api_prod/alarm.tf
+++ b/api/terraform/catalogue_api_prod/alarm.tf
@@ -8,10 +8,10 @@ resource "aws_cloudwatch_metric_alarm" "alarm_5xx" {
   statistic           = "Sum"
   threshold           = "0"
 
-  dimensions {
-    ApiName = "${local.api_gateway_name}"
+  dimensions = {
+    ApiName = local.api_gateway_name
     Stage   = "prod"
   }
 
-  alarm_actions = ["${local.gateway_server_error_alarm_arn}"]
+  alarm_actions = [local.gateway_server_error_alarm_arn]
 }

--- a/api/terraform/catalogue_api_prod/locals.tf
+++ b/api/terraform/catalogue_api_prod/locals.tf
@@ -1,20 +1,20 @@
 locals {
   namespace        = "catalogue_api"
-  namespace_hyphen = "${replace(local.namespace,"_","-")}"
+  namespace_hyphen = replace(local.namespace, "_", "-")
 
-  vpc_id                         = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
-  private_subnets                = "${data.terraform_remote_state.shared_infra.catalogue_vpc_private_subnets}"
-  gateway_server_error_alarm_arn = "${data.terraform_remote_state.shared_infra.gateway_server_error_alarm_arn}"
+  vpc_id                         = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_id
+  private_subnets                = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_private_subnets
+  gateway_server_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.gateway_server_error_alarm_arn
 
-  logstash_transit_service_name = "${data.terraform_remote_state.catalogue_api_shared.logstash_transit_service_name}"
+  logstash_transit_service_name = data.terraform_remote_state.catalogue_api_shared.outputs.logstash_transit_service_name
   logstash_host                 = "${local.logstash_transit_service_name}.${local.namespace_hyphen}"
 
-  api_gateway_id   = "${data.terraform_remote_state.catalogue_api_shared.api_gateway_id}"
-  api_gateway_name = "${data.terraform_remote_state.catalogue_api_shared.api_gateway_name}"
-  certificate_arn  = "${data.terraform_remote_state.catalogue_api_shared.certificate_arn}"
-  cluster_name     = "${data.terraform_remote_state.catalogue_api_shared.cluster_name}"
-  nlb_arn          = "${data.terraform_remote_state.catalogue_api_shared.nlb_arn}"
+  api_gateway_id   = data.terraform_remote_state.catalogue_api_shared.outputs.api_gateway_id
+  api_gateway_name = data.terraform_remote_state.catalogue_api_shared.outputs.api_gateway_name
+  certificate_arn  = data.terraform_remote_state.catalogue_api_shared.outputs.certificate_arn
+  cluster_arn      = data.terraform_remote_state.catalogue_api_shared.outputs.cluster_arn
+  nlb_arn          = data.terraform_remote_state.catalogue_api_shared.outputs.nlb_arn
 
-  interservice_security_group_id       = "${data.terraform_remote_state.catalogue_api_shared.interservice_security_group_id}"
-  service_lb_ingress_security_group_id = "${data.terraform_remote_state.catalogue_api_shared.service_lb_ingress_security_group_id}"
+  interservice_security_group_id       = data.terraform_remote_state.catalogue_api_shared.outputs.interservice_security_group_id
+  service_lb_ingress_security_group_id = data.terraform_remote_state.catalogue_api_shared.outputs.service_lb_ingress_security_group_id
 }

--- a/api/terraform/catalogue_api_prod/main.tf
+++ b/api/terraform/catalogue_api_prod/main.tf
@@ -4,27 +4,27 @@ module "catalogue_api_prod" {
   environment        = "prod"
   domain_name        = "catalogue.api.wellcomecollection.org"
   listener_port      = 80
-  task_desired_count = 3
+  desired_task_count = 3
 
-  namespace    = "${local.namespace}"
-  vpc_id       = "${local.vpc_id}"
-  subnets      = ["${local.private_subnets}"]
-  cluster_name = "${local.cluster_name}"
-  api_id       = "${local.api_gateway_id}"
+  namespace   = local.namespace
+  vpc_id      = local.vpc_id
+  subnets     = local.private_subnets
+  cluster_arn = local.cluster_arn
+  api_id      = local.api_gateway_id
 
-  lb_arn           = "${local.nlb_arn}"
-  lb_ingress_sg_id = "${local.service_lb_ingress_security_group_id}"
+  lb_arn           = local.nlb_arn
+  lb_ingress_sg_id = local.service_lb_ingress_security_group_id
 
-  logstash_host = "${local.logstash_host}"
+  logstash_host = local.logstash_host
 
-  interservice_sg_id = "${local.interservice_security_group_id}"
+  interservice_sg_id = local.interservice_security_group_id
 
-  certificate_arn = "${local.certificate_arn}"
+  certificate_arn = local.certificate_arn
 
-  api_gateway_id = "${local.api_gateway_id}"
+  api_gateway_id = local.api_gateway_id
 
   providers = {
-    aws.platform    = "aws.platform"
-    aws.routemaster = "aws.routemaster"
+    aws.platform    = aws.platform
+    aws.routemaster = aws.routemaster
   }
 }

--- a/api/terraform/catalogue_api_prod/provider.tf
+++ b/api/terraform/catalogue_api_prod/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
@@ -8,9 +8,10 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias   = "platform"
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  alias = "platform"
+
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -18,9 +19,10 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "1.57.0"
+  alias = "routemaster"
+
+  version = "~> 2.7"
   region  = "eu-west-1"
-  alias   = "routemaster"
 
   assume_role {
     role_arn = "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update"

--- a/api/terraform/catalogue_api_prod/terraform.tf
+++ b/api/terraform/catalogue_api_prod/terraform.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 0.9"
-
   backend "s3" {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
 
@@ -14,7 +12,7 @@ terraform {
 data "terraform_remote_state" "catalogue_api_shared" {
   backend = "s3"
 
-  config {
+  config = {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
 
     bucket = "wellcomecollection-catalogue-infra-delta"
@@ -26,8 +24,8 @@ data "terraform_remote_state" "catalogue_api_shared" {
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
-  config {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"

--- a/api/terraform/catalogue_api_staging/locals.tf
+++ b/api/terraform/catalogue_api_staging/locals.tf
@@ -2,17 +2,17 @@ locals {
   namespace        = "catalogue_api"
   namespace_hyphen = "${replace(local.namespace,"_","-")}"
 
-  vpc_id          = "${data.terraform_remote_state.shared_infra.catalogue_vpc_id}"
-  private_subnets = "${data.terraform_remote_state.shared_infra.catalogue_vpc_private_subnets}"
+  vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_id
+  private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_private_subnets
 
-  logstash_transit_service_name = "${data.terraform_remote_state.catalogue_api_shared.logstash_transit_service_name}"
+  logstash_transit_service_name = data.terraform_remote_state.catalogue_api_shared.outputs.logstash_transit_service_name
   logstash_host                 = "${local.logstash_transit_service_name}.${local.namespace_hyphen}"
 
-  api_gateway_id  = "${data.terraform_remote_state.catalogue_api_shared.api_gateway_id}"
-  certificate_arn = "${data.terraform_remote_state.catalogue_api_shared.certificate_arn}"
-  cluster_name    = "${data.terraform_remote_state.catalogue_api_shared.cluster_name}"
-  nlb_arn         = "${data.terraform_remote_state.catalogue_api_shared.nlb_arn}"
+  api_gateway_id  = data.terraform_remote_state.catalogue_api_shared.outputs.api_gateway_id
+  certificate_arn = data.terraform_remote_state.catalogue_api_shared.outputs.certificate_arn
+  cluster_arn     = data.terraform_remote_state.catalogue_api_shared.outputs.cluster_arn
+  nlb_arn         = data.terraform_remote_state.catalogue_api_shared.outputs.nlb_arn
 
-  interservice_security_group_id       = "${data.terraform_remote_state.catalogue_api_shared.interservice_security_group_id}"
-  service_lb_ingress_security_group_id = "${data.terraform_remote_state.catalogue_api_shared.service_lb_ingress_security_group_id}"
+  interservice_security_group_id       = data.terraform_remote_state.catalogue_api_shared.outputs.interservice_security_group_id
+  service_lb_ingress_security_group_id = data.terraform_remote_state.catalogue_api_shared.outputs.service_lb_ingress_security_group_id
 }

--- a/api/terraform/catalogue_api_staging/locals.tf
+++ b/api/terraform/catalogue_api_staging/locals.tf
@@ -1,6 +1,6 @@
 locals {
   namespace        = "catalogue_api"
-  namespace_hyphen = "${replace(local.namespace,"_","-")}"
+  namespace_hyphen = replace(local.namespace, "_", "-")
 
   vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_id
   private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_private_subnets

--- a/api/terraform/catalogue_api_staging/main.tf
+++ b/api/terraform/catalogue_api_staging/main.tf
@@ -4,13 +4,13 @@ module "catalogue_api_staging" {
   environment        = "staging"
   domain_name        = "catalogue.api-stage.wellcomecollection.org"
   listener_port      = 8080
-  task_desired_count = 1
+  desired_task_count = 1
 
-  namespace    = "${local.namespace}"
-  vpc_id       = "${local.vpc_id}"
-  subnets      = ["${local.private_subnets}"]
-  cluster_name = "${local.cluster_name}"
-  api_id       = "${local.api_gateway_id}"
+  namespace   = "${local.namespace}"
+  vpc_id      = "${local.vpc_id}"
+  subnets     = local.private_subnets
+  cluster_arn = local.cluster_arn
+  api_id      = "${local.api_gateway_id}"
 
   lb_arn           = "${local.nlb_arn}"
   lb_ingress_sg_id = "${local.service_lb_ingress_security_group_id}"

--- a/api/terraform/catalogue_api_staging/main.tf
+++ b/api/terraform/catalogue_api_staging/main.tf
@@ -6,25 +6,25 @@ module "catalogue_api_staging" {
   listener_port      = 8080
   desired_task_count = 1
 
-  namespace   = "${local.namespace}"
-  vpc_id      = "${local.vpc_id}"
+  namespace   = local.namespace
+  vpc_id      = local.vpc_id
   subnets     = local.private_subnets
   cluster_arn = local.cluster_arn
-  api_id      = "${local.api_gateway_id}"
+  api_id      = local.api_gateway_id
 
-  lb_arn           = "${local.nlb_arn}"
-  lb_ingress_sg_id = "${local.service_lb_ingress_security_group_id}"
+  lb_arn           = local.nlb_arn
+  lb_ingress_sg_id = local.service_lb_ingress_security_group_id
 
-  logstash_host = "${local.logstash_host}"
+  logstash_host = local.logstash_host
 
-  interservice_sg_id = "${local.interservice_security_group_id}"
+  interservice_sg_id = local.interservice_security_group_id
 
-  certificate_arn = "${local.certificate_arn}"
+  certificate_arn = local.certificate_arn
 
-  api_gateway_id = "${local.api_gateway_id}"
+  api_gateway_id = local.api_gateway_id
 
   providers = {
-    aws.platform    = "aws.platform"
-    aws.routemaster = "aws.routemaster"
+    aws.platform    = aws.platform
+    aws.routemaster = aws.routemaster
   }
 }

--- a/api/terraform/catalogue_api_staging/provider.tf
+++ b/api/terraform/catalogue_api_staging/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
@@ -8,9 +8,10 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias   = "platform"
-  region  = "${var.aws_region}"
-  version = "1.57.0"
+  alias = "platform"
+
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -18,9 +19,10 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "1.57.0"
+  alias = "routemaster"
+
   region  = "eu-west-1"
-  alias   = "routemaster"
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update"

--- a/api/terraform/catalogue_api_staging/terraform.tf
+++ b/api/terraform/catalogue_api_staging/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 data "terraform_remote_state" "catalogue_api_shared" {
   backend = "s3"
 
-  config {
+  config = {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
 
     bucket = "wellcomecollection-catalogue-infra-delta"
@@ -26,7 +26,7 @@ data "terraform_remote_state" "catalogue_api_shared" {
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
-  config {
+  config = {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"

--- a/api/terraform/modules/catalogue_api_stack/domains.tf
+++ b/api/terraform/modules/catalogue_api_stack/domains.tf
@@ -12,8 +12,8 @@ locals {
 }
 
 resource "aws_api_gateway_domain_name" "catalogue_api" {
-  domain_name              = "${var.domain_name}"
-  regional_certificate_arn = "${var.certificate_arn}"
+  domain_name              = var.domain_name
+  regional_certificate_arn = var.certificate_arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
@@ -24,12 +24,12 @@ resource "aws_route53_record" "catalogue_api" {
   provider = aws.routemaster
 
   zone_id = local.route53_zone_id
-  name    = "${aws_api_gateway_domain_name.catalogue_api.domain_name}"
+  name    = aws_api_gateway_domain_name.catalogue_api.domain_name
   type    = "A"
 
   alias {
-    name                   = "${aws_api_gateway_domain_name.catalogue_api.regional_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.catalogue_api.regional_zone_id}"
+    name                   = aws_api_gateway_domain_name.catalogue_api.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.catalogue_api.regional_zone_id
     evaluate_target_health = false
   }
 }

--- a/api/terraform/modules/catalogue_api_stack/domains.tf
+++ b/api/terraform/modules/catalogue_api_stack/domains.tf
@@ -1,7 +1,14 @@
-data "aws_route53_zone" "dotorg" {
-  provider = "aws.routemaster"
+/*data "aws_route53_zone" "dotorg" {
+  provider = aws.routemaster
 
   name = "wellcomecollection.org."
+}*/
+
+locals {
+  # This is the Zone ID for wellcomecollection.org in the routemaster account.
+  # We can't look this up programatically because the role we use doesn't have
+  # the right permissions in that account.
+  route53_zone_id = "Z3THRVQ5VDYDMC"
 }
 
 resource "aws_api_gateway_domain_name" "catalogue_api" {
@@ -14,10 +21,11 @@ resource "aws_api_gateway_domain_name" "catalogue_api" {
 }
 
 resource "aws_route53_record" "catalogue_api" {
-  provider = "aws.routemaster"
-  zone_id  = "${data.aws_route53_zone.dotorg.id}"
-  name     = "${aws_api_gateway_domain_name.catalogue_api.domain_name}"
-  type     = "A"
+  provider = aws.routemaster
+
+  zone_id = local.route53_zone_id
+  name    = "${aws_api_gateway_domain_name.catalogue_api.domain_name}"
+  type    = "A"
 
   alias {
     name                   = "${aws_api_gateway_domain_name.catalogue_api.regional_domain_name}"

--- a/api/terraform/modules/catalogue_api_stack/gateway.tf
+++ b/api/terraform/modules/catalogue_api_stack/gateway.tf
@@ -1,6 +1,6 @@
 resource "aws_api_gateway_base_path_mapping" "catalogue_api" {
-  api_id      = "${var.api_gateway_id}"
-  stage_name  = "${var.environment}"
-  domain_name = "${aws_api_gateway_domain_name.catalogue_api.domain_name}"
+  api_id      = var.api_gateway_id
+  stage_name  = var.environment
+  domain_name = aws_api_gateway_domain_name.catalogue_api.domain_name
   base_path   = "catalogue"
 }

--- a/api/terraform/modules/catalogue_api_stack/gateway_stage.tf
+++ b/api/terraform/modules/catalogue_api_stack/gateway_stage.tf
@@ -14,11 +14,7 @@ resource "aws_api_gateway_deployment" "stage" {
 
   variables = local.variables
 
-  # This forces a new deployment (which is necessary) when Gateway config changes
-  # TODO: This is temporarily frozen while the Terraform is rearranged/updated to
-  # Terraform 0.12.  I want to test updating this in the staging API before
-  # changing anything in production.
-  stage_description = "d23817abff23f3a3e383265f51aa4c25"  # "${filemd5("gateway.tf")}"
+  stage_description = filemd5("${path.module}/../../shared/gateway.tf")
 
   lifecycle {
     create_before_destroy = true

--- a/api/terraform/modules/catalogue_api_stack/gateway_stage.tf
+++ b/api/terraform/modules/catalogue_api_stack/gateway_stage.tf
@@ -1,18 +1,18 @@
 locals {
   variables = {
-    port = "${var.listener_port}"
+    port = var.listener_port
   }
 }
 
 resource "aws_api_gateway_deployment" "stage" {
-  rest_api_id = "${var.api_id}"
+  rest_api_id = var.api_id
 
   # If we specify the stage name here then API Gateway tries to create it even
   # if it already exists (from below). Setting it to an empty string prevents this.
   # See https://github.com/terraform-providers/terraform-provider-aws/issues/2918#issuecomment-356684239
   stage_name = ""
 
-  variables = "${local.variables}"
+  variables = local.variables
 
   # This forces a new deployment (which is necessary) when Gateway config changes
   # TODO: This is temporarily frozen while the Terraform is rearranged/updated to
@@ -26,8 +26,8 @@ resource "aws_api_gateway_deployment" "stage" {
 }
 
 resource "aws_api_gateway_stage" "stage" {
-  stage_name    = "${var.environment}"
-  rest_api_id   = "${var.api_id}"
-  deployment_id = "${aws_api_gateway_deployment.stage.id}"
-  variables     = "${local.variables}"
+  stage_name    = var.environment
+  rest_api_id   = var.api_id
+  deployment_id = aws_api_gateway_deployment.stage.id
+  variables     = local.variables
 }

--- a/api/terraform/modules/catalogue_api_stack/locals.tf
+++ b/api/terraform/modules/catalogue_api_stack/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  api_container_port   = "8888"
-  nginx_container_port = "9000"
+  api_container_port   = 8888
+  nginx_container_port = 9000
 }

--- a/api/terraform/modules/catalogue_api_stack/main.tf
+++ b/api/terraform/modules/catalogue_api_stack/main.tf
@@ -5,21 +5,21 @@ locals {
 module "service" {
   source = "./service"
 
-  namespace    = "${local.namespaced_env}"
-  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+  namespace    = local.namespaced_env
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
 
   subnets     = var.subnets
-  cluster_arn = "${var.cluster_arn}"
-  vpc_id      = "${var.vpc_id}"
-  lb_arn      = "${var.lb_arn}"
+  cluster_arn = var.cluster_arn
+  vpc_id      = var.vpc_id
+  lb_arn      = var.lb_arn
 
-  container_port = "${local.api_container_port}"
+  container_port = local.api_container_port
 
-  container_image = "${local.api_container_image}"
-  listener_port   = "${var.listener_port}"
+  container_image = local.api_container_image
+  listener_port   = var.listener_port
 
-  nginx_container_image = "${local.nginx_container_image}"
-  nginx_container_port  = "${local.nginx_container_port}"
+  nginx_container_image = local.nginx_container_image
+  nginx_container_port  = local.nginx_container_port
 
   desired_task_count = var.desired_task_count
 
@@ -29,18 +29,18 @@ module "service" {
     var.interservice_sg_id,
   ]
 
-  logstash_host = "${var.logstash_host}"
+  logstash_host = var.logstash_host
 }
 
 resource "aws_service_discovery_private_dns_namespace" "namespace" {
   name = "${var.namespace}-${var.environment}"
-  vpc  = "${var.vpc_id}"
+  vpc  = var.vpc_id
 }
 
 resource "aws_security_group" "service_egress_security_group" {
   name        = "${var.namespace}-${var.environment}-service_egress_security_group"
   description = "Allow any traffic on any port out of the (${var.namespace}-${var.environment}) service"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   egress {
     from_port   = 0
@@ -50,6 +50,6 @@ resource "aws_security_group" "service_egress_security_group" {
   }
 
   tags = {
-    Name = "${var.namespace}"
+    Name = var.namespace
   }
 }

--- a/api/terraform/modules/catalogue_api_stack/main.tf
+++ b/api/terraform/modules/catalogue_api_stack/main.tf
@@ -8,10 +8,10 @@ module "service" {
   namespace    = "${local.namespaced_env}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
 
-  subnets      = ["${var.subnets}"]
-  cluster_name = "${var.cluster_name}"
-  vpc_id       = "${var.vpc_id}"
-  lb_arn       = "${var.lb_arn}"
+  subnets     = var.subnets
+  cluster_arn = "${var.cluster_arn}"
+  vpc_id      = "${var.vpc_id}"
+  lb_arn      = "${var.lb_arn}"
 
   container_port = "${local.api_container_port}"
 
@@ -21,12 +21,13 @@ module "service" {
   nginx_container_image = "${local.nginx_container_image}"
   nginx_container_port  = "${local.nginx_container_port}"
 
-  task_desired_count = "${var.task_desired_count}"
+  desired_task_count = var.desired_task_count
 
-  security_group_ids = ["${var.lb_ingress_sg_id}"]
-
-  service_egress_security_group_id = "${aws_security_group.service_egress_security_group.id}"
-  interservice_security_group_id   = "${var.interservice_sg_id}"
+  security_group_ids = [
+    var.lb_ingress_sg_id,
+    aws_security_group.service_egress_security_group.id,
+    var.interservice_sg_id,
+  ]
 
   logstash_host = "${var.logstash_host}"
 }
@@ -48,7 +49,7 @@ resource "aws_security_group" "service_egress_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.namespace}"
   }
 }

--- a/api/terraform/modules/catalogue_api_stack/outputs.tf
+++ b/api/terraform/modules/catalogue_api_stack/outputs.tf
@@ -1,7 +1,0 @@
-data "aws_iam_role" "task_execution_role" {
-  name = "${module.service.task_execution_role_name}"
-}
-
-output "task_execution_role_arn" {
-  value = "${data.aws_iam_role.task_execution_role.arn}"
-}

--- a/api/terraform/modules/catalogue_api_stack/release_uris.tf
+++ b/api/terraform/modules/catalogue_api_stack/release_uris.tf
@@ -1,16 +1,16 @@
 data "aws_ssm_parameter" "api_container_image" {
-  provider = "aws.platform"
+  provider = aws.platform
 
   name = "/catalogue_api/images/${var.environment}/api"
 }
 
 data "aws_ssm_parameter" "nginx_container_image" {
-  provider = "aws.platform"
+  provider = aws.platform
 
   name = "/catalogue_api/images/${var.environment}/nginx_api-gw"
 }
 
 locals {
-  api_container_image   = "${data.aws_ssm_parameter.api_container_image.value}"
-  nginx_container_image = "${data.aws_ssm_parameter.nginx_container_image.value}"
+  api_container_image   = data.aws_ssm_parameter.api_container_image.value
+  nginx_container_image = data.aws_ssm_parameter.nginx_container_image.value
 }

--- a/api/terraform/modules/catalogue_api_stack/service/main.tf
+++ b/api/terraform/modules/catalogue_api_stack/service/main.tf
@@ -68,7 +68,7 @@ resource "aws_lb_target_group" "tcp" {
 
 resource "aws_lb_listener" "tcp" {
   load_balancer_arn = var.lb_arn
-  port              = var.nginx_container_port
+  port              = var.listener_port
   protocol          = "TCP"
 
   default_action {

--- a/api/terraform/modules/catalogue_api_stack/service/main.tf
+++ b/api/terraform/modules/catalogue_api_stack/service/main.tf
@@ -1,68 +1,25 @@
-data "aws_ecs_cluster" "cluster" {
-  cluster_name = "${var.cluster_name}"
+locals {
+  sidecar_container_name = "nginx"
 }
 
-module "service" {
-  source = "git::github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/rest/tcp?ref=v19.16.3"
+module "task_definition" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/container_with_sidecar?ref=v1.5.2"
 
-  service_name       = "${var.namespace}"
-  task_desired_count = "${var.task_desired_count}"
-
-  task_definition_arn = "${module.task.task_definition_arn}"
-
-  security_group_ids = ["${local.security_group_ids}"]
-
-  container_name = "sidecar"
-  container_port = "${var.nginx_container_port}"
-
-  ecs_cluster_id = "${data.aws_ecs_cluster.cluster.id}"
-
-  vpc_id  = "${var.vpc_id}"
-  subnets = "${var.subnets}"
-
-  namespace_id = "${var.namespace_id}"
-
-  launch_type = "FARGATE"
-
-  listener_port = "${var.listener_port}"
-  lb_arn        = "${var.lb_arn}"
-
-  # The default deregistration delay is 5 minutes, which means that ECS takes around 5-7 mins
-  # to fully drain connections to and deregister the old task in the course of its blue/green
-  # deployment of an updated service. Reducing this parameter to 90s hence makes deployments faster.
-  target_group_deregistration_delay = 90
-}
-
-module "task" {
-  source = "git::github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/container_with_sidecar?ref=v19.6.0"
+  task_name = var.namespace
 
   cpu    = 1024
   memory = 2048
 
-  launch_types = ["FARGATE"]
-
-  app_cpu    = 512
-  app_memory = 1024
-
-  sidecar_cpu    = 512
-  sidecar_memory = 1024
-
-  app_env_vars_length = 3
+  app_container_image = var.container_image
+  app_container_port  = var.container_port
+  app_cpu             = 512
+  app_memory          = 1024
 
   app_env_vars = {
     api_host         = "api.wellcomecollection.org"
-    apm_service_name = "${var.namespace}"
-    logstash_host    = "${var.logstash_host}"
+    apm_service_name = var.namespace
+    logstash_host    = var.logstash_host
   }
-
-  sidecar_env_vars_length = 2
-
-  sidecar_env_vars = {
-    APP_HOST = "localhost"
-    APP_PORT = "${var.container_port}"
-  }
-
-  secret_app_env_vars_length = 7
 
   secret_app_env_vars = {
     es_host        = "catalogue/api/es_host"
@@ -74,16 +31,69 @@ module "task" {
     apm_secret     = "catalogue/api/apm_secret"
   }
 
+  sidecar_container_image = var.nginx_container_image
+  sidecar_container_port  = var.nginx_container_port
+  sidecar_container_name  = local.sidecar_container_name
+  sidecar_cpu             = 512
+  sidecar_memory          = 1024
+
+  sidecar_env_vars = {
+    APP_HOST = "localhost"
+    APP_PORT = var.container_port
+  }
+
   aws_region = "eu-west-1"
-  task_name  = "${var.namespace}"
-
-  app_container_image = "${var.container_image}"
-  app_container_port  = "${var.container_port}"
-
-  sidecar_container_image = "${var.nginx_container_image}"
-  sidecar_container_port  = "${var.nginx_container_port}"
 }
 
-locals {
-  security_group_ids = "${concat(list(var.service_egress_security_group_id, var.interservice_security_group_id), var.security_group_ids)}"
+resource "aws_lb_target_group" "tcp" {
+  # Must only contain alphanumerics and hyphens.
+  name = replace(var.namespace, "_", "-")
+
+  target_type = "ip"
+
+  protocol = "TCP"
+  port     = var.nginx_container_port
+  vpc_id   = var.vpc_id
+
+  # The default deregistration delay is 5 minutes, which means that ECS
+  # takes around 5–7 mins to fully drain connections to and deregister
+  # the old task in the course of its blue/green. deployment of an
+  # updated service.  Reducing this parameter to 90s makes deployments faster.
+  deregistration_delay = 90
+
+  health_check {
+    protocol = "TCP"
+  }
+}
+
+resource "aws_lb_listener" "tcp" {
+  load_balancer_arn = var.lb_arn
+  port              = var.nginx_container_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tcp.arn
+  }
+}
+
+module "service" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.5.2"
+
+  service_name = var.namespace
+  cluster_arn  = var.cluster_arn
+
+  task_definition_arn = module.task_definition.arn
+
+  desired_task_count = var.desired_task_count
+
+  subnets = var.subnets
+
+  namespace_id = var.namespace_id
+
+  security_group_ids = var.security_group_ids
+
+  target_group_arn = aws_lb_target_group.tcp.arn
+  container_name   = local.sidecar_container_name
+  container_port   = var.nginx_container_port
 }

--- a/api/terraform/modules/catalogue_api_stack/service/outputs.tf
+++ b/api/terraform/modules/catalogue_api_stack/service/outputs.tf
@@ -1,3 +1,0 @@
-output "task_execution_role_name" {
-  value = "${module.task.task_execution_role_name}"
-}

--- a/api/terraform/modules/catalogue_api_stack/service/variables.tf
+++ b/api/terraform/modules/catalogue_api_stack/service/variables.tf
@@ -1,8 +1,8 @@
 variable "subnets" {
-  type = "list"
+  type = list(string)
 }
 
-variable "cluster_name" {}
+variable "cluster_arn" {}
 
 variable "namespace" {}
 variable "namespace_id" {}
@@ -16,15 +16,14 @@ variable "nginx_container_image" {}
 variable "nginx_container_port" {}
 
 variable "security_group_ids" {
-  type = "list"
+  type = list(string)
 }
-
-variable "service_egress_security_group_id" {}
-variable "interservice_security_group_id" {}
 
 variable "lb_arn" {}
 variable "listener_port" {}
 
-variable "task_desired_count" {}
+variable "desired_task_count" {
+  type = number
+}
 
 variable "logstash_host" {}

--- a/api/terraform/modules/catalogue_api_stack/service/variables.tf
+++ b/api/terraform/modules/catalogue_api_stack/service/variables.tf
@@ -10,7 +10,9 @@ variable "namespace_id" {}
 variable "vpc_id" {}
 
 variable "container_image" {}
-variable "container_port" {}
+variable "container_port" {
+  type = number
+}
 
 variable "nginx_container_image" {}
 variable "nginx_container_port" {}

--- a/api/terraform/modules/catalogue_api_stack/variables.tf
+++ b/api/terraform/modules/catalogue_api_stack/variables.tf
@@ -1,15 +1,17 @@
 variable "namespace" {}
 variable "environment" {}
 
-variable "task_desired_count" {}
+variable "desired_task_count" {
+  type = number
+}
 
 variable "subnets" {
-  type = "list"
+  type = list(string)
 }
 
 variable "vpc_id" {}
 
-variable "cluster_name" {}
+variable "cluster_arn" {}
 
 variable "listener_port" {}
 

--- a/api/terraform/shared/outputs.tf
+++ b/api/terraform/shared/outputs.tf
@@ -1,5 +1,5 @@
-output "cluster_name" {
-  value = aws_ecs_cluster.catalogue_api.name
+output "cluster_arn" {
+  value = aws_ecs_cluster.catalogue_api.arn
 }
 
 output "nlb_arn" {


### PR DESCRIPTION
This has been deployed successfully, and with zero downtime in the live API. 💃 

This is (AFAIK) the last bit of terraform 0.11 in the platform, so merging this will close https://github.com/wellcomecollection/platform/issues/4250 🎉 