### PR TITLE
remove keyword mapping from notes.content

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -23,9 +23,14 @@ trait IndexConfig {
   def keywordWithText(name: String) =
     keywordField(name).fields(textField("text"))
 
-  def englishTextField(name: String) =
+  def englishTextKeywordField(name: String) =
     textField(name).fields(
       keywordField("keyword"),
+      textField("english").analyzer("english")
+    )
+
+  def englishTextField(name: String) =
+    textField(name).fields(
       textField("english").analyzer("english")
     )
 
@@ -66,7 +71,7 @@ trait IndexConfig {
   val accessConditions =
     objectField("accessConditions")
       .fields(
-        englishTextField("terms"),
+        englishTextKeywordField("terms"),
         textField("to"),
         objectField("status").fields(keywordField("type"))
       )

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -109,7 +109,7 @@ case object WorksIndexConfig extends IndexConfig {
   def items(fieldName: String) = objectField(fieldName).fields(
     id(),
     location(),
-    englishTextField("title"),
+    englishTextKeywordField("title"),
     keywordField("ontologyType")
   )
 
@@ -160,12 +160,10 @@ case object WorksIndexConfig extends IndexConfig {
       mergeCandidates,
       workType,
       title,
-      englishTextField("alternativeTitles"),
-      textField("description").fields(
-        textField("english").analyzer("english")
-      ),
-      englishTextField("physicalDescription"),
-      englishTextField("lettering"),
+      englishTextKeywordField("alternativeTitles"),
+      englishTextField("description"),
+      englishTextKeywordField("physicalDescription"),
+      englishTextKeywordField("lettering"),
       objectField("createdDate").fields(period),
       contributors,
       subjects,


### PR DESCRIPTION
[Similar to this](https://github.com/wellcomecollection/catalogue/pull/677). Long text fields should not have a keyword mapping. Titles etc should for exact matching, which is why I am leaving them.

Once I get this index working I am going to do a more thorough audit of the mapping.