### PR TITLE
Merge zero-item Sierra works

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -36,17 +36,17 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       List(
         mergeIntoCalmTarget,
         mergeMetsIntoSingleItemSierraTarget,
-        mergeMiroIntoSingleItemSierraTarget,
-        mergeIntoMultiItemSierraTarget)
+        mergeMiroIntoSingleOrZeroItemSierraTarget,
+        mergeMetsIntoMultiItemSierraTarget)
 
     val singleItemSierraIds =
       mergeMetsIntoSingleItemSierraTarget(target, sources) |+|
-        mergeMiroIntoSingleItemSierraTarget(target, sources)
+        mergeMiroIntoSingleOrZeroItemSierraTarget(target, sources)
 
     val ids =
       (mergeIntoCalmTarget(target, sources)
         .orElse(singleItemSierraIds)
-        .orElse(mergeIntoMultiItemSierraTarget(target, sources))
+        .orElse(mergeMetsIntoMultiItemSierraTarget(target, sources))
         .getOrElse(target.otherIdentifiers) ++ digitisedSierraIds).distinct
 
     val mergedSources = sources.filter { source =>
@@ -69,8 +69,9 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       target.otherIdentifiers
   }
 
-  private val mergeMiroIntoSingleItemSierraTarget = new PartialRule {
-    val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
+  private val mergeMiroIntoSingleOrZeroItemSierraTarget = new PartialRule {
+    val isDefinedForTarget: WorkPredicate =
+      WorkPredicates.singleItemSierra or WorkPredicates.zeroItemSierra
     val isDefinedForSource: WorkPredicate =
       WorkPredicates.singleDigitalItemMiroWork
 
@@ -79,7 +80,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       target.otherIdentifiers ++ sources.toList.map(_.sourceIdentifier)
   }
 
-  private val mergeIntoMultiItemSierraTarget = new PartialRule {
+  private val mergeMetsIntoMultiItemSierraTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate = WorkPredicates.multiItemSierra
     val isDefinedForSource: WorkPredicate =
       WorkPredicates.singleDigitalItemMetsWork

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.models.work.internal.{
 }
 import uk.ac.wellcome.platform.merger.logging.MergerLogging
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
-import uk.ac.wellcome.platform.merger.rules.WorkPredicates.WorkPredicate
+import uk.ac.wellcome.platform.merger.rules.WorkPredicates.{
+  WorkPredicate,
+  WorkPredicateOps
+}
 
 /*
  * Thumbnails are chosen preferentially off of METS works, falling back to
@@ -59,7 +62,8 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
 
   val getMinMiroThumbnail =
     new PartialRule {
-      val isDefinedForTarget: WorkPredicate = WorkPredicates.singleItemSierra
+      val isDefinedForTarget: WorkPredicate =
+        WorkPredicates.singleItemSierra or WorkPredicates.zeroItemSierra
       val isDefinedForSource: WorkPredicate =
         WorkPredicates.singleDigitalItemMiroWork
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -20,6 +20,7 @@ object WorkPredicates {
     "miro-image-number")
 
   val sierraWork: WorkPredicate = sierraIdentified
+  val zeroItem: WorkPredicate = work => work.data.items.isEmpty
   val singleItem: WorkPredicate = work => work.data.items.size == 1
   val multiItem: WorkPredicate = work => work.data.items.size > 1
 
@@ -47,6 +48,7 @@ object WorkPredicates {
     allDigitalLocations
   )
 
+  val zeroItemSierra: WorkPredicate = satisfiesAll(sierraWork, zeroItem)
   val singleItemSierra: WorkPredicate = satisfiesAll(sierraWork, singleItem)
   val multiItemSierra: WorkPredicate = satisfiesAll(sierraWork, multiItem)
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -12,6 +12,7 @@ class ItemsRuleTest
     with WorksGenerators
     with Inside {
   val physicalSierra = createSierraPhysicalWork
+  val zeroItemPhysicalSierra = createUnidentifiedSierraWork
   val multiItemPhysicalSierra = createSierraWorkWithTwoPhysicalItems
   val digitalSierra = createSierraDigitalWork
   val metsWork = createUnidentifiedInvisibleMetsWork
@@ -34,9 +35,23 @@ class ItemsRuleTest
   }
 
   // Sierra zero item
-  it("merges the item from Miro works into zero-item Sierra works") {}
+  it("merges the item from Miro works into zero-item Sierra works") {
+    inside(ItemsRule.merge(zeroItemPhysicalSierra, List(miroWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 1
+        items.head shouldBe miroWork.data.items.head
+        mergedSources should be(Seq(miroWork))
+    }
+  }
 
-  it("merges the item from METS works into zero-item Sierra works") {}
+  it("merges the item from METS works into zero-item Sierra works") {
+    inside(ItemsRule.merge(zeroItemPhysicalSierra, List(metsWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 1
+        items.head shouldBe metsWork.data.items.head
+        mergedSources should be(Seq(metsWork))
+    }
+  }
 
   // Sierra single item
   it("merges locations from Miro items into single-item Sierra works") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -33,6 +33,11 @@ class ItemsRuleTest
     }
   }
 
+  // Sierra zero item
+  it("merges the item from Miro works into zero-item Sierra works") {}
+
+  it("merges the item from METS works into zero-item Sierra works") {}
+
   // Sierra single item
   it("merges locations from Miro items into single-item Sierra works") {
     inside(ItemsRule.merge(physicalSierra, List(miroWork))) {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -21,6 +21,7 @@ class OtherIdentifiersRuleTest
   val miroWorks = (0 to 3).map(_ => createMiroWork).toList
   val metsWorks = (0 to 3).map(_ => createUnidentifiedInvisibleMetsWork).toList
   val physicalSierra = createSierraPhysicalWork
+  val zeroItemPhysicalSierra = createUnidentifiedSierraWork
   val sierraWorkWithTwoPhysicalItems = createSierraWorkWithTwoPhysicalItems
   val calmWork =
     createUnidentifiedCalmWork
@@ -48,6 +49,16 @@ class OtherIdentifiersRuleTest
     }
   }
 
+  it("merges Miro source IDs into a Sierra work with zero items") {
+    inside(OtherIdentifiersRule.merge(zeroItemPhysicalSierra, miroWorks)) {
+      case FieldMergeResult(otherIdentifiers, mergedSources) =>
+        otherIdentifiers should contain theSameElementsAs
+          miroWorks.map(_.sourceIdentifier) ++ zeroItemPhysicalSierra.otherIdentifiers
+
+        mergedSources should contain theSameElementsAs miroWorks
+    }
+  }
+
   it(
     "merges Miro source IDs into Sierra work with single item with METS and miro merge candidates") {
     inside(
@@ -57,7 +68,7 @@ class OtherIdentifiersRuleTest
         otherIdentifiers should contain theSameElementsAs miroWorks
           .map(_.sourceIdentifier) ++ physicalSierra.otherIdentifiers
 
-        mergedSources should contain theSameElementsAs (metsWorks ++ miroWorks)
+        mergedSources should contain theSameElementsAs miroWorks
     }
   }
 
@@ -97,14 +108,14 @@ class OtherIdentifiersRuleTest
     }
   }
 
-  it("does not merge any METS IDs and have them as a merged source") {
+  it("does not merge any METS IDs") {
     inside(OtherIdentifiersRule.merge(physicalSierra, metsWorks)) {
       case FieldMergeResult(otherIdentifiers, mergedSources) =>
         forAll(otherIdentifiers) { id =>
           id.identifierType.id should not be ("mets")
         }
 
-        mergedSources should be(metsWorks)
+        mergedSources shouldBe empty
     }
   }
 }


### PR DESCRIPTION
Other than what it says in the title, this PR also removes the parts of the identifiers rule which didn't merge METS identifiers and were only there for getting a list of `mergedSources` that matched that of the items rule - as discussed in Slack with @jamesgorrie. This doesn't affect merge behaviour, and also doesn't affect redirect behaviour as the latter is covered by the items rule.

There are also some refactors where I've shuffled around some logic:
- In the items rule, the top-level merge function now just defines the "merge METS or if that's not possible merge Miro" logic and the METS partial rule itself handles the single vs multi vs zero item logic. I think this is clearer, and it's certainly more concise.
- In the identifiers rule, I've similarly moved some/most of the logic related to linked digitised Sierra works into the corresponding partial rule.

