### PR TITLE
don't redirect when we merge images

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -30,10 +30,10 @@ object ImagesRule extends FieldMergeRule {
         FieldMergeResult(
           data = getPictureImages(target, sources).getOrElse(Nil) ++
             getPairedMiroImages(target, sources).getOrElse(Nil),
-          sources = sources.filter { source =>
-            List(getPictureImages, getPairedMiroImages).exists(
-              _(target, source).isDefined)
-          }
+          // The images rule here is the exception where we don't want to redirect works as they have
+          // not technically been merged. This rule might change as the rules about merging items
+          // loosens up.
+          sources = List()
         )
     }
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -87,7 +87,7 @@ class PlatformMergerTest
     }
   }
 
-  it("merges a Sierra physical work with a single-page Miro work") {
+  it("merges a Sierra physical work with a Miro work") {
     val result = merger.merge(
       works = Seq(sierraPhysicalWork, miroWork)
     )
@@ -171,6 +171,25 @@ class PlatformMergerTest
     result.images should contain theSameElementsAs List(
       expectedImage
     )
+  }
+
+  it("does not merge a sierra work with multiple items with a linked Miro work") {
+    val result = merger.merge(
+      works = Seq(multipleItemsSierraWork, miroWork)
+    )
+
+    result.works.size shouldBe 2
+
+    val expectedMergedWork = multipleItemsSierraWork.withData { data =>
+      data.copy(
+        images = miroWork.data.images,
+        merged = true
+      )
+    }
+
+    result.works should contain theSameElementsAs Seq(
+      miroWork,
+      expectedMergedWork)
   }
 
   it("merges a non-picture Sierra work with a METS work") {


### PR DESCRIPTION
`ImagesRule` shouldn't currently affect the way redirection of works work.

Currently we redirect the Miro work because of this rule, where it needs to exist as it's own identified work as we haven't merged the metadata that's used by the works index.

This will probably change once we start using the `work.images` and/or loosen up on the rules around item merging.