### PR TITLE
Update sierra_adapter to use new deployment

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -1,58 +1,57 @@
 mets_adapter:
   environments:
-  - id: prod
-    name: Production
+    - id: prod
+      name: Production
   image_repositories:
-  - id: mets_adapter
-    namespace: uk.ac.wellcome
-    account_id: '760097843905'
-    services:
-    - mets-adapter
+    - id: mets_adapter
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - mets-adapter
   name: METS Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
-  github_repository: wellcometrust/catalogue
 
 calm_adapter:
   environments:
-  - id: prod
-    name: Production
+    - id: prod
+      name: Production
   image_repositories:
-  - id: calm_adapter
-    namespace: uk.ac.wellcome
-    account_id: '760097843905'
-    services:
-    - calm-adapter
+    - id: calm_adapter
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - calm-adapter
   name: Calm Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
 
 sierra_adapter:
   environments:
-  - id: prod
-    name: Production
+    - id: prod
+      name: Production
   image_repositories:
     - id: sierra_bib_merger
       namespace: uk.ac.wellcome
       account_id: '760097843905'
       services:
-      - bibs-merger
+        - bibs-merger
     - id: sierra_item_merger
       namespace: uk.ac.wellcome
       account_id: '760097843905'
       services:
-      - bibs-merger
+        - bibs-merger
     - id: sierra_items_to_dynamo
       namespace: uk.ac.wellcome
       account_id: '760097843905'
       services:
-      - items-to-dynamo
+        - items-to-dynamo
     - id: sierra_reader
       namespace: uk.ac.wellcome
       account_id: '760097843905'
       services:
-      - items-reader
-      - bibs-reader
+        - items-reader
+        - bibs-reader
   name: Sierra Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
@@ -60,8 +59,8 @@ sierra_adapter:
 
 reindexer:
   environments:
-  - id: prod
-    name: Production
+    - id: prod
+      name: Production
   name: Reindexer
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
@@ -69,10 +68,10 @@ reindexer:
 
 catalogue_pipeline:
   environments:
-  - id: prod
-    name: Production
-  - id: miro_merging_test
-    name: Miro merging test
+    - id: prod
+      name: Production
+    - id: miro_merging_test
+      name: Miro merging test
   name: Catalogue pipeline
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
@@ -80,10 +79,10 @@ catalogue_pipeline:
 
 catalogue_api:
   environments:
-  - id: staging
-    name: Staging
-  - id: prod
-    name: Production
+    - id: staging
+      name: Staging
+    - id: prod
+      name: Production
   name: Catalogue API
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1

--- a/.wellcome_project
+++ b/.wellcome_project
@@ -40,7 +40,7 @@ sierra_adapter:
       namespace: uk.ac.wellcome
       account_id: '760097843905'
       services:
-        - bibs-merger
+        - items-merger
     - id: sierra_items_to_dynamo
       namespace: uk.ac.wellcome
       account_id: '760097843905'

--- a/.wellcome_project
+++ b/.wellcome_project
@@ -26,12 +26,33 @@ calm_adapter:
   name: Calm Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1
-  github_repository: wellcometrust/catalogue
 
 sierra_adapter:
   environments:
   - id: prod
     name: Production
+  image_repositories:
+    - id: sierra_bib_merger
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+      - bibs-merger
+    - id: sierra_item_merger
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+      - bibs-merger
+    - id: sierra_items_to_dynamo
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+      - items-to-dynamo
+    - id: sierra_reader
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+      - items-reader
+      - bibs-reader
   name: Sierra Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -82,7 +82,7 @@ endef
 define publish_service_ssm
 	$(ROOT)/docker_run.py \
     	    --aws --dind -- \
-                wellcome/weco-deploy:4.0.0 \
+                wellcome/weco-deploy:4.1.0 \
                 --project-id="$(2)" \
                 --verbose \
                 publish \

