### PR TITLE
[MERGENOT] add calm to findTarget in PlatformMerger

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -241,6 +241,9 @@ trait WorksGenerators
   def createUnidentifiedSierraWork: UnidentifiedWork =
     createUnidentifiedSierraWorkWith()
 
+  def createSierraWork: UnidentifiedWork =
+    createUnidentifiedSierraWorkWith()
+
   def createSierraPhysicalWork: UnidentifiedWork =
     createUnidentifiedSierraWorkWith(items = List(createPhysicalItem))
 

--- a/docs/pipeline/merging.md
+++ b/docs/pipeline/merging.md
@@ -8,8 +8,10 @@ Merging works is split up into 2 steps:
 Using features from the source data to calculate which works are linked.
 
 e.g:
-* the `BNumber` from a Calm record
+* `BNumber` from a Calm record
 * Marcfield `776$w` linking a Sierra record to it's digitised counterpart
+* Marcfield `962$u` or `089$a` linking Miro works to Sierra works
+* `recordIdentifier` from METS works to Sierra works
 
 This is carried out by the transformers of the respective sources data.
 
@@ -19,5 +21,16 @@ https://excalidraw.com/#json=5964037271584768,ojtCECzrMrgSJuBp3VCvHw
 
 
 ### 2. Merging linked works
-TBD.
 
+## Finding the target
+
+The `target` in the merging process is the work
+* which all data will be merged into
+* the work merged sources will redirect to
+
+We select a `target` in a waterfall fashion
+* Calm
+* Sierra work with a physical location on an item
+* A Sierra work
+
+If a target isn't selected, all linked works will left unmerged.

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -103,10 +103,11 @@ object PlatformMerger extends Merger {
   override def findTarget(
     works: Seq[TransformedBaseWork]): Option[UnidentifiedWork] =
     works
-      .find(WorkPredicates.physicalSierra)
+      .find(WorkPredicates.calmWork)
+      .orElse(works.find(WorkPredicates.physicalSierra))
       .orElse(works.find(WorkPredicates.sierraWork)) match {
-      case Some(target: UnidentifiedWork) => Some(target)
-      case _                              => None
+      case Some(work: UnidentifiedWork) => Some(work)
+      case _                            => None
     }
 
   override def createMergeResult(


### PR DESCRIPTION
Uses calm as the target to ensure it's the canonical source.

Don't merge until we have all the calm rules in place.