### PR TITLE
Split up Router

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.platform.api
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
-import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.{
   Directives,
   MalformedQueryParamRejection,
@@ -11,35 +9,17 @@ import akka.http.scaladsl.server.{
   Route,
   ValidationRejection
 }
-import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
-import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
-import io.circe.Printer
-import grizzled.slf4j.Logger
-
-import uk.ac.wellcome.platform.api.services.{
-  CollectionService,
-  ElasticsearchService,
-  WorksService
-}
+import com.sksamuel.elastic4s.ElasticClient
 import uk.ac.wellcome.elasticsearch.ElasticConfig
-import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
 import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
-import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.display.models.v2._
-import uk.ac.wellcome.display.models.Implicits._
-import uk.ac.wellcome.display.json.DisplayJsonUtil
+import uk.ac.wellcome.platform.api.rest.{CustomDirectives, WorksController}
 
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,
-             apiConfig: ApiConfig)(implicit ec: ExecutionContext)
-    extends FailFastCirceSupport
-    with Directives
-    with Tracing {
-
-  import MultipleWorksResponse.encoder
-  import ResultResponse.encoder
+             implicit val apiConfig: ApiConfig)(implicit ec: ExecutionContext)
+    extends Directives
+    with CustomDirectives {
 
   def routes: Route = handleRejections(rejectionHandler) {
     ignoreTrailingSlash {
@@ -48,14 +28,10 @@ class Router(elasticClient: ElasticClient,
           pathPrefix("v2") {
             concat(
               path("works") {
-                MultipleWorksParams.parse { params =>
-                  getWithFuture(multipleWorks(params))
-                }
+                MultipleWorksParams.parse { worksController.multipleWorks }
               },
-              path("works" / Segment) { workId =>
-                SingleWorkParams.parse { params =>
-                  getWithFuture(singleWork(workId, params))
-                }
+              path("works" / Segment) { workId: String =>
+                SingleWorkParams.parse { worksController.singleWork(workId, _) }
               },
               path("context.json") {
                 getFromResource("context-v2.json")
@@ -66,7 +42,12 @@ class Router(elasticClient: ElasticClient,
             )
           },
           path("v1" / Remaining) { _ =>
-            v1ApiGone
+            gone(
+              """"
+                |This API is now decommissioned.
+                |Please use https://api.wellcomecollection.org/catalogue/v2/works.
+              """.stripMargin.replace('\n', ' ')
+            )
           },
           pathPrefix("management") {
             concat(
@@ -85,126 +66,16 @@ class Router(elasticClient: ElasticClient,
     }
   }
 
-  def multipleWorks(params: MultipleWorksParams): Future[Route] =
-    transactFuture("GET /works") {
-      val searchOptions = params.searchOptions(apiConfig)
-      val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
-      worksService
-        .listOrSearchWorks(index, searchOptions)
-        .map {
-          case Left(err) => elasticError(err)
-          case Right(resultList) =>
-            extractPublicUri { uri =>
-              complete(
-                MultipleWorksResponse(
-                  resultList,
-                  searchOptions,
-                  params.include.getOrElse(V2WorksIncludes()),
-                  uri,
-                  contextUri
-                )
-              )
-            }
-        }
-    }
+  lazy val worksController =
+    new WorksController(elasticClient, apiConfig, elasticConfig)
 
-  def singleWork(id: String, params: SingleWorkParams): Future[Route] =
-    transactFuture("GET /works/{workId}") {
-      val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
-      val includes = params.include.getOrElse(V2WorksIncludes())
-      worksService
-        .findWorkById(id)(index)
-        .flatMap {
-          case Right(Some(work: IdentifiedWork)) =>
-            if (includes.collection) {
-              val expandedPaths = params._expandPaths.getOrElse(Nil)
-              retrieveTree(index, work, expandedPaths).map {
-                workFound(work, _, includes)
-              }
-            } else
-              Future.successful(workFound(work, None, includes))
-          case Right(Some(work: IdentifiedRedirectedWork)) =>
-            Future.successful(workRedirect(work))
-          case Right(Some(_)) => Future.successful(workGone)
-          case Right(None)    => Future.successful(workNotFound(id))
-          case Left(err)      => Future.successful(elasticError(err))
-        }
-    }
-
-  def workFound(work: IdentifiedWork,
-                tree: Option[(Collection, List[String])],
-                includes: V2WorksIncludes): Route =
+  def swagger: Route = get {
     complete(
-      ResultResponse(
-        context = contextUri,
-        result = DisplayWorkV2(work, includes).copy(
-          collection = tree.map {
-            case (tree, expandedPaths) =>
-              DisplayCollection(tree, expandedPaths)
-          }
-        )
-      )
-    )
-
-  def workRedirect(work: IdentifiedRedirectedWork): Route =
-    extractPublicUri { uri =>
-      val newPath = (work.redirect.canonicalId :: uri.path.reverse.tail).reverse
-      redirect(uri.withPath(newPath), Found)
-    }
-
-  def workGone: Route = error(
-    DisplayError(
-      ErrorVariant.http410,
-      Some("This work has been deleted")
-    )
-  )
-
-  def workNotFound(id: String): Route = error(
-    DisplayError(
-      ErrorVariant.http404,
-      Some(s"Work not found for identifier ${id}")
-    )
-  )
-
-  def v1ApiGone = error(
-    DisplayError(
-      ErrorVariant.http410,
-      Some(
-        """"
-          |This API is now decommissioned.
-          |Please use https://api.wellcomecollection.org/catalogue/v2/works.
-        """.stripMargin.replace('\n', ' ')
-      )
-    )
-  )
-
-  def notFound = extractPublicUri { uri =>
-    error(
-      DisplayError(
-        ErrorVariant.http404,
-        Some(s"Page not found for URL ${uri.path}")
-      )
+      HttpEntity(MediaTypes.`application/json`, swaggerDocs.json)
     )
   }
 
-  def invalidParam(msg: String) = error(
-    DisplayError(ErrorVariant.http400, Some(s"$msg"))
-  )
-
-  def elasticError(err: ElasticError): Route = error(
-    ElasticsearchErrorHandler.buildDisplayError(err)
-  )
-
-  def error(err: DisplayError): Route = {
-    val status = err.httpStatus match {
-      case Some(400) => BadRequest
-      case Some(404) => NotFound
-      case Some(410) => Gone
-      case Some(500) => InternalServerError
-      case _         => InternalServerError
-    }
-    complete(status -> ResultResponse(context = contextUri, result = err))
-  }
+  val swaggerDocs = new SwaggerDocs(apiConfig)
 
   def getClusterHealth: Route = {
     import com.sksamuel.elastic4s.ElasticDsl._
@@ -215,81 +86,16 @@ class Router(elasticClient: ElasticClient,
     }
   }
 
-  def swagger: Route = get {
-    complete(
-      HttpEntity(MediaTypes.`application/json`, swaggerDocs.json)
-    )
-  }
-
   def rejectionHandler =
     RejectionHandler.newBuilder
       .handle {
         case MalformedQueryParamRejection(field, msg, _) =>
-          invalidParam(s"$field: $msg")
+          invalidRequest(s"$field: $msg")
         case ValidationRejection(msg, _) =>
-          invalidParam(s"$msg")
+          invalidRequest(s"$msg")
       }
-      .handleNotFound(notFound)
+      .handleNotFound(extractPublicUri { uri =>
+        notFound(s"Page not found for URL ${uri.path}")
+      })
       .result
-
-  def getWithFuture(future: Future[Route]): Route =
-    get {
-      onComplete(future) {
-        case Success(resp) => resp
-        case Failure(err) =>
-          error(
-            DisplayError(ErrorVariant.http500, Some("Unhandled error."))
-          )
-      }
-    }
-
-  def retrieveTree(
-    index: Index,
-    work: IdentifiedWork,
-    expandedPaths: List[String]): Future[Option[(Collection, List[String])]] =
-    work.data.collectionPath
-      .map {
-        case CollectionPath(path, _, _) =>
-          val allPaths = path :: expandedPaths
-          collectionService.retrieveTree(index, allPaths).map {
-            case Left(err) =>
-              // We just log this here rather than raising so as not to bring down
-              // the work API when tree retrieval fails
-              logger.error("Error retrieving collection tree", err)
-              None
-            case Right(tree) => Some((tree, allPaths))
-          }
-      }
-      .getOrElse(Future.successful(None))
-
-  // Directive for getting public URI of the current request, using the host
-  // and scheme as per the config.
-  // (without this URIs end up looking like https://localhost:8888/..., rather
-  // than https://api.wellcomecollection.org/...))
-  def extractPublicUri =
-    extractUri.map { uri =>
-      uri
-        .withHost(apiConfig.host)
-        // akka-http uses 0 to indicate no explicit port in the URI
-        .withPort(0)
-        .withScheme(apiConfig.scheme)
-    }
-
-  val swaggerDocs = new SwaggerDocs(apiConfig)
-
-  lazy val contextUri =
-    apiConfig match {
-      case ApiConfig(host, scheme, _, pathPrefix, contextSuffix) =>
-        s"$scheme://$host/$pathPrefix/${ApiVersions.v2}/$contextSuffix"
-    }
-
-  lazy val worksService =
-    new WorksService(new ElasticsearchService(elasticClient))
-
-  lazy val collectionService =
-    new CollectionService(elasticClient)
-
-  lazy val logger = Logger(this.getClass.getName)
-
-  implicit val jsonPrinter: Printer = DisplayJsonUtil.printer
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -13,7 +13,7 @@ import com.sksamuel.elastic4s.ElasticClient
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.rest.{CustomDirectives, WorksController}
+import uk.ac.wellcome.platform.api.rest._
 
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api
 import scala.concurrent.ExecutionContext
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import akka.http.scaladsl.server.{
-  Directives,
   MalformedQueryParamRejection,
   RejectionHandler,
   Route,
@@ -18,8 +17,7 @@ import uk.ac.wellcome.platform.api.rest._
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,
              implicit val apiConfig: ApiConfig)(implicit ec: ExecutionContext)
-    extends Directives
-    with CustomDirectives {
+    extends CustomDirectives {
 
   def routes: Route = handleRejections(rejectionHandler) {
     ignoreTrailingSlash {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
@@ -18,7 +18,6 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Printer
 import uk.ac.wellcome.display.json.DisplayJsonUtil
 import uk.ac.wellcome.display.models.ApiVersions
-import uk.ac.wellcome.platform.api.ResultResponse
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
 
 import scala.concurrent.Future

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
@@ -1,0 +1,100 @@
+package uk.ac.wellcome.platform.api.rest
+
+import akka.http.scaladsl.model.StatusCodes.{
+  BadRequest,
+  Gone,
+  InternalServerError,
+  NotFound
+}
+import akka.http.scaladsl.model.Uri
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  DisplayError,
+  ErrorVariant
+}
+import akka.http.scaladsl.server.{Directive, Directives, Route}
+import com.sksamuel.elastic4s.ElasticError
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Printer
+import uk.ac.wellcome.display.json.DisplayJsonUtil
+import uk.ac.wellcome.display.models.ApiVersions
+import uk.ac.wellcome.platform.api.ResultResponse
+import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+trait CustomDirectives extends Directives with FailFastCirceSupport {
+  import ResultResponse.encoder
+
+  implicit val apiConfig: ApiConfig
+
+  // Directive for getting public URI of the current request, using the host
+  // and scheme as per the config.
+  // (without this URIs end up looking like https://localhost:8888/..., rather
+  // than https://api.wellcomecollection.org/...))
+  def extractPublicUri: Directive[Tuple1[Uri]] =
+    extractUri.map { uri =>
+      uri
+        .withHost(apiConfig.host)
+        // akka-http uses 0 to indicate no explicit port in the URI
+        .withPort(0)
+        .withScheme(apiConfig.scheme)
+    }
+
+  def contextUri: String =
+    apiConfig match {
+      case ApiConfig(host, scheme, _, pathPrefix, contextSuffix) =>
+        s"$scheme://$host/$pathPrefix/${ApiVersions.v2}/$contextSuffix"
+    }
+
+  def elasticError(err: ElasticError): Route =
+    error(
+      ElasticsearchErrorHandler.buildDisplayError(err)
+    )
+
+  def gone(message: String): Route = error(
+    DisplayError(
+      ErrorVariant.http410,
+      Some(message)
+    )
+  )
+
+  def notFound(message: String): Route = error(
+    DisplayError(
+      ErrorVariant.http404,
+      Some(message)
+    )
+  )
+
+  def invalidRequest(message: String): Route = error(
+    DisplayError(
+      ErrorVariant.http400,
+      Some(message)
+    )
+  )
+
+  def getWithFuture(future: Future[Route]): Route =
+    get {
+      onComplete(future) {
+        case Success(resp) => resp
+        case Failure(_) =>
+          error(
+            DisplayError(ErrorVariant.http500, Some("Unhandled error."))
+          )
+      }
+    }
+
+  private def error(err: DisplayError): Route = {
+    val status = err.httpStatus match {
+      case Some(400) => BadRequest
+      case Some(404) => NotFound
+      case Some(410) => Gone
+      case Some(500) => InternalServerError
+      case _         => InternalServerError
+    }
+    complete(status -> ResultResponse(context = contextUri, result = err))
+  }
+
+  implicit val jsonPrinter: Printer = DisplayJsonUtil.printer
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
@@ -2,199 +2,12 @@ package uk.ac.wellcome.platform.api.rest
 
 import java.time.LocalDate
 
-import akka.http.scaladsl.server.{Directives, ValidationRejection}
+import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import io.circe.java8.time.TimeInstances
 import io.circe.{Decoder, Json}
-import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.services.WorksSearchOptions
 
-sealed trait QueryParams
-
-case class SingleWorkParams(
-  include: Option[V2WorksIncludes],
-  _expandPaths: Option[List[String]],
-  _index: Option[String],
-) extends QueryParams
-
-object SingleWorkParams extends QueryParamsUtils {
-
-  // This is a custom akka-http directive which extracts SingleWorkParams
-  // data from the query string, returning an invalid response when any given
-  // parameter is not correctly parsed. More info on custom directives is
-  // available here:
-  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
-  def parse =
-    parameter(
-      (
-        "include".as[V2WorksIncludes].?,
-        "_expandPaths".as[List[String]].?,
-        "_index".as[String].?
-      )
-    ).tmap((SingleWorkParams.apply _).tupled(_))
-
-  implicit val decodePaths: Decoder[List[String]] =
-    decodeCommaSeparated
-}
-
-case class MultipleWorksParams(
-  page: Option[Int],
-  pageSize: Option[Int],
-  workType: Option[WorkTypeFilter],
-  `items.locations.locationType`: Option[ItemLocationTypeFilter],
-  `production.dates.from`: Option[LocalDate],
-  `production.dates.to`: Option[LocalDate],
-  language: Option[LanguageFilter],
-  `genres.label`: Option[GenreFilter],
-  `subjects.label`: Option[SubjectFilter],
-  license: Option[LicenseFilter],
-  include: Option[V2WorksIncludes],
-  aggregations: Option[List[AggregationRequest]],
-  sort: Option[List[SortRequest]],
-  sortOrder: Option[SortingOrder],
-  query: Option[String],
-  collection: Option[CollectionPathFilter],
-  `collection.depth`: Option[CollectionDepthFilter],
-  _queryType: Option[SearchQueryType],
-  _index: Option[String],
-) extends QueryParams {
-
-  def searchOptions(apiConfig: ApiConfig): WorksSearchOptions =
-    WorksSearchOptions(
-      searchQuery = query map { query =>
-        SearchQuery(query, _queryType)
-      },
-      filters = filters,
-      pageSize = pageSize.getOrElse(apiConfig.defaultPageSize),
-      pageNumber = page.getOrElse(1),
-      aggregations = aggregations.getOrElse(Nil),
-      sortBy = sort.getOrElse(Nil),
-      sortOrder = sortOrder.getOrElse(SortingOrder.Ascending),
-    )
-
-  def validationErrors: List[String] =
-    List(
-      page
-        .filterNot(_ >= 1)
-        .map(_ => "page: must be greater than 1"),
-      pageSize
-        .filterNot(size => size >= 1 && size <= 100)
-        .map(_ => "pageSize: must be between 1 and 100")
-    ).flatten
-
-  private def filters: List[WorkFilter] =
-    List(
-      workType,
-      `items.locations.locationType`,
-      dateFilter,
-      language,
-      `genres.label`,
-      `subjects.label`,
-      collection,
-      `collection.depth`,
-      license
-    ).flatten
-
-  private def dateFilter: Option[DateRangeFilter] =
-    (`production.dates.from`, `production.dates.to`) match {
-      case (None, None)       => None
-      case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
-    }
-}
-
-object MultipleWorksParams extends QueryParamsUtils {
-
-  // This is a custom akka-http directive which extracts MultipleWorksParams
-  // data from the query string, returning an invalid response when any given
-  // parameter is not correctly parsed. More info on custom directives is
-  // available here:
-  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
-  def parse =
-    parameter(
-      (
-        "page".as[Int].?,
-        "pageSize".as[Int].?,
-        "workType".as[WorkTypeFilter] ?,
-        "items.locations.locationType".as[ItemLocationTypeFilter].?,
-        "production.dates.from".as[LocalDate].?,
-        "production.dates.to".as[LocalDate].?,
-        "language".as[LanguageFilter].?,
-        "genres.label".as[GenreFilter].?,
-        "subjects.label".as[SubjectFilter].?,
-        "license".as[LicenseFilter].?,
-        "include".as[V2WorksIncludes].?,
-        "aggregations".as[List[AggregationRequest]].?,
-        "sort".as[List[SortRequest]].?,
-        "sortOrder".as[SortingOrder].?,
-        "query".as[String].?,
-        "collection".as[CollectionPathFilter].?,
-        "collection.depth".as[CollectionDepthFilter].?,
-        "_queryType".as[SearchQueryType].?,
-        "_index".as[String].?,
-      )
-    ).tflatMap { args =>
-      val params = (MultipleWorksParams.apply _).tupled(args)
-      params.validationErrors match {
-        case Nil => provide(params)
-        case errs =>
-          reject(ValidationRejection(errs.mkString(", ")))
-            .toDirective[Tuple1[MultipleWorksParams]]
-      }
-    }
-
-  implicit val workTypeFilter: Decoder[WorkTypeFilter] =
-    decodeCommaSeparated.emap(strs => Right(WorkTypeFilter(strs)))
-
-  implicit val itemLocationTypeFilter: Decoder[ItemLocationTypeFilter] =
-    decodeCommaSeparated.emap(strs => Right(ItemLocationTypeFilter(strs)))
-
-  implicit val languageFilter: Decoder[LanguageFilter] =
-    decodeCommaSeparated.emap(strs => Right(LanguageFilter(strs)))
-
-  implicit val genreFilter: Decoder[GenreFilter] =
-    Decoder.decodeString.emap(str => Right(GenreFilter(str)))
-
-  implicit val subjectFilter: Decoder[SubjectFilter] =
-    Decoder.decodeString.emap(str => Right(SubjectFilter(str)))
-
-  implicit val licenseFilter: Decoder[LicenseFilter] =
-    decodeCommaSeparated.emap(strs => Right(LicenseFilter(strs)))
-
-  implicit val collectionsPathFilter: Decoder[CollectionPathFilter] =
-    Decoder.decodeString.emap(str => Right(CollectionPathFilter(str)))
-
-  implicit val collectionsDepthFilter: Decoder[CollectionDepthFilter] =
-    decodeInt map CollectionDepthFilter
-
-  implicit val aggregationsDecoder: Decoder[List[AggregationRequest]] =
-    decodeOneOfCommaSeparated(
-      "workType" -> AggregationRequest.WorkType,
-      "genres" -> AggregationRequest.Genre,
-      "production.dates" -> AggregationRequest.ProductionDate,
-      "subjects" -> AggregationRequest.Subject,
-      "language" -> AggregationRequest.Language,
-      "license" -> AggregationRequest.License,
-    )
-
-  implicit val sortDecoder: Decoder[List[SortRequest]] =
-    decodeOneOfCommaSeparated(
-      "production.dates" -> ProductionDateSortRequest
-    )
-
-  implicit val sortOrderDecoder: Decoder[SortingOrder] =
-    decodeOneOf(
-      "asc" -> SortingOrder.Ascending,
-      "desc" -> SortingOrder.Descending,
-    )
-
-  implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
-    decodeOneWithDefaultOf(
-      SearchQueryType.default,
-      "BoolBoosted" -> SearchQueryType.BoolBoosted,
-      "PhraserBeam" -> SearchQueryType.PhraserBeam,
-    )
-}
+trait QueryParams
 
 trait QueryParamsUtils extends Directives with TimeInstances {
 
@@ -206,18 +19,6 @@ trait QueryParamsUtils extends Directives with TimeInstances {
         case Right(value) => value
       }
     }
-
-  implicit val includesDecoder: Decoder[V2WorksIncludes] =
-    decodeOneOfCommaSeparated(
-      "identifiers" -> WorkInclude.Identifiers,
-      "items" -> WorkInclude.Items,
-      "subjects" -> WorkInclude.Subjects,
-      "genres" -> WorkInclude.Genres,
-      "contributors" -> WorkInclude.Contributors,
-      "production" -> WorkInclude.Production,
-      "notes" -> WorkInclude.Notes,
-      "collection" -> WorkInclude.Collection,
-    ).emap(values => Right(V2WorksIncludes(values)))
 
   implicit val decodeLocalDate: Decoder[LocalDate] =
     decodeLocalDateDefault.withErrorMessage(
@@ -259,7 +60,8 @@ trait QueryParamsUtils extends Directives with TimeInstances {
       }
     }
 
-  def invalidValuesMsg(values: List[String], validValues: List[String]) = {
+  def invalidValuesMsg(values: List[String],
+                       validValues: List[String]): String = {
     val oneOfMsg =
       s"Please choose one of: [${validValues.mkString("'", "', '", "'")}]"
     values match {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
@@ -1,15 +1,14 @@
-package uk.ac.wellcome.platform.api
+package uk.ac.wellcome.platform.api.rest
 
 import java.time.LocalDate
 
-import io.circe.Decoder
-import io.circe.java8.time.TimeInstances
 import akka.http.scaladsl.server.{Directives, ValidationRejection}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import io.circe.java8.time.TimeInstances
 import io.circe.{Decoder, Json}
-import uk.ac.wellcome.platform.api.services.WorksSearchOptions
-import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.platform.api.models._
+import uk.ac.wellcome.platform.api.services.WorksSearchOptions
 
 sealed trait QueryParams
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -7,6 +7,7 @@ import io.circe.{Encoder, Json}
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.v2._
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.services.WorksSearchOptions
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -1,17 +1,14 @@
-package uk.ac.wellcome.platform.api
+package uk.ac.wellcome.platform.api.rest
 
-import io.circe.generic.extras.semiauto.deriveEncoder
-import io.circe.generic.extras.JsonKey
-import io.circe.{Encoder, Json}
 import akka.http.scaladsl.model.Uri
+import io.circe.generic.extras.JsonKey
+import io.circe.generic.extras.semiauto.deriveEncoder
+import io.circe.{Encoder, Json}
 import io.swagger.v3.oas.annotations.media.Schema
-
-import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.v2._
-import uk.ac.wellcome.display.models.Implicits._
+import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.services.WorksSearchOptions
-import uk.ac.wellcome.display.json.DisplayJsonUtil._
 
 case class ResultResponse[T: Encoder](
   @JsonKey("@context") context: String,
@@ -53,8 +50,6 @@ case class MultipleWorksResponse(
 )
 
 object MultipleWorksResponse {
-
-  import DisplayAggregations.{encoder => aggsEncoder}
   implicit val encoder: Encoder[MultipleWorksResponse] = deriveEncoder
 
   def apply(resultList: ResultList,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -21,13 +21,7 @@ import uk.ac.wellcome.platform.api.services.{
   ElasticsearchService,
   WorksService
 }
-import uk.ac.wellcome.platform.api.{
-  MultipleWorksParams,
-  MultipleWorksResponse,
-  ResultResponse,
-  SingleWorkParams,
-  Tracing
-}
+import uk.ac.wellcome.platform.api.Tracing
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -1,0 +1,144 @@
+package uk.ac.wellcome.platform.api.rest
+
+import akka.http.scaladsl.model.StatusCodes.Found
+import akka.http.scaladsl.server.Route
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import grizzled.slf4j.Logger
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.display.models.v2._
+import uk.ac.wellcome.display.models.Implicits._
+import uk.ac.wellcome.elasticsearch.ElasticConfig
+import uk.ac.wellcome.models.work.internal.{
+  Collection,
+  CollectionPath,
+  IdentifiedRedirectedWork,
+  IdentifiedWork
+}
+import uk.ac.wellcome.platform.api.models.ApiConfig
+import uk.ac.wellcome.platform.api.services.{
+  CollectionService,
+  ElasticsearchService,
+  WorksService
+}
+import uk.ac.wellcome.platform.api.{
+  MultipleWorksParams,
+  MultipleWorksResponse,
+  ResultResponse,
+  SingleWorkParams,
+  Tracing
+}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WorksController(
+  elasticClient: ElasticClient,
+  implicit val apiConfig: ApiConfig,
+  elasticConfig: ElasticConfig)(implicit ec: ExecutionContext)
+    extends Tracing
+    with CustomDirectives
+    with FailFastCirceSupport {
+  import MultipleWorksResponse.encoder
+  import ResultResponse.encoder
+
+  def multipleWorks(params: MultipleWorksParams): Route =
+    getWithFuture {
+      transactFuture("GET /works") {
+        val searchOptions = params.searchOptions(apiConfig)
+        val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
+        worksService
+          .listOrSearchWorks(index, searchOptions)
+          .map {
+            case Left(err) => elasticError(err)
+            case Right(resultList) =>
+              extractPublicUri { uri =>
+                complete(
+                  MultipleWorksResponse(
+                    resultList,
+                    searchOptions,
+                    params.include.getOrElse(V2WorksIncludes()),
+                    uri,
+                    contextUri
+                  )
+                )
+              }
+          }
+      }
+    }
+
+  def singleWork(id: String, params: SingleWorkParams): Route =
+    getWithFuture {
+      transactFuture("GET /works/{workId}") {
+        val index = params._index.map(Index(_)).getOrElse(elasticConfig.index)
+        val includes = params.include.getOrElse(V2WorksIncludes())
+        worksService
+          .findWorkById(id)(index)
+          .flatMap {
+            case Right(Some(work: IdentifiedWork)) =>
+              if (includes.collection) {
+                val expandedPaths = params._expandPaths.getOrElse(Nil)
+                retrieveTree(index, work, expandedPaths).map {
+                  workFound(work, _, includes)
+                }
+              } else
+                Future.successful(workFound(work, None, includes))
+            case Right(Some(work: IdentifiedRedirectedWork)) =>
+              Future.successful(workRedirect(work))
+            case Right(Some(_)) =>
+              Future.successful(gone("This work has been deleted"))
+            case Right(None) =>
+              Future.successful(
+                notFound(s"Work not found for identifier ${id}"))
+            case Left(err) => Future.successful(elasticError(err))
+          }
+      }
+    }
+
+  private def retrieveTree(
+    index: Index,
+    work: IdentifiedWork,
+    expandedPaths: List[String]): Future[Option[(Collection, List[String])]] =
+    work.data.collectionPath
+      .map {
+        case CollectionPath(path, _, _) =>
+          val allPaths = path :: expandedPaths
+          collectionService.retrieveTree(index, allPaths).map {
+            case Left(err) =>
+              // We just log this here rather than raising so as not to bring down
+              // the work API when tree retrieval fails
+              logger.error("Error retrieving collection tree", err)
+              None
+            case Right(tree) => Some((tree, allPaths))
+          }
+      }
+      .getOrElse(Future.successful(None))
+
+  def workRedirect(work: IdentifiedRedirectedWork): Route =
+    extractPublicUri { uri =>
+      val newPath = (work.redirect.canonicalId :: uri.path.reverse.tail).reverse
+      redirect(uri.withPath(newPath), Found)
+    }
+
+  def workFound(work: IdentifiedWork,
+                tree: Option[(Collection, List[String])],
+                includes: V2WorksIncludes): Route =
+    complete(
+      ResultResponse(
+        context = contextUri,
+        result = DisplayWorkV2(work, includes).copy(
+          collection = tree.map {
+            case (tree, expandedPaths) =>
+              DisplayCollection(tree, expandedPaths)
+          }
+        )
+      )
+    )
+
+  private lazy val collectionService =
+    new CollectionService(elasticClient)
+
+  private lazy val worksService = new WorksService(
+    new ElasticsearchService(elasticClient))
+
+  private lazy val logger = Logger(this.getClass.getName)
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -1,0 +1,206 @@
+package uk.ac.wellcome.platform.api.rest
+
+import java.time.LocalDate
+
+import akka.http.scaladsl.server.ValidationRejection
+import io.circe.Decoder
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.platform.api.models._
+import uk.ac.wellcome.platform.api.services.WorksSearchOptions
+
+case class SingleWorkParams(
+  include: Option[V2WorksIncludes],
+  _expandPaths: Option[List[String]],
+  _index: Option[String],
+) extends QueryParams
+
+object SingleWorkParams extends QueryParamsUtils {
+
+  // This is a custom akka-http directive which extracts SingleWorkParams
+  // data from the query string, returning an invalid response when any given
+  // parameter is not correctly parsed. More info on custom directives is
+  // available here:
+  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
+  def parse =
+    parameter(
+      (
+        "include".as[V2WorksIncludes].?,
+        "_expandPaths".as[List[String]].?,
+        "_index".as[String].?
+      )
+    ).tmap((SingleWorkParams.apply _).tupled(_))
+
+  implicit val decodePaths: Decoder[List[String]] =
+    decodeCommaSeparated
+
+  implicit val includesDecoder: Decoder[V2WorksIncludes] =
+    decodeOneOfCommaSeparated(
+      "identifiers" -> WorkInclude.Identifiers,
+      "items" -> WorkInclude.Items,
+      "subjects" -> WorkInclude.Subjects,
+      "genres" -> WorkInclude.Genres,
+      "contributors" -> WorkInclude.Contributors,
+      "production" -> WorkInclude.Production,
+      "notes" -> WorkInclude.Notes,
+      "collection" -> WorkInclude.Collection,
+    ).emap(values => Right(V2WorksIncludes(values)))
+}
+
+case class MultipleWorksParams(
+  page: Option[Int],
+  pageSize: Option[Int],
+  workType: Option[WorkTypeFilter],
+  `items.locations.locationType`: Option[ItemLocationTypeFilter],
+  `production.dates.from`: Option[LocalDate],
+  `production.dates.to`: Option[LocalDate],
+  language: Option[LanguageFilter],
+  `genres.label`: Option[GenreFilter],
+  `subjects.label`: Option[SubjectFilter],
+  license: Option[LicenseFilter],
+  include: Option[V2WorksIncludes],
+  aggregations: Option[List[AggregationRequest]],
+  sort: Option[List[SortRequest]],
+  sortOrder: Option[SortingOrder],
+  query: Option[String],
+  collection: Option[CollectionPathFilter],
+  `collection.depth`: Option[CollectionDepthFilter],
+  _queryType: Option[SearchQueryType],
+  _index: Option[String],
+) extends QueryParams {
+
+  def searchOptions(apiConfig: ApiConfig): WorksSearchOptions =
+    WorksSearchOptions(
+      searchQuery = query map { query =>
+        SearchQuery(query, _queryType)
+      },
+      filters = filters,
+      pageSize = pageSize.getOrElse(apiConfig.defaultPageSize),
+      pageNumber = page.getOrElse(1),
+      aggregations = aggregations.getOrElse(Nil),
+      sortBy = sort.getOrElse(Nil),
+      sortOrder = sortOrder.getOrElse(SortingOrder.Ascending),
+    )
+
+  def validationErrors: List[String] =
+    List(
+      page
+        .filterNot(_ >= 1)
+        .map(_ => "page: must be greater than 1"),
+      pageSize
+        .filterNot(size => size >= 1 && size <= 100)
+        .map(_ => "pageSize: must be between 1 and 100")
+    ).flatten
+
+  private def filters: List[WorkFilter] =
+    List(
+      workType,
+      `items.locations.locationType`,
+      dateFilter,
+      language,
+      `genres.label`,
+      `subjects.label`,
+      collection,
+      `collection.depth`,
+      license
+    ).flatten
+
+  private def dateFilter: Option[DateRangeFilter] =
+    (`production.dates.from`, `production.dates.to`) match {
+      case (None, None)       => None
+      case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
+    }
+}
+
+object MultipleWorksParams extends QueryParamsUtils {
+  import SingleWorkParams.includesDecoder
+
+  // This is a custom akka-http directive which extracts MultipleWorksParams
+  // data from the query string, returning an invalid response when any given
+  // parameter is not correctly parsed. More info on custom directives is
+  // available here:
+  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
+  def parse =
+    parameter(
+      (
+        "page".as[Int].?,
+        "pageSize".as[Int].?,
+        "workType".as[WorkTypeFilter] ?,
+        "items.locations.locationType".as[ItemLocationTypeFilter].?,
+        "production.dates.from".as[LocalDate].?,
+        "production.dates.to".as[LocalDate].?,
+        "language".as[LanguageFilter].?,
+        "genres.label".as[GenreFilter].?,
+        "subjects.label".as[SubjectFilter].?,
+        "license".as[LicenseFilter].?,
+        "include".as[V2WorksIncludes].?,
+        "aggregations".as[List[AggregationRequest]].?,
+        "sort".as[List[SortRequest]].?,
+        "sortOrder".as[SortingOrder].?,
+        "query".as[String].?,
+        "collection".as[CollectionPathFilter].?,
+        "collection.depth".as[CollectionDepthFilter].?,
+        "_queryType".as[SearchQueryType].?,
+        "_index".as[String].?,
+      )
+    ).tflatMap { args =>
+      val params = (MultipleWorksParams.apply _).tupled(args)
+      params.validationErrors match {
+        case Nil => provide(params)
+        case errs =>
+          reject(ValidationRejection(errs.mkString(", ")))
+            .toDirective[Tuple1[MultipleWorksParams]]
+      }
+    }
+
+  implicit val workTypeFilter: Decoder[WorkTypeFilter] =
+    decodeCommaSeparated.emap(strs => Right(WorkTypeFilter(strs)))
+
+  implicit val itemLocationTypeFilter: Decoder[ItemLocationTypeFilter] =
+    decodeCommaSeparated.emap(strs => Right(ItemLocationTypeFilter(strs)))
+
+  implicit val languageFilter: Decoder[LanguageFilter] =
+    decodeCommaSeparated.emap(strs => Right(LanguageFilter(strs)))
+
+  implicit val genreFilter: Decoder[GenreFilter] =
+    Decoder.decodeString.emap(str => Right(GenreFilter(str)))
+
+  implicit val subjectFilter: Decoder[SubjectFilter] =
+    Decoder.decodeString.emap(str => Right(SubjectFilter(str)))
+
+  implicit val licenseFilter: Decoder[LicenseFilter] =
+    decodeCommaSeparated.emap(strs => Right(LicenseFilter(strs)))
+
+  implicit val collectionsPathFilter: Decoder[CollectionPathFilter] =
+    Decoder.decodeString.emap(str => Right(CollectionPathFilter(str)))
+
+  implicit val collectionsDepthFilter: Decoder[CollectionDepthFilter] =
+    decodeInt map CollectionDepthFilter
+
+  implicit val aggregationsDecoder: Decoder[List[AggregationRequest]] =
+    decodeOneOfCommaSeparated(
+      "workType" -> AggregationRequest.WorkType,
+      "genres" -> AggregationRequest.Genre,
+      "production.dates" -> AggregationRequest.ProductionDate,
+      "subjects" -> AggregationRequest.Subject,
+      "language" -> AggregationRequest.Language,
+      "license" -> AggregationRequest.License,
+    )
+
+  implicit val sortDecoder: Decoder[List[SortRequest]] =
+    decodeOneOfCommaSeparated(
+      "production.dates" -> ProductionDateSortRequest
+    )
+
+  implicit val sortOrderDecoder: Decoder[SortingOrder] =
+    decodeOneOf(
+      "asc" -> SortingOrder.Ascending,
+      "desc" -> SortingOrder.Descending,
+    )
+
+  implicit val _queryTypeDecoder: Decoder[SearchQueryType] =
+    decodeOneWithDefaultOf(
+      SearchQueryType.default,
+      "BoolBoosted" -> SearchQueryType.BoolBoosted,
+      "PhraserBeam" -> SearchQueryType.PhraserBeam,
+    )
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -18,7 +18,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.v2._
-import uk.ac.wellcome.platform.api.MultipleWorksResponse
+import uk.ac.wellcome.platform.api.rest.MultipleWorksResponse
 
 class SwaggerDocs(apiConfig: ApiConfig) extends Logging {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.Matchers
 import akka.http.scaladsl.model.ContentTypes
 import io.circe.Json
 import uk.ac.wellcome.platform.api.models.SearchQueryType
+import uk.ac.wellcome.platform.api.rest.{MultipleWorksParams, SingleWorkParams}
 import uk.ac.wellcome.platform.api.works.v2.ApiV2WorksTestBase
 
 class ApiSwaggerTest extends ApiV2WorksTestBase with Matchers {


### PR DESCRIPTION
There are no meaningful code changes/additions here, but I've moved some things into a new package, `rest`:

- entity-agnostic helper methods that were previously on `Router` live in a new trait, `CustomDirectives`
- the methods that performed the searching/fetching logic for Works now live in `WorksController`
- the works-specific query param parsing classes now live in `WorksParams`