### PR TITLE
Delete old sierra adapter vhs

### DIFF
--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -31,28 +31,6 @@ output "vhs_miro_inventory_assumable_read_role" {
   value = module.vhs_miro_migration.assumable_read_role
 }
 
-# Sierra Hybrid Store
-
-output "vhs_sierra_full_access_policy" {
-  value = module.vhs_sierra.full_access_policy
-}
-
-output "vhs_sierra_read_policy" {
-  value = module.vhs_sierra.read_policy
-}
-
-output "vhs_sierra_table_name" {
-  value = module.vhs_sierra.table_name
-}
-
-output "vhs_sierra_bucket_name" {
-  value = module.vhs_sierra.bucket_name
-}
-
-output "vhs_sierra_assumable_read_role" {
-  value = module.vhs_sierra.assumable_read_role
-}
-
 # Mets Store
 
 output "mets_dynamo_full_access_policy" {
@@ -65,22 +43,4 @@ output "mets_dynamo_read_policy" {
 
 output "mets_dynamo_table_name" {
   value = aws_dynamodb_table.mets_adapter_table.id
-}
-
-# Sierra Items Hybrid Store
-
-output "vhs_sierra_items_full_access_policy" {
-  value = module.vhs_sierra_items.full_access_policy
-}
-
-output "vhs_sierra_items_table_name" {
-  value = module.vhs_sierra_items.table_name
-}
-
-output "vhs_sierra_items_bucket_name" {
-  value = module.vhs_sierra_items.bucket_name
-}
-
-output "vhs_sierra_items_assumable_read_role" {
-  value = module.vhs_sierra_items.assumable_read_role
 }

--- a/infrastructure/critical/vhs_sierra_items.tf
+++ b/infrastructure/critical/vhs_sierra_items.tf
@@ -1,7 +1,0 @@
-module "vhs_sierra_items" {
-  source = "./modules/vhs"
-  name   = "sourcedata-sierra-items"
-
-  read_principles = local.read_principles
-}
-

--- a/infrastructure/critical/vhs_sierra_sourcedata.tf
+++ b/infrastructure/critical/vhs_sierra_sourcedata.tf
@@ -1,7 +1,0 @@
-module "vhs_sierra" {
-  source = "./modules/vhs"
-  name   = "sourcedata-sierra"
-
-  read_principles = local.read_principles
-}
-


### PR DESCRIPTION
The new one lives in the sierra_adapter stack. I've decided to do that as I don't think the adapters stores are truly critical and simplifies the terraform. Also, it's consistent with how the calm VHS is defined