### PR TITLE
Feature inferrer CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,12 +126,14 @@ install:
   # See https://github.com/travis-ci/travis-ci/issues/6534
   - sudo sysctl -w vm.max_map_count=262144
 
-language: sh
 
 services:
   - docker
 
-dist: trusty
+dist: bionic
+
+language: python
+python: "3.7"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,10 @@ jobs:
       script: ./.travis/run_job.py mets_adapter
     - name: calm_adapter
       script: ./.travis/run_job.py calm_adapter
-    - name: inference_manager
-      script: ./.travis/run_job.py inference_manager
+    - name: inferrer
+      script: |
+        ./.travis/run_job.py inference_manager
+        ./.travis/run_job.py feature_inferrer --changes-in pipeline/inferrer/feature_inferrer
     - name: snapshot_generator
       script: ./.travis/run_job.py snapshot_generator
     - name: lambda-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ jobs:
     - name: calm_adapter
       script: ./.travis/run_job.py calm_adapter
     - name: inferrer
-      script: |
-        ./.travis/run_job.py inference_manager
-        ./.travis/run_job.py feature_inferrer --changes-in pipeline/inferrer/feature_inferrer
+      script:
+        - ./.travis/run_job.py inference_manager
+        - ./.travis/run_job.py feature_inferrer --changes-in pipeline/inferrer/feature_inferrer
     - name: snapshot_generator
       script: ./.travis/run_job.py snapshot_generator
     - name: lambda-test

--- a/.travis/git_utils.py
+++ b/.travis/git_utils.py
@@ -14,7 +14,7 @@ def git(*args):
         sys.exit(err.returncode)
 
 
-def get_changed_paths(*args, globs=[]):
+def get_changed_paths(*args, globs=None):
     """
     Returns a set of changed paths in a given commit range.
 

--- a/.travis/git_utils.py
+++ b/.travis/git_utils.py
@@ -14,16 +14,15 @@ def git(*args):
         sys.exit(err.returncode)
 
 
-# Root of the Git repository
-ROOT = git("rev-parse", "--show-toplevel")
-
-
-def get_changed_paths(*args):
+def get_changed_paths(*args, globs=[]):
     """
     Returns a set of changed paths in a given commit range.
 
