### PR TITLE
Don't error creating Collection tree when some works are missing

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
@@ -111,7 +111,8 @@ class CollectionServiceTest
                     work = Some(workF),
                     children = List(
                       Collection(
-                        path = CollectionPath("a/e/f/g", Some(CollectionLevel.Item)),
+                        path =
+                          CollectionPath("a/e/f/g", Some(CollectionLevel.Item)),
                         work = Some(workG))
                     )
                   ),
@@ -162,7 +163,8 @@ class CollectionServiceTest
                 work = None,
                 children = List(
                   Collection(
-                    path = CollectionPath("x/missing/z", Some(CollectionLevel.Item)),
+                    path =
+                      CollectionPath("x/missing/z", Some(CollectionLevel.Item)),
                     work = Some(workZ),
                   )
                 )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
@@ -27,7 +27,7 @@ class CollectionServiceTest
   def work(path: String, level: CollectionLevel) =
     createIdentifiedWorkWith(
       collectionPath = Some(
-        CollectionPath(path = path, level = level)
+        CollectionPath(path = path, level = Some(level))
       ),
       title = Some(path),
       sourceIdentifier = createSourceIdentifierWith(value = path)
@@ -45,7 +45,7 @@ class CollectionServiceTest
   val workG = work("a/e/f/g", CollectionLevel.Item)
   val workX = work("x", CollectionLevel.Collection)
   val workY = work("x/y", CollectionLevel.Series)
-  val workZ = work("x/oops/z", CollectionLevel.Item)
+  val workZ = work("x/missing/z", CollectionLevel.Item)
 
   val works =
     List(workA, workB, workC, workD, workE, workF, workG, workX, workY, workZ)
@@ -56,24 +56,24 @@ class CollectionServiceTest
       whenReady(service.retrieveTree(index, List("a/b"))) { result =>
         result shouldBe Right(
           Collection(
-            path = CollectionPath("a", CollectionLevel.Collection),
-            work = workA,
+            path = CollectionPath("a", Some(CollectionLevel.Collection)),
+            work = Some(workA),
             children = List(
               Collection(
-                path = CollectionPath("a/b", CollectionLevel.Series),
-                work = workB,
+                path = CollectionPath("a/b", Some(CollectionLevel.Series)),
+                work = Some(workB),
                 children = List(
                   Collection(
-                    path = CollectionPath("a/b/c", CollectionLevel.Item),
-                    work = workC),
+                    path = CollectionPath("a/b/c", Some(CollectionLevel.Item)),
+                    work = Some(workC)),
                   Collection(
-                    path = CollectionPath("a/b/d", CollectionLevel.Item),
-                    work = workD)
+                    path = CollectionPath("a/b/d", Some(CollectionLevel.Item)),
+                    work = Some(workD))
                 )
               ),
               Collection(
-                path = CollectionPath("a/e", CollectionLevel.Series),
-                work = workE),
+                path = CollectionPath("a/e", Some(CollectionLevel.Series)),
+                work = Some(workE)),
             )
           )
         )
