### PR TITLE
Update fmt-sbt-s3-resolver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ libraryDependencies ++= Seq(
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
-addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.16.0")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.18.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
Use the latest version of fm-sbt-s3-resolver to avoid possible issues with missing jaxb deps in Java 11.

See https://github.com/frugalmechanic/fm-sbt-s3-resolver/pull/56