--- a/sierra_adapter/terraform/bib_merger/main.tf
+++ b/sierra_adapter/terraform/bib_merger/main.tf
@@ -1,8 +1,10 @@
-
 module "sierra_merger_service" {
   source = "../../../infrastructure/modules/worker"
 
   name = local.service_name
+
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
 
   image = var.container_image
 

--- a/sierra_adapter/terraform/bib_merger/variables.tf
+++ b/sierra_adapter/terraform/bib_merger/variables.tf
@@ -24,5 +24,9 @@ variable "namespace" {}
 variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
 
-variable "deployment_service_env" {}
-variable "deployment_service_name" {}
+variable "deployment_service_env" {
+  type = "string"
+}
+variable "deployment_service_name" {
+  type = "string"
+}

--- a/sierra_adapter/terraform/bib_merger/variables.tf
+++ b/sierra_adapter/terraform/bib_merger/variables.tf
@@ -23,3 +23,6 @@ variable "namespace_id" {}
 variable "namespace" {}
 variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
+
+variable "deployment_service_env" {}
+variable "deployment_service_name" {}

--- a/sierra_adapter/terraform/item_merger/main.tf
+++ b/sierra_adapter/terraform/item_merger/main.tf
@@ -3,6 +3,9 @@ module "sierra_merger_service" {
 
   name = local.service_name
 
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
+
   image = var.container_image
 
   env_vars = {

--- a/sierra_adapter/terraform/item_merger/variables.tf
+++ b/sierra_adapter/terraform/item_merger/variables.tf
@@ -27,3 +27,6 @@ variable "namespace_id" {}
 variable "namespace" {}
 variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
+
+variable "deployment_service_env" {}
+variable "deployment_service_name" {}

--- a/sierra_adapter/terraform/items_to_dynamo/main.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/main.tf
@@ -3,6 +3,9 @@ module "sierra_to_dynamo_service" {
 
   name = local.service_name
 
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
+
   image = var.container_image
 
   env_vars = {

--- a/sierra_adapter/terraform/items_to_dynamo/variables.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/variables.tf
@@ -24,3 +24,6 @@ variable "namespace_id" {}
 variable "namespace" {}
 variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
+
+variable "deployment_service_env" {}
+variable "deployment_service_name" {}

--- a/sierra_adapter/terraform/main.tf
+++ b/sierra_adapter/terraform/main.tf
@@ -14,4 +14,6 @@ module "sierra-adapter-20200604" {
   vpc_id                   = local.vpc_id
   bibs_windows_topic_arns  = [module.bibs_window_generator.topic_arn, module.bibs_reharvest_topic.arn]
   items_windows_topic_arns = [module.items_window_generator.topic_arn, module.items_reharvest_topic.arn]
+
+  deployment_env = "prod"
 }

--- a/sierra_adapter/terraform/provider.tf
+++ b/sierra_adapter/terraform/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.aws_region
-  version = "~> 2.45.0"
+  version = "~> 2.0"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/sierra_adapter/terraform/sierra_reader/main.tf
+++ b/sierra_adapter/terraform/sierra_reader/main.tf
@@ -3,6 +3,9 @@ module "sierra_reader_service" {
 
   name = local.service_name
 
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
+
   image = var.container_image
 
   env_vars = {

--- a/sierra_adapter/terraform/sierra_reader/variables.tf
+++ b/sierra_adapter/terraform/sierra_reader/variables.tf
@@ -30,3 +30,6 @@ variable "namespace_id" {}
 variable "namespace" {}
 variable "interservice_security_group_id" {}
 variable "service_egress_security_group_id" {}
+
+variable "deployment_service_env" {}
+variable "deployment_service_name" {}

--- a/sierra_adapter/terraform/stack/pipeline_bibs.tf
+++ b/sierra_adapter/terraform/stack/pipeline_bibs.tf
@@ -1,4 +1,3 @@
-
 module "bibs_reader" {
   source = "./../sierra_reader"
 
@@ -28,6 +27,9 @@ module "bibs_reader" {
 
   service_egress_security_group_id = var.egress_security_group_id
   interservice_security_group_id   = var.interservice_security_group_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "bibs-reader"
 }
 
 module "bibs_merger" {
@@ -55,4 +57,7 @@ module "bibs_merger" {
 
   service_egress_security_group_id = var.egress_security_group_id
   interservice_security_group_id   = var.interservice_security_group_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "bibs-merger"
 }

--- a/sierra_adapter/terraform/stack/pipeline_items.tf
+++ b/sierra_adapter/terraform/stack/pipeline_items.tf
@@ -27,6 +27,9 @@ module "items_reader" {
 
   service_egress_security_group_id = var.egress_security_group_id
   interservice_security_group_id   = var.interservice_security_group_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "items-reader"
 }
 
 module "items_to_dynamo" {
@@ -52,6 +55,9 @@ module "items_to_dynamo" {
 
   service_egress_security_group_id = var.egress_security_group_id
   interservice_security_group_id   = var.interservice_security_group_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "items-to-dynamo"
 }
 
 module "items_merger" {
@@ -81,4 +87,7 @@ module "items_merger" {
 
   service_egress_security_group_id = var.egress_security_group_id
   interservice_security_group_id   = var.interservice_security_group_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "items-merger"
 }

--- a/sierra_adapter/terraform/stack/variables.tf
+++ b/sierra_adapter/terraform/stack/variables.tf
@@ -9,3 +9,4 @@ variable "egress_security_group_id" {}
 variable "interservice_security_group_id" {}
 variable "bibs_windows_topic_arns" {}
 variable "items_windows_topic_arns" {}
+variable "deployment_env" {}


### PR DESCRIPTION
This moves all sierra_adapter services to use the new deployment mechanism.

The terraform for this change has been applied and deployment tested.