### PR TITLE
merge available works sent from matcher

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
@@ -9,20 +9,10 @@ class MergerManager(mergerRules: Merger) {
     * merging function, apply the function to these works.
     *
     * If we got an incomplete list of results from VHS (for example,
-    * wrong versions), we skip the merge and return the original works.
+    * wrong versions), we just merge which works are available.
     */
   def applyMerge(
     maybeWorks: Seq[Option[TransformedBaseWork]]): MergerOutcome = {
-    val transformedBaseWorks = maybeWorks
-      .collect {
-        case Some(transformedBaseWork: TransformedBaseWork) =>
-          transformedBaseWork
-      }
-
-    if (transformedBaseWorks.size == maybeWorks.size) {
-      mergerRules.merge(transformedBaseWorks)
-    } else {
-      MergerOutcome(maybeWorks.flatten, Nil)
-    }
+    mergerRules.merge(maybeWorks.flatten)
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -43,14 +43,24 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorksGenerators {
     }
   }
 
-  it("returns the works unmerged if any of the work entries are None") {
+  it("merges all available works and ignores None") {
     val expectedWorks = createUnidentifiedWorks(3)
 
     val maybeWorks = expectedWorks.map { Some(_) } ++ List(None)
 
     val result = mergerManager.applyMerge(maybeWorks = maybeWorks.toList)
 
-    result.works should contain theSameElementsAs expectedWorks
+    val redirectedWorks = expectedWorks.tail.map(
+      work =>
+        UnidentifiedRedirectedWork(
+          sourceIdentifier = work.sourceIdentifier,
+          version = work.version,
+          redirect = IdentifiableRedirect(expectedWorks.head.sourceIdentifier)
+      ))
+
+    result.works.head shouldBe expectedWorks.head
+
+    result.works.tail shouldBe redirectedWorks
   }
 
   val mergerRules = new Merger {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -88,7 +88,7 @@ class MergerWorkerServiceTest
     }
   }
 
-  it("fails if the work is not in vhs") {
+  it("skips if the work is not in vhs") {
     withMergerWorkerServiceFixtures {
       case (_, QueuePair(queue, dlq), topics, metrics) =>
         val work = createUnidentifiedWork
@@ -102,11 +102,11 @@ class MergerWorkerServiceTest
 
         eventually {
           assertQueueEmpty(queue)
-          assertQueueHasSize(dlq, 1)
+          assertQueueEmpty(dlq)
           listMessagesReceivedFromSNS(topics.works) shouldBe empty
 
-          metrics.incrementedCounts.length shouldBe 3
-          metrics.incrementedCounts.last should endWith("_failure")
+          metrics.incrementedCounts.length shouldBe 1
+          metrics.incrementedCounts.last should endWith("_success")
         }
     }
   }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -29,13 +29,15 @@ class RecorderPlaybackServiceTest
     }
   }
 
-  it("throws an error if asked to fetch a missing entry") {
-    val work = createUnidentifiedWork
+  it("returns None if asked to fetch a missing entry") {
+    val work1 = createUnidentifiedWork
+    val work2 = createUnidentifiedWork
 
     withVHS { vhs =>
-      whenReady(fetchAllWorks(vhs = vhs, work).failed) { result =>
-        result shouldBe a[NoSuchElementException]
-        result.getMessage shouldBe s"Work ${work.sourceIdentifier} is not in VHS!"
+      givenStoredInVhs(vhs, work1)
+
+      whenReady(fetchAllWorks(vhs = vhs, work1, work2)) { result =>
+        result shouldBe Seq(Some(work1), None)
       }
     }
   }


### PR DESCRIPTION
Sometimes the graph of IDs from the matcher will have works that haven't been stored in the recorder.

This ignores those  

- [ ] Make sure we aren't throwing an error, but rather returning `None` when something doesn't exist.