### PR TITLE
RelatedWorkService

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -1,16 +1,22 @@
 package uk.ac.wellcome.platform.api.services
 
+import scala.concurrent.{ExecutionContext, Future}
+
 import co.elastic.apm.api.Transaction
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.get.GetResponse
-import com.sksamuel.elastic4s.requests.searches.{SearchRequest, SearchResponse}
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  MultiSearchResponse,
+  SearchRequest,
+  SearchResponse
+}
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index, Response}
 import grizzled.slf4j.Logging
+
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.Tracing
 import uk.ac.wellcome.platform.api.models._
-
-import scala.concurrent.{ExecutionContext, Future}
 
 case class ElasticsearchQueryOptions(filters: List[DocumentFilter],
                                      limit: Int,
@@ -65,6 +71,38 @@ class ElasticsearchService(elasticClient: ElasticClient)(
           responseOrError.map { res =>
             transaction.addLabel("elasticTook", res.took)
             res
+          }
+        }
+    }
+
+  def executeMultiSearchRequest(request: MultiSearchRequest)
+    : Future[Either[ElasticError, List[SearchResponse]]] =
+    spanFuture(
+      name = "ElasticSearch#executeQuery",
+      spanType = "request",
+      subType = "elastic",
+      action = "query"
+    ) {
+      debug(s"Sending ES multirequest: ${request.show}")
+      val transaction = Tracing.currentTransaction
+      withActiveTrace(elasticClient.execute(request))
+        .map(toEither)
+        .map { response =>
+          response.right.flatMap {
+            case MultiSearchResponse(items) =>
+              val results = items.map(_.response)
+              val error = results.collectFirst { case Left(err) => err }
+              error match {
+                case Some(err) => Left(err)
+                case None =>
+                  Right(
+                    results.collect {
+                      case Right(resp) =>
+                        transaction.addLabel("elasticTook", resp.took)
+                        resp
+                    }.toList
+                  )
+              }
           }
         }
     }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkRequestBuilder.scala
