### PR TITLE
Use weco-deploy tool

### DIFF
--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -82,7 +82,7 @@ endef
 define publish_service_ssm
 	$(ROOT)/docker_run.py \
     	    --aws --dind -- \
-    	    wellcome/publish_service:86 \
+    	    wellcome/weco-deploy:0.19.0 publish \
     	    	--service_id="$(1)" \
     	        --project_id=$(2) \
     	        --account_id=$(3) \


### PR DESCRIPTION
Use the new [weco-deploy tool](https://github.com/wellcomecollection/weco-deploy) to publish images to ECR in order to open up to deploying the fixed tags (required to simplify the deployment process by removing terraform).

Part of https://github.com/wellcomecollection/platform/issues/4616