### PR TITLE
AccessCondition.to should be textField rather than dateField

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -55,6 +55,7 @@ trait IndexConfig {
       objectField("sourceIdentifier").fields(sourceIdentifierFields),
       objectField("otherIdentifiers").fields(sourceIdentifierFields)
     )
+
   def location(fieldName: String = "locations") =
     objectField(fieldName).fields(
       keywordField("type"),
@@ -70,11 +71,12 @@ trait IndexConfig {
       license,
       accessConditions
     )
+
   val accessConditions =
     objectField("accessConditions")
       .fields(
         englishTextField("terms"),
-        dateField("to"),
+        textField("to"),
         objectField("status").fields(keywordField("type"))
       )
 


### PR DESCRIPTION
Due to transformer errors parsing dates we changed this to a string in the model rather than a date. The mapping was not updated so do it here.