### PR TITLE
Logging RFC - worker module and calm adapter

### DIFF
--- a/calm_adapter/terraform/iam.tf
+++ b/calm_adapter/terraform/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role_policy" "cloudwatch_push_metrics" {
-  role   = module.task_definition.task_role_name
+  role   = module.worker.task_role_name
   policy = data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json
 }
 

--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -1,13 +1,12 @@
 locals {
   namespace = "calm-adapter"
 
-  infra_bucket           = data.terraform_remote_state.shared_infra.outputs.infra_bucket
-  account_id             = data.aws_caller_identity.current.account_id
-  aws_region             = "eu-west-1"
-  dlq_alarm_arn          = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
-  vpc_id                 = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
-  private_subnets        = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
-  shared_secrets_logging = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+  infra_bucket    = data.terraform_remote_state.shared_infra.outputs.infra_bucket
+  account_id      = data.aws_caller_identity.current.account_id
+  aws_region      = "eu-west-1"
+  dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
+  private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
 
   env_vars = {
     calm_api_url          = "https://wt-calm.wellcome.ac.uk/CalmAPI/ContentService.asmx"

--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -1,14 +1,13 @@
 locals {
-  namespace                     = "calm-adapter"
-  logstash_transit_service_name = "${local.namespace}_logstash_transit"
-  logstash_host                 = "${local.logstash_transit_service_name}.${local.namespace}"
+  namespace = "calm-adapter"
 
-  infra_bucket    = data.terraform_remote_state.shared_infra.outputs.infra_bucket
-  account_id      = data.aws_caller_identity.current.account_id
-  aws_region      = "eu-west-1"
-  dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
-  vpc_id          = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
-  private_subnets = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
+  infra_bucket           = data.terraform_remote_state.shared_infra.outputs.infra_bucket
+  account_id             = data.aws_caller_identity.current.account_id
+  aws_region             = "eu-west-1"
+  dlq_alarm_arn          = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  vpc_id                 = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_id
+  private_subnets        = data.terraform_remote_state.shared_infra.outputs.catalogue_vpc_delta_private_subnets
+  shared_secrets_logging = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
 
   env_vars = {
     calm_api_url          = "https://wt-calm.wellcome.ac.uk/CalmAPI/ContentService.asmx"

--- a/calm_adapter/terraform/queue.tf
+++ b/calm_adapter/terraform/queue.tf
@@ -8,6 +8,6 @@ module "calm_windows_queue" {
 }
 
 resource "aws_iam_role_policy" "read_from_queue" {
-  role   = module.task_definition.task_role_name
+  role   = module.worker.task_role_name
   policy = module.calm_windows_queue.read_policy
 }

--- a/calm_adapter/terraform/service.tf
+++ b/calm_adapter/terraform/service.tf
@@ -1,29 +1,17 @@
 module "service" {
-  source              = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.2.0"
-  service_name        = local.namespace
-  cluster_arn         = aws_ecs_cluster.cluster.arn
-  task_definition_arn = module.task_definition.arn
-  subnets             = local.private_subnets
-  namespace_id        = aws_service_discovery_private_dns_namespace.namespace.id
-  security_group_ids  = []
-  launch_type         = "FARGATE"
-  desired_task_count  = 1
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.1"
+
+  task_definition_arn            = module.task_definition.arn
+  service_name                   = local.namespace
+  cluster_arn                    = aws_ecs_cluster.cluster.arn
+  subnets                        = local.private_subnets
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  launch_type                    = "FARGATE"
+  desired_task_count             = 1
 }
 
-module "task_definition" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.2.0"
-  task_name       = local.namespace
-  container_image = local.calm_adapter_image
-  cpu             = "256"
-  memory          = "512"
-  env_vars        = local.env_vars
-  secret_env_vars = local.secret_env_vars
-  launch_type     = "FARGATE"
-  aws_region      = local.aws_region
-}
-
-module "scaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//autoscaling?ref=v1.2.0"
+module "autoscaling" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v2.4.1"
 
   name = local.namespace
 
@@ -32,4 +20,48 @@ module "scaling" {
 
   min_capacity = 1
   max_capacity = 2
+}
+
+module "task_definition" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.4.1"
+
+  cpu    = 256
+  memory = 512
+
+  launch_types = ["FARGATE"]
+  task_name    = local.namespace
+
+  container_definitions = [
+    module.log_router_container.container_definition,
+    module.app_container.container_definition
+  ]
+}
+
+module "app_container" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+
+  name  = local.namespace
+  image = local.calm_adapter_image
+
+  environment = local.env_vars
+  secrets     = local.secret_env_vars
+
+  log_configuration = module.log_router_container.container_log_configuration
+}
+
+module "app_permissions" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  secrets   = local.secret_env_vars
+  role_name = module.task_definition.task_execution_role_name
+}
+
+module "log_router_container" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.4.1"
+  namespace = local.namespace
+}
+
+module "log_router_permissions" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  secrets   = local.shared_secrets_logging
+  role_name = module.task_definition.task_execution_role_name
 }

--- a/calm_adapter/terraform/topics.tf
+++ b/calm_adapter/terraform/topics.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "publish_to_adapter_topic" {
 }
 
 resource "aws_iam_role_policy" "adapter_policy" {
-  role   = module.task_definition.task_role_name
+  role   = module.worker.task_role_name
   policy = data.aws_iam_policy_document.publish_to_adapter_topic.json
 }
 

