### PR TITLE
add test to prove otherIdentifiers merger rule redirects calm work to Sierra

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/FieldMergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/FieldMergeResult.scala
@@ -4,9 +4,8 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 /*
  * FieldMergeResult is the return type of a FieldMergeRule's `merge` method
- * and contains both the new (merged) value for the field but also a list
- * of sources which the rule would like the merger to redirect. It is up to
- * the merger how to handle these.
+ * and contains both the new (merged) `data` for the field but also a list
+ * of `sources` which values were used to compute the new value.
+ * It is up to the merger how to handle these.
  */
-case class FieldMergeResult[T](fieldData: T,
-                               redirects: Seq[TransformedBaseWork])
+case class FieldMergeResult[T](data: T, sources: Seq[TransformedBaseWork])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -22,8 +22,8 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = calmRule(target, sources) getOrElse getData(target),
-      redirects = Nil
+      data = calmRule(target, sources) getOrElse getData(target),
+      sources = Nil
     )
 
   val calmRule =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -24,14 +24,14 @@ object ImagesRule extends FieldMergeRule {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork] = Nil): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = sources match {
+      data = sources match {
         case Nil =>
           getSingleMiroImage.applyOrElse(target, const(Nil))
         case _ :: _ =>
           getPictureImages(target, sources).getOrElse(Nil) ++
             getPairedMiroImages(target, sources).getOrElse(Nil)
       },
-      redirects = Nil
+      sources = Nil
     )
 
   private lazy val getSingleMiroImage

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -25,8 +25,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = mergeItems(target, sources),
-      redirects = sources.filter { source =>
+      data = mergeItems(target, sources),
+      sources = sources.filter { source =>
         (mergeMetsItems(target, source) orElse mergeMiroPhysicalAndDigitalItems(
           target,
           source)).isDefined

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -27,15 +27,16 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       physicalDigitalIdsRule(target, sources) getOrElse Nil
     val calmIds =
       calmIdsRule(target, sources) getOrElse Nil
+
     FieldMergeResult(
-      fieldData = (physicalDigitalIds ++ miroIds ++ calmIds).distinct match {
+      data = (physicalDigitalIds ++ miroIds ++ calmIds).distinct match {
         case Nil          => target.otherIdentifiers
         case nonEmptyList => nonEmptyList
       },
-      redirects = sources.filter { source =>
+      sources = sources.filter { source =>
         (miroIdsRule(target, source) orElse physicalDigitalIdsRule(
           target,
-          source)).isDefined
+          source) orElse calmIdsRule(target, sources)).isDefined
       }
     )
   }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -24,10 +24,10 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = getMetsThumbnail(target, sources)
+      data = getMetsThumbnail(target, sources)
         orElse getMinMiroThumbnail(target, sources)
         getOrElse target.data.thumbnail,
-      redirects = Nil
+      sources = Nil
     )
 
   private val getMetsThumbnail =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
@@ -24,7 +24,7 @@ class ImagesRuleTest
   describe("image creation rules") {
     it("creates 1 image from a 1 Miro work") {
       val miroWork = createMiroWork
-      val result = ImagesRule.merge(miroWork).fieldData
+      val result = ImagesRule.merge(miroWork).data
 
       result should have length 1
       result.head.location should be(miroWork.data.images.head.location)
@@ -36,7 +36,7 @@ class ImagesRuleTest
       val n = 3
       val miroWorks = (1 to n).map(_ => createMiroWork).toList
       val sierraWork = createSierraDigitalWork
-      val result = ImagesRule.merge(sierraWork, miroWorks).fieldData
+      val result = ImagesRule.merge(sierraWork, miroWorks).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs
@@ -50,7 +50,7 @@ class ImagesRuleTest
       val metsWork = createUnidentifiedInvisibleMetsWorkWith(numImages = n)
       val sierraPictureWork =
         createUnidentifiedSierraWorkWith(workType = Some(WorkType.Pictures))
-      val result = ImagesRule.merge(sierraPictureWork, List(metsWork)).fieldData
+      val result = ImagesRule.merge(sierraPictureWork, List(metsWork)).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs
@@ -67,7 +67,7 @@ class ImagesRuleTest
       val sierraPictureWork =
         createUnidentifiedSierraWorkWith(workType = Some(WorkType.Pictures))
       val result =
-        ImagesRule.merge(sierraPictureWork, miroWorks :+ metsWork).fieldData
+        ImagesRule.merge(sierraPictureWork, miroWorks :+ metsWork).data
 
       result should have length n + m
       result.map(_.location) should contain theSameElementsAs
@@ -82,7 +82,7 @@ class ImagesRuleTest
       val metsWork = createUnidentifiedInvisibleMetsWorkWith(numImages = 3)
       val miroWorks = (1 to n).map(_ => createMiroWork).toList
       val sierraWork = createSierraDigitalWork
-      val result = ImagesRule.merge(sierraWork, miroWorks :+ metsWork).fieldData
+      val result = ImagesRule.merge(sierraWork, miroWorks :+ metsWork).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -84,11 +84,13 @@ class OtherIdentifiersRuleTest
     }
   }
 
-  it("merges Calm identifiers") {
+  it("merges Calm identifiers and redirects Calm work to Sierra work") {
     inside(OtherIdentifiersRule.merge(physicalSierra, List(calmWork))) {
-      case FieldMergeResult(otherIdentifiers, _) =>
+      case FieldMergeResult(otherIdentifiers, redirects) =>
         val sierraId = physicalSierra.otherIdentifiers.head.value
         otherIdentifiers.map(_.value) shouldBe List(sierraId, "123", "a", "b")
+
+        redirects shouldBe List(calmWork)
     }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -22,8 +22,8 @@ class MergerTest extends FunSpec with Matchers with WorksGenerators {
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
       FieldMergeResult(
-        fieldData = mergedTargetItems,
-        redirects = List(sources.tail.head)
+        data = mergedTargetItems,
+        sources = List(sources.tail.head)
       )
   }
 
@@ -34,8 +34,8 @@ class MergerTest extends FunSpec with Matchers with WorksGenerators {
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
       FieldMergeResult(
-        fieldData = mergedOtherIdentifiers,
-        redirects = sources.tail.tail)
+        data = mergedOtherIdentifiers,
+        sources = sources.tail.tail)
   }
 
   object TestMerger extends Merger {


### PR DESCRIPTION
Appends the Calm work to create as a redirect if merged.

---

## Previously

After a conversation with @warrd we were wondering if the calm merger would spit out a merged sierra work and redirected calm work.

The answer is yes, after digging through realising it the `FieldMergeRule`s that return a MergeState which is in the shape of `(Redirects, MergedWork)` from which we then [calculate the unmerged works from the remaining sources](https://github.com/wellcomecollection/catalogue/blob/master/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala#L60-L64).

I might have a go at seeing if I can make this a little clearer, or at least document the process from Transformer => Matcher => Merger => List of things to ingest