### PR TITLE
Suppress calm records on CatalogueStatus

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -85,7 +85,7 @@ object CalmTransformer
     }
 
   def shouldSuppress(record: CalmRecord): Boolean =
-    transmissionIsNo(record) match {
+    catalogueStatusIsSuppressible(record) match {
       case true  => true
       case false =>
         // Records prefixed with AMSG (Archives and Manuscripts Resource Guides)
@@ -96,17 +96,17 @@ object CalmTransformer
           .exists(_.startsWith("AMSG"))
     }
 
-  def transmissionIsNo(record: CalmRecord): Boolean =
+  // We suppress unless CatalogueStatus exists and is valid
+  def catalogueStatusIsSuppressible(record: CalmRecord): Boolean =
     record
-      .get("Transmission")
-      .exists { value =>
-        value.toLowerCase match {
-          case "no"  => true
-          case "yes" => false
-          case _ =>
-            info(
-              s"Unrecognised value for Transmission field; assuming 'Yes': $value")
+      .get("CatalogueStatus")
+      .forall { value =>
+        value.toLowerCase.trim match {
+          // As much as it might not look like it, these values mean it should
+          // not be suppressed.
+          case "catalogued" | "not yet available" | "partially catalogued" =>
             false
+          case _ => true
         }
       }
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -85,7 +85,7 @@ object CalmTransformer
     }
 
   def shouldSuppress(record: CalmRecord): Boolean =
-    catalogueStatusIsSuppressible(record) match {
+    catalogueStatusSuppressesRecord(record) match {
       case true  => true
       case false =>
         // Records prefixed with AMSG (Archives and Manuscripts Resource Guides)
@@ -97,7 +97,7 @@ object CalmTransformer
     }
 
   // We suppress unless CatalogueStatus exists and is valid
-  def catalogueStatusIsSuppressible(record: CalmRecord): Boolean =
+  def catalogueStatusSuppressesRecord(record: CalmRecord): Boolean =
     record
       .get("CatalogueStatus")
       .forall { value =>

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -18,6 +18,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version) shouldBe Right(
       UnidentifiedWork(
@@ -67,6 +68,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
       "BNumber" -> "b456",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.otherIdentifiers shouldBe
       List(
@@ -89,6 +91,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
       "BNumber" -> "b456",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.mergeCandidates shouldBe
       List(
@@ -111,6 +114,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "UserDate1" -> "10/10/2050",
       "AccessConditions" -> "nope.",
       "AccessConditions" -> "nope.",
+      "CatalogueStatus" -> "Catalogued"
     )
     val item = CalmTransformer(record, version).right.get.data.items.head
     item.locations.head.accessConditions shouldBe List(
@@ -129,6 +133,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
       "Description" -> "description of the thing",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.description shouldBe
       Some("description of the thing")
@@ -142,6 +147,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "AltRefNo" -> "a.b.c",
       "Extent" -> "long",
       "UserWrapped6" -> "thing",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.physicalDescription shouldBe
       Some("long thing")
@@ -173,6 +179,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "AltRefNo" -> "a.b.c",
       "Subject" -> "botany",
       "Subject" -> "anatomy",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.subjects should contain
     allOf(
@@ -187,7 +194,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "English"
+      "Language" -> "English",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.language shouldBe Some(
       Language("English", Some("en"))
@@ -200,14 +208,16 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "English "
+      "Language" -> "English ",
+      "CatalogueStatus" -> "Catalogued"
     )
     val recordB = calmRecord(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "  "
+      "Language" -> "  ",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
       Language("English", Some("en"))
@@ -221,14 +231,16 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "Dutch"
+      "Language" -> "Dutch",
+      "CatalogueStatus" -> "Catalogued"
     )
     val recordB = calmRecord(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "Flemish"
+      "Language" -> "Flemish",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
       Language("Dutch", Some("nl"))
@@ -245,7 +257,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
       "CreatorName" -> "Bebop",
-      "CreatorName" -> "Rocksteady"
+      "CreatorName" -> "Rocksteady",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.contributors should contain
     allOf(
@@ -262,7 +275,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "AltRefNo" -> "a.b.c",
       "Copyright" -> "no copyright",
       "ReproductionConditions" -> "reproduce at will",
-      "Arrangement" -> "meet at midnight"
+      "Arrangement" -> "meet at midnight",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.notes should contain allOf (
       CopyrightNote("no copyright"),
@@ -277,6 +291,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Subseries",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.collectionPath.get.level shouldBe Some(
       CollectionLevel.Series
@@ -349,15 +364,18 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
     "Returns UnidentifiedInvisibleWorkWork when missing required source fields") {
     val noTitle = calmRecord(
       "Level" -> "Collection",
-      "RefNo" -> "a/b/c"
+      "RefNo" -> "a/b/c",
+      "CatalogueStatus" -> "Catalogued"
     )
     val noLevel = calmRecord(
       "Title" -> "Stay calm",
-      "RefNo" -> "a/b/c"
+      "RefNo" -> "a/b/c",
+      "CatalogueStatus" -> "Catalogued"
     )
     val noRefNo = calmRecord(
       "Title" -> "Stay calm",
-      "Level" -> "Collection"
+      "Level" -> "Collection",
+      "CatalogueStatus" -> "Catalogued"
     )
 
     List(noTitle, noLevel, noRefNo) map { record =>
@@ -373,6 +391,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
       "AccessStatus" -> "AAH",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get shouldBe a[
       UnidentifiedInvisibleWork]
@@ -383,6 +402,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get shouldBe a[
       UnidentifiedInvisibleWork]
@@ -393,6 +413,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Title" -> "abc",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get shouldBe a[
       UnidentifiedInvisibleWork]
@@ -404,6 +425,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "TopLevel",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get shouldBe a[
       UnidentifiedInvisibleWork]
@@ -414,6 +436,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Title" -> "abc",
       "Level" -> "Collection",
       "AltRefNo" -> "a.b.c",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get shouldBe a[
       UnidentifiedInvisibleWork]
@@ -425,7 +448,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
-      "Language" -> "Lolol"
+      "Language" -> "Lolol",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.language shouldBe Some(
       Language("Lolol", None))
@@ -437,6 +461,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Title" -> "Should suppress",
       "Level" -> "Section",
       "RefNo" -> "AMSG/X/Y",
+      "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version) shouldBe Right(
       UnidentifiedInvisibleWork(


### PR DESCRIPTION
> suppress everything except Catalogued / Not yet available / Partially catalogued

-- The cataloguers

We also get some funky versions:
```
CatalogueStatus,Count
Catalogued,233298
"Third-party metadata",39322
Uncatalogued,3379
"Catalogued ",282
catalogued,89
"Not yet available",37
"Closed description",34
Draft,27
"In Conservation",16
"Partially catalogued",12
Deaccessioned,5
"Box list",3
"In Progress",3
"Catalogued 	 ",1
"Partially Third-party metadata",1
```