### PR TITLE
Decrease maximum inferrer count

### DIFF
--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -64,8 +64,11 @@ module "image_inferrer" {
     MODEL_DATA_BUCKET = var.inferrer_model_data_bucket_name
   }
 
-  subnets             = var.subnets
-  max_capacity        = 10
+  subnets = var.subnets
+
+  # Any higher than this currently causes latency spikes from Loris
+  max_capacity = 8
+
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.image_inferrer_queue.read_policy
 }


### PR DESCRIPTION
Loris latency (particularly the p99) spikes with the addition of the last couple of workers so this should relieve the load a bit (and probably won't work out all that much slower)