### PR TITLE
Apply deployment tags to pipeline services in ECS

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -72,6 +72,63 @@ catalogue_pipeline:
       name: Production
     - id: miro_merging_test
       name: Miro merging test
+  image_repositories:
+    - id: id_minter
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - image-id-minter
+        - work-id-minter
+    - id: inference_manager
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - image-inferrer
+    - id: matcher
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - matcher
+    - id: merger
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - merger
+    - id: recorder
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - recorder
+    - id: ingestor_images
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - image-ingestor
+    - id: ingestor_works
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - work-ingestor
+    - id: transformer_calm
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - calm-transformer
+    - id: transformer_mets
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - mets-transformer
+    - id: transformer_miro
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - miro-transformer
+    - id: transformer_sierra
+      namespace: uk.ac.wellcome
+      account_id: '760097843905'
+      services:
+        - sierra-transformer
   name: Catalogue pipeline
   role_arn: arn:aws:iam::760097843905:role/platform-ci
   aws_region_name: eu-west-1

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -83,6 +83,7 @@ variable "deployment_service_name" {
   description = "Used by weco-deploy to determine which services to deploy, if unset the value used will be var.name"
   default     = ""
 }
+
 variable "deployment_service_env" {
   type        = string
   description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"

--- a/infrastructure/modules/worker_with_sidecar/main.tf
+++ b/infrastructure/modules/worker_with_sidecar/main.tf
@@ -1,5 +1,10 @@
+locals {
+  # Override the default service name if requested
+  deployment_service_name = var.deployment_service_name == "" ? var.name : var.deployment_service_name
+}
+
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.0.0"
 
   task_definition_arn            = module.task_definition.arn
   service_name                   = var.name
@@ -10,10 +15,15 @@ module "service" {
   desired_task_count             = var.desired_task_count
   security_group_ids             = var.security_group_ids
   use_fargate_spot               = var.use_fargate_spot
+
+  tags = {
+    "deployment:service" = local.deployment_service_name
+    "deployment:env"     = var.deployment_service_env
+  }
 }
 
 module "autoscaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.0.0"
 
   name = var.name
 
@@ -25,7 +35,7 @@ module "autoscaling" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.0.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -41,7 +51,7 @@ module "task_definition" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.0.0"
 
   name  = var.name
   image = var.app_image
@@ -58,13 +68,13 @@ module "app_container" {
 }
 
 module "app_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
   secrets   = var.app_secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "sidecar_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.0.0"
 
   name  = var.sidecar_name
   image = var.sidecar_image
@@ -84,19 +94,19 @@ module "sidecar_container" {
 }
 
 module "sidecar_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
   secrets   = var.sidecar_secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.0.0"
   namespace = var.name
 }
 
 module "log_router_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
   secrets   = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }

--- a/infrastructure/modules/worker_with_sidecar/variables.tf
+++ b/infrastructure/modules/worker_with_sidecar/variables.tf
@@ -114,3 +114,15 @@ variable "app_healthcheck" {
   type    = any
   default = null
 }
+
+variable "deployment_service_name" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy, if unset the value used will be var.name"
+  default     = ""
+}
+
+variable "deployment_service_env" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
+  default     = "prod"
+}

--- a/pipeline/terraform/modules/service/main.tf
+++ b/pipeline/terraform/modules/service/main.tf
@@ -21,4 +21,7 @@ module "worker" {
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
+
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
 }

--- a/pipeline/terraform/modules/service/variables.tf
+++ b/pipeline/terraform/modules/service/variables.tf
@@ -48,3 +48,10 @@ variable "min_capacity" {
   type    = number
   default = 0
 }
+
+variable "deployment_service_env" {
+  type = string
+}
+variable "deployment_service_name" {
+  type = string
+}

--- a/pipeline/terraform/modules/service_with_manager/main.tf
+++ b/pipeline/terraform/modules/service_with_manager/main.tf
@@ -32,4 +32,7 @@ module "worker" {
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
+
+  deployment_service_env  = var.deployment_service_env
+  deployment_service_name = var.deployment_service_name
 }

--- a/pipeline/terraform/modules/service_with_manager/variables.tf
+++ b/pipeline/terraform/modules/service_with_manager/variables.tf
@@ -97,3 +97,10 @@ variable "manager_memory" {
   default = 1024
 }
 
+variable "deployment_service_env" {
+  type = string
+}
+
+variable "deployment_service_name" {
+  type = string
+}

--- a/pipeline/terraform/stack/service_image_id_minter.tf
+++ b/pipeline/terraform/stack/service_image_id_minter.tf
@@ -52,6 +52,9 @@ module "image_id_minter" {
 
   cpu    = 1024
   memory = 2048
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "image-id-minter"
 }
 
 # Output topic

