### PR TITLE
Remove service discovery from pipeline services

### DIFF
--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -15,7 +15,8 @@ variable "cluster_arn" {
 }
 
 variable "namespace_id" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "subnets" {

--- a/infrastructure/modules/worker_with_sidecar/variables.tf
+++ b/infrastructure/modules/worker_with_sidecar/variables.tf
@@ -11,7 +11,8 @@ variable "cluster_arn" {
 }
 
 variable "namespace_id" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "subnets" {

--- a/pipeline/terraform/modules/service/main.tf
+++ b/pipeline/terraform/modules/service/main.tf
@@ -9,8 +9,6 @@ module "worker" {
 
   subnets = var.subnets
 
-  namespace_id = var.namespace_id
-
   cluster_name = var.cluster_name
   cluster_arn  = var.cluster_arn
 

--- a/pipeline/terraform/modules/service/variables.tf
+++ b/pipeline/terraform/modules/service/variables.tf
@@ -6,7 +6,6 @@ variable "subnets" {
   type = list(string)
 }
 
-variable "namespace_id" {}
 variable "container_image" {}
 
 variable "secret_env_vars" {

--- a/pipeline/terraform/modules/service_with_manager/main.tf
+++ b/pipeline/terraform/modules/service_with_manager/main.tf
@@ -5,8 +5,6 @@ module "worker" {
 
   subnets = var.subnets
 
-  namespace_id = var.namespace_id
-
   cluster_name = var.cluster_name
   cluster_arn  = var.cluster_arn
 

--- a/pipeline/terraform/modules/service_with_manager/variables.tf
+++ b/pipeline/terraform/modules/service_with_manager/variables.tf
@@ -2,9 +2,6 @@ variable "subnets" {
   type = list(string)
 }
 
-variable "namespace_id" {
-}
-
 variable "cluster_name" {
 }
 

--- a/pipeline/terraform/stack/network.tf
+++ b/pipeline/terraform/stack/network.tf
@@ -1,4 +1,0 @@
-resource "aws_service_discovery_private_dns_namespace" "namespace" {
-  name = local.namespace_hyphen
-  vpc  = var.vpc_id
-}

--- a/pipeline/terraform/stack/service_image_id_minter.tf
+++ b/pipeline/terraform/stack/service_image_id_minter.tf
@@ -20,8 +20,6 @@ module "image_id_minter" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.id
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     metrics_namespace    = "${local.namespace_hyphen}_image_id_minter"
     messages_bucket_name = aws_s3_bucket.messages.id

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -28,8 +28,6 @@ module "image_inferrer" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   host_cpu    = 4096
   host_memory = 8192
 

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -20,8 +20,6 @@ module "ingestor_works" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     metrics_namespace   = "${local.namespace_hyphen}_ingestor_works"
     es_index            = var.es_works_index

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -21,8 +21,6 @@ module "ingestor_images" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     metrics_namespace   = "${local.namespace_hyphen}_ingestor_images"
     es_index            = var.es_images_index

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -27,8 +27,6 @@ module "matcher" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     queue_url         = module.matcher_queue.url
     metrics_namespace = "${local.namespace_hyphen}_matcher"

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -19,8 +19,6 @@ module "merger" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     metrics_namespace        = "${local.namespace_hyphen}_merger"
     messages_bucket_name     = aws_s3_bucket.messages.id

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -23,8 +23,6 @@ module "recorder" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     recorder_queue_url             = module.recorder_queue.url
     metrics_namespace              = "${local.namespace_hyphen}_recorder"

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -18,8 +18,6 @@ module "calm_transformer" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     sns_arn              = module.calm_transformer_topic.arn
     transformer_queue_id = module.calm_transformer_queue.url

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -18,8 +18,6 @@ module "mets_transformer" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     sns_arn              = module.mets_transformer_topic.arn
     transformer_queue_id = module.mets_transformer_queue.url

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -18,8 +18,6 @@ module "miro_transformer" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     sns_arn              = module.miro_transformer_topic.arn
     transformer_queue_id = module.miro_transformer_queue.url

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -18,8 +18,6 @@ module "sierra_transformer" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     sns_arn                = module.sierra_transformer_topic.arn
     transformer_queue_id   = module.sierra_transformer_queue.url

--- a/pipeline/terraform/stack/service_work_id_minter.tf
+++ b/pipeline/terraform/stack/service_work_id_minter.tf
@@ -20,8 +20,6 @@ module "work_id_minter" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.id
 
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
   env_vars = {
     metrics_namespace    = "${local.namespace_hyphen}_work_id_minter"
     messages_bucket_name = aws_s3_bucket.messages.id


### PR DESCRIPTION
This is not being used, and the current dependence of the DNS namespace id variable on a resource requires a targeted apply beforehand to create the resource.