-    :param commit_range: Arguments to pass to ``git diff``.
+    :param args: Arguments to pass to ``git diff``.
+    :param globs: List of file globs to include in changed paths.
     """
+    if globs:
+        args = list(args) + ["--", *globs]
     diff_output = git("diff", "--name-only", *args)
 
     return set([line.strip() for line in diff_output.splitlines()])

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     travis_commit_range = os.environ["TRAVIS_COMMIT_RANGE"]
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("project_name", default=os.environ["SBT_PROJECT"])
+    parser.add_argument("project_name", default=os.environ.get("SBT_PROJECT"))
     parser.add_argument("--changes-in", nargs="*")
     args = parser.parse_args()
 

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -90,12 +90,13 @@ if __name__ == "__main__":
 
         task = f"{args.project_name}-test"
 
+        change_globs = args.changes_in + [".travis.yml"] if args.changes_in else None
         if travis_event_type == "pull_request":
-            changed_paths = get_changed_paths("HEAD", "master", globs=args.changes_in)
+            changed_paths = get_changed_paths("HEAD", "master", globs=change_globs)
         else:
             git("fetch", "origin")
             changed_paths = get_changed_paths(
-                travis_commit_range, globs=args.changes_in
+                travis_commit_range, globs=change_globs
             )
 
         sbt_repo = Repository(".sbt_metadata")

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -90,7 +90,11 @@ if __name__ == "__main__":
 
         task = f"{args.project_name}-test"
 
-        change_globs = args.changes_in + [".travis.yml"] if args.changes_in else None
+        if args.changes_in:
+            change_globs = args.changes_in + [".travis.yml"]
+        else:
+            change_globs = None
+
         if travis_event_type == "pull_request":
             changed_paths = get_changed_paths("HEAD", "master", globs=change_globs)
         else:

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -79,15 +79,15 @@ if __name__ == "__main__":
     travis_build_stage = os.environ["TRAVIS_BUILD_STAGE_NAME"]
     travis_commit_range = os.environ["TRAVIS_COMMIT_RANGE"]
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("project_name", default=os.environ.get("SBT_PROJECT"))
-    parser.add_argument("--changes-in", nargs="*")
-    args = parser.parse_args()
-
     try:
         # If it's not an sbt task, we always run it no matter what.
         task = os.environ["TASK"]
     except KeyError:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("project_name", default=os.environ.get("SBT_PROJECT"))
+        parser.add_argument("--changes-in", nargs="*")
+        args = parser.parse_args()
+
         task = f"{args.project_name}-test"
 
         if travis_event_type == "pull_request":

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -95,9 +95,7 @@ if __name__ == "__main__":
             changed_paths = get_changed_paths("HEAD", "master", globs=change_globs)
         else:
             git("fetch", "origin")
-            changed_paths = get_changed_paths(
-                travis_commit_range, globs=change_globs
-            )
+            changed_paths = get_changed_paths(travis_commit_range, globs=change_globs)
 
         sbt_repo = Repository(".sbt_metadata")
         try:

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -94,16 +94,22 @@ if __name__ == "__main__":
             changed_paths = get_changed_paths("HEAD", "master", globs=args.changes_in)
         else:
             git("fetch", "origin")
-            changed_paths = get_changed_paths(travis_commit_range, globs=args.changes_in)
+            changed_paths = get_changed_paths(
+                travis_commit_range, globs=args.changes_in
+            )
 
         sbt_repo = Repository(".sbt_metadata")
         try:
             if not should_run_sbt_project(sbt_repo, args.project_name, changed_paths):
-                print(f"Nothing in this patch affects {args.project_name}, so skipping tests")
+                print(
+                    f"Nothing in this patch affects {args.project_name}, so skipping tests"
+                )
                 sys.exit(0)
         except KeyError:
             if args.changes_in and not changed_paths:
-                print(f"Nothing in this patch affects the files {args.changes_in}, so skipping tests")
+                print(
+                    f"Nothing in this patch affects the files {args.changes_in}, so skipping tests"
+                )
                 sys.exit(0)
 
     make(task)

--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
                     f"Nothing in this patch affects {args.project_name}, so skipping tests"
                 )
                 sys.exit(0)
-        except KeyError:
+        except (FileNotFoundError, KeyError):
             if args.changes_in and not changed_paths:
                 print(
                     f"Nothing in this patch affects the files {args.changes_in}, so skipping tests"

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,8 @@ lazy val ingestor_works = setupProject(
 lazy val ingestor_images = setupProject(
   project,
   "pipeline/ingestor/ingestor_images",
-  localDependencies = Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common),
+  localDependencies =
+    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common),
   externalDependencies = Seq()
 )
 

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -264,8 +264,10 @@ define __python_ssm_target
 $(1)-build:
 	$(call build_image,$(1),$(2))
 
+ifneq ($(TEST_OVERRIDE), $(1))
 $(1)-test:
 	$(call test_python,$(STACK_ROOT)/$(1))
+endif
 
 $(1)-publish: $(1)-build
 	$(call publish_service_ssm,$(1),$(3),$(4),$(5))

--- a/pipeline/inferrer/Makefile
+++ b/pipeline/inferrer/Makefile
@@ -18,4 +18,16 @@ TF_PATH =
 
 inference_manager-test: feature_inferrer-build
 
+inference_manager-integration-only:
+	$(ROOT)/docker_run.py --dind --sbt --root -- \
+		--net host \
+		wellcome/sbt_wrapper \
+		"project inference_manager" ";dockerComposeUp;testOnly **.integration.*;dockerComposeStop"
+
+TEST_OVERRIDE = feature_inferrer
+feature_inferrer-test: feature_inferrer-build
+	$(ROOT)/docker_run.py --dind -- feature_inferrer \
+		python -m compileall /app
+	$(MAKE) inference_manager-integration-only
+
 $(val $(call stack_setup))


### PR DESCRIPTION
Things this does:

- Runs inference manager integration test for changes in manager *or* inferrer
- Publishes the inferrer when necessary
- "tests" the inferrer by checking that it compiles
- Adds the ability to define a custom test command for Python projects
- Adds the ability to watch changes matching a glob for certain Makefile recipes
- Upgrades the travis build scripts/environment to Python 3
- Upgrades the travis build VM to the latest (until Thursday 🙃) Ubuntu LTS

Tests are broken because they are in master - will rebase when that's fixed.