### PR TITLE
Change images model to be restrictive in what is possible

### DIFF
--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -15,7 +15,7 @@ import com.sksamuel.elastic4s.requests.indexes.IndexResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.{ElasticError, Response}
 import io.circe.Encoder
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
@@ -30,7 +30,7 @@ class WorksIndexConfigTest
     with Eventually
     with Matchers
     with JsonAssertions
-    with PropertyChecks
+    with ScalaCheckPropertyChecks
     with WorksGenerators {
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import org.scalacheck.ScalacheckShapeless._
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalacheck.Gen.chooseNum
@@ -16,6 +15,7 @@ import com.sksamuel.elastic4s.requests.indexes.IndexResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.{ElasticError, Response}
 import io.circe.Encoder
+import org.scalatest.prop.PropertyChecks
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
@@ -30,7 +30,7 @@ class WorksIndexConfigTest
     with Eventually
     with Matchers
     with JsonAssertions
-    with ScalaCheckPropertyChecks
+    with PropertyChecks
     with WorksGenerators {
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -58,8 +58,8 @@ object Implicits extends TimeInstances {
   implicit val _dec38: Decoder[Item[Minted]] = deriveDecoder
   implicit val _dec39: Decoder[Contributor[Unminted]] = deriveDecoder
   implicit val _dec40: Decoder[Contributor[Minted]] = deriveDecoder
-  implicit val _dec41: Decoder[WorkData[Unminted]] = deriveDecoder
-  implicit val _dec42: Decoder[WorkData[Minted]] = deriveDecoder
+  implicit val _dec41: Decoder[WorkData[Unminted, Identifiable]] = deriveDecoder
+  implicit val _dec42: Decoder[WorkData[Minted, Identified]] = deriveDecoder
   implicit val _dec43: Decoder[UnidentifiedWork] = deriveDecoder
   implicit val _dec44: Decoder[UnidentifiedInvisibleWork] = deriveDecoder
   implicit val _dec45: Decoder[IdentifiedWork] = deriveDecoder
@@ -68,14 +68,15 @@ object Implicits extends TimeInstances {
   implicit val _dec48: Decoder[IdentifiedBaseWork] = deriveDecoder
   implicit val _dec49: Decoder[BaseWork] = deriveDecoder
   implicit val _dec50: Decoder[SierraTransformable] = deriveDecoder
-  implicit val _dec51: Decoder[UnmergedImage[Unminted]] = deriveDecoder
-  implicit val _dec52: Decoder[UnmergedImage[Minted]] = deriveDecoder
-  implicit val _dec53: Decoder[MergedImage[Unminted]] = deriveDecoder
-  implicit val _dec54: Decoder[MergedImage[Minted]] = deriveDecoder
-  implicit val _dec55: Decoder[BaseImage[Unminted]] = deriveDecoder
-  implicit val _dec56: Decoder[BaseImage[Minted]] = deriveDecoder
-  implicit val _dec57: Decoder[AugmentedImage[Unminted]] = deriveDecoder
-  implicit val _dec58: Decoder[AugmentedImage[Minted]] = deriveDecoder
+  implicit val _dec51: Decoder[UnmergedImage[Identifiable]] = deriveDecoder
+  implicit val _dec52: Decoder[UnmergedImage[Identified]] = deriveDecoder
+  implicit val _dec53: Decoder[MergedImage[Identifiable]] = deriveDecoder
+  implicit val _dec54: Decoder[MergedImage[Identified]] = deriveDecoder
+  implicit val _dec55: Decoder[BaseImage[Identifiable]] = deriveDecoder
+  implicit val _dec56: Decoder[BaseImage[Identified]] = deriveDecoder
+  implicit val _dec57: Decoder[AugmentedImage[Identifiable]] = deriveDecoder
+//  implicit val _dec58: Decoder[AugmentedImage[Minted]] = deriveDecoder
+  implicit val _dec59: Decoder[AugmentedImage[Identified]] = deriveDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveEncoder
   implicit val _enc01: Encoder[Note] = deriveEncoder
@@ -116,8 +117,8 @@ object Implicits extends TimeInstances {
   implicit val _enc38: Encoder[Item[Minted]] = deriveEncoder
   implicit val _enc39: Encoder[Contributor[Unminted]] = deriveEncoder
   implicit val _enc40: Encoder[Contributor[Minted]] = deriveEncoder
-  implicit val _enc41: Encoder[WorkData[Unminted]] = deriveEncoder
-  implicit val _enc42: Encoder[WorkData[Minted]] = deriveEncoder
+  implicit val _enc41: Encoder[WorkData[Unminted, Identifiable]] = deriveEncoder
+  implicit val _enc42: Encoder[WorkData[Minted, Identified]] = deriveEncoder
   implicit val _enc43: Encoder[UnidentifiedWork] = deriveEncoder
   implicit val _enc44: Encoder[UnidentifiedInvisibleWork] = deriveEncoder
   implicit val _enc45: Encoder[IdentifiedWork] = deriveEncoder
@@ -126,12 +127,13 @@ object Implicits extends TimeInstances {
   implicit val _enc48: Encoder[IdentifiedBaseWork] = deriveEncoder
   implicit val _enc49: Encoder[BaseWork] = deriveEncoder
   implicit val _enc50: Encoder[SierraTransformable] = deriveEncoder
-  implicit val _enc51: Encoder[UnmergedImage[Unminted]] = deriveEncoder
-  implicit val _enc52: Encoder[UnmergedImage[Minted]] = deriveEncoder
-  implicit val _enc53: Encoder[MergedImage[Unminted]] = deriveEncoder
-  implicit val _enc54: Encoder[MergedImage[Minted]] = deriveEncoder
-  implicit val _enc55: Encoder[BaseImage[Unminted]] = deriveEncoder
-  implicit val _enc56: Encoder[BaseImage[Minted]] = deriveEncoder
-  implicit val _enc57: Encoder[AugmentedImage[Unminted]] = deriveEncoder
-  implicit val _enc58: Encoder[AugmentedImage[Minted]] = deriveEncoder
+  implicit val _enc51: Encoder[UnmergedImage[Identifiable]] = deriveEncoder
+  implicit val _enc52: Encoder[UnmergedImage[Identified]] = deriveEncoder
+  implicit val _enc53: Encoder[MergedImage[Identifiable]] = deriveEncoder
+  implicit val _enc54: Encoder[MergedImage[Identified]] = deriveEncoder
+  implicit val _enc55: Encoder[BaseImage[Identifiable]] = deriveEncoder
+  implicit val _enc56: Encoder[BaseImage[Identified]] = deriveEncoder
+  implicit val _enc57: Encoder[AugmentedImage[Identifiable]] = deriveEncoder
+//  implicit val _enc58: Encoder[AugmentedImage[Minted]] = deriveEncoder
+  implicit val _enc59: Encoder[AugmentedImage[Identified]] = deriveEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -74,9 +74,7 @@ object Implicits extends TimeInstances {
   implicit val _dec54: Decoder[MergedImage[Identified]] = deriveDecoder
   implicit val _dec55: Decoder[BaseImage[Identifiable]] = deriveDecoder
   implicit val _dec56: Decoder[BaseImage[Identified]] = deriveDecoder
-  implicit val _dec57: Decoder[AugmentedImage[Identifiable]] = deriveDecoder
-//  implicit val _dec58: Decoder[AugmentedImage[Minted]] = deriveDecoder
-  implicit val _dec59: Decoder[AugmentedImage[Identified]] = deriveDecoder
+  implicit val _dec57: Decoder[AugmentedImage] = deriveDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveEncoder
   implicit val _enc01: Encoder[Note] = deriveEncoder
@@ -133,7 +131,5 @@ object Implicits extends TimeInstances {
   implicit val _enc54: Encoder[MergedImage[Identified]] = deriveEncoder
   implicit val _enc55: Encoder[BaseImage[Identifiable]] = deriveEncoder
   implicit val _enc56: Encoder[BaseImage[Identified]] = deriveEncoder
-  implicit val _enc57: Encoder[AugmentedImage[Identifiable]] = deriveEncoder
-//  implicit val _enc58: Encoder[AugmentedImage[Minted]] = deriveEncoder
-  implicit val _enc59: Encoder[AugmentedImage[Identified]] = deriveEncoder
+  implicit val _enc57: Encoder[AugmentedImage] = deriveEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
@@ -6,6 +6,7 @@ sealed trait IdState {
   def allSourceIdentifiers: List[SourceIdentifier]
 }
 sealed trait WithSourceIdentifier extends IdState
+
 /** Parent trait for an ID of an object that is pre minter. */
 sealed trait Unminted extends IdState
 
@@ -19,7 +20,8 @@ case class Identified(
   sourceIdentifier: SourceIdentifier,
   otherIdentifiers: List[SourceIdentifier] = Nil,
 ) extends IdState
-    with Minted with WithSourceIdentifier{
+    with Minted
+    with WithSourceIdentifier {
   def maybeCanonicalId = Some(canonicalId)
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }
@@ -31,7 +33,8 @@ case class Identifiable(
   otherIdentifiers: List[SourceIdentifier] = Nil,
   identifiedType: String = classOf[Identified].getSimpleName,
 ) extends IdState
-    with Unminted with WithSourceIdentifier{
+    with Unminted
+    with WithSourceIdentifier {
   def maybeCanonicalId = None
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
@@ -5,7 +5,7 @@ sealed trait IdState {
   def maybeCanonicalId: Option[String]
   def allSourceIdentifiers: List[SourceIdentifier]
 }
-sealed trait pff extends IdState
+sealed trait WithSourceIdentifier extends IdState
 /** Parent trait for an ID of an object that is pre minter. */
 sealed trait Unminted extends IdState
 
@@ -19,7 +19,7 @@ case class Identified(
   sourceIdentifier: SourceIdentifier,
   otherIdentifiers: List[SourceIdentifier] = Nil,
 ) extends IdState
-    with Minted with pff{
+    with Minted with WithSourceIdentifier{
   def maybeCanonicalId = Some(canonicalId)
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }
@@ -31,7 +31,7 @@ case class Identifiable(
   otherIdentifiers: List[SourceIdentifier] = Nil,
   identifiedType: String = classOf[Identified].getSimpleName,
 ) extends IdState
-    with Unminted with pff{
+    with Unminted with WithSourceIdentifier{
   def maybeCanonicalId = None
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
@@ -5,7 +5,7 @@ sealed trait IdState {
   def maybeCanonicalId: Option[String]
   def allSourceIdentifiers: List[SourceIdentifier]
 }
-
+sealed trait pff extends IdState
 /** Parent trait for an ID of an object that is pre minter. */
 sealed trait Unminted extends IdState
 
@@ -19,7 +19,7 @@ case class Identified(
   sourceIdentifier: SourceIdentifier,
   otherIdentifiers: List[SourceIdentifier] = Nil,
 ) extends IdState
-    with Minted {
+    with Minted with pff{
   def maybeCanonicalId = Some(canonicalId)
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }
@@ -31,7 +31,7 @@ case class Identifiable(
   otherIdentifiers: List[SourceIdentifier] = Nil,
   identifiedType: String = classOf[Identified].getSimpleName,
 ) extends IdState
-    with Unminted {
+    with Unminted with pff{
   def maybeCanonicalId = None
   def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait BaseImage[+Id <: IdState] extends HasIdState[Id] {
+sealed trait BaseImage[+Id <: pff] extends HasIdState[Id] {
   val id: Id
   val location: DigitalLocation
 }
 
-case class UnmergedImage[Id <: IdState](
+case class UnmergedImage[Id <: pff](
   id: Id,
   location: DigitalLocation
 ) extends BaseImage[Id] {
@@ -19,7 +19,7 @@ case class UnmergedImage[Id <: IdState](
     )
 }
 
-case class MergedImage[Id <: IdState](
+case class MergedImage[Id <: pff](
   id: Id,
   location: DigitalLocation,
   parentWork: Id,
@@ -41,7 +41,7 @@ case class MergedImage[Id <: IdState](
     )
 }
 
-case class AugmentedImage[Id <: IdState](
+case class AugmentedImage[Id <: pff](
   id: Id,
   location: DigitalLocation,
   parentWork: Id,
@@ -59,7 +59,7 @@ case class InferredData(
 
 object UnmergedImage {
   def apply(sourceIdentifier: SourceIdentifier,
-            location: DigitalLocation): UnmergedImage[Unminted] =
+            location: DigitalLocation): UnmergedImage[Identifiable] =
     UnmergedImage(
       id = Identifiable(sourceIdentifier),
       location

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -30,24 +30,28 @@ case class MergedImage[Id <: pff](
       id = id,
       location = location
     )
-
-  def augment(inferredData: => Option[InferredData]): AugmentedImage[Id] =
-    AugmentedImage[Id](
-      id = id,
-      location = location,
-      parentWork = parentWork,
-      fullText = fullText,
-      inferredData = inferredData
-    )
 }
 
-case class AugmentedImage[Id <: pff](
-  id: Id,
+object MergedImage {
+  implicit class IdentifiedMergedImageOps(mergedImage: MergedImage[Identified]) {
+    def augment(inferredData: => Option[InferredData]): AugmentedImage =
+      AugmentedImage(
+        id = mergedImage.id,
+        location = mergedImage.location,
+        parentWork = mergedImage.parentWork,
+        fullText = mergedImage.fullText,
+        inferredData = inferredData
+      )
+  }
+}
+
+case class AugmentedImage(
+  id: Identified,
   location: DigitalLocation,
-  parentWork: Id,
+  parentWork: Identified,
   fullText: Option[String] = None,
   inferredData: Option[InferredData] = None
-) extends BaseImage[Id]
+) extends BaseImage[Identified]
 
 case class InferredData(
   // We split the feature vector so that it can fit into

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -33,7 +33,8 @@ case class MergedImage[Id <: WithSourceIdentifier](
 }
 
 object MergedImage {
-  implicit class IdentifiedMergedImageOps(mergedImage: MergedImage[Identified]) {
+  implicit class IdentifiedMergedImageOps(
+    mergedImage: MergedImage[Identified]) {
     def augment(inferredData: => Option[InferredData]): AugmentedImage =
       AugmentedImage(
         id = mergedImage.id,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait BaseImage[+Id <: pff] extends HasIdState[Id] {
+sealed trait BaseImage[+Id <: WithSourceIdentifier] extends HasIdState[Id] {
   val id: Id
   val location: DigitalLocation
 }
 
-case class UnmergedImage[Id <: pff](
+case class UnmergedImage[Id <: WithSourceIdentifier](
   id: Id,
   location: DigitalLocation
 ) extends BaseImage[Id] {
@@ -19,7 +19,7 @@ case class UnmergedImage[Id <: pff](
     )
 }
 
-case class MergedImage[Id <: pff](
+case class MergedImage[Id <: WithSourceIdentifier](
   id: Id,
   location: DigitalLocation,
   parentWork: Id,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -22,7 +22,7 @@ sealed trait RedirectedWork extends BaseWork {
   val redirect: Redirect
 }
 
-case class WorkData[Id <: IdState,ImageId <: WithSourceIdentifier](
+case class WorkData[Id <: IdState, ImageId <: WithSourceIdentifier](
   title: Option[String] = None,
   otherIdentifiers: List[SourceIdentifier] = Nil,
   mergeCandidates: List[MergeCandidate] = Nil,
@@ -55,7 +55,8 @@ case class UnidentifiedWork(
   identifiedType: String = classOf[IdentifiedWork].getSimpleName
 ) extends TransformedBaseWork {
 
-  def withData(f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
+  def withData(
+    f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
     this.copy(data = f(data))
 }
 
@@ -69,7 +70,8 @@ case class IdentifiedWork(
     with MultipleSourceIdentifiers {
   val otherIdentifiers = data.otherIdentifiers
 
-  def withData(f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
+  def withData(
+    f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
     this.copy(data = f(data))
 }
 
@@ -80,7 +82,8 @@ case class UnidentifiedInvisibleWork(
   identifiedType: String = classOf[IdentifiedInvisibleWork].getSimpleName
 ) extends TransformedBaseWork
     with InvisibleWork {
-  def withData(f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
+  def withData(
+    f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
     this.copy(data = f(data))
 }
 
@@ -91,7 +94,8 @@ case class IdentifiedInvisibleWork(
   data: WorkData[Minted, Identified]
 ) extends IdentifiedBaseWork
     with InvisibleWork {
-  def withData(f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
+  def withData(
+    f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
     this.copy(data = f(data))
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -12,7 +12,7 @@ sealed trait IdentifiedBaseWork extends BaseWork {
 sealed trait TransformedBaseWork
     extends BaseWork
     with MultipleSourceIdentifiers {
-  val data: WorkData[Unminted]
+  val data: WorkData[Unminted, Identifiable]
   val otherIdentifiers = data.otherIdentifiers
 }
 
@@ -22,7 +22,7 @@ sealed trait RedirectedWork extends BaseWork {
   val redirect: Redirect
 }
 
-case class WorkData[Id <: IdState](
+case class WorkData[Id <: IdState,PP <: pff](
   title: Option[String] = None,
   otherIdentifiers: List[SourceIdentifier] = Nil,
   mergeCandidates: List[MergeCandidate] = Nil,
@@ -44,18 +44,18 @@ case class WorkData[Id <: IdState](
   items: List[Item[Id]] = Nil,
   merged: Boolean = false,
   collectionPath: Option[CollectionPath] = None,
-  images: List[UnmergedImage[Id]] = Nil
+  images: List[UnmergedImage[PP]] = Nil
 )
 
 case class UnidentifiedWork(
   version: Int,
   sourceIdentifier: SourceIdentifier,
-  data: WorkData[Unminted],
+  data: WorkData[Unminted, Identifiable],
   ontologyType: String = "Work",
   identifiedType: String = classOf[IdentifiedWork].getSimpleName
 ) extends TransformedBaseWork {
 
-  def withData(f: WorkData[Unminted] => WorkData[Unminted]) =
+  def withData(f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
     this.copy(data = f(data))
 }
 
@@ -63,24 +63,24 @@ case class IdentifiedWork(
   canonicalId: String,
   version: Int,
   sourceIdentifier: SourceIdentifier,
-  data: WorkData[Minted],
+  data: WorkData[Minted, Identified],
   ontologyType: String = "Work"
 ) extends IdentifiedBaseWork
     with MultipleSourceIdentifiers {
   val otherIdentifiers = data.otherIdentifiers
 
-  def withData(f: WorkData[Minted] => WorkData[Minted]) =
+  def withData(f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
     this.copy(data = f(data))
 }
 
 case class UnidentifiedInvisibleWork(
   version: Int,
   sourceIdentifier: SourceIdentifier,
-  data: WorkData[Unminted],
+  data: WorkData[Unminted, Identifiable],
   identifiedType: String = classOf[IdentifiedInvisibleWork].getSimpleName
 ) extends TransformedBaseWork
     with InvisibleWork {
-  def withData(f: WorkData[Unminted] => WorkData[Unminted]) =
+  def withData(f: WorkData[Unminted, Identifiable] => WorkData[Unminted, Identifiable]) =
     this.copy(data = f(data))
 }
 
@@ -88,10 +88,10 @@ case class IdentifiedInvisibleWork(
   canonicalId: String,
   version: Int,
   sourceIdentifier: SourceIdentifier,
-  data: WorkData[Minted]
+  data: WorkData[Minted, Identified]
 ) extends IdentifiedBaseWork
     with InvisibleWork {
-  def withData(f: WorkData[Minted] => WorkData[Minted]) =
+  def withData(f: WorkData[Minted, Identified] => WorkData[Minted, Identified]) =
     this.copy(data = f(data))
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -22,7 +22,7 @@ sealed trait RedirectedWork extends BaseWork {
   val redirect: Redirect
 }
 
-case class WorkData[Id <: IdState,PP <: pff](
+case class WorkData[Id <: IdState,ImageId <: WithSourceIdentifier](
   title: Option[String] = None,
   otherIdentifiers: List[SourceIdentifier] = Nil,
   mergeCandidates: List[MergeCandidate] = Nil,
@@ -44,7 +44,7 @@ case class WorkData[Id <: IdState,PP <: pff](
   items: List[Item[Id]] = Nil,
   merged: Boolean = false,
   collectionPath: Option[CollectionPath] = None,
-  images: List[UnmergedImage[PP]] = Nil
+  images: List[UnmergedImage[ImageId]] = Nil
 )
 
 case class UnidentifiedWork(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -1,43 +1,43 @@
 package uk.ac.wellcome.models.work.generators
 
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  Identifiable,
-  Identified,
-  IdentifierType,
-  MergedImage,
-  Minted,
-  SourceIdentifier,
-  UnmergedImage,
-  Unminted
-}
+import uk.ac.wellcome.models.work.internal._
+
+import scala.util.Random
 
 trait ImageGenerators extends IdentifiersGenerators with ItemsGenerators {
   def createUnmergedImageWith(
     location: DigitalLocation = createDigitalLocation,
     identifierType: IdentifierType = IdentifierType("miro-image-number")
-  ): UnmergedImage[Unminted] = UnmergedImage(
+  ): UnmergedImage[Identifiable] = UnmergedImage(
     sourceIdentifier =
       createSourceIdentifierWith(identifierType = identifierType),
     location = location
   )
 
-  def createUnmergedImage: UnmergedImage[Unminted] = createUnmergedImageWith()
+  def createUnmergedImage: UnmergedImage[Identifiable] = createUnmergedImageWith()
 
   def createMergedImageWith(
     location: DigitalLocation = createDigitalLocation,
     identifierType: IdentifierType = IdentifierType("miro-image-number"),
     parentWork: SourceIdentifier = createSierraSystemSourceIdentifier,
-    fullText: Option[String] = None): MergedImage[Unminted] =
+    fullText: Option[String] = None): MergedImage[Identifiable] =
     createUnmergedImageWith(location, identifierType) mergeWith (
       parentWork = Identifiable(parentWork),
       fullText = fullText
     )
 
-  def createMergedImage: MergedImage[Unminted] = createMergedImageWith()
+  def createMergedImage: MergedImage[Identifiable] = createMergedImageWith()
 
-  implicit class ImageIdOps(val image: MergedImage[Unminted]) {
-    val toMinted: MergedImage[Minted] = MergedImage(
+  def createInferredData = {
+    val features1 = (0 until 2048).map(_ => Random.nextFloat()*100).toList
+    val features2 = (0 until 2048).map(_ => Random.nextFloat()*100).toList
+    Some(InferredData(features1, features2, List(randomAlphanumeric(10))))
+  }
+
+  def createAugmentedImage = createMergedImage.toMinted.augment(createInferredData)
+
+  implicit class ImageIdOps(val image: MergedImage[Identifiable]) {
+    val toMinted: MergedImage[Identified] = MergedImage(
       id = Identified(
         canonicalId = createCanonicalId,
         sourceIdentifier = image.id.allSourceIdentifiers.head

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -14,7 +14,8 @@ trait ImageGenerators extends IdentifiersGenerators with ItemsGenerators {
     location = location
   )
 
-  def createUnmergedImage: UnmergedImage[Identifiable] = createUnmergedImageWith()
+  def createUnmergedImage: UnmergedImage[Identifiable] =
+    createUnmergedImageWith()
 
   def createMergedImageWith(
     location: DigitalLocation = createDigitalLocation,
@@ -29,12 +30,13 @@ trait ImageGenerators extends IdentifiersGenerators with ItemsGenerators {
   def createMergedImage: MergedImage[Identifiable] = createMergedImageWith()
 
   def createInferredData = {
-    val features1 = (0 until 2048).map(_ => Random.nextFloat()*100).toList
-    val features2 = (0 until 2048).map(_ => Random.nextFloat()*100).toList
+    val features1 = (0 until 2048).map(_ => Random.nextFloat() * 100).toList
+    val features2 = (0 until 2048).map(_ => Random.nextFloat() * 100).toList
     Some(InferredData(features1, features2, List(randomAlphanumeric(10))))
   }
 
-  def createAugmentedImage = createMergedImage.toMinted.augment(createInferredData)
+  def createAugmentedImage =
+    createMergedImage.toMinted.augment(createInferredData)
 
   implicit class ImageIdOps(val image: MergedImage[Identifiable]) {
     val toMinted: MergedImage[Identified] = MergedImage(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -206,9 +206,10 @@ trait WorksGenerators
       items = items
     )
 
-  def createUnidentifiedCalmWork(data: WorkData[Unminted, Identifiable] = WorkData(
-                                   items = List(createCalmItem)
-                                 ),
+  def createUnidentifiedCalmWork(data: WorkData[Unminted, Identifiable] =
+                                   WorkData(
+                                     items = List(createCalmItem)
+                                   ),
                                  id: String = randomAlphanumeric(6),
                                  version: Int = 0) =
     UnidentifiedWork(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -55,7 +55,7 @@ trait WorksGenerators
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     items: List[Item[Unminted]] = Nil,
-    images: List[UnmergedImage[Unminted]] = Nil,
+    images: List[UnmergedImage[Identifiable]] = Nil,
   ): UnidentifiedInvisibleWork =
     UnidentifiedInvisibleWork(
       sourceIdentifier = sourceIdentifier,
@@ -104,7 +104,7 @@ trait WorksGenerators
     edition: Option[String] = None,
     duration: Option[Int] = None,
     items: List[Item[Unminted]] = Nil,
-    images: List[UnmergedImage[Unminted]] = Nil): UnidentifiedWork =
+    images: List[UnmergedImage[Identifiable]] = Nil): UnidentifiedWork =
     UnidentifiedWork(
       sourceIdentifier = sourceIdentifier,
       version = version,
@@ -206,7 +206,7 @@ trait WorksGenerators
       items = items
     )
 
-  def createUnidentifiedCalmWork(data: WorkData[Unminted] = WorkData(
+  def createUnidentifiedCalmWork(data: WorkData[Unminted, Identifiable] = WorkData(
                                    items = List(createCalmItem)
                                  ),
                                  id: String = randomAlphanumeric(6),

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
@@ -7,12 +7,9 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.model.Message
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
-import uk.ac.wellcome.models.work.internal.{AugmentedImage, MergedImage, Minted}
+import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, MergedImage}
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.platform.inference_manager.services.{
-  FeatureVectorInferrerAdapter,
-  InferenceManagerWorkerService
-}
+import uk.ac.wellcome.platform.inference_manager.services.{FeatureVectorInferrerAdapter, InferenceManagerWorkerService}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -23,8 +20,8 @@ import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
   // This inference manager operates on images
-  type Input = MergedImage[Minted]
-  type Output = AugmentedImage[Minted]
+  type Input = MergedImage[Identified]
+  type Output = AugmentedImage[Identified]
   val inferrerAdapter = FeatureVectorInferrerAdapter
 
   runWithConfig { config: Config =>

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
@@ -7,9 +7,16 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.model.Message
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
-import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, MergedImage}
+import uk.ac.wellcome.models.work.internal.{
+  AugmentedImage,
+  Identified,
+  MergedImage
+}
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.platform.inference_manager.services.{FeatureVectorInferrerAdapter, InferenceManagerWorkerService}
+import uk.ac.wellcome.platform.inference_manager.services.{
+  FeatureVectorInferrerAdapter,
+  InferenceManagerWorkerService
+}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext
 object Main extends WellcomeTypesafeApp {
   // This inference manager operates on images
   type Input = MergedImage[Identified]
-  type Output = AugmentedImage[Identified]
+  type Output = AugmentedImage
   val inferrerAdapter = FeatureVectorInferrerAdapter
 
   runWithConfig { config: Config =>

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
@@ -50,7 +50,7 @@ trait InferrerAdapter[Input, Output] extends Logging {
 // The InferrerAdaptor for feature vectors, consuming MergedImages and
 // augmenting them into AugmentedImages
 object FeatureVectorInferrerAdapter
-    extends InferrerAdapter[MergedImage[Identified], AugmentedImage[Identified]] {
+    extends InferrerAdapter[MergedImage[Identified], AugmentedImage] {
   type InferrerResponse = FeatureVectorInferrerResponse
 
   def createRequest(image: MergedImage[Identified]): HttpRequest =
@@ -66,7 +66,7 @@ object FeatureVectorInferrerAdapter
 
   def augmentInput(
     image: MergedImage[Identified],
-    inferrerResponse: Option[InferrerResponse]): AugmentedImage[Identified] =
+    inferrerResponse: Option[InferrerResponse]): AugmentedImage =
     image.augment {
       inferrerResponse collect {
         case FeatureVectorInferrerResponse(features, lsh_encoded_features)

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
@@ -7,12 +7,7 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import uk.ac.wellcome.models.work.internal.{
-  AugmentedImage,
-  InferredData,
-  MergedImage,
-  Minted
-}
+import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, InferredData, MergedImage}
 import uk.ac.wellcome.platform.inference_manager.models.FeatureVectorInferrerResponse
 
 import scala.concurrent.Future
@@ -55,10 +50,10 @@ trait InferrerAdapter[Input, Output] extends Logging {
 // The InferrerAdaptor for feature vectors, consuming MergedImages and
 // augmenting them into AugmentedImages
 object FeatureVectorInferrerAdapter
-    extends InferrerAdapter[MergedImage[Minted], AugmentedImage[Minted]] {
+    extends InferrerAdapter[MergedImage[Identified], AugmentedImage[Identified]] {
   type InferrerResponse = FeatureVectorInferrerResponse
 
-  def createRequest(image: MergedImage[Minted]): HttpRequest =
+  def createRequest(image: MergedImage[Identified]): HttpRequest =
     HttpRequest(
       method = HttpMethods.GET,
       uri = Uri("/feature-vectors/").withQuery(
@@ -70,8 +65,8 @@ object FeatureVectorInferrerAdapter
     )
 
   def augmentInput(
-    image: MergedImage[Minted],
-    inferrerResponse: Option[InferrerResponse]): AugmentedImage[Minted] =
+    image: MergedImage[Identified],
+    inferrerResponse: Option[InferrerResponse]): AugmentedImage[Identified] =
     image.augment {
       inferrerResponse collect {
         case FeatureVectorInferrerResponse(features, lsh_encoded_features)

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
@@ -7,7 +7,12 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, InferredData, MergedImage}
+import uk.ac.wellcome.models.work.internal.{
+  AugmentedImage,
+  Identified,
+  InferredData,
+  MergedImage
+}
 import uk.ac.wellcome.platform.inference_manager.models.FeatureVectorInferrerResponse
 
 import scala.concurrent.Future
@@ -64,9 +69,8 @@ object FeatureVectorInferrerAdapter
       )
     )
 
-  def augmentInput(
-    image: MergedImage[Identified],
-    inferrerResponse: Option[InferrerResponse]): AugmentedImage =
+  def augmentInput(image: MergedImage[Identified],
+                   inferrerResponse: Option[InferrerResponse]): AugmentedImage =
     image.augment {
       inferrerResponse collect {
         case FeatureVectorInferrerResponse(features, lsh_encoded_features)

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -1,13 +1,29 @@
 package uk.ac.wellcome.platform.inference_manager.services
 
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Inside, Inspectors, Matchers, OptionValues}
+import org.scalatest.{
+  BeforeAndAfterAll,
+  FunSpec,
+  Inside,
+  Inspectors,
+  Matchers,
+  OptionValues
+}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, InferredData, MergedImage}
+import uk.ac.wellcome.models.work.internal.{
+  AugmentedImage,
+  Identified,
+  InferredData,
+  MergedImage
+}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ImageGenerators
-import uk.ac.wellcome.platform.inference_manager.fixtures.{FeatureVectorInferrerMock, InferenceManagerWorkerServiceFixture, InferrerWiremock}
+import uk.ac.wellcome.platform.inference_manager.fixtures.{
+  FeatureVectorInferrerMock,
+  InferenceManagerWorkerServiceFixture,
+  InferrerWiremock
+}
 
 class InferenceManagerWorkerServiceTest
     extends FunSpec

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -19,7 +19,7 @@ class InferenceManagerWorkerServiceTest
     with BeforeAndAfterAll
     with InferenceManagerWorkerServiceFixture[
       MergedImage[Identified],
-      AugmentedImage[Identified]
+      AugmentedImage
     ] {
 
   val inferrerMock = new InferrerWiremock(FeatureVectorInferrerMock)
@@ -43,9 +43,9 @@ class InferenceManagerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          val augmentedWork = getMessages[AugmentedImage[Identified]](topic).head
+          val augmentedWork = getMessages[AugmentedImage](topic).head
           inside(augmentedWork) {
-            case AugmentedImage(id, _, _, _, _, inferredData) =>
+            case AugmentedImage(id, _, _, _, inferredData) =>
               id should be(image.id)
               inside(inferredData.value) {
                 case InferredData(features1, features2, lshEncodedFeatures) =>
@@ -86,9 +86,9 @@ class InferenceManagerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          val output = getMessages[AugmentedImage[Identified]](topic).head
+          val output = getMessages[AugmentedImage](topic).head
           inside(output) {
-            case AugmentedImage(id, _, _, _, _, inferredData) =>
+            case AugmentedImage(id, _, _, _, inferredData) =>
               id should be(image500.id)
               inferredData should not be defined
           }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -1,29 +1,13 @@
 package uk.ac.wellcome.platform.inference_manager.services
 
-import org.scalatest.{
-  BeforeAndAfterAll,
-  FunSpec,
-  Inside,
-  Inspectors,
-  Matchers,
-  OptionValues
-}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Inside, Inspectors, Matchers, OptionValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.work.internal.{
-  AugmentedImage,
-  InferredData,
-  MergedImage,
-  Minted
-}
+import uk.ac.wellcome.models.work.internal.{AugmentedImage, Identified, InferredData, MergedImage}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ImageGenerators
-import uk.ac.wellcome.platform.inference_manager.fixtures.{
-  FeatureVectorInferrerMock,
-  InferenceManagerWorkerServiceFixture,
-  InferrerWiremock
-}
+import uk.ac.wellcome.platform.inference_manager.fixtures.{FeatureVectorInferrerMock, InferenceManagerWorkerServiceFixture, InferrerWiremock}
 
 class InferenceManagerWorkerServiceTest
     extends FunSpec
@@ -34,8 +18,8 @@ class InferenceManagerWorkerServiceTest
     with Inspectors
     with BeforeAndAfterAll
     with InferenceManagerWorkerServiceFixture[
-      MergedImage[Minted],
-      AugmentedImage[Minted]
+      MergedImage[Identified],
+      AugmentedImage[Identified]
     ] {
 
   val inferrerMock = new InferrerWiremock(FeatureVectorInferrerMock)
@@ -59,9 +43,9 @@ class InferenceManagerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          val augmentedWork = getMessages[AugmentedImage[Minted]](topic).head
+          val augmentedWork = getMessages[AugmentedImage[Identified]](topic).head
           inside(augmentedWork) {
-            case AugmentedImage(id, _, _, _, inferredData) =>
+            case AugmentedImage(id, _, _, _, _, inferredData) =>
               id should be(image.id)
               inside(inferredData.value) {
                 case InferredData(features1, features2, lshEncodedFeatures) =>
@@ -102,9 +86,9 @@ class InferenceManagerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          val output = getMessages[AugmentedImage[Minted]](topic).head
+          val output = getMessages[AugmentedImage[Identified]](topic).head
           inside(output) {
-            case AugmentedImage(id, _, _, _, inferredData) =>
+            case AugmentedImage(id, _, _, _, _, inferredData) =>
               id should be(image500.id)
               inferredData should not be defined
           }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -5,7 +5,12 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
-import uk.ac.wellcome.models.work.internal.{BaseWork, Identifiable, MergedImage, TransformedBaseWork}
+import uk.ac.wellcome.models.work.internal.{
+  BaseWork,
+  Identifiable,
+  MergedImage,
+  TransformedBaseWork
+}
 import uk.ac.wellcome.platform.merger.services._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -5,12 +5,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
-import uk.ac.wellcome.models.work.internal.{
-  BaseWork,
-  MergedImage,
-  TransformedBaseWork,
-  Unminted
-}
+import uk.ac.wellcome.models.work.internal.{BaseWork, Identifiable, MergedImage, TransformedBaseWork}
 import uk.ac.wellcome.platform.merger.services._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -32,7 +27,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val s3Client =
       S3Builder.buildS3Client(config)
     implicit val workMessageStore = S3TypedStore[BaseWork]
-    implicit val imageMessageStore = S3TypedStore[MergedImage[Unminted]]
+    implicit val imageMessageStore = S3TypedStore[MergedImage[Identifiable]]
 
     val playbackService = new RecorderPlaybackService(
       vhs = VHSBuilder.build[TransformedBaseWork](config)
@@ -45,7 +40,7 @@ object Main extends WellcomeTypesafeApp {
         config.getConfig("work-sender").withFallback(config)
       )
     val imageSender =
-      BigMessagingBuilder.buildBigMessageSender[MergedImage[Unminted]](
+      BigMessagingBuilder.buildBigMessageSender[MergedImage[Identifiable]](
         config.getConfig("image-sender").withFallback(config)
       )
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
@@ -2,8 +2,7 @@ package uk.ac.wellcome.platform.merger.logging
 
 import grizzled.slf4j.Logging
 import cats.data.NonEmptyList
-
-import uk.ac.wellcome.models.work.internal.{BaseImage, BaseWork, Unminted}
+import uk.ac.wellcome.models.work.internal.{BaseImage, BaseWork, Identifiable}
 
 trait MergerLogging extends Logging {
   def describeWork(work: BaseWork): String =
@@ -15,10 +14,10 @@ trait MergerLogging extends Logging {
   def describeWorks(works: NonEmptyList[BaseWork]): String =
     describeWorks(works.toList)
 
-  def describeImage(image: BaseImage[Unminted]): String =
+  def describeImage(image: BaseImage[Identifiable]): String =
     s"(id=${image.id})"
 
-  def describeImages(images: Seq[BaseImage[Unminted]]): String =
+  def describeImages(images: Seq[BaseImage[Identifiable]]): String =
     s"[${images.map(describeImage).mkString(",")}]"
 
   def describeMergeSet(target: BaseWork, sources: Seq[BaseWork]): String =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.merger.models
 
-import uk.ac.wellcome.models.work.internal.{Identifiable, MergedImage, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  Identifiable,
+  MergedImage,
+  UnidentifiedWork
+}
 
 /*
  * MergeResult holds the resultant target after all fields have been merged,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
@@ -1,14 +1,10 @@
 package uk.ac.wellcome.platform.merger.models
 
-import uk.ac.wellcome.models.work.internal.{
-  MergedImage,
-  UnidentifiedWork,
-  Unminted
-}
+import uk.ac.wellcome.models.work.internal.{Identifiable, MergedImage, UnidentifiedWork}
 
 /*
  * MergeResult holds the resultant target after all fields have been merged,
  * and the images that were created in the process
  */
 case class MergeResult(mergedTarget: UnidentifiedWork,
-                       images: Seq[MergedImage[Unminted]])
+                       images: Seq[MergedImage[Identifiable]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.merger.models
 
-import uk.ac.wellcome.models.work.internal.{BaseWork, MergedImage, Unminted}
+import uk.ac.wellcome.models.work.internal.{BaseWork, Identifiable, MergedImage}
 
 /*
  * MergerOutcome is the final output of the merger:
  * all merged, redirected, and remaining works, as well as all merged images
  */
 case class MergerOutcome(works: Seq[BaseWork],
-                         images: Seq[MergedImage[Unminted]])
+                         images: Seq[MergedImage[Identifiable]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -7,8 +7,7 @@ import uk.ac.wellcome.models.work.internal.{
   Identifiable,
   MergedImage,
   TransformedBaseWork,
-  UnidentifiedWork,
-  Unminted
+  UnidentifiedWork
 }
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 import uk.ac.wellcome.platform.merger.rules.WorkPredicates.{
@@ -18,7 +17,7 @@ import uk.ac.wellcome.platform.merger.rules.WorkPredicates.{
 }
 
 object ImagesRule extends FieldMergeRule {
-  type FieldData = List[MergedImage[Unminted]]
+  type FieldData = List[MergedImage[Identifiable]]
 
   override def merge(
     target: UnidentifiedWork,
@@ -65,7 +64,7 @@ object ImagesRule extends FieldMergeRule {
   trait FlatImageMergeRule extends PartialRule {
     final override def rule(target: UnidentifiedWork,
                             sources: NonEmptyList[TransformedBaseWork])
-      : List[MergedImage[Unminted]] = {
+      : List[MergedImage[Identifiable]] = {
       val works = sources.prepend(target).toList
       works flatMap {
         _.data.images.map {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -4,7 +4,7 @@ import akka.Done
 
 import scala.concurrent.{ExecutionContext, Future}
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
-import uk.ac.wellcome.models.work.internal.{BaseWork, MergedImage, Unminted}
+import uk.ac.wellcome.models.work.internal.{BaseWork, Identifiable, MergedImage}
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.Implicits._
@@ -17,7 +17,7 @@ class MergerWorkerService[WorkDestination, ImageDestination](
   playbackService: RecorderPlaybackService,
   mergerManager: MergerManager,
   workSender: BigMessageSender[WorkDestination, BaseWork],
-  imageSender: BigMessageSender[ImageDestination, MergedImage[Unminted]]
+  imageSender: BigMessageSender[ImageDestination, MergedImage[Identifiable]]
 )(implicit ec: ExecutionContext)
     extends Runnable {
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.models.work.internal.{BaseWork, MergedImage, Unminted}
+import uk.ac.wellcome.models.work.internal.{BaseWork, Identifiable, MergedImage}
 import uk.ac.wellcome.platform.merger.services._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
@@ -24,7 +24,7 @@ trait WorkerServiceFixture extends LocalWorksVhs {
     testWith: TestWith[MergerWorkerService[SNSConfig, SNSConfig], R]): R =
     withLocalS3Bucket { bucket =>
       withSqsBigMessageSender[BaseWork, R](bucket, worksTopic) { workSender =>
-        withSqsBigMessageSender[MergedImage[Unminted], R](bucket, imagesTopic) {
+        withSqsBigMessageSender[MergedImage[Identifiable], R](bucket, imagesTopic) {
           imageSender =>
             withActorSystem { implicit actorSystem =>
               withSQSStream[NotificationMessage, R](queue, metrics) {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -24,22 +24,22 @@ trait WorkerServiceFixture extends LocalWorksVhs {
     testWith: TestWith[MergerWorkerService[SNSConfig, SNSConfig], R]): R =
     withLocalS3Bucket { bucket =>
       withSqsBigMessageSender[BaseWork, R](bucket, worksTopic) { workSender =>
-        withSqsBigMessageSender[MergedImage[Identifiable], R](bucket, imagesTopic) {
-          imageSender =>
-            withActorSystem { implicit actorSystem =>
-              withSQSStream[NotificationMessage, R](queue, metrics) {
-                sqsStream =>
-                  val workerService = new MergerWorkerService(
-                    sqsStream = sqsStream,
-                    playbackService = new RecorderPlaybackService(vhs),
-                    mergerManager = new MergerManager(PlatformMerger),
-                    workSender = workSender,
-                    imageSender = imageSender
-                  )
-                  workerService.run()
-                  testWith(workerService)
-              }
+        withSqsBigMessageSender[MergedImage[Identifiable], R](
+          bucket,
+          imagesTopic) { imageSender =>
+          withActorSystem { implicit actorSystem =>
+            withSQSStream[NotificationMessage, R](queue, metrics) { sqsStream =>
+              val workerService = new MergerWorkerService(
+                sqsStream = sqsStream,
+                playbackService = new RecorderPlaybackService(vhs),
+                mergerManager = new MergerManager(PlatformMerger),
+                workSender = workSender,
+                imageSender = imageSender
+              )
+              workerService.run()
+              testWith(workerService)
             }
+          }
         }
       }
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -236,7 +236,7 @@ class MergerWorkerServiceTest
           worksSent should have size 3
 
           val imagesSent =
-            getMessages[MergedImage[Unminted]](topics.images).distinct
+            getMessages[MergedImage[Identifiable]](topics.images).distinct
           imagesSent should have size 1
 
           val redirectedWorks = worksSent.collect {

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -34,7 +34,7 @@ object CalmTransformer extends Transformer[CalmRecord] with CalmOps {
       )
     }
 
-  def workData(record: CalmRecord): Result[WorkData[Unminted]] =
+  def workData(record: CalmRecord): Result[WorkData[Unminted, Identifiable]] =
     for {
       accessStatus <- accessStatus(record)
       title <- title(record)

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -69,7 +69,7 @@ class MiroRecordTransformer
 
       val (title, description) = getTitleAndDescription(miroRecord)
 
-      val data = WorkData[Unminted](
+      val data = WorkData[Unminted, Identifiable](
         otherIdentifiers = getOtherIdentifiers(miroRecord),
         title = Some(title),
         workType = getWorkType,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
@@ -1,13 +1,6 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
-import uk.ac.wellcome.models.work.internal.{
-  DigitalLocation,
-  IdentifierType,
-  LocationType,
-  SourceIdentifier,
-  UnmergedImage,
-  Unminted
-}
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Identifiable, IdentifierType, LocationType, SourceIdentifier, UnmergedImage}
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 trait MiroImage {
@@ -26,7 +19,7 @@ trait MiroImage {
     imageUriTemplate.format(iiifImageApiBaseUri, miroId)
   }
 
-  def getImage(miroRecord: MiroRecord): UnmergedImage[Unminted] =
+  def getImage(miroRecord: MiroRecord): UnmergedImage[Identifiable] =
     UnmergedImage(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("miro-image-number"),

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
@@ -1,6 +1,13 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
-import uk.ac.wellcome.models.work.internal.{DigitalLocation, Identifiable, IdentifierType, LocationType, SourceIdentifier, UnmergedImage}
+import uk.ac.wellcome.models.work.internal.{
+  DigitalLocation,
+  Identifiable,
+  IdentifierType,
+  LocationType,
+  SourceIdentifier,
+  UnmergedImage
+}
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 trait MiroImage {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -91,7 +91,7 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
       }
 
   def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
-    WorkData(
+    WorkData[Unminted, Identifiable](
       otherIdentifiers = SierraIdentifiers(bibId, bibData),
       mergeCandidates = SierraMergeCandidates(bibId, bibData),
       title = SierraTitle(bibId, bibData),


### PR DESCRIPTION
There are a few things in our current image model that are a bit annoying:
* `AugmentedImage` has a id type param, although they will always be`AugmentedImage[Identified]`in practice. It would be good if our model reflected that.
* `BaseImage` has a type parameter `Id <: IdState` which means they can be `Unidentifiable` which is impossible in practice as we always create a `sourceIdentifier` for them and then a `canonicalId` after the idMinter. Do we ever foresee a situation where that' not going to be true?

