### PR TITLE
make id optional in language

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -59,7 +59,7 @@ trait ApiWorksTestBase
   def languageResponse(language: Language): String =
     s"""
       | "language": {
-      |   "id": "${language.id}",
+      |   ${language.id.map(lang => s""""id": "$lang",""").getOrElse("")}
       |   "label": "${language.label}",
       |   "type": "Language"
       | },

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -208,16 +208,15 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on language") {
-
     val works = List(
       createIdentifiedWorkWith(
-        language = Some(Language("eng", "English"))
+        language = Some(Language("English", Some("eng")))
       ),
       createIdentifiedWorkWith(
-        language = Some(Language("ger", "German"))
+        language = Some(Language("German", Some("ger")))
       ),
       createIdentifiedWorkWith(
-        language = Some(Language("ger", "German"))
+        language = Some(Language("German", Some("ger")))
       ),
       createIdentifiedWorkWith(language = None)
     ).sortBy(_.canonicalId)
@@ -235,8 +234,8 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "data" : {
-                        "label": "German",
                         "id": "ger",
+                        "label": "German",
                         "type": "Language"
                       },
                       "count" : 2,
@@ -244,8 +243,8 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                     },
                     {
                       "data" : {
-                        "label": "English",
                         "id": "eng",
+                        "label": "English",
                         "type": "Language"
                       },
                       "count" : 1,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -10,16 +10,16 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         val works = List(
-          (Books, Language("dogs", "Bark")),
-          (Journals, Language("cats", "Meow")),
-          (Pictures, Language("ducks", "Quack")),
-          (Audio, Language("dogs", "Bark")),
-          (Books, Language("dogs", "Bark")),
-          (Books, Language("dogs", "Bark")),
-          (Journals, Language("ducks", "Quack")),
-          (Books, Language("cats", "Meow")),
-          (Journals, Language("ducks", "Quack")),
-          (Audio, Language("frogs", "Croak"))
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Meow", Some("cats"))),
+          (Pictures, Language("Quack", Some("ducks"))),
+          (Audio, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Books, Language("Meow", Some("cats"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Audio, Language("Croak", Some("frogs")))
         ).zipWithIndex.map {
           case ((workType, language), i) =>
             createIdentifiedWorkWith(
@@ -80,16 +80,16 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         val works = List(
-          (Books, Language("dogs", "Bark")),
-          (Journals, Language("cats", "Meow")),
-          (Pictures, Language("ducks", "Quack")),
-          (Audio, Language("dogs", "Bark")),
-          (Books, Language("dogs", "Bark")),
-          (Books, Language("dogs", "Bark")),
-          (Journals, Language("ducks", "Quack")),
-          (Books, Language("cats", "Meow")),
-          (Journals, Language("ducks", "Quack")),
-          (Audio, Language("frogs", "Croak"))
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Meow", Some("cats"))),
+          (Pictures, Language("Quack", Some("ducks"))),
+          (Audio, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Books, Language("Meow", Some("cats"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Audio, Language("Croak", Some("frogs")))
         ).zipWithIndex.map {
           case ((workType, language), i) =>
             createIdentifiedWorkWith(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -273,12 +273,12 @@ class WorksFiltersTest extends ApiWorksTestBase {
     val englishWork = createIdentifiedWorkWith(
       canonicalId = "1",
       title = Some("Caterpiller"),
-      language = Some(Language("eng", "English"))
+      language = Some(Language("English", Some("eng")))
     )
     val germanWork = createIdentifiedWorkWith(
       canonicalId = "2",
       title = Some("Ubergang"),
-      language = Some(Language("ger", "German"))
+      language = Some(Language("German", Some("ger")))
     )
     val noLanguageWork = createIdentifiedWorkWith(title = Some("£@@!&$"))
     val works = List(englishWork, germanWork, noLanguageWork)

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLanguage.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.Language
 case class DisplayLanguage(
   @Schema(
     description = "An ISO 639-2 language code."
-  ) id: String,
+  ) id: Option[String],
   @Schema(
     description = "The name of a language"
   ) label: String,

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -132,7 +132,7 @@ class DisplayWorkTest
 
   it("gets the language from a Work") {
     val language = Language(
-      id = "bsl",
+      id = Some("bsl"),
       label = "British Sign Language"
     )
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
@@ -5,8 +5,8 @@ import scala.io.Source
 import uk.ac.wellcome.models.work.internal.result.Result
 
 case class Language(
-  id: String,
   label: String,
+  id: Option[String],
   ontologyType: String = "Language"
 )
 
@@ -15,18 +15,16 @@ object Language {
   def fromCode(code: String): Result[Language] =
     languageCodeMap
       .get(code)
-      .map(label => Right(Language(code, label)))
+      .map(label => Right(Language(label, Some(code))))
       .getOrElse {
         Left(new Exception(s"Invalid ISO 693-2 language code: $code"))
       }
 
   def fromLabel(label: String): Result[Language] =
-    languageLabelMap
-      .get(label)
-      .map(code => Right(Language(code, label)))
-      .getOrElse {
-        Left(new Exception(s"Unrecognised language label: $label"))
-      }
+    languageLabelMap.get(label) match {
+      case Some(code) => Right(Language(label, Some(code)))
+      case None       => Right(Language(label, None))
+    }
 
   private def languageCodes: List[(String, String)] =
     Source

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.work.internal
 import org.scalatest.{FunSpec, Matchers}
 
 class LanguageTest extends FunSpec with Matchers {
-  it("get's labels for known code or errors") {
+  it("gets labels for known code or errors") {
     val withValidCode = Language.fromCode("yo")
     val withInvalidCode = Language.fromCode("no such code")
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.models.work.internal
+import org.scalatest.{FunSpec, Matchers}
+
+class LanguageTest extends FunSpec with Matchers {
+  it("get's labels for known code or errors") {
+    val withValidCode = Language.fromCode("yo")
+    val withInvalidCode = Language.fromCode("no such code")
+
+    withValidCode should be(Right(Language("Yoruba", Some("yo"))))
+    withInvalidCode shouldBe a[Left[_, _]]
+  }
+
+  it(
+    "gets Language with code from known labels and omits code for unknown labels") {
+    val withValidLabel = Language.fromLabel("Yoruba")
+    val withMultiLabel1 = Language.fromLabel("Haitian")
+    val withMultiLabel2 = Language.fromLabel("Haitian Creole")
+    val withInvalidLabel = Language.fromLabel("no such label")
+
+    withValidLabel shouldBe Right(Language("Yoruba", Some("yo")))
+    withMultiLabel1 shouldBe Right(Language("Haitian", Some("ht")))
+    withMultiLabel2 shouldBe Right(Language("Haitian Creole", Some("ht")))
+    withInvalidLabel shouldBe Right(Language("no such label", None))
+  }
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -188,7 +188,7 @@ class CalmTransformerTest extends FunSpec with Matchers {
       "Language" -> "English"
     )
     CalmTransformer(record, version).right.get.data.language shouldBe Some(
-      Language("en", "English")
+      Language("English", Some("en"))
     )
   }
 
@@ -208,7 +208,7 @@ class CalmTransformerTest extends FunSpec with Matchers {
       "Language" -> "  "
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
-      Language("en", "English")
+      Language("English", Some("en"))
     )
     CalmTransformer(recordB, version).right.get.data.language shouldBe None
   }
@@ -229,10 +229,10 @@ class CalmTransformerTest extends FunSpec with Matchers {
       "Language" -> "Flemish"
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
-      Language("nl", "Dutch")
+      Language("Dutch", Some("nl"))
     )
     CalmTransformer(recordB, version).right.get.data.language shouldBe Some(
-      Language("nl", "Flemish")
+      Language("Flemish", Some("nl"))
     )
   }
 
@@ -391,7 +391,7 @@ class CalmTransformerTest extends FunSpec with Matchers {
     CalmTransformer(record, version) shouldBe a[Left[_, _]]
   }
 
-  it("errors if language not recognised") {
+  it("does not add language code if language not recognised") {
     val record = calmRecord(
       "Title" -> "abc",
       "Level" -> "Collection",
@@ -399,7 +399,8 @@ class CalmTransformerTest extends FunSpec with Matchers {
       "AltRefNo" -> "a.b.c",
       "Language" -> "Lolol"
     )
-    CalmTransformer(record, version) shouldBe a[Left[_, _]]
+    CalmTransformer(record, version).right.get.data.language shouldBe Some(
+      Language("Lolol", None))
   }
 
   def calmRecord(fields: (String, String)*): CalmRecord =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
@@ -21,8 +21,8 @@ object SierraLanguage extends SierraTransformer {
   def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
     bibData.lang.map { lang =>
       Language(
-        id = lang.code,
-        label = lang.name
+        label = lang.name,
+        id = Some(lang.code)
       )
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
@@ -26,7 +26,7 @@ class SierraLanguageTest
 
     SierraLanguage(createSierraBibNumber, bibData) shouldBe Some(
       Language(
-        id = "eng",
+        id = Some("eng"),
         label = "English"
       ))
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -465,7 +465,7 @@ class SierraTransformableTransformerTest
          |}""".stripMargin
 
     val expectedLanguage = Language(
-      id = "fra",
+      id = Some("fra"),
       label = "French"
     )
 


### PR DESCRIPTION
We currently have strings coming from the source data that isn't parsable into a language code.

We still want these to come through, but as "unstructured". This makes the `code` / `id` optional. 