### PR TITLE
Fix autoscaling in pipeline

### DIFF
--- a/pipeline/terraform/stack/service_image_id_minter.tf
+++ b/pipeline/terraform/stack/service_image_id_minter.tf
@@ -70,7 +70,7 @@ module "image_id_minter_topic" {
 }
 
 module "image_id_minter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.image_id_minter_queue.name
 
   queue_high_actions = [module.image_id_minter.scale_up_arn]

--- a/pipeline/terraform/stack/service_image_id_minter.tf
+++ b/pipeline/terraform/stack/service_image_id_minter.tf
@@ -70,7 +70,7 @@ module "image_id_minter_topic" {
 }
 
 module "image_id_minter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.image_id_minter_queue.name
 
   queue_high_actions = [module.image_id_minter.scale_up_arn]

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -104,7 +104,7 @@ module "image_inferrer_topic" {
 }
 
 module "image_inferrer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.image_inferrer_queue.name
 
   queue_high_actions = [module.image_inferrer.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -48,7 +48,7 @@ module "ingestor_works" {
 }
 
 module "ingestor_works_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.ingestor_works_queue.name
 
   queue_high_actions = [module.ingestor_works.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -48,7 +48,7 @@ module "ingestor_works" {
 }
 
 module "ingestor_works_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.ingestor_works_queue.name
 
   queue_high_actions = [module.ingestor_works.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -49,7 +49,7 @@ module "ingestor_images" {
 }
 
 module "ingestor_images_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.ingestor_images_queue.name
 
   queue_high_actions = [module.ingestor_images.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -49,7 +49,7 @@ module "ingestor_images" {
 }
 
 module "ingestor_images_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.ingestor_images_queue.name
 
   queue_high_actions = [module.ingestor_images.scale_up_arn]

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -81,7 +81,7 @@ module "matcher_topic" {
 }
 
 module "matcher_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.matcher_queue.name
 
   queue_high_actions = [module.matcher.scale_up_arn]

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -81,7 +81,7 @@ module "matcher_topic" {
 }
 
 module "matcher_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.matcher_queue.name
 
   queue_high_actions = [module.matcher.scale_up_arn]

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -64,7 +64,7 @@ module "merger_images_topic" {
 }
 
 module "merger_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.merger_queue.name
 
   queue_high_actions = [module.merger.scale_up_arn]

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -64,7 +64,7 @@ module "merger_images_topic" {
 }
 
 module "merger_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.merger_queue.name
 
   queue_high_actions = [module.merger.scale_up_arn]

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -57,7 +57,7 @@ module "recorder_topic" {
 }
 
 module "recorder_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.recorder_queue.name
 
   queue_high_actions = [module.recorder.scale_up_arn]

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -57,7 +57,7 @@ module "recorder_topic" {
 }
 
 module "recorder_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.recorder_queue.name
 
   queue_high_actions = [module.recorder.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -55,7 +55,7 @@ module "calm_transformer_topic" {
 }
 
 module "calm_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.calm_transformer_queue.name
 
   queue_high_actions = [module.calm_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -55,7 +55,7 @@ module "calm_transformer_topic" {
 }
 
 module "calm_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.calm_transformer_queue.name
 
   queue_high_actions = [module.calm_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -54,7 +54,7 @@ module "mets_transformer_topic" {
 }
 
 module "mets_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.mets_transformer_queue.name
 
   queue_high_actions = [module.mets_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -54,7 +54,7 @@ module "mets_transformer_topic" {
 }
 
 module "mets_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.mets_transformer_queue.name
 
   queue_high_actions = [module.mets_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -52,7 +52,7 @@ module "miro_transformer_topic" {
 }
 
 module "miro_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.miro_transformer_queue.name
 
   queue_high_actions = [module.miro_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -52,7 +52,7 @@ module "miro_transformer_topic" {
 }
 
 module "miro_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.miro_transformer_queue.name
 
   queue_high_actions = [module.miro_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -55,7 +55,7 @@ module "sierra_transformer_topic" {
 }
 
 module "sierra_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.sierra_transformer_queue.name
 
   queue_high_actions = [module.sierra_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -55,7 +55,7 @@ module "sierra_transformer_topic" {
 }
 
 module "sierra_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.sierra_transformer_queue.name
 
   queue_high_actions = [module.sierra_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_work_id_minter.tf
+++ b/pipeline/terraform/stack/service_work_id_minter.tf
@@ -71,7 +71,7 @@ module "work_id_minter_topic" {
 }
 
 module "work_id_minter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
   queue_name = module.work_id_minter_queue.name
 
   queue_high_actions = [module.work_id_minter.scale_up_arn]

--- a/pipeline/terraform/stack/service_work_id_minter.tf
+++ b/pipeline/terraform/stack/service_work_id_minter.tf
@@ -71,7 +71,7 @@ module "work_id_minter_topic" {
 }
 
 module "work_id_minter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=8b53ad48ca041851c52d2b8c6f1f9ceba926ef6c"
   queue_name = module.work_id_minter_queue.name
 
   queue_high_actions = [module.work_id_minter.scale_up_arn]


### PR DESCRIPTION
As explained [here](https://github.com/wellcomecollection/terraform-aws-sqs), during a reindex I noticed that services were scaled down when they reached a point where they could process messages as fast as they were being sent.
This is to use a different scale down metric to avoid scaling down services that are not idle