### PR TITLE
Do not create images from METS files with restricted access statuses

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -108,9 +108,10 @@ case class MetsData(
         }
       }
 
-  private def thumbnail(bnumber: String,
-                        license: Option[License],
-                        accessStatus: Option[AccessStatus]) =
+  private def thumbnail(
+    bnumber: String,
+    license: Option[License],
+    accessStatus: Option[AccessStatus]): Option[DigitalLocation] =
     for {
       fileReference <- titlePageFileReference
         .orElse(fileReferences.find(ImageUtils.isThumbnail))
@@ -130,7 +131,9 @@ case class MetsData(
       case _                       => true
     }
 
-  private def images(version: Int, accessStatus: Option[AccessStatus]) =
+  private def images(
+    version: Int,
+    accessStatus: Option[AccessStatus]): List[UnmergedImage[Identifiable]] =
     if (accessStatus.forall(shouldCreateDigitalLocation)) {
       fileReferences
         .filter(ImageUtils.isImage)

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -26,24 +26,16 @@ case class MetsData(
       UnidentifiedInvisibleWork(
         version = version,
         sourceIdentifier = sourceIdentifier,
-        workData(
-          item,
-          thumbnail(sourceIdentifier.value, license, accessStatus),
-          version)
+        data = WorkData(
+          items = List(item),
+          mergeCandidates = List(mergeCandidate),
+          thumbnail = thumbnail(sourceIdentifier.value, license, accessStatus),
+          images = images(version, accessStatus)
+        )
       )
 
   private lazy val fileReferences: List[FileReference] =
     fileReferencesMapping.map { case (_, fileReference) => fileReference }
-
-  private def workData(item: Item[Unminted],
-                       thumbnail: Option[DigitalLocation],
-                       version: Int) =
-    WorkData(
-      items = List(item),
-      mergeCandidates = List(mergeCandidate),
-      thumbnail = thumbnail,
-      images = images(version)
-    )
 
   private def mergeCandidate = MergeCandidate(
     identifier = SourceIdentifier(
@@ -123,7 +115,7 @@ case class MetsData(
       fileReference <- titlePageFileReference
         .orElse(fileReferences.find(ImageUtils.isThumbnail))
       url <- ImageUtils.buildThumbnailUrl(bnumber, fileReference)
-      if accessStatus.forall(shouldCreateThumbnail)
+      if accessStatus.forall(shouldCreateDigitalLocation)
     } yield
       DigitalLocation(
         url = url,
@@ -131,27 +123,32 @@ case class MetsData(
         license = license
       )
 
-  private def shouldCreateThumbnail(accessStatus: AccessStatus) =
+  private def shouldCreateDigitalLocation(accessStatus: AccessStatus) =
     accessStatus match {
       case AccessStatus.Restricted => false
       case AccessStatus.Closed     => false
       case _                       => true
     }
 
-  private def images(version: Int) =
-    fileReferences
-      .filter(ImageUtils.isImage)
-      .flatMap { fileReference =>
-        ImageUtils.buildImageUrl(recordIdentifier, fileReference).map { url =>
-          UnmergedImage(
-            ImageUtils
-              .getImageSourceId(recordIdentifier, fileReference.id),
-            version = version,
-            DigitalLocation(
-              url = url,
-              locationType = LocationType("iiif-image")
+  private def images(version: Int, accessStatus: Option[AccessStatus]) =
+    if (accessStatus.forall(shouldCreateDigitalLocation)) {
+      fileReferences
+        .filter(ImageUtils.isImage)
+        .flatMap { fileReference =>
+          ImageUtils.buildImageUrl(recordIdentifier, fileReference).map { url =>
+            UnmergedImage(
+              ImageUtils
+                .getImageSourceId(recordIdentifier, fileReference.id),
+              version = version,
+              DigitalLocation(
+                url = url,
+                locationType = LocationType("iiif-image")
+              )
             )
-          )
+          }
         }
-      }
+    } else {
+      Nil
+    }
+
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -351,6 +351,20 @@ class MetsDataTest
       "ID/C")
   }
 
+  it("creates a work without images for restricted access statuses") {
+    val result = MetsData(
+      recordIdentifier = "ID",
+      accessConditionDz = Some("CC-BY-NC"),
+      accessConditionStatus = Some("Restricted files"),
+      fileReferencesMapping = List(
+        "A" -> FileReference("A", "location1.jp2", Some("image/jp2")),
+        "B" -> FileReference("B", "location2.jp2", Some("image/jp2"))
+      )
+    ).toWork(1)
+    result shouldBe a[Right[_, _]]
+    result.right.get.data.images shouldBe empty
+  }
+
   it("creates a work with a single accessCondition including usage terms") {
     val result = MetsData(
       recordIdentifier = "ID",


### PR DESCRIPTION
This just extends the logic to suppress thumbnails to `Image`s as well

Closes https://github.com/wellcomecollection/platform/issues/4566