### PR TITLE
Similarity search queries

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-import uk.ac.wellcome.typesafe.{Runnable, WellcomeTypesafeApp}
+import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 
 import scala.concurrent.{ExecutionContext, Promise}
 
@@ -49,11 +49,9 @@ object Main extends WellcomeTypesafeApp {
 
     val router = new Router(elasticClient, elasticConfig, apiConfig)
 
-    new Runnable {
-      def run() =
-        Http()
-          .bindAndHandle(router.routes, "0.0.0.0", 8888)
-          .flatMap(_ => Promise[Done].future)
-    }
+    () =>
+      Http()
+        .bindAndHandle(router.routes, "0.0.0.0", 8888)
+        .flatMap(_ => Promise[Done].future)
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.rest._
+import uk.ac.wellcome.platform.api.services.ElasticsearchService
 
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,
@@ -72,11 +73,13 @@ class Router(elasticClient: ElasticClient,
     }
   }
 
+  lazy val elasticsearchService = new ElasticsearchService(elasticClient)
+
   lazy val worksController =
-    new WorksController(elasticClient, apiConfig, elasticConfig)
+    new WorksController(elasticsearchService, apiConfig, elasticConfig)
 
   lazy val imagesController =
-    new ImagesController(elasticClient, apiConfig, elasticConfig)
+    new ImagesController(elasticsearchService, apiConfig, elasticConfig)
 
   def swagger: Route = get {
     complete(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchQuery.scala
@@ -297,8 +297,7 @@ final case class BoolBoostedQuery(q: String) extends ElasticsearchPartialQuery {
 final case class ImageSimilarityQuery(q: String, index: Index)
     extends ElasticsearchQuery {
   private final val lshFields = List("inferredData.lshEncodedFeatures")
-
-  lazy val documentRef = DocumentRef(index = index, id = q)
+  private lazy val documentRef = DocumentRef(index, q)
 
   lazy val elasticQuery =
     moreLikeThisQuery(lshFields)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchQuery.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.api.elasticsearch
 
-import com.sksamuel.elastic4s.ElasticDsl.{must, should}
-import com.sksamuel.elastic4s.requests.common.Operator
+import com.sksamuel.elastic4s.ElasticDsl.{moreLikeThisQuery, must, should}
+import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.requests.common.{DocumentRef, Operator}
 import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   FieldWithOptionalBoost,
@@ -291,4 +292,20 @@ final case class BoolBoostedQuery(q: String) extends ElasticsearchPartialQuery {
     must(ContributorQuery(q).elasticQuery).boost(2000),
     must(TitleQuery(q).elasticQuery).boost(1000)
   )
+}
+
+final case class ImageSimilarityQuery(q: String, index: Index)
+    extends ElasticsearchQuery {
+  private final val lshFields = List("inferredData.lshEncodedFeatures")
+
+  lazy val documentRef = DocumentRef(index = index, id = q)
+
+  lazy val elasticQuery =
+    moreLikeThisQuery(lshFields)
+      .likeDocs(List(documentRef))
+      .copy(
+        minTermFreq = Some(1),
+        maxQueryTerms = Some(1000),
+        minShouldMatch = Some("1")
+      )
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.rest
 
 import akka.http.scaladsl.server.Route
-import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.Index
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.Implicits._
@@ -10,14 +10,13 @@ import uk.ac.wellcome.platform.api.Tracing
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchService,
-  ImagesRequestBuilder,
   ImagesService
 }
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ImagesController(
-  elasticClient: ElasticClient,
+  elasticsearchService: ElasticsearchService,
   implicit val apiConfig: ApiConfig,
   elasticConfig: ElasticConfig)(implicit ec: ExecutionContext)
     extends CustomDirectives
@@ -85,6 +84,5 @@ class ImagesController(
       }
     }
 
-  private lazy val imagesService = new ImagesService(
-    new ElasticsearchService(elasticClient, ImagesRequestBuilder))
+  private lazy val imagesService = new ImagesService(elasticsearchService)
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -1,16 +1,28 @@
 package uk.ac.wellcome.platform.api.rest
 
+import io.circe.Decoder
+import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.services.ImagesSearchOptions
 
 case class SingleImageParams(
+  include: Option[SingleImageIncludes],
   _index: Option[String]
 ) extends QueryParams
 
 object SingleImageParams extends QueryParamsUtils {
   def parse =
-    parameter("_index".as[String].?)
-      .map(SingleImageParams.apply)
+    parameter(
+      (
+        "include".as[SingleImageIncludes].?,
+        "_index".as[String].?
+      )
+    ).tmap((SingleImageParams.apply _).tupled(_))
+
+  implicit val includesDecoder: Decoder[SingleImageIncludes] =
+    decodeOneOfCommaSeparated(
+      "visuallySimilar" -> ImageInclude.VisuallySimilar,
+    ).emap(values => Right(SingleImageIncludes(values)))
 }
 
 case class MultipleImagesParams(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.rest
 
 import akka.http.scaladsl.model.StatusCodes.Found
 import akka.http.scaladsl.server.Route
-import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.Index
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import grizzled.slf4j.Logger
 import uk.ac.wellcome.display.models._
@@ -13,7 +13,6 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.{
   CollectionService,
   ElasticsearchService,
-  WorksRequestBuilder,
   WorksService
 }
 import uk.ac.wellcome.platform.api.Tracing
@@ -21,7 +20,7 @@ import uk.ac.wellcome.platform.api.Tracing
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorksController(
-  elasticClient: ElasticClient,
+  elasticsearchService: ElasticsearchService,
   implicit val apiConfig: ApiConfig,
   elasticConfig: ElasticConfig)(implicit ec: ExecutionContext)
     extends Tracing
@@ -126,10 +125,9 @@ class WorksController(
     )
 
   private lazy val collectionService =
-    new CollectionService(elasticClient)
+    new CollectionService(elasticsearchService)
 
-  private lazy val worksService = new WorksService(
-    new ElasticsearchService(elasticClient, WorksRequestBuilder))
+  private lazy val worksService = new WorksService(elasticsearchService)
 
   private lazy val logger = Logger(this.getClass.getName)
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -61,8 +61,8 @@ class ElasticsearchService(elasticClient: ElasticClient)(
       val transaction = Tracing.currentTransaction
       withActiveTrace(elasticClient.execute(request))
         .map(toEither)
-        .map {
-          _.map { res =>
+        .map { responseOrError =>
+          responseOrError.map { res =>
             transaction.addLabel("elasticTook", res.took)
             res
           }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -22,7 +22,7 @@ case class ElasticsearchQueryOptions(filters: List[DocumentFilter],
                                      sortOrder: SortingOrder,
                                      searchQuery: Option[SearchQuery])
 
-class ElasticsearchService(elasticClient: ElasticClient,
+class ElasticsearchService(val elasticClient: ElasticClient,
                            requestBuilder: ElasticsearchRequestBuilder)(
   implicit ec: ExecutionContext
 ) extends Logging

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -5,7 +5,10 @@ import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.sort._
-import uk.ac.wellcome.platform.api.elasticsearch.CoreImagesQuery
+import uk.ac.wellcome.platform.api.elasticsearch.{
+  CoreImagesQuery,
+  ImageSimilarityQuery
+}
 import uk.ac.wellcome.platform.api.models.{ImageFilter, LicenseFilter}
 
 object ImagesRequestBuilder extends ElasticsearchRequestBuilder {
@@ -41,4 +44,9 @@ object ImagesRequestBuilder extends ElasticsearchRequestBuilder {
       case LicenseFilter(licenseIds) =>
         termsQuery(field = "location.license.id", values = licenseIds)
     }
+
+  def requestVisuallySimilar(index: Index, id: String, n: Int): SearchRequest =
+    search(index)
+      .query(ImageSimilarityQuery(q = id, index = index).elasticQuery)
+      .size(n)
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -71,10 +71,12 @@ class ImagesService(searchService: ElasticsearchService)(
           n = nVisuallySimilarImages
         )
       )
-      .map {
-        _.map {
-          _.hits.hits.map(hit => jsonTo(hit.sourceAsString)).toList
-        }.getOrElse(Nil)
+      .map { result =>
+        result
+          .map { response =>
+            response.hits.hits.map(hit => jsonTo(hit.sourceAsString)).toList
+          }
+          .getOrElse(Nil)
       }
 
   def toElasticsearchQueryOptions(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -35,7 +35,7 @@ class WorksService(searchService: ElasticsearchService)(
   def findWorkById(canonicalId: String)(
     index: Index): Future[Either[ElasticError, Option[IdentifiedBaseWork]]] =
     searchService
-      .findResultById(canonicalId)(index)
+      .executeGet(canonicalId)(index)
       .map { result: Either[ElasticError, GetResponse] =>
         result.map { response: GetResponse =>
           if (response.exists)
@@ -49,6 +49,7 @@ class WorksService(searchService: ElasticsearchService)(
     searchService
       .executeSearch(
         queryOptions = toElasticsearchQueryOptions(searchOptions),
+        requestBuilder = WorksRequestBuilder,
         index = index
       )
       .map { _.map(createResultList) }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -67,6 +67,15 @@ trait SingleImageSwagger {
         in = ParameterIn.PATH,
         description = "The image to return",
         required = true
+      ),
+      new Parameter(
+        name = "include",
+        in = ParameterIn.QUERY,
+        description = "A comma-separated list of extra fields to include",
+        schema = new Schema(
+          allowableValues = Array("visuallySimilar")
+        ),
+        required = false
       )
     )
   )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/FreeTextQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/FreeTextQueryTest.scala
@@ -36,10 +36,7 @@ class FreeTextQueryTest
     with WorksGenerators
     with ContributorGenerators {
 
-  val searchService = new ElasticsearchService(
-    elasticClient = elasticClient,
-    WorksRequestBuilder
-  )
+  val searchService = new ElasticsearchService(elasticClient)
 
   describe("Free text query functionality") {
 
@@ -381,7 +378,7 @@ class FreeTextQueryTest
   private def searchResults(index: Index,
                             queryOptions: ElasticsearchQueryOptions) = {
     val searchResponseFuture =
-      searchService.executeSearch(queryOptions, index)
+      searchService.executeSearch(queryOptions, WorksRequestBuilder, index)
     whenReady(searchResponseFuture) { response =>
       searchResponseToWorks(response)
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/QueryVariantsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/QueryVariantsTest.scala
@@ -12,10 +12,7 @@ import uk.ac.wellcome.models.work.generators.{
   WorksGenerators
 }
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
-import uk.ac.wellcome.platform.api.services.{
-  ElasticsearchService,
-  WorksRequestBuilder
-}
+import uk.ac.wellcome.platform.api.services.ElasticsearchService
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 import com.sksamuel.elastic4s.ElasticDsl._
@@ -33,10 +30,7 @@ class QueryVariantsTest
     with WorksGenerators
     with ContributorGenerators {
 
-  val searchService = new ElasticsearchService(
-    elasticClient = elasticClient,
-    WorksRequestBuilder
-  )
+  val searchService = new ElasticsearchService(elasticClient)
 
   /**
     * These test are more to explain what the query is doing

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -1,0 +1,53 @@
+package uk.ac.wellcome.platform.api.images
+
+import uk.ac.wellcome.elasticsearch.ElasticConfig
+
+class ImagesSimilarityTest extends ApiImagesTestBase {
+
+  it(
+    "includes visually similar images on a single image if we pass ?include=visuallySimilar") {
+    withApi {
+      case (ElasticConfig(_, imagesIndex), routes) =>
+        val images = createVisuallySimilarImages(6)
+        val image = images.head
+        insertImagesIntoElasticsearch(imagesIndex, images: _*)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/images/${images.head.id.canonicalId}?include=visuallySimilar",
+          unordered = true) {
+          Status.OK ->
+            s"""
+           |{
+           |  $singleImageResult,
+           |  "id": "${image.id.canonicalId}",
+           |  "locations": [${digitalLocation(image.location)}],
+           |  "visuallySimilar": [
+           |    ${images.tail.map(imageResponse).mkString(",")}
+           |  ],
+           |  "source": {
+           |    "id": "${image.source.id.canonicalId}",
+           |    "type": "Work"
+           |  }
+           |}""".stripMargin
+        }
+    }
+  }
+
+  it("never includes visually similar images on an images search") {
+    withApi {
+      case (ElasticConfig(_, imagesIndex), routes) =>
+        val focacciaImage = createAugmentedImageWith(
+          id = "b",
+          fullText = Some("A Ligurian style of bread, Focaccia")
+        )
+        insertImagesIntoElasticsearch(imagesIndex, focacciaImage)
+
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/images?query=focaccia&include=visuallySimilar") {
+          Status.OK -> imagesListResponse(List(focacciaImage))
+        }
+    }
+  }
+
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -27,7 +27,7 @@ class AggregationsTest
     with WorksGenerators {
 
   val worksService = new WorksService(
-    searchService = new ElasticsearchService(elasticClient, WorksRequestBuilder)
+    searchService = new ElasticsearchService(elasticClient)
   )
 
   it("returns more than 10 workType aggregations") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/CollectionServiceTest.scala
@@ -22,7 +22,7 @@ class CollectionServiceTest
     with ItemsGenerators
     with WorksGenerators {
 
-  val service = new CollectionService(elasticClient)
+  val service = new CollectionService(new ElasticsearchService(elasticClient))
 
   def work(path: String, level: CollectionLevel) =
     createIdentifiedWorkWith(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
@@ -48,4 +48,39 @@ class ImagesServiceTest
         .map { _.left.value shouldBe a[ElasticError] }
     }
   }
+
+  describe("retrieveSimilarImages") {
+    it("gets visually similarImages") {
+      withLocalImagesIndex { index =>
+        val images = createVisuallySimilarImages(6)
+        insertImagesIntoElasticsearch(index, images: _*)
+
+        imagesService
+          .retrieveSimilarImages(index, images.head)
+          .map { results =>
+            results should not be empty
+            results should contain theSameElementsAs images.tail
+          }
+      }
+    }
+
+    it("returns Nil when no visually similar images can be found") {
+      withLocalImagesIndex { index =>
+        val image = createAugmentedImage()
+        insertImagesIntoElasticsearch(index, image)
+
+        imagesService.retrieveSimilarImages(index, image).map { results =>
+          results shouldBe empty
+        }
+      }
+    }
+
+    it("returns Nil when Elasticsearch returns an error") {
+      imagesService
+        .retrieveSimilarImages(Index("doesn't exist"), createAugmentedImage())
+        .map { results =>
+          results shouldBe empty
+        }
+    }
+  }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
@@ -13,10 +13,7 @@ class ImagesServiceTest
     with EitherValues
     with OptionValues {
 
-  val elasticsearchService = new ElasticsearchService(
-    elasticClient = elasticClient,
-    ImagesRequestBuilder
-  )
+  val elasticsearchService = new ElasticsearchService(elasticClient)
 
   val imagesService = new ImagesService(
     elasticsearchService

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -37,10 +37,7 @@ class WorksServiceTest
     with WorksGenerators
     with ProductionEventGenerators {
 
-  val elasticsearchService = new ElasticsearchService(
-    elasticClient = elasticClient,
-    WorksRequestBuilder
-  )
+  val elasticsearchService = new ElasticsearchService(elasticClient)
 
   val worksService = new WorksService(
     searchService = elasticsearchService

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
@@ -21,6 +21,10 @@ case class DisplayImage(
     `type` = "uk.ac.wellcone.Display.models.DisplayImageSource",
     description = "A description of the image's source"
   ) source: DisplayImageSource,
+  @Schema(
+    `type` = "Image",
+    description = "A list of visually similar images"
+  ) visuallySimilar: Option[Seq[DisplayImage]],
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Image"
 )
 
@@ -30,7 +34,12 @@ object DisplayImage {
     new DisplayImage(
       id = image.id.canonicalId,
       locations = Seq(DisplayDigitalLocation(image.location)),
-      source = DisplayImageSource(image.source)
+      source = DisplayImageSource(image.source),
+      visuallySimilar = None
     )
 
+  def apply(image: AugmentedImage, similar: Seq[AugmentedImage]): DisplayImage =
+    DisplayImage(image).copy(
+      visuallySimilar = Some(similar.map(DisplayImage.apply))
+    )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.display.models
+
+sealed trait ImageInclude
+
+object ImageInclude {
+  case object VisuallySimilar extends ImageInclude
+}
+
+case class SingleImageIncludes(includes: List[ImageInclude]) {
+  def visuallySimilar = includes.contains(ImageInclude.VisuallySimilar)
+}
+
+object SingleImageIncludes {
+  import ImageInclude._
+
+  def apply(visuallySimilar: Boolean = false): SingleImageIncludes =
+    SingleImageIncludes(
+      List(
+        if (visuallySimilar) Some(VisuallySimilar) else None
+      ).flatten
+    )
+}

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayImageTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayImageTest.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.display.models
+
+import org.scalatest.OptionValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.ImageGenerators
+
+class DisplayImageTest
+    extends AnyFunSpec
+    with Matchers
+    with OptionValues
+    with ImageGenerators {
+
+  it("adds a list of visuallySimilar images if specified") {
+    val image = createAugmentedImage()
+    val similarImages = (1 to 3).map(_ => createAugmentedImage()).toSeq
+
+    val displayImage = DisplayImage(image, similar = similarImages)
+    displayImage.visuallySimilar.value should have length similarImages.size
+    displayImage.visuallySimilar.value
+      .map(_.id) should contain theSameElementsAs
+      similarImages.map(_.id.canonicalId)
+  }
+
+}


### PR DESCRIPTION
This PR adds the option to `?include=visuallySimilar` on `/images/{id}` queries

 It also refactors `ElasticsearchService` so that it can be used (to transform our data into requests, handle APM stuff, and transform responses into the form we want) across the application, as we'd previously been using it as intended for "simple" search/get requests but were not able to use it for collection requests and would not have been able to use it for image similarity searches.