@@ -87,32 +87,32 @@ class CollectionServiceTest
       whenReady(service.retrieveTree(index, List("a/b", "a/e/f"))) { result =>
         result shouldBe Right(
           Collection(
-            path = CollectionPath("a", CollectionLevel.Collection),
-            work = workA,
+            path = CollectionPath("a", Some(CollectionLevel.Collection)),
+            work = Some(workA),
             children = List(
               Collection(
-                path = CollectionPath("a/b", CollectionLevel.Series),
-                work = workB,
+                path = CollectionPath("a/b", Some(CollectionLevel.Series)),
+                work = Some(workB),
                 children = List(
                   Collection(
-                    path = CollectionPath("a/b/c", CollectionLevel.Item),
-                    work = workC),
+                    path = CollectionPath("a/b/c", Some(CollectionLevel.Item)),
+                    work = Some(workC)),
                   Collection(
-                    path = CollectionPath("a/b/d", CollectionLevel.Item),
-                    work = workD)
+                    path = CollectionPath("a/b/d", Some(CollectionLevel.Item)),
+                    work = Some(workD))
                 )
               ),
               Collection(
-                path = CollectionPath("a/e", CollectionLevel.Series),
-                work = workE,
+                path = CollectionPath("a/e", Some(CollectionLevel.Series)),
+                work = Some(workE),
                 children = List(
                   Collection(
-                    path = CollectionPath("a/e/f", CollectionLevel.Series),
-                    work = workF,
+                    path = CollectionPath("a/e/f", Some(CollectionLevel.Series)),
+                    work = Some(workF),
                     children = List(
                       Collection(
-                        path = CollectionPath("a/e/f/g", CollectionLevel.Item),
-                        work = workG)
+                        path = CollectionPath("a/e/f/g", Some(CollectionLevel.Item)),
+                        work = Some(workG))
                     )
                   ),
                 )
@@ -130,16 +130,16 @@ class CollectionServiceTest
       whenReady(service.retrieveTree(index, List("a"))) { result =>
         result shouldBe Right(
           Collection(
-            path = CollectionPath("a", CollectionLevel.Collection),
-            work = workA,
+            path = CollectionPath("a", Some(CollectionLevel.Collection)),
+            work = Some(workA),
             children = List(
               Collection(
-                path = CollectionPath("a/b", CollectionLevel.Series),
-                work = workB,
+                path = CollectionPath("a/b", Some(CollectionLevel.Series)),
+                work = Some(workB),
               ),
               Collection(
-                path = CollectionPath("a/e", CollectionLevel.Series),
-                work = workE,
+                path = CollectionPath("a/e", Some(CollectionLevel.Series)),
+                work = Some(workE),
               )
             )
           )
@@ -148,12 +148,32 @@ class CollectionServiceTest
     }
   }
 
-  it("Fails creating a tree when incomplete data") {
+  it("Successfully creates a tree when incomplete data") {
     withLocalWorksIndex { index =>
       storeWorks(index)
-      whenReady(service.retrieveTree(index, List("x/oops"))) { result =>
-        result shouldBe a[Left[_, _]]
-        result.left.get.getMessage shouldBe "Not all works in collection are connected to root 'x': x/oops/z"
+      whenReady(service.retrieveTree(index, List("x/missing"))) { result =>
+        result shouldBe Right(
+          Collection(
+            path = CollectionPath("x", Some(CollectionLevel.Collection)),
+            work = Some(workX),
+            children = List(
+              Collection(
+                path = CollectionPath("x/missing"),
+                work = None,
+                children = List(
+                  Collection(
+                    path = CollectionPath("x/missing/z", Some(CollectionLevel.Item)),
+                    work = Some(workZ),
+                  )
+                )
+              ),
+              Collection(
+                path = CollectionPath("x/y", Some(CollectionLevel.Series)),
+                work = Some(workY),
+              )
+            )
+          )
+        )
       }
     }
   }
@@ -178,12 +198,12 @@ class CollectionServiceTest
       whenReady(service.retrieveTree(index, List("p/q"))) { result =>
         result shouldBe Right(
           Collection(
-            path = CollectionPath("p", CollectionLevel.Collection),
-            work = p.withData(_.copy(items = Nil)),
+            path = CollectionPath("p", Some(CollectionLevel.Collection)),
+            work = Some(p.withData(_.copy(items = Nil))),
             children = List(
               Collection(
-                path = CollectionPath("p/q", CollectionLevel.Item),
-                work = q.withData(_.copy(notes = Nil)),
+                path = CollectionPath("p/q", Some(CollectionLevel.Item)),
+                work = Some(q.withData(_.copy(notes = Nil))),
               )
             )
           )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -485,13 +485,13 @@ class ApiV2WorksIncludesTest
           createIdentifiedWorkWith(
             canonicalId = "1",
             collectionPath = Some(
-              CollectionPath("PP/MI", CollectionLevel.Item, Some("PP/MI")))),
+              CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI")))),
           createIdentifiedWorkWith(
             canonicalId = "2",
             collectionPath = Some(
               CollectionPath(
                 "CRGH",
-                CollectionLevel.Collection,
+                Some(CollectionLevel.Collection),
                 Some("CRGH")))),
         )
         insertIntoElasticsearch(indexV2, works: _*)
@@ -537,7 +537,7 @@ class ApiV2WorksIncludesTest
       case (indexV2, routes) =>
         val work = createIdentifiedWorkWith(
           collectionPath =
-            Some(CollectionPath("PP/MI", CollectionLevel.Item, Some("PP/MI"))))
+            Some(CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
         insertIntoElasticsearch(indexV2, work)
         assertJsonResponse(
           routes,
@@ -553,6 +553,26 @@ class ApiV2WorksIncludesTest
                 "path": "PP/MI",
                 "level": "Item",
                 "type" : "CollectionPath"
+              },
+              "collection" : {
+                "path" : { "path" : "PP", "type" : "CollectionPath" },
+                "children" : [
+                  {
+                    "path" : {
+                      "label" : "PP/MI",
+                      "level" : "Item",
+                      "path" : "PP/MI",
+                      "type" : "CollectionPath"
+                    },
+                    "work" : {
+                      "id": "${work.canonicalId}",
+                      "title": "${work.data.title.get}",
+                      "alternativeTitles" : [],
+                      "type" : "Work"
+                    },
+                    "children" : []
+                  }
+                ]
               }
             }
           """

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksIncludesTest.scala
@@ -485,7 +485,10 @@ class ApiV2WorksIncludesTest
           createIdentifiedWorkWith(
             canonicalId = "1",
             collectionPath = Some(
-              CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI")))),
+              CollectionPath(
+                "PP/MI",
+                Some(CollectionLevel.Item),
+                Some("PP/MI")))),
           createIdentifiedWorkWith(
             canonicalId = "2",
             collectionPath = Some(
@@ -536,8 +539,8 @@ class ApiV2WorksIncludesTest
     withApi {
       case (indexV2, routes) =>
         val work = createIdentifiedWorkWith(
-          collectionPath =
-            Some(CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
+          collectionPath = Some(
+            CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
         insertIntoElasticsearch(indexV2, work)
         assertJsonResponse(
           routes,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -317,13 +317,15 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         )
         val work2Archive1Depth2 = createIdentifiedWorkWith(
           canonicalId = "work2Archive1Depth2",
-          collectionPath =
-            Some(CollectionPath("archive1/depth2", Some(CollectionLevel.Series)))
+          collectionPath = Some(
+            CollectionPath("archive1/depth2", Some(CollectionLevel.Series)))
         )
         val work3Archive1Depth3 = createIdentifiedWorkWith(
           canonicalId = "work3Archive1Depth3",
-          collectionPath =
-            Some(CollectionPath("archive1/depth2/depth3", Some(CollectionLevel.Item)))
+          collectionPath = Some(
+            CollectionPath(
+              "archive1/depth2/depth3",
+              Some(CollectionLevel.Item)))
         )
         val work4Archive2Depth1 = createIdentifiedWorkWith(
           canonicalId = "work4Archive2Depth1",
@@ -332,13 +334,15 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         )
         val work5Archive2Depth2 = createIdentifiedWorkWith(
           canonicalId = "work5Archive2Depth2",
-          collectionPath =
-            Some(CollectionPath("archive2/depth2", Some(CollectionLevel.Series)))
+          collectionPath = Some(
+            CollectionPath("archive2/depth2", Some(CollectionLevel.Series)))
         )
         val work6Archive2Depth3 = createIdentifiedWorkWith(
           canonicalId = "work6Archive2Depth3",
-          collectionPath =
-            Some(CollectionPath("archive2/depth2/depth3", Some(CollectionLevel.Item)))
+          collectionPath = Some(
+            CollectionPath(
+              "archive2/depth2/depth3",
+              Some(CollectionLevel.Item)))
         )
         val work7Archiveless = createIdentifiedWorkWith(
           canonicalId = "work7Archiveless",
@@ -420,13 +424,13 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         )
         val work4Depth3 = createIdentifiedWorkWith(
           canonicalId = "4",
-          collectionPath =
-            Some(CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
+          collectionPath = Some(
+            CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work5Depth3 = createIdentifiedWorkWith(
           canonicalId = "5",
-          collectionPath =
-            Some(CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
+          collectionPath = Some(
+            CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work6NoDepth = createIdentifiedWorkWith(
           canonicalId = "6",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/v2/ApiV2WorksTest.scala
@@ -313,32 +313,32 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         val work1Archive1Depth1 = createIdentifiedWorkWith(
           canonicalId = "work1Archive1Depth1",
           collectionPath =
-            Some(CollectionPath("archive1", CollectionLevel.Collection))
+            Some(CollectionPath("archive1", Some(CollectionLevel.Collection)))
         )
         val work2Archive1Depth2 = createIdentifiedWorkWith(
           canonicalId = "work2Archive1Depth2",
           collectionPath =
-            Some(CollectionPath("archive1/depth2", CollectionLevel.Series))
+            Some(CollectionPath("archive1/depth2", Some(CollectionLevel.Series)))
         )
         val work3Archive1Depth3 = createIdentifiedWorkWith(
           canonicalId = "work3Archive1Depth3",
           collectionPath =
-            Some(CollectionPath("archive1/depth2/depth3", CollectionLevel.Item))
+            Some(CollectionPath("archive1/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work4Archive2Depth1 = createIdentifiedWorkWith(
           canonicalId = "work4Archive2Depth1",
           collectionPath =
-            Some(CollectionPath("archive2", CollectionLevel.Collection))
+            Some(CollectionPath("archive2", Some(CollectionLevel.Collection)))
         )
         val work5Archive2Depth2 = createIdentifiedWorkWith(
           canonicalId = "work5Archive2Depth2",
           collectionPath =
-            Some(CollectionPath("archive2/depth2", CollectionLevel.Series))
+            Some(CollectionPath("archive2/depth2", Some(CollectionLevel.Series)))
         )
         val work6Archive2Depth3 = createIdentifiedWorkWith(
           canonicalId = "work6Archive2Depth3",
           collectionPath =
-            Some(CollectionPath("archive2/depth2/depth3", CollectionLevel.Item))
+            Some(CollectionPath("archive2/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work7Archiveless = createIdentifiedWorkWith(
           canonicalId = "work7Archiveless",
@@ -406,27 +406,27 @@ class ApiV2WorksTest extends ApiV2WorksTestBase {
         val work1Depth1 = createIdentifiedWorkWith(
           canonicalId = "1",
           collectionPath =
-            Some(CollectionPath("/depth1", CollectionLevel.Collection))
+            Some(CollectionPath("/depth1", Some(CollectionLevel.Collection)))
         )
         val work2Depth1 = createIdentifiedWorkWith(
           canonicalId = "2",
           collectionPath =
-            Some(CollectionPath("/depth1", CollectionLevel.Collection))
+            Some(CollectionPath("/depth1", Some(CollectionLevel.Collection)))
         )
         val work3Depth2 = createIdentifiedWorkWith(
           canonicalId = "3",
           collectionPath =
-            Some(CollectionPath("/depth1/depth2", CollectionLevel.Series))
+            Some(CollectionPath("/depth1/depth2", Some(CollectionLevel.Series)))
         )
         val work4Depth3 = createIdentifiedWorkWith(
           canonicalId = "4",
           collectionPath =
-            Some(CollectionPath("/depth1/depth2/depth3", CollectionLevel.Item))
+            Some(CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work5Depth3 = createIdentifiedWorkWith(
           canonicalId = "5",
           collectionPath =
-            Some(CollectionPath("/depth1/depth2/depth3", CollectionLevel.Item))
+            Some(CollectionPath("/depth1/depth2/depth3", Some(CollectionLevel.Item)))
         )
         val work6NoDepth = createIdentifiedWorkWith(
           canonicalId = "6",

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayCollection.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/v2/DisplayCollection.scala
@@ -16,7 +16,7 @@ case class DisplayCollection(
   @Schema(
     description =
       "The work. This only contains a limited set of fields, regardless of the includes."
-  ) work: DisplayWorkV2,
+  ) work: Option[DisplayWorkV2] = None,
   @Schema(
     description =
       "An array containing any children. This value is null when a given node has not been expanded."
@@ -28,7 +28,7 @@ object DisplayCollection {
   def apply(tree: Collection, expandedPaths: List[String]): DisplayCollection =
     DisplayCollection(
       path = DisplayCollectionPath(tree.path),
-      work = DisplayWorkV2(tree.work),
+      work = tree.work.map(DisplayWorkV2(_)),
       children =
         if (isExpanded(tree.path, expandedPaths))
           Some(tree.children.map(DisplayCollection(_, expandedPaths)))
@@ -52,7 +52,7 @@ case class DisplayCollectionPath(
   ) path: String,
   @Schema(
     description = "The level of the node."
-  ) level: String,
+  ) level: Option[String] = None,
   @Schema(
     description = "The label of the collection"
   ) label: Option[String] = None,
@@ -64,7 +64,7 @@ object DisplayCollectionPath {
   def apply(collectionPath: CollectionPath): DisplayCollectionPath =
     DisplayCollectionPath(
       path = collectionPath.path,
-      level = DisplayCollectionLevel(collectionPath.level),
+      level = collectionPath.level.map(DisplayCollectionLevel(_)),
       label = collectionPath.label,
     )
 }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayCollectionTreeTest.scala
@@ -10,7 +10,7 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
 
   def work(path: String, level: CollectionLevel) =
     createIdentifiedWorkWith(
-      collectionPath = Some(CollectionPath(path = path, level = level)))
+      collectionPath = Some(CollectionPath(path = path, level = Some(level))))
 
   it("creates a display tree with a path expanded") {
     val a = work("a", CollectionLevel.Collection)
@@ -19,18 +19,18 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
     val tree = Collection(List(a, b, c)).right.get
     DisplayCollection(tree, List("a/b/c")) shouldBe
       DisplayCollection(
-        path = DisplayCollectionPath("a", "Collection"),
-        work = DisplayWorkV2(a),
+        path = DisplayCollectionPath("a", Some("Collection")),
+        work = Some(DisplayWorkV2(a)),
         children = Some(
           List(
             DisplayCollection(
-              path = DisplayCollectionPath("a/b", "Series"),
-              work = DisplayWorkV2(b),
+              path = DisplayCollectionPath("a/b", Some("Series")),
+              work = Some(DisplayWorkV2(b)),
               children = Some(
                 List(
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/b/c", "Item"),
-                    work = DisplayWorkV2(c),
+                    path = DisplayCollectionPath("a/b/c", Some("Item")),
+                    work = Some(DisplayWorkV2(c)),
                     children = Some(Nil)
                   )
                 )
@@ -47,18 +47,18 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
       collectionPath = Some(
         CollectionPath(
           path = "a/b",
-          level = CollectionLevel.Item,
+          level = Some(CollectionLevel.Item),
           label = Some("!!!"))))
     val tree = Collection(List(a, b)).right.get
     DisplayCollection(tree, List("a")) shouldBe
       DisplayCollection(
-        path = DisplayCollectionPath("a", "Collection"),
-        work = DisplayWorkV2(a),
+        path = DisplayCollectionPath("a", Some("Collection")),
+        work = Some(DisplayWorkV2(a)),
         children = Some(
           List(
             DisplayCollection(
-              path = DisplayCollectionPath("a/b", "Item", Some("!!!")),
-              work = DisplayWorkV2(b),
+              path = DisplayCollectionPath("a/b", Some("Item"), Some("!!!")),
+              work = Some(DisplayWorkV2(b)),
             )
           )
         )
@@ -74,31 +74,31 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
     val tree = Collection(List(a, b, c, d, e)).right.get
     DisplayCollection(tree, List("a/b/c", "a/d/e")) shouldBe
       DisplayCollection(
-        path = DisplayCollectionPath("a", "Collection"),
-        work = DisplayWorkV2(a),
+        path = DisplayCollectionPath("a", Some("Collection")),
+        work = Some(DisplayWorkV2(a)),
         children = Some(
           List(
             DisplayCollection(
-              path = DisplayCollectionPath("a/b", "Series"),
-              work = DisplayWorkV2(b),
+              path = DisplayCollectionPath("a/b", Some("Series")),
+              work = Some(DisplayWorkV2(b)),
               children = Some(
                 List(
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/b/c", "Item"),
-                    work = DisplayWorkV2(c),
+                    path = DisplayCollectionPath("a/b/c", Some("Item")),
+                    work = Some(DisplayWorkV2(c)),
                     children = Some(Nil)
                   )
                 )
               )
             ),
             DisplayCollection(
-              path = DisplayCollectionPath("a/d", "Series"),
-              work = DisplayWorkV2(d),
+              path = DisplayCollectionPath("a/d", Some("Series")),
+              work = Some(DisplayWorkV2(d)),
               children = Some(
                 List(
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/d/e", "Item"),
-                    work = DisplayWorkV2(e),
+                    path = DisplayCollectionPath("a/d/e", Some("Item")),
+                    work = Some(DisplayWorkV2(e)),
                     children = Some(Nil)
                   )
                 )
@@ -118,31 +118,31 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
     val tree = Collection(List(a, b, c, d, e)).right.get
     DisplayCollection(tree, List("a/b/c")) shouldBe
       DisplayCollection(
-        path = DisplayCollectionPath("a", "Collection"),
-        work = DisplayWorkV2(a),
+        path = DisplayCollectionPath("a", Some("Collection")),
+        work = Some(DisplayWorkV2(a)),
         children = Some(
           List(
             DisplayCollection(
-              path = DisplayCollectionPath("a/b", "Series"),
-              work = DisplayWorkV2(b),
+              path = DisplayCollectionPath("a/b", Some("Series")),
+              work = Some(DisplayWorkV2(b)),
               children = Some(
                 List(
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/b/c", "Item"),
-                    work = DisplayWorkV2(c),
+                    path = DisplayCollectionPath("a/b/c", Some("Item")),
+                    work = Some(DisplayWorkV2(c)),
                     children = Some(Nil)
                   ),
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/b/e", "Item"),
-                    work = DisplayWorkV2(e),
+                    path = DisplayCollectionPath("a/b/e", Some("Item")),
+                    work = Some(DisplayWorkV2(e)),
                     children = None
                   ),
                 )
               )
             ),
             DisplayCollection(
-              path = DisplayCollectionPath("a/d", "Item"),
-              work = DisplayWorkV2(d),
+              path = DisplayCollectionPath("a/d", Some("Item")),
+              work = Some(DisplayWorkV2(d)),
               children = None
             )
           )
@@ -159,26 +159,26 @@ class DisplayCollectionTest extends FunSpec with Matchers with WorksGenerators {
     val tree = Collection(List(a, b, c, d, e)).right.get
     DisplayCollection(tree, List("a/b")) shouldBe
       DisplayCollection(
-        path = DisplayCollectionPath("a", "Collection"),
-        work = DisplayWorkV2(a),
+        path = DisplayCollectionPath("a", Some("Collection")),
+        work = Some(DisplayWorkV2(a)),
         children = Some(
           List(
             DisplayCollection(
-              path = DisplayCollectionPath("a/b", "Series"),
-              work = DisplayWorkV2(b),
+              path = DisplayCollectionPath("a/b", Some("Series")),
+              work = Some(DisplayWorkV2(b)),
               children = Some(
                 List(
                   DisplayCollection(
-                    path = DisplayCollectionPath("a/b/c", "Item"),
-                    work = DisplayWorkV2(c),
+                    path = DisplayCollectionPath("a/b/c", Some("Item")),
+                    work = Some(DisplayWorkV2(c)),
                     children = None
                   )
                 )
               )
             ),
             DisplayCollection(
-              path = DisplayCollectionPath("a/d", "Series"),
-              work = DisplayWorkV2(d),
+              path = DisplayCollectionPath("a/d", Some("Series")),
+              work = Some(DisplayWorkV2(d)),
               children = None
             )
           )

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -114,7 +114,7 @@ class WorksIndexConfigTest
       Some(
         CollectionPath(
           path = "PATH/FOR/THE/COLLECTION",
-          level = CollectionLevel.Item,
+          level = Some(CollectionLevel.Item),
           label = Some("PATH/FOR/THE/COLLECTION")))
 
     withLocalWorksIndex { index =>

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Collection.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Collection.scala
@@ -44,7 +44,11 @@ case class Collection(
   path: CollectionPath,
   work: Option[IdentifiedWork],
   children: List[Collection] = Nil
-)
+) {
+
+  def isRoot: Boolean =
+    path.depth == 1
+}
 
 object Collection {
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Collection.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Collection.scala
@@ -11,7 +11,7 @@ import cats.implicits._
   */
 case class CollectionPath(
   path: String,
-  level: CollectionLevel,
+  level: Option[CollectionLevel] = None,
   label: Option[String] = None,
 ) {
 
@@ -42,19 +42,9 @@ object CollectionLevel {
   */
 case class Collection(
   path: CollectionPath,
-  work: IdentifiedWork,
+  work: Option[IdentifiedWork],
   children: List[Collection] = Nil
-) {
-
-  def size: Int =
-    children.map(_.size).sum + 1
-
-  def pathList: List[String] =
-    path.path :: children.flatMap(_.pathList)
-
-  def isRoot: Boolean =
-    path.depth == 1
-}
+)
 
 object Collection {
 
@@ -62,7 +52,7 @@ object Collection {
     * Create a Collection from a list of works. This errors given the following
     * situations:
     *
-    *   * If the works do not form a fully connected tree
+    *   * If the works are not all connected to the same root
     *   * The given list contains works with duplicate paths.
     *   * There are works which do not contain a Collection
     *   * The list is empty
@@ -71,7 +61,7 @@ object Collection {
     works
       .map { work =>
         work.data.collectionPath match {
-          case Some(path) => Right(path -> work)
+          case Some(_) => Right(work)
           case None =>
             Left(
               new Exception(
@@ -79,16 +69,46 @@ object Collection {
         }
       }
       .toResult
-      .flatMap {
-        case head :: tail => Right(apply(NonEmptyList(head, tail), depth = 1))
-        case Nil          => Left(new Exception("Cannot create empty tree"))
-      }
-      .flatMap { tree =>
-        checkTreeErrors(tree, works).map(Left(_)).getOrElse(Right(tree))
+      .map(getWorkMapping(_))
+      .flatMap { mapping =>
+        checkErrors(works, mapping).map(Left(_)).getOrElse {
+          mapping match {
+            case head :: tail =>
+              Right(apply(NonEmptyList(head, tail), depth = 1))
+            case Nil => Left(new Exception("Cannot create empty tree"))
+          }
+        }
       }
 
-  private def apply(workMapping: NonEmptyList[(CollectionPath, IdentifiedWork)],
-                    depth: Int): Collection =
+  private def getWorkMapping(works: List[IdentifiedWork])
+    : List[(CollectionPath, Option[IdentifiedWork])] = {
+    val partialMapping = works
+      .map(work => work.data.collectionPath.get.path -> work)
+      .toMap
+    partialMapping.keys
+      .flatMap(path => path :: ancestorPaths(path))
+      .toList
+      .sorted
+      .distinct
+      .map { path =>
+        val work = partialMapping.get(path)
+        work
+          .map(_.data.collectionPath.get)
+          .getOrElse(CollectionPath(path)) -> work
+      }
+  }
+
+  private def ancestorPaths(path: String): List[String] =
+    path.split("/").toList match {
+      case parentTokens :+ _ if parentTokens.nonEmpty =>
+        val parent = parentTokens.mkString("/")
+        parent :: ancestorPaths(parent)
+      case _ => Nil
+    }
+
+  private def apply(
+    workMapping: NonEmptyList[(CollectionPath, Option[IdentifiedWork])],
+    depth: Int): Collection =
     workMapping.sortBy { case (path, _) => path.tokens.length } match {
       case NonEmptyList((path, work), tail) =>
         val childDepth = depth + 1
@@ -108,20 +128,22 @@ object Collection {
         )
     }
 
-  private def checkTreeErrors(tree: Collection, works: List[IdentifiedWork]) = {
-    val pathList = tree.pathList
-    if (pathList.length < works.length) {
-      val unconnected =
-        works.map(_.data.collectionPath.get.path).filterNot(pathList.toSet)
-      Some(new Exception(
-        s"Not all works in collection are connected to root '${tree.path.path}': ${unconnected
-          .mkString(",")}"))
-    } else if (pathList.length > pathList.toSet.size) {
-      val duplicates = pathList.diff(pathList.distinct).distinct
+  private def checkErrors(
+    works: List[IdentifiedWork],
+    mapping: List[(CollectionPath, Option[IdentifiedWork])]) = {
+    val rootPaths = mapping.map { case (path, _) => path.tokens.head }.distinct
+    val workPaths = works.map(_.data.collectionPath.get.path)
+    val duplicates = workPaths.diff(workPaths.distinct).distinct
+    if (rootPaths.length > 1) {
+      Some(
+        new Exception(
+          s"Multiple root paths not permitted: ${rootPaths.mkString(", ")}"))
+    } else if (duplicates.nonEmpty) {
       Some(
         new Exception(
           s"Tree contains duplicate paths: ${duplicates.mkString(",")}"))
-    } else
+    } else {
       None
+    }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -346,7 +346,8 @@ class PlatformMergerTest
     val calmWork = createUnidentifiedCalmWork(
       data = WorkData(
         title = Some("123"),
-        collectionPath = Some(CollectionPath("ref/no", CollectionLevel.Item)),
+        collectionPath =
+          Some(CollectionPath("ref/no", Some(CollectionLevel.Item))),
         physicalDescription = Some("description"),
         contributors = List(Contributor(Agent("agent"), Nil)),
         subjects = List(Subject("subject", Nil)),

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -106,7 +106,7 @@ object CalmTransformer extends Transformer[CalmRecord] with CalmOps {
         Right(
           CollectionPath(
             path = path,
-            level = level,
+            level = Some(level),
             label = record.get("AltRefNo"))
         )
       }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -29,7 +29,7 @@ class CalmTransformerTest extends FunSpec with Matchers {
           collectionPath = Some(
             CollectionPath(
               path = "a/b/c",
-              level = CollectionLevel.Collection,
+              level = Some(CollectionLevel.Collection),
               label = Some("a.b.c")
             )
           ),
@@ -246,7 +246,9 @@ class CalmTransformerTest extends FunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
     )
-    CalmTransformer(record, version).right.get.data.collectionPath.get.level shouldBe CollectionLevel.Series
+    CalmTransformer(record, version).right.get.data.collectionPath.get.level shouldBe Some(
+      CollectionLevel.Series
+    )
   }
 
   it("errors if invalid access status") {


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4433

## Description

Currently when we fetch a work which is part of a collection, the collection won't be returned if any of it's ancestors in the tree are missing for any reason (such as transformer errors meaning the associated work has not been ingested).

This updates `Collection` so that the `work` field is optional, and in the case where works are not found in the index we set this to `None`.