### PR TITLE
Shorter logs in bigmessaging

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
@@ -58,7 +58,7 @@ trait BigMessageSender[Destination, T] extends Logging {
 
     (for {
       location <- typedStore.put(id)(entry)
-      _ = info(s"Successfully stored message in location: $location")
+      _ = info(s"Successfully stored message in location: ${location.id}")
       notification = RemoteNotification(id)
     } yield notification) match {
       case Right(value) =>


### PR DESCRIPTION
When we bigmessage very long (> 65000 bytes) messages, the UDP appender truncates them, then logstash fails to parse the JSON and complains loudly about it. This case is the main culprit for these errors