### PR TITLE
A bit more refactoring in the METS adapter

### DIFF
--- a/mets_adapter/mets_adapter/docker-compose.yml
+++ b/mets_adapter/mets_adapter/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
@@ -84,7 +84,8 @@ class MetsAdapterWorkerService[Destination](
         case (ctx, notification) if notification.space == "digitised" =>
           (ctx, Some(notification))
         case (ctx, notification) =>
-          info(s"Skipping notification $notification because it is not in the digitised space")
+          info(
+            s"Skipping notification $notification because it is not in the digitised space")
           (ctx, None)
       }
 

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
@@ -7,12 +7,13 @@ import akka.stream.scaladsl._
 import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.mets_adapter.models._
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.bigmessaging.FlowOps
+import uk.ac.wellcome.messaging.MessageSender
 
 import scala.concurrent.Future
 
@@ -25,9 +26,9 @@ import scala.concurrent.Future
   *  - Store the METS data in the VHS
   *  - Publish the VHS key to SNS
   */
-class MetsAdapterWorkerService(
+class MetsAdapterWorkerService[Destination](
   msgStream: SQSStream[NotificationMessage],
-  msgSender: SNSMessageSender,
+  msgSender: MessageSender[Destination],
   bagRetriever: BagRetriever,
   metsStore: MetsStore,
   concurrentHttpConnections: Int = 6,

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -62,7 +62,8 @@ class MetsAdapterWorkerServiceTest
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
-        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+          expectedVersion)
 
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
           Identified(expectedVersion, metsLocation())
@@ -79,7 +80,8 @@ class MetsAdapterWorkerServiceTest
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
-        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+          expectedVersion)
 
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
           Identified(expectedVersion, metsLocation())
@@ -96,7 +98,8 @@ class MetsAdapterWorkerServiceTest
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
-        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+          expectedVersion)
 
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
           Identified(expectedVersion, metsLocation("existing-data"))
@@ -205,9 +208,12 @@ class MetsAdapterWorkerServiceTest
 
   def withWorkerService[R](bagRetriever: BagRetriever,
                            store: VersionedStore[String, Int, MetsLocation],
-                           messageSender: MemoryMessageSender = new MemoryMessageSender())(
-    testWith: TestWith[(MetsAdapterWorkerService[String], QueuePair, MemoryMessageSender), R])
-    : R =
+                           messageSender: MemoryMessageSender =
+                             new MemoryMessageSender())(
+    testWith: TestWith[(MetsAdapterWorkerService[String],
+                        QueuePair,
+                        MemoryMessageSender),
+                       R]): R =
     withActorSystem { implicit actorSystem =>
       withLocalSqsQueueAndDlq {
         case QueuePair(queue, dlq) =>

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.mets_adapter.models._
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
+import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig, SNSMessageSender}
 import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.json.JsonUtil._
 
@@ -184,7 +184,7 @@ class MetsAdapterWorkerServiceTest
                            store: VersionedStore[String, Int, MetsLocation],
                            createMsgSender: SNS.Topic => SNSMessageSender =
                              createMsgSender)(
-    testWith: TestWith[(MetsAdapterWorkerService, QueuePair, SNS.Topic), R])
+    testWith: TestWith[(MetsAdapterWorkerService[SNSConfig], QueuePair, SNS.Topic), R])
     : R =
     withActorSystem { implicit actorSystem =>
       withLocalSnsTopic { topic =>

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -7,22 +7,22 @@ import org.scalatest.matchers.should.Matchers
 import io.circe.Encoder
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
+import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.mets_adapter.models._
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig, SNSMessageSender}
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
 class MetsAdapterWorkerServiceTest
     extends AnyFunSpec
     with Matchers
     with Akka
-    with SQS
-    with SNS {
+    with SQS {
 
   val bag = Bag(
     BagInfo("external-identifier"),
@@ -52,16 +52,20 @@ class MetsAdapterWorkerServiceTest
       externalIdentifier = externalIdentifier
     )
 
+  val expectedVersion = Version(externalIdentifier, version = 1)
+
   it("processes ingest updates and store and publish METS data") {
     val vhs = createStore()
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
-        getMessages(topic) shouldEqual List(Version(externalIdentifier, 1))
+
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
-          Identified(Version(externalIdentifier, 1), metsLocation())
+          Identified(expectedVersion, metsLocation())
         )
     }
   }
@@ -69,14 +73,16 @@ class MetsAdapterWorkerServiceTest
   it("publishes new METS data when old version exists in the store") {
     val vhs = createStore(Map(Version(externalIdentifier, 0) -> "old-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
-        getMessages(topic) shouldEqual List(Version("123", 1))
+
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
-          Identified(Version(externalIdentifier, 1), metsLocation())
+          Identified(expectedVersion, metsLocation())
         )
     }
   }
@@ -85,15 +91,15 @@ class MetsAdapterWorkerServiceTest
     val vhs =
       createStore(Map(Version(externalIdentifier, 1) -> "existing-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
-        getMessages(topic) shouldEqual List(Version("123", 1))
+
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(expectedVersion)
+
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
-          Identified(
-            Version(externalIdentifier, 1),
-            metsLocation("existing-data"))
+          Identified(expectedVersion, metsLocation("existing-data"))
         )
     }
   }