@@ -1,0 +1,109 @@
+package uk.ac.wellcome.platform.api.services
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  SearchRequest
+}
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+
+case class RelatedWorkRequestBuilder(index: Index,
+                                     path: String,
+                                     maxRelatedWorks: Int = 1000) {
+
+  // To reduce response size and improve Elasticsearch performance we only
+  // return core fields for works in the tree.
+  val fieldWhitelist = List(
+    "canonicalId",
+    "version",
+    "ontologyType",
+    "sourceIdentifier.identifierType.id",
+    "sourceIdentifier.identifierType.label",
+    "sourceIdentifier.identifierType.ontologyType",
+    "sourceIdentifier.value",
+    "sourceIdentifier.ontologyType",
+    "data.title",
+    "data.alternativeTitles",
+    "data.collectionPath.path",
+    "data.collectionPath.level.type",
+    "data.collectionPath.label",
+    "data.ontologyType",
+  )
+
+  lazy val request: MultiSearchRequest =
+    multi(
+      childrenRequest,
+      siblingsRequest,
+      ancestorsRequest
+    )
+
+  /**
+    * Query all direct children of the node with the given path.
+    */
+  lazy val childrenRequest: SearchRequest =
+    relatedWorksRequest(
+      pathQuery(path, depth + 1)
+    )
+
+  /**
+    * Query all siblings of the node with the given path.
+    */
+  lazy val siblingsRequest: SearchRequest =
+    relatedWorksRequest(
+      ancestors.lastOption match {
+        case Some(parent) =>
+          must(
+            pathQuery(parent, depth),
+            not(termQuery(field = "data.collectionPath.path", value = path))
+          )
+        case None => boolQuery()
+      }
+    )
+
+  /**
+    * Query all ancestors of the node with the given path.
+    */
+  lazy val ancestorsRequest: SearchRequest =
+    relatedWorksRequest(
+      should(
+        ancestors.map(ancestor => pathQuery(ancestor, pathDepth(ancestor)))
+      )
+    )
+
+  lazy val ancestors: List[String] =
+    pathAncestors(path)
+
+  lazy val depth: Int =
+    ancestors.length + 1
+
+  def pathQuery(path: String, depth: Int) =
+    must(
+      termQuery(field = "data.collectionPath.path", value = path),
+      termQuery(field = "data.collectionPath.depth", value = depth),
+    )
+
+  def relatedWorksRequest(query: Query): SearchRequest =
+    search(index)
+      .query(query)
+      .from(0)
+      .limit(maxRelatedWorks)
+      .sourceInclude(fieldWhitelist)
+
+  def pathAncestors(path: String): List[String] =
+    tokenize(path) match {
+      case head :+ tail :+ _ =>
+        val ancestor = join(head :+ tail)
+        pathAncestors(ancestor) :+ ancestor
+      case _ => Nil
+    }
+
+  def pathDepth(path: String): Int =
+    tokenize(path).length
+
+  def tokenize(path: String): List[String] =
+    path.split("/").toList
+
+  def join(tokens: List[String]): String =
+    tokens.mkString("/")
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
@@ -1,0 +1,121 @@
+package uk.ac.wellcome.platform.api.services
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+import scala.annotation.tailrec
+
+import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.requests.searches.SearchHit
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.internal.result._
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.platform.api.Tracing
+
+case class RelatedWorks(
+  parts: List[IdentifiedWork],
+  partOf: List[IdentifiedWork],
+  preceededBy: List[IdentifiedWork],
+  suceededBy: List[IdentifiedWork],
+)
+
+class RelatedWorkService(elasticsearchService: ElasticsearchService)(
+  implicit ec: ExecutionContext)
+    extends Tracing {
+
+  type PathToken = Either[Int, String]
+
+  type TokenizedPath = List[PathToken]
+
+  def retrieveRelatedWorks(index: Index,
+                           work: IdentifiedWork): Future[Result[RelatedWorks]] =
+    work.data.collectionPath match {
+      case None => Future.successful(Right(RelatedWorks(Nil, Nil, Nil, Nil)))
+      case Some(CollectionPath(path, _, _)) =>
+        elasticsearchService
+          .executeMultiSearchRequest(
+            RelatedWorkRequestBuilder(index, path).request
+          )
+          .map { result =>
+            val works = result.left
+              .map(_.asException)
+              .flatMap { searchResponses =>
+                searchResponses.map { resp =>
+                  resp.hits.hits.toList.map(toWork).toResult
+                }.toResult
+              }
+            works.flatMap {
+              case List(children, siblings, ancestors) =>
+                Right(toRelatedWorks(path, children, siblings, ancestors))
+              case works =>
+                Left(
+                  new Exception(
+                    "Expected multisearch response containing 3 items")
+                )
+            }
+          }
+    }
+
+  private def toWork(hit: SearchHit): Result[IdentifiedWork] =
+    fromJson[IdentifiedWork](hit.sourceAsString).toEither
+
+  private def toRelatedWorks(path: String,
+                             children: List[IdentifiedWork],
+                             siblings: List[IdentifiedWork],
+                             ancestors: List[IdentifiedWork]): RelatedWorks = {
+    val mainPath = tokenizePath(path)
+    val (preceededBy, suceededBy) = siblings.sortBy(tokenizePath).partition {
+      work =>
+        tokenizePath(work) match {
+          case None => true
+          case Some(workPath) =>
+            tokenizedPathOrdering.compare(mainPath, workPath) >= 0
+        }
+    }
+    RelatedWorks(
+      parts = children.sortBy(tokenizePath),
+      partOf = ancestors.sortBy(tokenizePath),
+      preceededBy = preceededBy,
+      suceededBy = suceededBy
+    )
+  }
+
+  private def tokenizePath(path: String): TokenizedPath =
+    path.split("/").toList.map { str =>
+      Try(str.toInt).map(Left(_)).getOrElse(Right(str))
+    }
+
+  private def tokenizePath(work: IdentifiedWork): Option[TokenizedPath] =
+    work.data.collectionPath
+      .map { collectionPath =>
+        tokenizePath(collectionPath.path)
+      }
+
+  implicit val tokenizedPathOrdering: Ordering[TokenizedPath] =
+    new Ordering[TokenizedPath] {
+      @tailrec
+      override def compare(a: TokenizedPath, b: TokenizedPath): Int =
+        (a, b) match {
+          case (Nil, Nil) => 0
+          case (Nil, _)   => -1
+          case (_, Nil)   => 1
+          case (xHead :: xTail, yHead :: yTail) =>
+            if (xHead == yHead)
+              compare(xTail, yTail)
+            else
+              pathTokenOrdering.compare(xHead, yHead)
+        }
+    }
+
+  implicit val pathTokenOrdering: Ordering[PathToken] =
+    new Ordering[PathToken] {
+      override def compare(a: PathToken, b: PathToken): Int =
+        (a, b) match {
+          case (Left(a), Left(b))   => a.compareTo(b)
+          case (Right(a), Right(b)) => a.compareTo(b)
+          case (Left(_), _)         => -1
+          case _                    => 1
+        }
+    }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -6,6 +6,7 @@ import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs._
 import com.sksamuel.elastic4s.requests.searches.queries._
 import com.sksamuel.elastic4s.requests.searches.sort._
+
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchComboQuery
 import uk.ac.wellcome.platform.api.models._

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -1,0 +1,143 @@
+package uk.ac.wellcome.platform.api.services
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.concurrent.ScalaFutures
+import com.sksamuel.elastic4s.Index
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.generators.{
+  IdentifiersGenerators,
+  ItemsGenerators,
+  WorksGenerators
+}
+
+class RelatedWorkServiceTest
+    extends AnyFunSpec
+    with Matchers
+    with ScalaFutures
+    with ElasticsearchFixtures
+    with IdentifiersGenerators
+    with ItemsGenerators
+    with WorksGenerators {
+
+  val service = new RelatedWorkService(new ElasticsearchService(elasticClient))
+
+  def work(path: String, level: CollectionLevel) =
+    createIdentifiedWorkWith(
+      collectionPath = Some(
+        CollectionPath(path = path, level = Some(level))
+      ),
+      title = Some(path),
+      sourceIdentifier = createSourceIdentifierWith(value = path)
+    )
+
+  def storeWorks(index: Index, works: List[IdentifiedWork] = works) =
+    insertIntoElasticsearch(index, works: _*)
+
+  val workA = work("a", CollectionLevel.Collection)
+  val work1 = work("a/1", CollectionLevel.Series)
+  val workB = work("a/1/b", CollectionLevel.Item)
+  val workC = work("a/1/c", CollectionLevel.Item)
+  val work2 = work("a/2", CollectionLevel.Series)
+  val workD = work("a/2/d", CollectionLevel.Series)
+  val workE = work("a/2/e", CollectionLevel.Item)
+  val workF = work("a/2/e/f", CollectionLevel.Item)
+  val work3 = work("a/3", CollectionLevel.Item)
+  val work4 = work("a/4", CollectionLevel.Item)
+
+  val works =
+    List(workA, workB, workC, workD, workE, workF, work4, work3, work2, work1)
+
+  it(
+    "Retrieves a related works for the given path with children and siblings sorted correctly") {
+    withLocalWorksIndex { index =>
+      storeWorks(index)
+      whenReady(service.retrieveRelatedWorks(index, work2)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = List(workD, workE),
+            partOf = List(workA),
+            preceededBy = List(work1),
+            suceededBy = List(work3, work4),
+          )
+        )
+      }
+    }
+  }
+
+  it(
+    "Retrieves a related works for the given path with ancestors sorted correctly") {
+    withLocalWorksIndex { index =>
+      storeWorks(index)
+      whenReady(service.retrieveRelatedWorks(index, workF)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = Nil,
+            partOf = List(workA, work2, workE),
+            preceededBy = Nil,
+            suceededBy = Nil,
+          )
+        )
+      }
+    }
+  }
+
+  it("Ignores missing ancestors") {
+    withLocalWorksIndex { index =>
+      storeWorks(index, List(workA, workB, workC, workD, workE, workF))
+      whenReady(service.retrieveRelatedWorks(index, workF)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = Nil,
+            partOf = List(workA, workE),
+            preceededBy = Nil,
+            suceededBy = Nil,
+          )
+        )
+      }
+    }
+  }
+
+  it("Only returns core fields on related works") {
+    withLocalWorksIndex { index =>
+      val workP = work("p", CollectionLevel.Collection) withData (_.copy(
+        items = List(createIdentifiedItem)))
+      val workQ = work("p/q", CollectionLevel.Series) withData (_.copy(
+        notes = List(GeneralNote("hi"))))
+      val workR = work("p/q/r", CollectionLevel.Item)
+      storeWorks(index, List(workP, workQ, workR))
+      whenReady(service.retrieveRelatedWorks(index, workR)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = Nil,
+            partOf = List(
+              workP.withData(_.copy(items = Nil)),
+              workQ.withData(_.copy(notes = Nil)),
+            ),
+            preceededBy = Nil,
+            suceededBy = Nil,
+          )
+        )
+      }
+    }
+  }
+
+  it("Returns no related works when work is not part of a collection") {
+    withLocalWorksIndex { index =>
+      val workX = createIdentifiedWork
+      storeWorks(index, List(workA, work1, workX))
+      whenReady(service.retrieveRelatedWorks(index, workX)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = Nil,
+            partOf = Nil,
+            preceededBy = Nil,
+            suceededBy = Nil
+          )
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4671

## Description

First part of the new archive API. Contains a service for querying work relations in elastic, a subsequent PR will use the `RelatedWorkService` for actually rendering the related data in the API.