### PR TITLE
Activate (and fix) the inferrer

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -35,7 +35,9 @@ trait ImageGenerators extends IdentifiersGenerators with ItemsGenerators {
   def createInferredData = {
     val features1 = (0 until 2048).map(_ => Random.nextFloat() * 100).toList
     val features2 = (0 until 2048).map(_ => Random.nextFloat() * 100).toList
-    Some(InferredData(features1, features2, List(randomAlphanumeric(10))))
+    val lshEncodedFeatures =
+      (0 until 256).map(_ => randomAlphanumeric(3)).toList
+    Some(InferredData(features1, features2, lshEncodedFeatures))
   }
 
   def createAugmentedImage(

--- a/pipeline/inferrer/feature_inferrer/Dockerfile
+++ b/pipeline/inferrer/feature_inferrer/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get -y install gcc g++ libffi-dev
+RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/pipeline/inferrer/feature_inferrer/prestart.py
+++ b/pipeline/inferrer/feature_inferrer/prestart.py
@@ -14,7 +14,7 @@ try:
     download_object_from_s3(
         bucket_name=bucket,
         object_key=key,
-        file_name=os.path.join("data", os.path.basename(key)),
+        file_name=os.path.join("app/data", os.path.basename(key)),
     )
     logger.info("Fetched pretrained LSHEncoder model")
 except KeyError:

--- a/pipeline/inferrer/inference_manager/src/main/resources/application.conf
+++ b/pipeline/inferrer/inference_manager/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 akka.http.host-connection-pool {
     max-connections=16
-    max-open-requests=32
+    max-open-requests=16
 }
 inferrer.host=${?inferrer_host}
 inferrer.port=${?inferrer_port}

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferrerAdapter.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.inference_manager.services
 
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util.Base64
 
 import akka.http.scaladsl.model._
@@ -95,7 +95,11 @@ object FeatureVectorInferrerAdapter
     }
 
   private def decodeBase64ToFloatList(base64str: String): List[Float] = {
-    val buf = ByteBuffer.wrap(Base64.getDecoder.decode(base64str))
+    // The JVM is big-endian whereas Python has encoded this with
+    // little-endian ordering, so we need to manually set the order
+    val buf = ByteBuffer
+      .wrap(Base64.getDecoder.decode(base64str))
+      .order(ByteOrder.LITTLE_ENDIAN)
     Stream
       .continually(Try(buf.getFloat))
       .takeWhile(_.isSuccess)

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/Encoding.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/Encoding.scala
@@ -1,11 +1,13 @@
 package uk.ac.wellcome.platform.inference_manager.fixtures
 
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util.Base64
 
 object Encoding {
-  def toBase64(floats: List[Float]): String = {
-    val bytes = ByteBuffer.allocate(4 * floats.size)
+  def toLittleEndianBase64(floats: List[Float]): String = {
+    val bytes = ByteBuffer
+      .allocate(4 * floats.size)
+      .order(ByteOrder.LITTLE_ENDIAN)
     floats.foreach { bytes.putFloat }
     Base64.getEncoder.encodeToString(bytes.array())
   }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferrerWiremock.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferrerWiremock.scala
@@ -37,7 +37,8 @@ object FeatureVectorInferrerMock extends InferrerStubs {
           .withStatus(200)
           .withHeader("Content-Type", "application/json")
           .withBody(s"""{
-          |  "features_b64": "${Encoding.toBase64(randomFeatureVector)}",
+          |  "features_b64": "${Encoding.toLittleEndianBase64(
+                         randomFeatureVector)}",
           |  "lsh_encoded_features": [${randomLshVector
                          .map(str => s""""${str}"""")
                          .mkString(", ")}]

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.inference_manager.integration
 
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.{FunSpec, Inside, Matchers, OptionValues}
+import org.scalatest.{FunSpec, Inside, Inspectors, Matchers, OptionValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
@@ -26,6 +26,7 @@ class ManagerInferrerIntegrationTest
     with ImageGenerators
     with OptionValues
     with Inside
+    with Inspectors
     with IntegrationPatience
     with InferenceManagerWorkerServiceFixture[
       MergedImage[Identified],
@@ -58,6 +59,7 @@ class ManagerInferrerIntegrationTest
                 case InferredData(features1, features2, lshEncodedFeatures) =>
                   features1 should have length 2048
                   features2 should have length 2048
+                  forAll(features1 ++ features2) { _.isNaN shouldBe false }
                   every(lshEncodedFeatures) should fullyMatch regex """(\d+)-(\d+)"""
               }
           }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/FeatureVectorInferrerAdapterTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/FeatureVectorInferrerAdapterTest.scala
@@ -51,7 +51,7 @@ class FeatureVectorInferrerAdapterTest
     it("creates an AugmentedImage with the data from the inferrer response") {
       val image = createMergedImage.toIdentified
       val features = (0 until 4096).map(_ / 4096f).toList
-      val featuresB64 = Encoding.toBase64(features)
+      val featuresB64 = Encoding.toLittleEndianBase64(features)
       val lshEncodedFeatures = ('a' to 'z').map(_.toString * 3).toList
       val response = FeatureVectorInferrerResponse(
         features_b64 = featuresB64,

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -1,11 +1,7 @@
 module "image_inferrer_queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name = "${local.namespace_hyphen}_image_inferrer"
-
-  // TODO: Re-attach this when the inferrer is ready for large workloads
-  //  topic_arns      = [module.image_id_minter_topic.arn]
-  topic_arns = []
-
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  queue_name      = "${local.namespace_hyphen}_image_inferrer"
+  topic_arns      = [module.image_id_minter_topic.arn]
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 }

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -1,16 +1,21 @@
-module "image_inferrer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_image_inferrer"
-  topic_arns      = [module.image_id_minter_topic.arn]
-  aws_region      = var.aws_region
-  alarm_topic_arn = var.dlq_alarm_arn
-}
-
 locals {
   inferrer_host                  = "localhost"
   inferrer_port                  = 80
   inferrer_model_key_config_name = "lsh_model"
   logstash_port                  = 514
+  //  High inferrer throughput comes at the cost of the latency distribution
+  // having heavy tails - this stops some unfortunate messages from being
+  // put on the DLQ when they are consumed but not processed.
+  queue_visibility_timeout = 60
+}
+
+module "image_inferrer_queue" {
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  queue_name                 = "${local.namespace_hyphen}_image_inferrer"
+  topic_arns                 = [module.image_id_minter_topic.arn]
+  aws_region                 = var.aws_region
+  alarm_topic_arn            = var.dlq_alarm_arn
+  visibility_timeout_seconds = local.queue_visibility_timeout
 }
 
 module "image_inferrer" {

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -1,7 +1,7 @@
 module "ingestor_images_queue" {
   source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name      = "${local.namespace_hyphen}_ingestor_images"
-  topic_arns      = [module.image_id_minter_topic.arn]
+  topic_arns      = [module.image_inferrer_topic.arn]
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 }


### PR DESCRIPTION
This slots the inference services between the image minter and the ingestor, and fixes a few outstanding bugs that I hadn't caught before.