### PR TITLE
Patch/split miro mets merging

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -12,8 +12,11 @@ import cats.data.NonEmptyList
 /**
   * Items are merged as follows
   *
-  * Miro and METS item locations merged onto Sierra with single item
-  * METS item added to Sierra with multiple items
+  * * Sierra - Single items
+  *   * METS works
+  *   * Miro works
+  * * Sierra - Multi item
+  *   * METS works
   */
 object ItemsRule extends FieldMergeRule with MergerLogging {
   type FieldData = List[Item[Unminted]]

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -55,6 +55,19 @@ class ItemsRuleTest
     }
   }
 
+  it(
+    "override Miro merging with METS merging into single-item Sierra works item") {
+    inside(ItemsRule.merge(physicalSierra, List(miroWork, metsWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 1
+        items.head.locations shouldBe
+          physicalSierra.data.items.head.locations ++
+            metsWork.data.items.head.locations
+
+        mergedSources should contain theSameElementsAs (Seq(metsWork, miroWork))
+    }
+  }
+
   // Sierra multi items
   it("doesn't merge Miro works into multi-item Sierra works") {
     inside(ItemsRule.merge(multiItemPhysicalSierra, List(miroWork))) {


### PR DESCRIPTION
Moving the logic up to the `merge` function simplifying the Partial rules.