### PR TITLE
Add sources used to merge a field to FieldMergeResult

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/FieldMergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/FieldMergeResult.scala
@@ -4,9 +4,8 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 
 /*
  * FieldMergeResult is the return type of a FieldMergeRule's `merge` method
- * and contains both the new (merged) value for the field but also a list
- * of sources which the rule would like the merger to redirect. It is up to
- * the merger how to handle these.
+ * and contains both the new (merged) `data` for the field but also a list
+ * of `sources` which values were used to compute the new value.
+ * It is up to the merger how to handle these.
  */
-case class FieldMergeResult[T](fieldData: T,
-                               redirects: Seq[TransformedBaseWork])
+case class FieldMergeResult[T](data: T, sources: Seq[TransformedBaseWork])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -22,8 +22,8 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = calmRule(target, sources) getOrElse getData(target),
-      redirects = Nil
+      data = calmRule(target, sources) getOrElse getData(target),
+      sources = Nil
     )
 
   val calmRule =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -23,7 +23,9 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
       data = calmRule(target, sources) getOrElse getData(target),
-      sources = getSourcesToMerge(List(calmRule), target, sources)
+      sources = sources.filter { source =>
+        List(calmRule).exists(_(target, source).isDefined)
+      }
     )
 
   val calmRule =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -23,7 +23,7 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
       data = calmRule(target, sources) getOrElse getData(target),
-      sources = getMergedSources(List(calmRule), target, sources)
+      sources = getSourcesToMerge(List(calmRule), target, sources)
     )
 
   val calmRule =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -23,7 +23,7 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
       data = calmRule(target, sources) getOrElse getData(target),
-      sources = Nil
+      sources = getMergedSources(List(calmRule), target, sources)
     )
 
   val calmRule =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
