### PR TITLE
Add tags to catalogue api services for new deployment tool

### DIFF
--- a/api/terraform/modules/stack/main.tf
+++ b/api/terraform/modules/stack/main.tf
@@ -9,6 +9,9 @@ module "service" {
   service_name                   = local.namespaced_env
   service_discovery_namespace_id = var.service_discovery_namespace_id
 
+  deployment_service_env  = var.environment
+  deployment_service_name = "catalogue-api"
+
   subnets           = var.subnets
   cluster_arn       = var.cluster_arn
   vpc_id            = var.vpc_id

--- a/api/terraform/modules/stack/service/main.tf
+++ b/api/terraform/modules/stack/service/main.tf
@@ -1,23 +1,23 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.0.0"
   namespace = var.service_name
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.0.0"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.0.0"
   name   = "app"
 
   image = var.container_image
@@ -32,13 +32,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.4.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
   secrets   = var.secrets
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.0.0"
 
   cpu    = 1024
   memory = 2048
@@ -52,8 +52,13 @@ module "task_definition" {
   task_name = var.service_name
 }
 
+locals {
+  # Override the default service name if requested
+  deployment_service_name = var.deployment_service_name == "" ? var.service_name : var.deployment_service_name
+}
+
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.0.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
@@ -72,4 +77,10 @@ module "service" {
 
   container_name = module.nginx_container.container_name
   container_port = module.nginx_container.container_port
+
+
+  tags = {
+    "deployment:service" = local.deployment_service_name
+    "deployment:env"     = var.deployment_service_env
+  }
 }

--- a/api/terraform/modules/stack/service/variables.tf
+++ b/api/terraform/modules/stack/service/variables.tf
@@ -68,3 +68,15 @@ variable "load_balancer_arn" {
 variable "load_balancer_listener_port" {
   type = number
 }
+
+variable "deployment_service_name" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy, if unset the value used will be var.name"
+  default     = ""
+}
+
+variable "deployment_service_env" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
+  default     = "prod"
+}


### PR DESCRIPTION
Adds tags to ECS services needed to do ECS deploys with the weco-deploy tool.