### PR TITLE
Increase size of minter RDS instance

### DIFF
--- a/infrastructure/critical/modules/rds/main.tf
+++ b/infrastructure/critical/modules/rds/main.tf
@@ -3,7 +3,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
   identifier           = "${var.cluster_identifier}-${count.index}"
   cluster_identifier   = aws_rds_cluster.default.id
-  instance_class       = "db.t2.small"
+  instance_class       = "${var.instance_class}"
   db_subnet_group_name = aws_db_subnet_group.default.name
   publicly_accessible  = false
 }

--- a/infrastructure/critical/modules/rds/variables.tf
+++ b/infrastructure/critical/modules/rds/variables.tf
@@ -21,3 +21,5 @@ variable "admin_cidr_ingress" {}
 variable "db_access_security_group" {
   type = list(string)
 }
+
+variable "instance_class" {}

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -20,6 +20,7 @@ module "identifiers_rds_cluster" {
   vpc_subnet_ids     = local.private_subnets_new
   vpc_id             = local.vpc_id_new
   admin_cidr_ingress = local.admin_cidr_ingress
+  instance_class     = "db.t3.medium"
 
   db_access_security_group = [aws_security_group.rds_ingress_security_group.id]
 


### PR DESCRIPTION
When I actually apply this I intend to do it with `apply_immediately = true`, so we don't have to wait until the Monday maintenance window - this means there will be a bit of downtime, is that a problem?