### PR TITLE
Fix work remover

### DIFF
--- a/scripts/remove_work/README.md
+++ b/scripts/remove_work/README.md
@@ -1,0 +1,23 @@
+# Work remover
+
+This script:
+
+- replaces works with InvisibleIdentifiedWorks in ES indices (thereby preventing further reindexing)
+- suppresses Miro works in the VHS
+- removes images from Loris's S3 buckets
+- creates CloudFront invalidations for Loris
+- updates the Miro VHS inventory
+
+You also need to create a CloudFront invalidation for `works/<id>` in the wellcomecollection.org distribution.
+
+### Usage
+
+```
+Usage: run.py [OPTIONS] CATALOGUE_ID
+
+Options:
+  -i, --index TEXT  [required]
+```
+
+Because we can no longer get the current ES index from task definitions (it's hardcoded in the `elasticsearch` module), you must specify the index which you want the work removed from.
+Multiple indices can be specified like `-i index_1 -i index_2` etc.

--- a/scripts/remove_work/requirements.txt
+++ b/scripts/remove_work/requirements.txt
@@ -4,15 +4,16 @@
 #
 #    pip-compile
 #
-boto3==1.9.199
-botocore==1.12.199        # via boto3, s3transfer
-certifi==2019.6.16        # via requests
+boto3==1.13.18            # via Wellcome Collection catalogue scripts: remove_work (setup.py)
+botocore==1.16.18         # via boto3, s3transfer
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-docutils==0.14            # via botocore
-idna==2.8                 # via requests
-jmespath==0.9.4           # via boto3, botocore
-python-dateutil==2.8.0    # via botocore
-requests==2.22.0
-s3transfer==0.2.1         # via boto3
-six==1.12.0               # via python-dateutil
-urllib3==1.25.3           # via botocore, requests
+click==7.1.2              # via Wellcome Collection catalogue scripts: remove_work (setup.py)
+docutils==0.15.2          # via botocore
+idna==2.9                 # via requests
+jmespath==0.10.0          # via boto3, botocore
+python-dateutil==2.8.1    # via botocore
+requests==2.23.0          # via Wellcome Collection catalogue scripts: remove_work (setup.py)
+s3transfer==0.3.3         # via boto3
+six==1.15.0               # via python-dateutil
+urllib3==1.25.9           # via botocore, requests

--- a/scripts/remove_work/run.py
+++ b/scripts/remove_work/run.py
@@ -163,7 +163,7 @@ def remove_image_from_es_indexes(catalogue_id, indices):
                 # We bump the version so any in-flight works won't overwrite
                 # this one.
                 "version": existing_work["version"] + 1,
-                "data": blank_data
+                "data": blank_data,
             }
 
             print("··· Replacing work with an IdentifiedInvisibleWork")
@@ -321,4 +321,3 @@ def main(catalogue_id, index):
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/remove_work/run.py
+++ b/scripts/remove_work/run.py
@@ -10,7 +10,6 @@ import getpass
 import hashlib
 import json
 import os
-import sys
 
 import boto3
 import click

--- a/scripts/remove_work/setup.py
+++ b/scripts/remove_work/setup.py
@@ -4,5 +4,5 @@ setup(
     name="Wellcome Collection catalogue scripts: remove_work",
     description="If you want to delete a work from the Catalogue API and prevent it reappearing",
     python_requires=">=3",
-    install_requires=["boto3", "requests"],
+    install_requires=["boto3", "requests", "click"],
 )


### PR DESCRIPTION
We haven't spiked any works for a loooong time so this needed a few changes to get it working. Unfortunately you now need to specify the index/indices that you want works removed from, as they're no longer parametrised in the Task Definitions.