### PR TITLE
supress group of pieces

### DIFF
--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -306,21 +306,41 @@ class CalmTransformerTest extends FunSpec with Matchers {
     CalmTransformer(recordC, version).right.get shouldBe a[UnidentifiedWork]
   }
 
-  it("transforms to invisible work when WorkData not parsable") {
-    val recordA = calmRecord(
-      "Level" -> "UnknownLevel",
+  it("transforms to invisible work when Level=Group of Pieces") {
+    val record = calmRecord(
+      "Title" -> "abc",
+      "Level" -> "Group of Pieces",
+      "RefNo" -> "a/b/c"
+    )
+    CalmTransformer(record, version).right.get shouldBe a[
+      UnidentifiedInvisibleWork]
+  }
+
+  it("uses empty WorkData for suppressed works when not parsable") {
+    val record = calmRecord(
+      "Level" -> "Invalid",
       "RefNo" -> "a/b/c",
       "Transmission" -> "No"
     )
-    CalmTransformer(recordA, version) shouldBe Right(
+
+    CalmTransformer(record, version) shouldBe Right(
       UnidentifiedInvisibleWork(
         version = version,
         sourceIdentifier = SourceIdentifier(
           value = id,
-          identifierType = CalmIdentifierTypes.recordId),
-        data = WorkData()
-      )
+          identifierType = CalmIdentifierTypes.recordId
+        ),
+        data = WorkData())
     )
+  }
+
+  it("errors with invalid Level") {
+    val record = calmRecord(
+      "Level" -> "UnknownLevel",
+      "RefNo" -> "a/b/c"
+    )
+
+    CalmTransformer(record, version) shouldBe a[Left[_, _]]
   }
 
   it("errors if invalid access status") {


### PR DESCRIPTION
Suppresses `Group of Pieces` Level from Calm.

These will eventually not exist, as they are being changed in the source data.

Another solution would be to have the transformer understand deterministic an nondeterministic failure, but don't want to shake the boat even further while trying to get this release out.