### PR TITLE
Patch/simplify work predicates

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/CalmRules.scala
@@ -31,7 +31,8 @@ trait UseCalmWhenExistsRule extends FieldMergeRule with MergerLogging {
   val calmRule =
     new PartialRule {
       val isDefinedForTarget: WorkPredicate = WorkPredicates.sierraWork
-      val isDefinedForSource: WorkPredicate = WorkPredicates.calmWork
+      val isDefinedForSource: WorkPredicate =
+        WorkPredicates.singlePhysicalItemCalmWork
 
       def rule(sierraWork: UnidentifiedWork,
                calmWorks: NonEmptyList[TransformedBaseWork]): FieldData =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -40,7 +40,7 @@ object ImagesRule extends FieldMergeRule {
 
   private lazy val getSingleMiroImage
     : PartialFunction[UnidentifiedWork, FieldData] = {
-    case target if WorkPredicates.miroWork(target) =>
+    case target if WorkPredicates.singleDigitalItemMiroWork(target) =>
       target.data.images.map {
         _.mergeWith(
           parentWork = Identifiable(target.sourceIdentifier),
@@ -52,13 +52,14 @@ object ImagesRule extends FieldMergeRule {
   private lazy val getPictureImages = new FlatImageMergeRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.sierraPicture
     val isDefinedForSource
-      : WorkPredicate = WorkPredicates.metsWork or WorkPredicates.miroWork
+      : WorkPredicate = WorkPredicates.singleDigitalItemMetsWork or WorkPredicates.singleDigitalItemMiroWork
   }
 
   private lazy val getPairedMiroImages = new FlatImageMergeRule {
     val isDefinedForTarget: WorkPredicate =
       WorkPredicates.sierraWork and not(WorkPredicates.sierraPicture)
-    val isDefinedForSource: WorkPredicate = WorkPredicates.miroWork
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singleDigitalItemMiroWork
   }
 
   trait FlatImageMergeRule extends PartialRule {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -33,8 +33,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
 
     val items =
       mergeIntoCalmTarget(target, sources)
-        .orElse(mergeMetsIntoSingleItemSierraTarget(target, sources).orElse(
-          mergeMiroIntoSingleItemSierraTarget(target, sources)))
+        .orElse(mergeMetsIntoSingleItemSierraTarget(target, sources)
+          .orElse(mergeMiroIntoSingleItemSierraTarget(target, sources)))
         .orElse(mergeIntoMultiItemSierraTarget(target, sources))
         .getOrElse(target.data.items)
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -69,7 +69,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     */
   private val mergeMetsIntoSingleItemSierraTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
-    val isDefinedForSource: WorkPredicate = WorkPredicates.metsWork
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singleDigitalItemMetsWork
 
     def rule(target: UnidentifiedWork,
              sources: NonEmptyList[TransformedBaseWork]): FieldData = {
@@ -91,7 +92,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     */
   private val mergeMiroIntoSingleItemSierraTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
-    val isDefinedForSource: WorkPredicate = WorkPredicates.miroWork
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singleDigitalItemMiroWork
 
     def rule(target: UnidentifiedWork,
              sources: NonEmptyList[TransformedBaseWork]): FieldData = {
@@ -119,7 +121,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     */
   private val mergeIntoMultiItemSierraTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.multiItemSierra
-    val isDefinedForSource: WorkPredicate = WorkPredicates.metsWork
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singleDigitalItemMetsWork
 
     def rule(target: UnidentifiedWork,
              sources: NonEmptyList[TransformedBaseWork]): FieldData =
@@ -134,17 +137,18 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * We merge that into the Calm item.
     */
   private val mergeIntoCalmTarget = new PartialRule {
-    val isDefinedForTarget: WorkPredicate = WorkPredicates.calmWork
+    val isDefinedForTarget: WorkPredicate =
+      WorkPredicates.singlePhysicalItemCalmWork
     val isDefinedForSource
-      : WorkPredicate = WorkPredicates.metsWork or WorkPredicates.sierraWork
+      : WorkPredicate = WorkPredicates.singleDigitalItemMetsWork or WorkPredicates.sierraWork
 
     def rule(target: UnidentifiedWork,
              sources: NonEmptyList[TransformedBaseWork]): FieldData = {
 
-      // The calmWork predicate ensures this is safe
+      // The calm Work predicate ensures this is safe
       val calmItem = target.data.items.head
 
-      val metsSources = sources.filter(WorkPredicates.metsWork)
+      val metsSources = sources.filter(WorkPredicates.singleDigitalItemMetsWork)
       val metsDigitalLocations =
         metsSources.flatMap(_.data.items.flatMap(_.locations))
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -41,7 +41,8 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
 
   private val miroIdsRule = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
-    val isDefinedForSource: WorkPredicate = WorkPredicates.singleItemMiro
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singleDigitalItemMiroWork
 
     override def rule(
       target: UnidentifiedWork,
@@ -67,7 +68,8 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
 
   private val calmIdsRule = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.sierraWork
-    val isDefinedForSource: WorkPredicate = WorkPredicates.calmWork
+    val isDefinedForSource: WorkPredicate =
+      WorkPredicates.singlePhysicalItemCalmWork
 
     override def rule(
       target: UnidentifiedWork,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -37,7 +37,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
     new PartialRule {
       val isDefinedForTarget: WorkPredicate = WorkPredicates.sierraWork
       val isDefinedForSource: WorkPredicate =
-        WorkPredicates.singleItemDigitalMets
+        WorkPredicates.singleDigitalItemMetsWork
 
       def rule(target: UnidentifiedWork,
                sources: NonEmptyList[TransformedBaseWork]): FieldData = {
@@ -49,7 +49,8 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
   private val getMinMiroThumbnail =
     new PartialRule {
       val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
-      val isDefinedForSource: WorkPredicate = WorkPredicates.singleItemMiro
+      val isDefinedForSource: WorkPredicate =
+        WorkPredicates.singleDigitalItemMiroWork
 
       def rule(target: UnidentifiedWork,
                sources: NonEmptyList[TransformedBaseWork]): FieldData = {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
@@ -41,19 +41,19 @@ class WorkPredicatesTest
   }
 
   it("selects METS works") {
-    forAll(works.filter(WorkPredicates.metsWork)) { work =>
+    forAll(works.filter(WorkPredicates.singleDigitalItemMetsWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "mets"
     }
   }
 
   it("selects Miro works") {
-    forAll(works.filter(WorkPredicates.miroWork)) { work =>
+    forAll(works.filter(WorkPredicates.singleDigitalItemMiroWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "miro-image-number"
     }
   }
 
   it("selects single-item digital METS works") {
-    forAll(works.filter(WorkPredicates.singleItemDigitalMets)) { work =>
+    forAll(works.filter(WorkPredicates.singleDigitalItemMetsWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "mets"
       work.data.items should have length 1
       every(work.data.items.head.locations) should matchPattern {
@@ -63,7 +63,7 @@ class WorkPredicatesTest
   }
 
   it("selects single-item Miro works") {
-    forAll(works.filter(WorkPredicates.singleItemMiro)) { work =>
+    forAll(works.filter(WorkPredicates.singleDigitalItemMiroWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "miro-image-number"
       work.data.items should have length 1
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
@@ -40,32 +40,19 @@ class WorkPredicatesTest
     }
   }
 
-  it("selects METS works") {
+  it("selects singleDigitalItemMetsWork works") {
     forAll(works.filter(WorkPredicates.singleDigitalItemMetsWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "mets"
+      work.data.items should have size 1
+      work.data.items.head.locations.head shouldBe a[DigitalLocation]
     }
   }
 
-  it("selects Miro works") {
+  it("selects singleDigitalItemMiroWork works") {
     forAll(works.filter(WorkPredicates.singleDigitalItemMiroWork)) { work =>
       work.sourceIdentifier.identifierType.id shouldBe "miro-image-number"
-    }
-  }
-
-  it("selects single-item digital METS works") {
-    forAll(works.filter(WorkPredicates.singleDigitalItemMetsWork)) { work =>
-      work.sourceIdentifier.identifierType.id shouldBe "mets"
-      work.data.items should have length 1
-      every(work.data.items.head.locations) should matchPattern {
-        case _: DigitalLocation =>
-      }
-    }
-  }
-
-  it("selects single-item Miro works") {
-    forAll(works.filter(WorkPredicates.singleDigitalItemMiroWork)) { work =>
-      work.sourceIdentifier.identifierType.id shouldBe "miro-image-number"
-      work.data.items should have length 1
+      work.data.items should have size 1
+      work.data.items.head.locations.head shouldBe a[DigitalLocation]
     }
   }
 


### PR DESCRIPTION
We had separate predicates for `miro`, `singleItemMiro` etc.

☝️ That logic isn't significant to the merging logic, it was just saying "When it's from this source". I have been more specific so future people 🛰️ coming to this code, specifically from the land of transformers might easily figure out that we merge a specific shape of work coming from said transformer land.

TODO
- [x] Update tests