### PR TITLE
Disable sierra progress reporter

### DIFF
--- a/sierra_adapter/terraform/stack/progress_reporter.tf
+++ b/sierra_adapter/terraform/stack/progress_reporter.tf
@@ -1,13 +1,16 @@
-module "progress_reporter" {
-  source = "./../sierra_progress_reporter"
+// The progress reporter currently times out (even at the 15min limit)
+// TODO: fix it
 
-  trigger_interval_minutes = 240
-  s3_adapter_bucket_name   = aws_s3_bucket.sierra_adapter.id
-  slack_access_token       = local.critical_slack_webhook
-
-  infra_bucket = var.infra_bucket
-
-  lambda_error_alarm_arn = var.lambda_error_alarm_arn
-
-  namespace = local.namespace_hyphen
-}
+//module "progress_reporter" {
+//  source = "./../sierra_progress_reporter"
+//
+//  trigger_interval_minutes = 240
+//  s3_adapter_bucket_name   = aws_s3_bucket.sierra_adapter.id
+//  slack_access_token       = local.critical_slack_webhook
+//
+//  infra_bucket = var.infra_bucket
+//
+//  lambda_error_alarm_arn = var.lambda_error_alarm_arn
+//
+//  namespace = local.namespace_hyphen
+//}


### PR DESCRIPTION
I fixed the error it's been throwing recently, but then it just timed out at 15 minutes. Since we don't appear to be using it I thought disabling it for now made sense...