### PR TITLE
Handle empty code fields in sierra "lang"

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 }
 import uk.ac.wellcome.platform.transformer.sierra.transformers._
 import uk.ac.wellcome.platform.transformer.sierra.source.SierraMaterialType._
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.sierra_adapter.model.{
   SierraBibNumber,
@@ -20,7 +21,6 @@ import uk.ac.wellcome.sierra_adapter.model.{
   SierraItemNumber,
   SierraTransformable
 }
-
 import scala.util.{Failure, Success, Try}
 
 object SierraTransformableTransformer {
@@ -65,7 +65,7 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
           throw e
       }
 
-  def workFromBibRecord(bibRecord: SierraBibRecord): Try[TransformedBaseWork] =
+  def workFromBibRecord(bibRecord: SierraBibRecord): Try[TransformedBaseWork] = {
     fromJson[SierraBibData](bibRecord.data)
       .map { bibData =>
         if (bibData.deleted || bibData.suppressed) {
@@ -89,6 +89,7 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
             data = WorkData()
           )
       }
+  }
 
   def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
     WorkData[Unminted, Identifiable](

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -65,7 +65,8 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
           throw e
       }
 
-  def workFromBibRecord(bibRecord: SierraBibRecord): Try[TransformedBaseWork] = {
+  def workFromBibRecord(
+    bibRecord: SierraBibRecord): Try[TransformedBaseWork] = {
     fromJson[SierraBibData](bibRecord.data)
       .map { bibData =>
         if (bibData.deleted || bibData.suppressed) {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -1,10 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
-import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{
-  SierraSourceCountry,
-  SierraSourceLanguage,
-  SierraSourceLocation
-}
+import io.circe.{Decoder, DecodingFailure, HCursor}
+import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{SierraSourceCountry, SierraSourceLanguage, SierraSourceLocation}
 
 // https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm
 case class SierraBibData(
@@ -18,3 +15,18 @@ case class SierraBibData(
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()
 )
+
+object SierraBibData {
+
+  // the "lang" field in sierra can be "lang": {"code": " "} for example for paintings that don't have a language.
+  // We want those records to be decoded as `None` as this effectively means the record doesn't have a language,
+  // so we use a custom decoder to achieve that
+  implicit def d(implicit dec: Decoder[Option[SierraSourceLanguage]]): Decoder[Option[SierraSourceLanguage]] =
+    dec.handleErrorWith{err: DecodingFailure =>
+      Decoder.instance{ hcursor: HCursor =>
+      hcursor.downField("code").as[String].flatMap {
+        case c if c.trim.isEmpty => Right(None)
+        case _ => Left(err)
+      }
+    }}
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
 import io.circe.{Decoder, DecodingFailure, HCursor}
-import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{SierraSourceCountry, SierraSourceLanguage, SierraSourceLocation}
+import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{
+  SierraSourceCountry,
+  SierraSourceLanguage,
+  SierraSourceLocation
+}
 
 // https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm
 case class SierraBibData(
@@ -21,12 +25,14 @@ object SierraBibData {
   // the "lang" field in sierra can be "lang": {"code": " "} for example for paintings that don't have a language.
   // We want those records to be decoded as `None` as this effectively means the record doesn't have a language,
   // so we use a custom decoder to achieve that
-  implicit def d(implicit dec: Decoder[Option[SierraSourceLanguage]]): Decoder[Option[SierraSourceLanguage]] =
-    dec.handleErrorWith{err: DecodingFailure =>
-      Decoder.instance{ hcursor: HCursor =>
-      hcursor.downField("code").as[String].flatMap {
-        case c if c.trim.isEmpty => Right(None)
-        case _ => Left(err)
+  implicit def d(implicit dec: Decoder[Option[SierraSourceLanguage]])
+    : Decoder[Option[SierraSourceLanguage]] =
+    dec.handleErrorWith { err: DecodingFailure =>
+      Decoder.instance { hcursor: HCursor =>
+        hcursor.downField("code").as[String].flatMap {
+          case c if c.trim.isEmpty => Right(None)
+          case _                   => Left(err)
+        }
       }
-    }}
+    }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
@@ -1,0 +1,50 @@
+package uk.ac.wellcome.platform.transformer.sierra.source
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import SierraBibData._
+import uk.ac.wellcome.json.exceptions.JsonDecodingError
+import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLanguage
+
+
+class SierraBibDataTest extends AnyFunSpec with Matchers{
+  it("should decode a bibData with language"){
+    val bibDataJson =
+      s"""
+         |{
+         |  "lang": {
+         |    "code": "eng",
+         |    "name": "English"
+         |  }
+         |}"""
+        .stripMargin
+
+    fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData(lang = Some(SierraSourceLanguage("eng", "English")))
+  }
+
+  it("should decode a bibData with language with empty code as None"){
+    val bibDataJson =
+      s"""
+         |{
+         |  "lang": {
+         |    "code": " "
+         |  }
+         |}"""
+        .stripMargin
+
+    fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData()
+  }
+  it("should fail decoding a bibData without name and non-empty code"){
+    val bibDataJson =
+      s"""
+         |{
+         |  "lang": {
+         |    "code": "blah"
+         |  }
+         |}"""
+        .stripMargin
+
+    intercept[JsonDecodingError]{fromJson[SierraBibData](bibDataJson).get}
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
@@ -7,9 +7,8 @@ import SierraBibData._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLanguage
 
-
-class SierraBibDataTest extends AnyFunSpec with Matchers{
-  it("should decode a bibData with language"){
+class SierraBibDataTest extends AnyFunSpec with Matchers {
+  it("should decode a bibData with language") {
     val bibDataJson =
       s"""
          |{
@@ -17,34 +16,32 @@ class SierraBibDataTest extends AnyFunSpec with Matchers{
          |    "code": "eng",
          |    "name": "English"
          |  }
-         |}"""
-        .stripMargin
+         |}""".stripMargin
 
-    fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData(lang = Some(SierraSourceLanguage("eng", "English")))
+    fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData(
+      lang = Some(SierraSourceLanguage("eng", "English")))
   }
 
-  it("should decode a bibData with language with empty code as None"){
+  it("should decode a bibData with language with empty code as None") {
     val bibDataJson =
       s"""
          |{
          |  "lang": {
          |    "code": " "
          |  }
-         |}"""
-        .stripMargin
+         |}""".stripMargin
 
     fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData()
   }
-  it("should fail decoding a bibData without name and non-empty code"){
+  it("should fail decoding a bibData without name and non-empty code") {
     val bibDataJson =
       s"""
          |{
          |  "lang": {
          |    "code": "blah"
          |  }
-         |}"""
-        .stripMargin
+         |}""".stripMargin
 
-    intercept[JsonDecodingError]{fromJson[SierraBibData](bibDataJson).get}
+    intercept[JsonDecodingError] { fromJson[SierraBibData](bibDataJson).get }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -71,7 +71,7 @@ class SierraTransformableTransformerTest
          |}
          |""".stripMargin
     val sierraTransformable = createSierraTransformableWith(
-      maybeBibRecord = Some(createSierraBibRecordWith(number,data)),
+      maybeBibRecord = Some(createSierraBibRecordWith(number, data)),
     )
 
     val work = transformToWork(sierraTransformable)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformableTransformerTest.scala
@@ -59,6 +59,30 @@ class SierraTransformableTransformerTest
 
     actualIdentifiers should contain theSameElementsAs expectedIdentifiers
   }
+  it("performs a transformation on a work with empty code in the lang field") {
+    val number = createSierraBibNumber
+    val data =
+      s"""
+         |{
+         |  "id": "$number",
+         |  "lang": {
+         |    "code": " "
+         |  }
+         |}
+         |""".stripMargin
+    val sierraTransformable = createSierraTransformableWith(
+      maybeBibRecord = Some(createSierraBibRecordWith(number,data)),
+    )
+
+    val work = transformToWork(sierraTransformable)
+
+    val language = work
+      .asInstanceOf[UnidentifiedInvisibleWork]
+      .data
+      .language
+
+    language shouldBe None
+  }
 
   it("trims whitespace from the materialType code") {
     val id = createSierraBibNumber


### PR DESCRIPTION
Fixes some transformer errors since circe upgrade that were previously hidden by https://github.com/circe/circe/issues/1024