### PR TITLE
Making the merger only work on how to merge

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -78,4 +78,18 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
         .filterNot(_.identifierType == IdentifierType("sierra-system-number"))
     }
   }
+
+  private val calmIdssRule = new PartialRule {
+    val isDefinedForTarget: WorkPredicate = WorkPredicates.calmWork
+    val isDefinedForSource: WorkPredicate = WorkPredicates.sierraWork
+
+    override def rule(
+      target: UnidentifiedWork,
+      sources: NonEmptyList[TransformedBaseWork]): List[SourceIdentifier] = {
+      debug(s"Merging physical and digital IDs from ${describeWorks(sources)}")
+      target.data.otherIdentifiers ++ sources.toList
+        .flatMap(_.identifiers)
+        .filterNot(_.identifierType == IdentifierType("sierra-system-number"))
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -90,10 +90,15 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
           )
       }
 
-  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
+  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) = {
+    val items = SierraItems(itemDataMap)(bibId, bibData)
+    val mergeCandidates = items match {
+      case List(_) => SierraWithSingleItemMergeCandidates(bibId, bibData)
+      case _ :: _  => SierraWithMultiItemsMergeCandidates(bibId, bibData)
+    }
     WorkData[Unminted, Identifiable](
       otherIdentifiers = SierraIdentifiers(bibId, bibData),
-      mergeCandidates = SierraMergeCandidates(bibId, bibData),
+      mergeCandidates = mergeCandidates,
       title = SierraTitle(bibId, bibData),
       alternativeTitles = SierraAlternativeTitles(bibId, bibData),
       workType = SierraWorkType(bibId, bibData),
@@ -108,8 +113,9 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
       edition = SierraEdition(bibId, bibData),
       notes = SierraNotes(bibId, bibData),
       duration = SierraDuration(bibId, bibData),
-      items = SierraItems(itemDataMap)(bibId, bibData)
+      items = items
     )
+  }
 
   lazy val bibId = sierraTransformable.sierraId
 


### PR DESCRIPTION
**This PR is for me to think aloud and have anyone interested to be able to contribute - if someone would rather scribble on excalidraw, let's do that**

Thinking about moving the logic to link works out of the `merger`, making it responsible for _how things merge_ rather than _should things merge_ which is already partially being defined by the `transformer`.

I'm not 100% convinced that the `transformer` is the place for this, but the service creating the links needs access to:
1. Source data to access linked IDs
1. Transformed target data
1. [Transformed sources data] ❓ 

Point 3 I am unsure of, and if it is required, we're a bit stuck on this path.

## Other options
### Move "if something can merge" logic to matcher 1/5 review

Transformer just gets any available linked IDs
Matcher fetches graph of links **and applies logic as to whether they should merge**
Merger works out how to merge ☝️ 

### Move all "if something can merge" logic to matcher 1/5 review

Transformer just gets any available linked IDs
Matcher fetches graph of links **and applies logic as to whether they should merge**
Merger works out how to merge ☝️ 

... more thinking coming soon.