--- a/calm_adapter/terraform/vhs.tf
+++ b/calm_adapter/terraform/vhs.tf
@@ -6,6 +6,6 @@ module "vhs" {
 }
 
 resource "aws_iam_role_policy" "vhs_readwrite" {
-  role   = module.task_definition.task_role_name
+  role   = module.worker.task_role_name
   policy = module.vhs.full_access_policy
 }

--- a/calm_adapter/terraform/worker.tf
+++ b/calm_adapter/terraform/worker.tf
@@ -1,0 +1,19 @@
+module "worker" {
+  source = "../../infrastructure/modules/worker"
+
+  name = local.namespace
+
+  image              = local.calm_adapter_image
+  env_vars           = local.env_vars
+  secret_env_vars    = local.secret_env_vars
+  min_capacity       = 1
+  max_capacity       = 2
+  desired_task_count = 1
+  cpu                = 512
+  memory             = 1024
+
+  cluster_name = local.namespace
+  cluster_arn  = aws_ecs_cluster.cluster.arn
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  subnets      = local.private_subnets
+}

--- a/infrastructure/modules/worker/outputs.tf
+++ b/infrastructure/modules/worker/outputs.tf
@@ -1,0 +1,7 @@
+output "task_role_name" {
+  value = module.task_definition.task_role_name
+}
+
+output "task_role_arn" {
+  value = module.task_definition.task_role_arn
+}

--- a/infrastructure/modules/worker/outputs.tf
+++ b/infrastructure/modules/worker/outputs.tf
@@ -5,3 +5,11 @@ output "task_role_name" {
 output "task_role_arn" {
   value = module.task_definition.task_role_arn
 }
+
+output "scale_up_arn" {
+  value = module.autoscaling.scale_up_arn
+}
+
+output "scale_down_arn" {
+  value = module.autoscaling.scale_down_arn
+}

--- a/infrastructure/modules/worker/terraform.tf
+++ b/infrastructure/modules/worker/terraform.tf
@@ -2,34 +2,34 @@ module "service" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.1"
 
   task_definition_arn            = module.task_definition.arn
-  service_name                   = local.namespace
-  cluster_arn                    = aws_ecs_cluster.cluster.arn
-  subnets                        = local.private_subnets
-  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  service_name                   = var.name
+  cluster_arn                    = var.cluster_arn
+  subnets                        = var.subnets
+  service_discovery_namespace_id = var.namespace_id
   launch_type                    = "FARGATE"
-  desired_task_count             = 1
+  desired_task_count             = var.desired_task_count
 }
 
 module "autoscaling" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v2.4.1"
 
-  name = local.namespace
+  name = var.name
 
-  cluster_name = local.namespace
-  service_name = local.namespace
+  cluster_name = var.cluster_name
+  service_name = var.name
 
-  min_capacity = 1
-  max_capacity = 2
+  min_capacity = var.min_capacity
+  max_capacity = var.max_capacity
 }
 
 module "task_definition" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.4.1"
 
-  cpu    = 256
-  memory = 512
+  cpu    = var.cpu
+  memory = var.memory
 
   launch_types = ["FARGATE"]
-  task_name    = local.namespace
+  task_name    = var.name
 
   container_definitions = [
     module.log_router_container.container_definition,
@@ -40,28 +40,40 @@ module "task_definition" {
 module "app_container" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
 
-  name  = local.namespace
-  image = local.calm_adapter_image
+  name  = var.name
+  image = var.image
 
-  environment = local.env_vars
-  secrets     = local.secret_env_vars
+  environment = var.env_vars
+  secrets     = var.secret_env_vars
 
   log_configuration = module.log_router_container.container_log_configuration
 }
 
 module "app_permissions" {
   source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
-  secrets   = local.secret_env_vars
+  secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "log_router_container" {
   source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.4.1"
-  namespace = local.namespace
+  namespace = var.name
 }
 
 module "log_router_permissions" {
   source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
-  secrets   = local.shared_secrets_logging
+  secrets   = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
+}
+
+data "terraform_remote_state" "shared_infra" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/shared.tfstate"
+    region = "eu-west-1"
+  }
 }

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -1,0 +1,58 @@
+variable "name" {
+  type = string
+}
+
+variable "image" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "cluster_arn" {
+  type = string
+}
+
+variable "namespace_id" {
+  type = string
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "env_vars" {
+  type    = map(string)
+  default = {}
+}
+
+variable "secret_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
+variable "desired_task_count" {
+  type    = number
+  default = 1
+}
+
+variable "min_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "max_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "cpu" {
+  type    = number
+  default = 512
+}
+
+variable "memory" {
+  type    = number
+  default = 1024
+}

--- a/pipeline/transformer/transformer_calm/src/main/resources/logback.xml
+++ b/pipeline/transformer/transformer_calm/src/main/resources/logback.xml
@@ -5,20 +5,8 @@
     </encoder>
   </appender>
 
-  <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
-    <layout class="net.logstash.logback.layout.LogstashLayout">
-      <customFields>
-        {"introspection": {"namespace":"${NAMESPACE:-unset}","service_id":"${SERVICE_ID:-unset}","task_id": "${TASK_ID:-unset}","image_id": "${IMAGE_ID:-unset}"}}
-      </customFields>
-    </layout>
-
-    <host>${logstash_host}</host>
-    <port>514</port>
-  </appender>
-
   <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT"/>
-    <appender-ref ref="LOGSTASH"/>
   </root>
 
   <!-- reduce external logging -->


### PR DESCRIPTION
Includes a new `worker` module with the new infrastructure setup, which will be used in all the catalogue applications using firelens / fluent bit.

The calm adapter is the only app so far to use this (with the terraform already have been applied), but should be pretty straightforward to do for other apps once this is in.