--- a/pipeline/terraform/stack/service_image_id_minter.tf
+++ b/pipeline/terraform/stack/service_image_id_minter.tf
@@ -53,7 +53,7 @@ module "image_id_minter" {
   cpu    = 1024
   memory = 2048
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "image-id-minter"
 }
 

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -68,6 +68,9 @@ module "image_inferrer" {
 
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.image_inferrer_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name =  "image-inferrer"
 }
 
 resource "aws_iam_role_policy" "read_inferrer_data" {

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -69,8 +69,8 @@ module "image_inferrer" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.image_inferrer_queue.read_policy
 
-  deployment_service_env = var.release_label
-  deployment_service_name =  "image-inferrer"
+  deployment_service_env  = var.release_label
+  deployment_service_name = "image-inferrer"
 }
 
 resource "aws_iam_role_policy" "read_inferrer_data" {

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -42,7 +42,7 @@ module "ingestor_works" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_works_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "work-ingestor"
 }
 

--- a/pipeline/terraform/stack/service_ingestor.tf
+++ b/pipeline/terraform/stack/service_ingestor.tf
@@ -41,6 +41,9 @@ module "ingestor_works" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_works_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "work-ingestor"
 }
 
 module "ingestor_works_scaling_alarm" {

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -43,7 +43,7 @@ module "ingestor_images" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_images_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "image-ingestor"
 }
 

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -42,6 +42,9 @@ module "ingestor_images" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_images_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "image-ingestor"
 }
 
 module "ingestor_images_scaling_alarm" {

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -49,7 +49,7 @@ module "matcher" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.matcher_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "matcher"
 }
 

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -48,6 +48,9 @@ module "matcher" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.matcher_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "matcher"
 }
 
 resource "aws_iam_role_policy" "matcher_vhs_recorder_read" {

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -36,6 +36,9 @@ module "merger" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.merger_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "merger"
 }
 
 resource "aws_iam_role_policy" "merger_vhs_recorder_read" {

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -37,7 +37,7 @@ module "merger" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.merger_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "merger"
 }
 

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -37,6 +37,9 @@ module "recorder" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.recorder_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "recorder"
 }
 
 resource "aws_iam_role_policy" "recorder_vhs_recorder_readwrite" {

--- a/pipeline/terraform/stack/service_recorder.tf
+++ b/pipeline/terraform/stack/service_recorder.tf
@@ -38,7 +38,7 @@ module "recorder" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.recorder_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "recorder"
 }
 

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -35,7 +35,7 @@ module "calm_transformer" {
 
   queue_read_policy = module.calm_transformer_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "calm-transformer"
 }
 

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -34,6 +34,9 @@ module "calm_transformer" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
 
   queue_read_policy = module.calm_transformer_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "calm-transformer"
 }
 
 resource "aws_iam_role_policy" "calm_transformer_vhs_calm_adapter_read" {

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -38,7 +38,7 @@ module "mets_transformer" {
   cpu    = 1024
   memory = 2048
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "mets-transformer"
 }
 

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -37,6 +37,9 @@ module "mets_transformer" {
 
   cpu    = 1024
   memory = 2048
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "mets-transformer"
 }
 
 module "mets_transformer_topic" {

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -32,7 +32,7 @@ module "miro_transformer" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.miro_transformer_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "miro-transformer"
 }
 

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -31,6 +31,9 @@ module "miro_transformer" {
   max_capacity        = 10
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.miro_transformer_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "miro-transformer"
 }
 
 resource "aws_iam_role_policy" "miro_transformer_vhs_miro_adapter_read" {

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -34,6 +34,9 @@ module "sierra_transformer" {
   messages_bucket_arn = aws_s3_bucket.messages.arn
 
   queue_read_policy = module.sierra_transformer_queue.read_policy
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "sierra-transformer"
 }
 
 resource "aws_iam_role_policy" "sierra_transformer_vhs_sierra_adapter_read" {

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -35,7 +35,7 @@ module "sierra_transformer" {
 
   queue_read_policy = module.sierra_transformer_queue.read_policy
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "sierra-transformer"
 }
 

--- a/pipeline/terraform/stack/service_work_id_minter.tf
+++ b/pipeline/terraform/stack/service_work_id_minter.tf
@@ -53,7 +53,7 @@ module "work_id_minter" {
   cpu    = 1024
   memory = 2048
 
-  deployment_service_env = var.release_label
+  deployment_service_env  = var.release_label
   deployment_service_name = "work-id-minter"
 }
 

--- a/pipeline/terraform/stack/service_work_id_minter.tf
+++ b/pipeline/terraform/stack/service_work_id_minter.tf
@@ -52,6 +52,9 @@ module "work_id_minter" {
 
   cpu    = 1024
   memory = 2048
+
+  deployment_service_env = var.release_label
+  deployment_service_name = "work-id-minter"
 }
 
 # Output topic


### PR DESCRIPTION
This adds the tags required for automating ECS deployments using the `weco-deploy` tool.

Further work is required to update image references in services to allow the tool to deploy to ECS (deployments should continue to function as before).