@@ -34,13 +34,23 @@ trait FieldMergeRule {
   def apply(target: UnidentifiedWork,
             sources: Seq[TransformedBaseWork]): MergeState =
     merge(target, sources) match {
-      case FieldMergeResult(field, ruleRedirects) =>
-        State(existingRedirects =>
-          (existingRedirects ++ ruleRedirects.toSet, field))
+      case FieldMergeResult(field, mergedSources) =>
+        State(existingMergedSources =>
+          (existingMergedSources ++ mergedSources.toSet, field))
     }
 
   def merge(target: UnidentifiedWork,
             sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData]
+
+  protected def getMergedSources(
+    rules: List[PartialRule],
+    target: UnidentifiedWork,
+    sources: Seq[TransformedBaseWork]): Seq[TransformedBaseWork] = {
+
+    sources.filter { source =>
+      rules.exists(_(target, source).isDefined)
+    }
+  }
 
   protected trait PartialRule {
     val isDefinedForTarget: WorkPredicate

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
@@ -42,7 +42,7 @@ trait FieldMergeRule {
   def merge(target: UnidentifiedWork,
             sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData]
 
-  protected def getMergedSources(
+  protected def getSourcesToMerge(
     rules: List[PartialRule],
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): Seq[TransformedBaseWork] = {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRule.scala
@@ -42,16 +42,6 @@ trait FieldMergeRule {
   def merge(target: UnidentifiedWork,
             sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData]
 
-  protected def getSourcesToMerge(
-    rules: List[PartialRule],
-    target: UnidentifiedWork,
-    sources: Seq[TransformedBaseWork]): Seq[TransformedBaseWork] = {
-
-    sources.filter { source =>
-      rules.exists(_(target, source).isDefined)
-    }
-  }
-
   protected trait PartialRule {
     val isDefinedForTarget: WorkPredicate
     val isDefinedForSource: WorkPredicate

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -32,7 +32,7 @@ object ImagesRule extends FieldMergeRule {
         FieldMergeResult(
           data = getPictureImages(target, sources).getOrElse(Nil) ++
             getPairedMiroImages(target, sources).getOrElse(Nil),
-          sources = getMergedSources(
+          sources = getSourcesToMerge(
             List(getPictureImages, getPairedMiroImages),
             target,
             sources)

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -24,14 +24,14 @@ object ImagesRule extends FieldMergeRule {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork] = Nil): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = sources match {
+      data = sources match {
         case Nil =>
           getSingleMiroImage.applyOrElse(target, const(Nil))
         case _ :: _ =>
           getPictureImages(target, sources).getOrElse(Nil) ++
             getPairedMiroImages(target, sources).getOrElse(Nil)
       },
-      redirects = Nil
+      sources = Nil
     )
 
   private lazy val getSingleMiroImage

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -32,10 +32,10 @@ object ImagesRule extends FieldMergeRule {
         FieldMergeResult(
           data = getPictureImages(target, sources).getOrElse(Nil) ++
             getPairedMiroImages(target, sources).getOrElse(Nil),
-          sources = getSourcesToMerge(
-            List(getPictureImages, getPairedMiroImages),
-            target,
-            sources)
+          sources = sources.filter { source =>
+            List(getPictureImages, getPairedMiroImages).exists(
+              _(target, source).isDefined)
+          }
         )
     }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -23,16 +23,21 @@ object ImagesRule extends FieldMergeRule {
   override def merge(
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork] = Nil): FieldMergeResult[FieldData] =
-    FieldMergeResult(
-      data = sources match {
-        case Nil =>
-          getSingleMiroImage.applyOrElse(target, const(Nil))
-        case _ :: _ =>
-          getPictureImages(target, sources).getOrElse(Nil) ++
-            getPairedMiroImages(target, sources).getOrElse(Nil)
-      },
-      sources = Nil
-    )
+    sources match {
+      case Nil =>
+        FieldMergeResult(
+          data = getSingleMiroImage.applyOrElse(target, const(Nil)),
+          sources = Nil)
+      case _ :: _ =>
+        FieldMergeResult(
+          data = getPictureImages(target, sources).getOrElse(Nil) ++
+            getPairedMiroImages(target, sources).getOrElse(Nil),
+          sources = getMergedSources(
+            List(getPictureImages, getPairedMiroImages),
+            target,
+            sources)
+        )
+    }
 
   private lazy val getSingleMiroImage
     : PartialFunction[UnidentifiedWork, FieldData] = {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -25,8 +25,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = mergeItems(target, sources),
-      redirects = sources.filter { source =>
+      data = mergeItems(target, sources),
+      sources = sources.filter { source =>
         (mergeMetsItems(target, source) orElse mergeMiroPhysicalAndDigitalItems(
           target,
           source)).isDefined

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -24,7 +24,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] = {
 
     val rules = List(miroIdsRule, physicalDigitalIdsRule, calmIdsRule)
-    val mergedSources = getMergedSources(rules, target, sources)
+    val mergedSources = getSourcesToMerge(rules, target, sources)
     val ids = rules.flatMap(_(target, sources)).flatten
 
     FieldMergeResult(

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.platform.merger.rules.WorkPredicates.WorkPredicate
  * - Miro IDs
  * - Digital sierra IDs
  */
+
 object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   type FieldData = List[SourceIdentifier]
 
@@ -23,17 +24,15 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] = {
 
     val rules = List(miroIdsRule, physicalDigitalIdsRule, calmIdsRule)
+    val mergedSources = getMergedSources(rules, target, sources)
     val ids = rules.flatMap(_(target, sources)).flatten
-    val mergeSources = sources.filter { source =>
-      rules.exists(_(target, source).isDefined)
-    }
 
     FieldMergeResult(
       data = ids.distinct match {
         case Nil          => target.otherIdentifiers
         case nonEmptyList => nonEmptyList
       },
-      sources = mergeSources
+      sources = mergedSources
     )
   }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -27,15 +27,16 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       physicalDigitalIdsRule(target, sources) getOrElse Nil
     val calmIds =
       calmIdsRule(target, sources) getOrElse Nil
+
     FieldMergeResult(
-      fieldData = (physicalDigitalIds ++ miroIds ++ calmIds).distinct match {
+      data = (physicalDigitalIds ++ miroIds ++ calmIds).distinct match {
         case Nil          => target.otherIdentifiers
         case nonEmptyList => nonEmptyList
       },
-      redirects = sources.filter { source =>
+      sources = sources.filter { source =>
         (miroIdsRule(target, source) orElse physicalDigitalIdsRule(
           target,
-          source)).isDefined
+          source) orElse calmIdsRule(target, sources)).isDefined
       }
     )
   }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -22,17 +22,17 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   override def merge(
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] = {
-
     val rules = List(miroIdsRule, physicalDigitalIdsRule, calmIdsRule)
-    val mergedSources = getSourcesToMerge(rules, target, sources)
-    val ids = rules.flatMap(_(target, sources)).flatten
+    val mergedIds = rules.flatMap(_(target, sources)).flatten.distinct match {
+      case Nil          => target.otherIdentifiers
+      case nonEmptyList => nonEmptyList
+    }
 
     FieldMergeResult(
-      data = ids.distinct match {
-        case Nil          => target.otherIdentifiers
-        case nonEmptyList => nonEmptyList
-      },
-      sources = mergedSources
+      data = mergedIds,
+      sources = sources.filter { source =>
+        rules.exists(_(target, source).isDefined)
+      }
     )
   }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -27,7 +27,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
       data = getMetsThumbnail(target, sources)
         orElse getMinMiroThumbnail(target, sources)
         getOrElse target.data.thumbnail,
-      sources = getMergedSources(
+      sources = getSourcesToMerge(
         List(getMetsThumbnail, getMinMiroThumbnail),
         target,
         sources)

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -24,10 +24,10 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
     target: UnidentifiedWork,
     sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
     FieldMergeResult(
-      fieldData = getMetsThumbnail(target, sources)
+      data = getMetsThumbnail(target, sources)
         orElse getMinMiroThumbnail(target, sources)
         getOrElse target.data.thumbnail,
-      redirects = Nil
+      sources = Nil
     )
 
   private val getMetsThumbnail =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -27,7 +27,10 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
       data = getMetsThumbnail(target, sources)
         orElse getMinMiroThumbnail(target, sources)
         getOrElse target.data.thumbnail,
-      sources = Nil
+      sources = getMergedSources(
+        List(getMetsThumbnail, getMinMiroThumbnail),
+        target,
+        sources)
     )
 
   private val getMetsThumbnail =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -27,10 +27,10 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
       data = getMetsThumbnail(target, sources)
         orElse getMinMiroThumbnail(target, sources)
         getOrElse target.data.thumbnail,
-      sources = getSourcesToMerge(
-        List(getMetsThumbnail, getMinMiroThumbnail),
-        target,
-        sources)
+      sources = sources.filter { source =>
+        List(getMetsThumbnail, getMinMiroThumbnail).exists(
+          _(target, source).isDefined)
+      }
     )
 
   private val getMetsThumbnail =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/CalmRulesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/CalmRulesTest.scala
@@ -22,7 +22,7 @@ class CalmRulesTest extends FunSpec with Matchers with WorksGenerators {
 
   it("merges from Calm work when it exists") {
     rule.merge(target, List(otherWork, calmWork)) shouldBe
-      FieldMergeResult(Some("123"), Nil)
+      FieldMergeResult(Some("123"), List(calmWork))
   }
 
   it("merges from target work when Calm work doesn't exist") {
@@ -32,6 +32,6 @@ class CalmRulesTest extends FunSpec with Matchers with WorksGenerators {
 
   it("merges from first Calm work when multiple exists") {
     rule.merge(target, List(calmWork, secondCalmWork)) shouldBe
-      FieldMergeResult(Some("123"), Nil)
+      FieldMergeResult(Some("123"), List(calmWork, secondCalmWork))
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
@@ -73,6 +73,18 @@ class FieldMergeRuleTest
     }
   }
 
+  describe("getSourcesToMerge") {
+    it("returns only sources that rules would merged") {
+      val rules = List(sourceTitleIsA)
+      val mergedSources = getSourcesToMerge(
+        rules,
+        workWithTitleA,
+        Seq(workWithTitleA, workWithTitleB))
+
+      mergedSources shouldBe Seq(workWithTitleA)
+    }
+  }
+
   // This is here because we are extending ComposedFieldMergeRule
   // to access the private PartialRule trait
   override def merge(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
@@ -73,18 +73,6 @@ class FieldMergeRuleTest
     }
   }
 
-  describe("getSourcesToMerge") {
-    it("returns only sources that rules would merged") {
-      val rules = List(sourceTitleIsA)
-      val mergedSources = getSourcesToMerge(
-        rules,
-        workWithTitleA,
-        Seq(workWithTitleA, workWithTitleB))
-
-      mergedSources shouldBe Seq(workWithTitleA)
-    }
-  }
-
   // This is here because we are extending ComposedFieldMergeRule
   // to access the private PartialRule trait
   override def merge(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
@@ -24,7 +24,7 @@ class ImagesRuleTest
   describe("image creation rules") {
     it("creates 1 image from a 1 Miro work") {
       val miroWork = createMiroWork
-      val result = ImagesRule.merge(miroWork).fieldData
+      val result = ImagesRule.merge(miroWork).data
 
       result should have length 1
       result.head.location should be(miroWork.data.images.head.location)
@@ -36,7 +36,7 @@ class ImagesRuleTest
       val n = 3
       val miroWorks = (1 to n).map(_ => createMiroWork).toList
       val sierraWork = createSierraDigitalWork
-      val result = ImagesRule.merge(sierraWork, miroWorks).fieldData
+      val result = ImagesRule.merge(sierraWork, miroWorks).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs
@@ -50,7 +50,7 @@ class ImagesRuleTest
       val metsWork = createUnidentifiedInvisibleMetsWorkWith(numImages = n)
       val sierraPictureWork =
         createUnidentifiedSierraWorkWith(workType = Some(WorkType.Pictures))
-      val result = ImagesRule.merge(sierraPictureWork, List(metsWork)).fieldData
+      val result = ImagesRule.merge(sierraPictureWork, List(metsWork)).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs
@@ -67,7 +67,7 @@ class ImagesRuleTest
       val sierraPictureWork =
         createUnidentifiedSierraWorkWith(workType = Some(WorkType.Pictures))
       val result =
-        ImagesRule.merge(sierraPictureWork, miroWorks :+ metsWork).fieldData
+        ImagesRule.merge(sierraPictureWork, miroWorks :+ metsWork).data
 
       result should have length n + m
       result.map(_.location) should contain theSameElementsAs
@@ -82,7 +82,7 @@ class ImagesRuleTest
       val metsWork = createUnidentifiedInvisibleMetsWorkWith(numImages = 3)
       val miroWorks = (1 to n).map(_ => createMiroWork).toList
       val sierraWork = createSierraDigitalWork
-      val result = ImagesRule.merge(sierraWork, miroWorks :+ metsWork).fieldData
+      val result = ImagesRule.merge(sierraWork, miroWorks :+ metsWork).data
 
       result should have length n
       result.map(_.location) should contain theSameElementsAs

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -84,11 +84,13 @@ class OtherIdentifiersRuleTest
     }
   }
 
-  it("merges Calm identifiers") {
+  it("merges Calm identifiers and redirects Calm work to Sierra work") {
     inside(OtherIdentifiersRule.merge(physicalSierra, List(calmWork))) {
-      case FieldMergeResult(otherIdentifiers, _) =>
+      case FieldMergeResult(otherIdentifiers, redirects) =>
         val sierraId = physicalSierra.otherIdentifiers.head.value
         otherIdentifiers.map(_.value) shouldBe List(sierraId, "123", "a", "b")
+
+        redirects shouldBe List(calmWork)
     }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -90,10 +90,10 @@ class ThumbnailRuleTest
     }
   }
 
-  it("does not return any redirects") {
+  it("returns redirects of merged thumbnails") {
     inside(ThumbnailRule.merge(digitalSierraWork, miroWorks :+ metsWork)) {
       case FieldMergeResult(_, redirects) =>
-        redirects shouldBe empty
+        redirects shouldBe miroWorks :+ metsWork
     }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -22,8 +22,8 @@ class MergerTest extends FunSpec with Matchers with WorksGenerators {
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
       FieldMergeResult(
-        fieldData = mergedTargetItems,
-        redirects = List(sources.tail.head)
+        data = mergedTargetItems,
+        sources = List(sources.tail.head)
       )
   }
 
@@ -34,8 +34,8 @@ class MergerTest extends FunSpec with Matchers with WorksGenerators {
       target: UnidentifiedWork,
       sources: Seq[TransformedBaseWork]): FieldMergeResult[FieldData] =
       FieldMergeResult(
-        fieldData = mergedOtherIdentifiers,
-        redirects = sources.tail.tail)
+        data = mergedOtherIdentifiers,
+        sources = sources.tail.tail)
   }
 
   object TestMerger extends Merger {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -174,7 +174,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork.withData { data =>
       data.copy(
-        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ sierraDigitalWork.identifiers ++ miroWork.identifiers,
+        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers ++ sierraDigitalWork.identifiers,
         thumbnail = miroWork.data.thumbnail,
         items = List(
           sierraItem.copy(
@@ -208,9 +208,7 @@ class PlatformMergerTest
       expectedMergedWork,
       expectedRedirectedDigitalWork,
       expectedMiroRedirectedWork)
-    result.images should contain theSameElementsAs List(
-      expectedImage
-    )
+    result.images should contain theSameElementsAs List(expectedImage)
   }
 
   it("merges a non-picture Sierra work with a METS work") {
@@ -304,7 +302,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork.withData { data =>
       data.copy(
-        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ sierraDigitalWork.identifiers ++ miroWork.identifiers,
+        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers ++ sierraDigitalWork.identifiers,
         thumbnail = metsWork.data.thumbnail,
         items = List(
           sierraItem.copy(


### PR DESCRIPTION
Given `WorkA` and `WorkB`
If work `B` is merged in anyway into `WorkA`, `WorkB` should redirect to `WorkA`.

This does that by running checking which `PartialRule`s were applicable to the `FieldMergeRule`, and returning those sources.

Those then get returned to the `Merger` where they are turned into redirects.

There are probably more abstracted ways to ensure that this is enforced, but it feels like we would be creating code too rigid and potentially coupling concepts that don't need to be.