@@ -102,12 +108,14 @@ class MetsAdapterWorkerServiceTest
     val vhs =
       createStore(Map(Version(externalIdentifier, 2) -> "existing-data"))
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, size = 1)
-        getMessages(topic) shouldEqual Nil
+
+        messageSender.messages shouldBe empty
+
         vhs.getLatest(id = externalIdentifier) shouldBe Right(
           Identified(
             Version(externalIdentifier, 2),
@@ -122,26 +130,42 @@ class MetsAdapterWorkerServiceTest
       def getBag(space: String, externalIdentifier: String): Future[Bag] =
         Future.failed(new Exception("Failed retrieving bag"))
     }
-    withWorkerService(brokenBagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+
+    val brokenMessageSender = new MemoryMessageSender {
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+        Failure(new Throwable("BOOM!"))
+    }
+
+    withWorkerService(brokenBagRetriever, vhs, brokenMessageSender) {
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, size = 1)
-        getMessages(topic) shouldEqual Nil
+
+        messageSender.messages shouldBe empty
+
         vhs.getLatest(id = externalIdentifier) shouldBe a[Left[_, _]]
     }
   }
 
   it("should store METS data if publishing fails") {
     val vhs = createStore()
-    withWorkerService(bagRetriever, vhs, createBrokenMsgSender) {
-      case (_, QueuePair(queue, dlq), topic) =>
+
+    val brokenMessageSender = new MemoryMessageSender {
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+        Failure(new Throwable("BOOM!"))
+    }
+
+    withWorkerService(bagRetriever, vhs, brokenMessageSender) {
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, size = 1)
-        getMessages(topic) shouldEqual Nil
+
+        messageSender.messages shouldBe empty
+
         vhs.getLatest(id = externalIdentifier) shouldBe a[Right[_, _]]
     }
   }
@@ -150,14 +174,13 @@ class MetsAdapterWorkerServiceTest
     "sends message to the dlq if message is not wrapped in NotificationMessage") {
     val vhs = createStore()
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
-        sendSqsMessage(
-          queue,
-          createBagRegistrationNotificationWith("digitised", "123"))
+      case (_, QueuePair(queue, dlq), messageSender) =>
+        sendSqsMessage(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, 1)
-        getMessages(topic) shouldEqual Nil
+
+        messageSender.messages shouldBe empty
     }
   }
 
@@ -170,55 +193,35 @@ class MetsAdapterWorkerServiceTest
     )
 
     withWorkerService(bagRetriever, vhs) {
-      case (_, QueuePair(queue, dlq), topic) =>
+      case (_, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(queue, notification)
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
-        getMessages(topic) shouldEqual Nil
+        messageSender.messages shouldBe empty
         vhs.getLatest(id = externalIdentifier) shouldBe a[Left[_, _]]
     }
   }
 
   def withWorkerService[R](bagRetriever: BagRetriever,
                            store: VersionedStore[String, Int, MetsLocation],
-                           createMsgSender: SNS.Topic => SNSMessageSender =
-                             createMsgSender)(
-    testWith: TestWith[(MetsAdapterWorkerService[SNSConfig], QueuePair, SNS.Topic), R])
+                           messageSender: MemoryMessageSender = new MemoryMessageSender())(
+    testWith: TestWith[(MetsAdapterWorkerService[String], QueuePair, MemoryMessageSender), R])
     : R =
     withActorSystem { implicit actorSystem =>
-      withLocalSnsTopic { topic =>
-        withLocalSqsQueueAndDlq {
-          case QueuePair(queue, dlq) =>
-            withSQSStream[NotificationMessage, R](queue) { stream =>
-              val workerService = new MetsAdapterWorkerService(
-                stream,
-                createMsgSender(topic),
-                bagRetriever,
-                new MetsStore(store)
-              )
-              workerService.run()
-              testWith((workerService, QueuePair(queue, dlq), topic))
-            }
-        }
+      withLocalSqsQueueAndDlq {
+        case QueuePair(queue, dlq) =>
+          withSQSStream[NotificationMessage, R](queue) { stream =>
+            val workerService = new MetsAdapterWorkerService(
+              msgStream = stream,
+              msgSender = messageSender,
+              bagRetriever = bagRetriever,
+              metsStore = new MetsStore(store)
+            )
+            workerService.run()
+            testWith((workerService, QueuePair(queue, dlq), messageSender))
+          }
       }
-    }
-
-  def createMsgSender(topic: SNS.Topic): SNSMessageSender =
-    new SNSMessageSender(
-      snsClient = snsClient,
-      snsConfig = createSNSConfigWith(topic),
-      subject = "SNSMessageSender"
-    )
-
-  def createBrokenMsgSender(topic: SNS.Topic): SNSMessageSender =
-    new SNSMessageSender(
-      snsClient = snsClient,
-      snsConfig = createSNSConfigWith(topic),
-      subject = "BrokenSNSMessageSender"
-    ) {
-      override def sendT[T](item: T)(implicit encoder: Encoder[T]): Try[Unit] =
-        Failure(new Exception("Waaah I couldn't send message"))
     }
 
   def createStore(data: Map[Version[String, Int], String] = Map.empty) =
@@ -226,11 +229,6 @@ class MetsAdapterWorkerServiceTest
 
   def metsLocation(file: String = "mets.xml", version: Int = 1) =
     MetsLocation("bucket", "root", version, file, Nil)
-
-  def getMessages(topic: SNS.Topic): List[Version[String, Int]] =
-    listMessagesReceivedFromSNS(topic)
-      .map(msgInfo => fromJson[Version[String, Int]](msgInfo.message).get)
-      .toList
 
   def createBagRegistrationNotificationWith(
     space: String,


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4564

Plus skip the need for an SNS Docker container in the tests; we can do it all in-memory.