### PR TITLE
Refactoring in the METS adapter

### DIFF
--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/BagRetriever.scala
@@ -34,9 +34,8 @@ class HttpBagRetriever(baseUrl: String, tokenService: TokenService)(
     for {
       token <- tokenService.getToken
 
-      httpRequest =
-        HttpRequest(uri = requestUri)
-          .addHeader(Authorization(token))
+      httpRequest = HttpRequest(uri = requestUri)
+        .addHeader(Authorization(token))
 
       response <- Http().singleRequest(httpRequest)
       maybeBag <- {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/fixtures/BagsWiremock.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/fixtures/BagsWiremock.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.fixtures.TestWith
 import scala.util.Try
 
 trait BagsWiremock { this: Suite =>
-
   def withBagsService[R](host: String)(testWith: TestWith[Int, R]): R = {
     val wireMockServer = new WireMockServer(
       WireMockConfiguration

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
@@ -128,14 +128,12 @@ class BagRetrieverTest
     }
   }
 
-  def getBag(bagRetriever: BagRetriever, space: String, bagId: String) =
-    bagRetriever.getBag(
-      IngestUpdate(IngestUpdateContext(space, bagId))
-    )
+  def getBag(bagRetriever: BagRetriever, space: String, externalIdentifier: String): Future[Bag] =
+    bagRetriever.getBag(space = space, externalIdentifier = externalIdentifier)
 
   def withBagRetriever[R](tokenService: TokenService)(
     testWith: TestWith[BagRetriever, R])(implicit actorSystem: ActorSystem,
-                                         materializer: Materializer) =
+                                         materializer: Materializer): R =
     withBagsService("localhost") { port =>
       testWith(
         new HttpBagRetriever(
@@ -146,7 +144,7 @@ class BagRetrieverTest
 
   def withBagRetriever[R](testWith: TestWith[BagRetriever, R])(
     implicit actorSystem: ActorSystem,
-    materializer: Materializer) =
+    materializer: Materializer): Unit =
     withBagsService("localhost") { port =>
       withTokenService(
         s"http://localhost:$port",

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
@@ -75,13 +75,11 @@ class BagRetrieverTest
         .when(tokenService.getToken)
         .thenReturn(Future.successful(OAuth2BearerToken("not-valid-token")))
       withBagRetriever(tokenService) { bagRetriever =>
-        whenReady(getBag(bagRetriever, "digitised", "b30246039").failed) {
-          e =>
-            e shouldBe a[Throwable]
-            verify(
-              1,
-              getRequestedFor(
-                urlEqualTo("/storage/v1/bags/digitised/b30246039")))
+        whenReady(getBag(bagRetriever, "digitised", "b30246039").failed) { e =>
+          e shouldBe a[Throwable]
+          verify(
+            1,
+            getRequestedFor(urlEqualTo("/storage/v1/bags/digitised/b30246039")))
         }
       }
     }
@@ -93,8 +91,7 @@ class BagRetrieverTest
         stubFor(
           get(urlMatching("/storage/v1/bags/digitised/this-shall-crash"))
             .willReturn(aResponse().withStatus(500)))
-        whenReady(
-          getBag(bagRetriever, "digitised", "this-shall-crash").failed) {
+        whenReady(getBag(bagRetriever, "digitised", "this-shall-crash").failed) {
           _ shouldBe a[Throwable]
         }
       }
@@ -106,9 +103,10 @@ class BagRetrieverTest
       withBagRetriever { bagRetriever =>
         stubFor(
           get(urlMatching("/storage/v1/bags/digitised/this-will-fault"))
-            .willReturn(aResponse()
-              .withStatus(200)
-              .withFault(Fault.CONNECTION_RESET_BY_PEER)))
+            .willReturn(
+              aResponse()
+                .withStatus(200)
+                .withFault(Fault.CONNECTION_RESET_BY_PEER)))
         whenReady(getBag(bagRetriever, "digitised", "this-will-fault").failed) {
           _ shouldBe a[Throwable]
         }
@@ -116,7 +114,9 @@ class BagRetrieverTest
     }
   }
 
-  def getBag(bagRetriever: BagRetriever, space: String, externalIdentifier: String): Future[Bag] =
+  def getBag(bagRetriever: BagRetriever,
+             space: String,
+             externalIdentifier: String): Future[Bag] =
     bagRetriever.getBag(space = space, externalIdentifier = externalIdentifier)
 
   def withBagRetriever[R](tokenService: TokenService)(

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -40,7 +40,7 @@ class MetsAdapterWorkerServiceTest
 
   val bagRetriever =
     new BagRetriever {
-      def getBag(update: IngestUpdate): Future[Bag] =
+      def getBag(space: String, externalIdentifier: String): Future[Bag] =
         Future.successful(bag)
     }
 
@@ -105,7 +105,7 @@ class MetsAdapterWorkerServiceTest
   it("should not store / publish anything when bag retrieval fails") {
     val vhs = createStore()
     val brokenBagRetriever = new BagRetriever {
-      def getBag(update: IngestUpdate): Future[Bag] =
+      def getBag(space: String, externalIdentifier: String): Future[Bag] =
         Future.failed(new Exception("Failed retrieving bag"))
     }
     withWorkerService(brokenBagRetriever, vhs) {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -47,7 +47,7 @@ class MetsAdapterWorkerServiceTest
   it("processes ingest updates and store and publish METS data") {
     val vhs = createStore()
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
@@ -61,7 +61,7 @@ class MetsAdapterWorkerServiceTest
   it("publishes new METS data when old version exists in the store") {
     val vhs = createStore(Map(Version("123", 0) -> "old-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -76,7 +76,7 @@ class MetsAdapterWorkerServiceTest
   it("re-publishes existing data when current version exists in the store") {
     val vhs = createStore(Map(Version("123", 1) -> "existing-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
@@ -90,7 +90,7 @@ class MetsAdapterWorkerServiceTest
   it("ignores messages when greater version exists in the store") {
     val vhs = createStore(Map(Version("123", 2) -> "existing-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -109,7 +109,7 @@ class MetsAdapterWorkerServiceTest
         Future.failed(new Exception("Failed retrieving bag"))
     }
     withWorkerService(brokenBagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -121,8 +121,8 @@ class MetsAdapterWorkerServiceTest
 
   it("should store METS data if publishing fails") {
     val vhs = createStore()
-    withWorkerService(bagRetriever, vhs, createBrokenMsgSender(_)) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+    withWorkerService(bagRetriever, vhs, createBrokenMsgSender) {
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("digitised", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -136,7 +136,7 @@ class MetsAdapterWorkerServiceTest
     "sends message to the dlq if message is not wrapped in NotificationMessage") {
     val vhs = createStore()
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendSqsMessage(queue, ingestUpdate("digitised", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -148,7 +148,7 @@ class MetsAdapterWorkerServiceTest
   it("doesn't process the update when storageSpace isn't equal to 'digitised'") {
     val vhs = createStore()
     withWorkerService(bagRetriever, vhs) {
-      case (workerService, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), topic) =>
         sendNotificationToSQS(queue, ingestUpdate("something-different", "123"))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
@@ -161,8 +161,8 @@ class MetsAdapterWorkerServiceTest
   def withWorkerService[R](bagRetriever: BagRetriever,
                            store: VersionedStore[String, Int, MetsLocation],
                            createMsgSender: SNS.Topic => SNSMessageSender =
-                             createMsgSender(_))(
-    testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R]) =
+                             createMsgSender)(
+    testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R]): R =
     withActorSystem { implicit actorSystem =>
       withLocalSnsTopic { topic =>
         withLocalSqsQueueAndDlq {
@@ -181,14 +181,14 @@ class MetsAdapterWorkerServiceTest
       }
     }
 
-  def createMsgSender(topic: SNS.Topic) =
+  def createMsgSender(topic: SNS.Topic): SNSMessageSender =
     new SNSMessageSender(
       snsClient = snsClient,
       snsConfig = createSNSConfigWith(topic),
       subject = "SNSMessageSender"
     )
 
-  def createBrokenMsgSender(topic: SNS.Topic) =
+  def createBrokenMsgSender(topic: SNS.Topic): SNSMessageSender =
     new SNSMessageSender(
       snsClient = snsClient,
       snsConfig = createSNSConfigWith(topic),
@@ -204,7 +204,7 @@ class MetsAdapterWorkerServiceTest
   def metsLocation(file: String = "mets.xml", version: Int = 1) =
     MetsLocation("bucket", "root", version, file, Nil)
 
-  def getMessages(topic: SNS.Topic) =
+  def getMessages(topic: SNS.Topic): List[Version[String, Int]] =
     listMessagesReceivedFromSNS(topic)
       .map(msgInfo => fromJson[Version[String, Int]](msgInfo.message).get)
       .toList

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -162,7 +162,8 @@ class MetsAdapterWorkerServiceTest
                            store: VersionedStore[String, Int, MetsLocation],
                            createMsgSender: SNS.Topic => SNSMessageSender =
                              createMsgSender)(
-    testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R]): R =
+    testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R])
+    : R =
     withActorSystem { implicit actorSystem =>
       withLocalSnsTopic { topic =>
         withLocalSqsQueueAndDlq {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/TokenServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/TokenServiceTest.scala
@@ -21,25 +21,23 @@ class TokenServiceTest
   it("requests a token to the storage service") {
     withBagsService("localhost") { port =>
       withActorSystem { implicit actorSystem =>
-        withMaterializer(actorSystem) { implicit mat =>
-          val tokenService = new TokenService(
-            s"http://localhost:$port",
-            "client",
-            "secret",
-            "https://api.wellcomecollection.org/scope")
+        val tokenService = new TokenService(
+          url = s"http://localhost:$port",
+          clientId = "client",
+          secret = "secret",
+          scope = "https://api.wellcomecollection.org/scope")
 
-          whenReady(tokenService.getToken) { token =>
-            token shouldBe OAuth2BearerToken("token")
-          }
+        whenReady(tokenService.getToken) {
+          _ shouldBe OAuth2BearerToken("token")
+        }
 
-          eventually {
-            verify(
-              moreThan(1),
-              postRequestedFor(urlEqualTo("/oauth2/token"))
-                .withRequestBody(matching(".*client_id=client.*"))
-                .withRequestBody(matching(".*client_secret=secret.*"))
-            )
-          }
+        eventually {
+          verify(
+            moreThan(1),
+            postRequestedFor(urlEqualTo("/oauth2/token"))
+              .withRequestBody(matching(".*client_id=client.*"))
+              .withRequestBody(matching(".*client_secret=secret.*"))
+          )
         }
       }
     }
@@ -49,17 +47,14 @@ class TokenServiceTest
     "returns a failed future if it cannot get a token from the storage service") {
     withBagsService("localhost") { port =>
       withActorSystem { implicit actorSystem =>
-        withMaterializer(actorSystem) { implicit mat =>
-          val tokenService = new TokenService(
-            s"http://localhost:$port",
-            "wrongclient",
-            "wrongsecret",
-            "https://api.wellcomecollection.org/scope")
+        val tokenService = new TokenService(
+          s"http://localhost:$port",
+          "wrongclient",
+          "wrongsecret",
+          "https://api.wellcomecollection.org/scope")
 
-          whenReady(tokenService.getToken.failed) { throwable =>
-            throwable shouldBe a[Throwable]
-          }
-
+        whenReady(tokenService.getToken.failed) {
+          _ shouldBe a[Throwable]
         }
       }
     }


### PR DESCRIPTION
Prep work for https://github.com/wellcomecollection/platform/issues/4558

No change in functionality, but cleaning up some of the internals a bit. In particular, the exact format of the message sent by the storage service doesn't sink quite so deep into the METS adapter, so it'll be a smaller patch when we change it.