### PR TITLE
Include related works in API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -13,7 +13,9 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.{
   CollectionService,
   ElasticsearchService,
-  WorksService
+  WorksService,
+  RelatedWorkService,
+  RelatedWorks
 }
 import uk.ac.wellcome.platform.api.Tracing
 
@@ -65,13 +67,18 @@ class WorksController(
           .findWorkById(id)(index)
           .flatMap {
             case Right(Some(work: IdentifiedWork)) =>
-              if (includes.collection) {
+              if (includes.anyRelation) {
+                retrieveRelatedWorks(index, work).map { relatedWorks =>
+                  workFound(work, relatedWorks, None, includes)
+                }
+              }
+              else if (includes.collection) {
                 val expandedPaths = params._expandPaths.getOrElse(Nil)
-                retrieveTree(index, work, expandedPaths).map {
-                  workFound(work, _, includes)
+                retrieveTree(index, work, expandedPaths).map { tree =>
+                  workFound(work, None, tree, includes)
                 }
               } else
-                Future.successful(workFound(work, None, includes))
+                Future.successful(workFound(work, None, None, includes))
             case Right(Some(work: IdentifiedRedirectedWork)) =>
               Future.successful(workRedirect(work))
             case Right(Some(_)) =>
@@ -103,6 +110,20 @@ class WorksController(
       }
       .getOrElse(Future.successful(None))
 
+  private def retrieveRelatedWorks(
+    index: Index,
+    work: IdentifiedWork): Future[Option[RelatedWorks]] =
+    relatedWorkService
+      .retrieveRelatedWorks(index, work)
+      .map {
+        case Left(err) =>
+          // We just log this here rather than raising so as not to bring down
+          // the work API when related work retrieval fails
+          logger.error("Error retrieving related works", err)
+          None
+        case Right(relatedWorks) => Some(relatedWorks)
+      }
+
   def workRedirect(work: IdentifiedRedirectedWork): Route =
     extractPublicUri { uri =>
       val newPath = (work.redirect.canonicalId :: uri.path.reverse.tail).reverse
@@ -110,6 +131,7 @@ class WorksController(
     }
 
   def workFound(work: IdentifiedWork,
+                relatedWorks: Option[RelatedWorks],
                 tree: Option[(Collection, List[String])],
                 includes: WorksIncludes): Route =
     complete(
@@ -119,13 +141,28 @@ class WorksController(
           collection = tree.map {
             case (tree, expandedPaths) =>
               DisplayCollection(tree, expandedPaths)
-          }
+          },
+          parts = relatedWorks.map { relatedWorks =>
+            relatedWorks.parts.map(DisplayWork(_))
+          },
+          partOf = relatedWorks.map { relatedWorks =>
+            relatedWorks.partOf.map(DisplayWork(_))
+          },
+          preceededBy = relatedWorks.map { relatedWorks =>
+            relatedWorks.preceededBy.map(DisplayWork(_))
+          },
+          suceededBy = relatedWorks.map { relatedWorks =>
+            relatedWorks.suceededBy.map(DisplayWork(_))
+          },
         )
       )
     )
 
   private lazy val collectionService =
     new CollectionService(elasticsearchService)
+
+  private lazy val relatedWorkService =
+    new RelatedWorkService(elasticsearchService)
 
   private lazy val worksService = new WorksService(elasticsearchService)
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -13,9 +13,9 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.{
   CollectionService,
   ElasticsearchService,
-  WorksService,
   RelatedWorkService,
-  RelatedWorks
+  RelatedWorks,
+  WorksService
 }
 import uk.ac.wellcome.platform.api.Tracing
 
@@ -71,8 +71,7 @@ class WorksController(
                 retrieveRelatedWorks(index, work).map { relatedWorks =>
                   workFound(work, relatedWorks, None, includes)
                 }
-              }
-              else if (includes.collection) {
+              } else if (includes.collection) {
                 val expandedPaths = params._expandPaths.getOrElse(Nil)
                 retrieveTree(index, work, expandedPaths).map { tree =>
                   workFound(work, None, tree, includes)
@@ -142,22 +141,26 @@ class WorksController(
             case (tree, expandedPaths) =>
               DisplayCollection(tree, expandedPaths)
           },
-          parts = if (includes.parts)
-            relatedWorks.map { relatedWorks =>
-              relatedWorks.parts.map(DisplayWork(_))
-            } else None,
-          partOf = if (includes.partOf)
-            relatedWorks.map { relatedWorks =>
-              relatedWorks.partOf.map(DisplayWork(_))
-            } else None,
-          precededBy = if (includes.precededBy)
-            relatedWorks.map { relatedWorks =>
-              relatedWorks.precededBy.map(DisplayWork(_))
-            } else None,
-          succeededBy = if (includes.succeededBy)
-            relatedWorks.map { relatedWorks =>
-              relatedWorks.succeededBy.map(DisplayWork(_))
-            } else None,
+          parts =
+            if (includes.parts)
+              relatedWorks.map { relatedWorks =>
+                relatedWorks.parts.map(DisplayWork(_))
+              } else None,
+          partOf =
+            if (includes.partOf)
+              relatedWorks.map { relatedWorks =>
+                relatedWorks.partOf.map(DisplayWork(_))
+              } else None,
+          precededBy =
+            if (includes.precededBy)
+              relatedWorks.map { relatedWorks =>
+                relatedWorks.precededBy.map(DisplayWork(_))
+              } else None,
+          succeededBy =
+            if (includes.succeededBy)
+              relatedWorks.map { relatedWorks =>
+                relatedWorks.succeededBy.map(DisplayWork(_))
+              } else None,
         )
       )
     )

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -142,18 +142,22 @@ class WorksController(
             case (tree, expandedPaths) =>
               DisplayCollection(tree, expandedPaths)
           },
-          parts = relatedWorks.map { relatedWorks =>
-            relatedWorks.parts.map(DisplayWork(_))
-          },
-          partOf = relatedWorks.map { relatedWorks =>
-            relatedWorks.partOf.map(DisplayWork(_))
-          },
-          preceededBy = relatedWorks.map { relatedWorks =>
-            relatedWorks.preceededBy.map(DisplayWork(_))
-          },
-          suceededBy = relatedWorks.map { relatedWorks =>
-            relatedWorks.suceededBy.map(DisplayWork(_))
-          },
+          parts = if (includes.parts)
+            relatedWorks.map { relatedWorks =>
+              relatedWorks.parts.map(DisplayWork(_))
+            } else None,
+          partOf = if (includes.partOf)
+            relatedWorks.map { relatedWorks =>
+              relatedWorks.partOf.map(DisplayWork(_))
+            } else None,
+          precededBy = if (includes.precededBy)
+            relatedWorks.map { relatedWorks =>
+              relatedWorks.precededBy.map(DisplayWork(_))
+            } else None,
+          succeededBy = if (includes.succeededBy)
+            relatedWorks.map { relatedWorks =>
+              relatedWorks.succeededBy.map(DisplayWork(_))
+            } else None,
         )
       )
     )

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -44,6 +44,10 @@ object SingleWorkParams extends QueryParamsUtils {
       "notes" -> WorkInclude.Notes,
       "collection" -> WorkInclude.Collection,
       "images" -> WorkInclude.Images,
+      "parts" -> WorkInclude.Parts,
+      "partOf" -> WorkInclude.PartOf,
+      "precededBy" -> WorkInclude.PrecededBy,
+      "succeededBy" -> WorkInclude.SucceededBy,
     ).emap(values => Right(WorksIncludes(values)))
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
@@ -16,8 +16,8 @@ import uk.ac.wellcome.platform.api.Tracing
 case class RelatedWorks(
   parts: List[IdentifiedWork],
   partOf: List[IdentifiedWork],
-  preceededBy: List[IdentifiedWork],
-  suceededBy: List[IdentifiedWork],
+  precededBy: List[IdentifiedWork],
+  succeededBy: List[IdentifiedWork],
 )
 
 class RelatedWorkService(elasticsearchService: ElasticsearchService)(
@@ -65,7 +65,7 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
                              siblings: List[IdentifiedWork],
                              ancestors: List[IdentifiedWork]): RelatedWorks = {
     val mainPath = tokenizePath(path)
-    val (preceededBy, suceededBy) = siblings.sortBy(tokenizePath).partition {
+    val (precededBy, succeededBy) = siblings.sortBy(tokenizePath).partition {
       work =>
         tokenizePath(work) match {
           case None => true
@@ -76,8 +76,8 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
     RelatedWorks(
       parts = children.sortBy(tokenizePath),
       partOf = ancestors.sortBy(tokenizePath),
-      preceededBy = preceededBy,
-      suceededBy = suceededBy
+      precededBy = precededBy,
+      succeededBy = succeededBy
     )
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -59,8 +59,8 @@ class RelatedWorkServiceTest
           RelatedWorks(
             parts = List(workD, workE),
             partOf = List(workA),
-            preceededBy = List(work1),
-            suceededBy = List(work3, work4),
+            precededBy = List(work1),
+            succeededBy = List(work3, work4),
           )
         )
       }
@@ -76,8 +76,8 @@ class RelatedWorkServiceTest
           RelatedWorks(
             parts = Nil,
             partOf = List(workA, work2, workE),
-            preceededBy = Nil,
-            suceededBy = Nil,
+            precededBy = Nil,
+            succeededBy = Nil,
           )
         )
       }
@@ -92,8 +92,8 @@ class RelatedWorkServiceTest
           RelatedWorks(
             parts = Nil,
             partOf = List(workA, workE),
-            preceededBy = Nil,
-            suceededBy = Nil,
+            precededBy = Nil,
+            succeededBy = Nil,
           )
         )
       }
@@ -116,8 +116,8 @@ class RelatedWorkServiceTest
               workP.withData(_.copy(items = Nil)),
               workQ.withData(_.copy(notes = Nil)),
             ),
-            preceededBy = Nil,
-            suceededBy = Nil,
+            precededBy = Nil,
+            succeededBy = Nil,
           )
         )
       }
@@ -133,8 +133,8 @@ class RelatedWorkServiceTest
           RelatedWorks(
             parts = Nil,
             partOf = Nil,
-            preceededBy = Nil,
-            suceededBy = Nil
+            precededBy = Nil,
+            succeededBy = Nil
           )
         )
       }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -7,7 +7,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo",
         description =
-          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images']"
+          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -15,7 +15,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo,bar",
         description =
-          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images']"
+          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -23,7 +23,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo,identifiers,bar",
         description =
-          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images']"
+          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -31,7 +31,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works/nfdn7wac?include=foo",
         description =
-          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images']"
+          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'collection', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -14,79 +14,81 @@ class WorksIncludesTest
     with SubjectGenerators
     with ImageGenerators {
 
-  it(
-    "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val identifier0 = createSourceIdentifier
-        val identifier1 = createSourceIdentifier
-        val work0 = createIdentifiedWorkWith(
-          canonicalId = "1",
-          otherIdentifiers = List(identifier0))
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "2",
-          otherIdentifiers = List(identifier1))
+  describe("identifiers includes") {
+    it(
+      "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val identifier0 = createSourceIdentifier
+          val identifier1 = createSourceIdentifier
+          val work0 = createIdentifiedWorkWith(
+            canonicalId = "1",
+            otherIdentifiers = List(identifier0))
+          val work1 = createIdentifiedWorkWith(
+            canonicalId = "2",
+            otherIdentifiers = List(identifier1))
 
-        insertIntoElasticsearch(worksIndex, work0, work1)
+          insertIntoElasticsearch(worksIndex, work0, work1)
 
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=identifiers") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work0.canonicalId}",
-                 "title": "${work0.data.title.get}",
-                 "alternativeTitles": [],
-                 "identifiers": [
-                   ${identifier(work0.sourceIdentifier)},
-                   ${identifier(identifier0)}
-                 ]
-               },
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-                 "identifiers": [
-                   ${identifier(work1.sourceIdentifier)},
-                   ${identifier(identifier1)}
-                 ]
-               }
-              ]
-            }
-          """
-        }
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=identifiers") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                 {
+                   "type": "Work",
+                   "id": "${work0.canonicalId}",
+                   "title": "${work0.data.title.get}",
+                   "alternativeTitles": [],
+                   "identifiers": [
+                     ${identifier(work0.sourceIdentifier)},
+                     ${identifier(identifier0)}
+                   ]
+                 },
+                 {
+                   "type": "Work",
+                   "id": "${work1.canonicalId}",
+                   "title": "${work1.data.title.get}",
+                   "alternativeTitles": [],
+                   "identifiers": [
+                     ${identifier(work1.sourceIdentifier)},
+                     ${identifier(identifier1)}
+                   ]
+                 }
+                ]
+              }
+            """
+          }
+      }
     }
-  }
 
-  it(
-    "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val otherIdentifier = createSourceIdentifier
-        val work = createIdentifiedWorkWith(
-          otherIdentifiers = List(otherIdentifier)
-        )
-        insertIntoElasticsearch(worksIndex, work)
+    it(
+      "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val otherIdentifier = createSourceIdentifier
+          val work = createIdentifiedWorkWith(
+            otherIdentifiers = List(otherIdentifier)
+          )
+          insertIntoElasticsearch(worksIndex, work)
 
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=identifiers") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "identifiers": [
-                ${identifier(work.sourceIdentifier)},
-                ${identifier(otherIdentifier)}
-              ]
-            }
-          """
-        }
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=identifiers") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "identifiers": [
+                  ${identifier(work.sourceIdentifier)},
+                  ${identifier(otherIdentifier)}
+                ]
+              }
+            """
+          }
+      }
     }
   }
 
@@ -118,471 +120,484 @@ class WorksIncludesTest
     }
   }
 
-  it(
-    "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val subjects1 = List(createSubject)
-        val subjects2 = List(createSubject)
-        val work0 =
-          createIdentifiedWorkWith(canonicalId = "1", subjects = subjects1)
-        val work1 =
-          createIdentifiedWorkWith(canonicalId = "2", subjects = subjects2)
+  describe("subject includes") {
+    it(
+      "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val subjects1 = List(createSubject)
+          val subjects2 = List(createSubject)
+          val work0 =
+            createIdentifiedWorkWith(canonicalId = "1", subjects = subjects1)
+          val work1 =
+            createIdentifiedWorkWith(canonicalId = "2", subjects = subjects2)
 
-        insertIntoElasticsearch(worksIndex, work0, work1)
+          insertIntoElasticsearch(worksIndex, work0, work1)
 
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=subjects") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work0.canonicalId}",
-                 "title": "${work0.data.title.get}",
-                 "alternativeTitles": [],
-                 "subjects": [ ${subjects(subjects1)}]
-               },
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-                 "subjects": [ ${subjects(subjects2)}]
-               }
-              ]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val subject = List(createSubject)
-        val work = createIdentifiedWorkWith(subjects = subject)
-
-        insertIntoElasticsearch(worksIndex, work)
-
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=subjects") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "subjects": [ ${subjects(subject)}]
-            }
-          """
-        }
-    }
-  }
-
-  it("includes a list of genres on a list endpoint if we pass ?include=genres") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val genres1 = List(Genre("ornithology", List(Concept("ornithology"))))
-        val genres2 = List(Genre("flying cars", List(Concept("flying cars"))))
-        val work0 =
-          createIdentifiedWorkWith(canonicalId = "1", genres = genres1)
-        val work1 =
-          createIdentifiedWorkWith(canonicalId = "2", genres = genres2)
-
-        insertIntoElasticsearch(worksIndex, work0, work1)
-
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=genres") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work0.canonicalId}",
-                 "title": "${work0.data.title.get}",
-                 "alternativeTitles": [],
-                 "genres": [ ${genres(genres1)}]
-               },
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-                 "genres": [ ${genres(genres2)}]
-               }
-              ]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of genres on a single work endpoint if we pass ?include=genres") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val genre = List(Genre("ornithology", List(Concept("ornithology"))))
-        val work = createIdentifiedWorkWith(genres = genre)
-
-        insertIntoElasticsearch(worksIndex, work)
-
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=genres") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "genres": [ ${genres(genre)}]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val contributors1 =
-          List(Contributor(Person("Ginger Rogers"), roles = Nil))
-        val contributors2 =
-          List(Contributor(Person("Fred Astair"), roles = Nil))
-        val work0 = createIdentifiedWorkWith(
-          canonicalId = "1",
-          contributors = contributors1)
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "2",
-          contributors = contributors2)
-
-        insertIntoElasticsearch(worksIndex, work0, work1)
-
-        assertJsonResponse(routes, s"/$apiPrefix/works/?include=contributors") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work0.canonicalId}",
-                 "title": "${work0.data.title.get}",
-                 "alternativeTitles": [],
-                 "contributors": [ ${contributors(contributors1)}]
-               },
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-                 "contributors": [ ${contributors(contributors2)}]
-               }
-              ]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val contributor =
-          List(Contributor(Person("Ginger Rogers"), roles = Nil))
-        val work = createIdentifiedWorkWith(contributors = contributor)
-
-        insertIntoElasticsearch(worksIndex, work)
-
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=contributors") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "contributors": [ ${contributors(contributor)}]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of production events on a list endpoint if we pass ?include=production") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val productionEvents1 = createProductionEventList(count = 1)
-        val productionEvents2 = createProductionEventList(count = 2)
-        val work0 = createIdentifiedWorkWith(
-          canonicalId = "1",
-          production = productionEvents1)
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "2",
-          production = productionEvents2)
-
-        insertIntoElasticsearch(worksIndex, work0, work1)
-
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=production") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-               {
-                 "type": "Work",
-                 "id": "${work0.canonicalId}",
-                 "title": "${work0.data.title.get}",
-                 "alternativeTitles": [],
-                 "production": [ ${production(productionEvents1)}]
-               },
-               {
-                 "type": "Work",
-                 "id": "${work1.canonicalId}",
-                 "title": "${work1.data.title.get}",
-                 "alternativeTitles": [],
-                 "production": [ ${production(productionEvents2)}]
-               }
-              ]
-            }
-          """
-        }
-    }
-  }
-
-  it(
-    "includes a list of production on a single work endpoint if we pass ?include=production") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val productionEventList = createProductionEventList()
-        val work = createIdentifiedWorkWith(
-          production = productionEventList
-        )
-
-        insertIntoElasticsearch(worksIndex, work)
-
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=production") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "production": [ ${production(productionEventList)}]
-            }
-          """
-        }
-    }
-  }
-
-  it("includes notes on the list endpoint if we pass ?include=notes") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val works = List(
-          createIdentifiedWorkWith(
-            canonicalId = "A",
-            notes = List(GeneralNote("A"), FundingInformation("B"))),
-          createIdentifiedWorkWith(
-            canonicalId = "B",
-            notes = List(GeneralNote("C"), GeneralNote("D"))),
-        )
-        insertIntoElasticsearch(worksIndex, works: _*)
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=notes") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=subjects") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
                  {
                    "type": "Work",
-                   "id": "${works(0).canonicalId}",
-                   "title": "${works(0).data.title.get}",
+                   "id": "${work0.canonicalId}",
+                   "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
-                   "notes": [
-                     {
-                       "noteType": {
-                         "id": "general-note",
-                         "label": "Notes",
-                         "type": "NoteType"
-                       },
-                       "contents": ["A"],
-                       "type": "Note"
-                     },
-                     {
-                       "noteType": {
-                         "id": "funding-info",
-                         "label": "Funding information",
-                         "type": "NoteType"
-                       },
-                       "contents": ["B"],
-                       "type": "Note"
-                     }
-                   ]
+                   "subjects": [ ${subjects(subjects1)}]
                  },
                  {
                    "type": "Work",
-                   "id": "${works(1).canonicalId}",
-                   "title": "${works(1).data.title.get}",
+                   "id": "${work1.canonicalId}",
+                   "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
-                   "notes": [
-                     {
-                       "noteType": {
-                         "id": "general-note",
-                         "label": "Notes",
-                         "type": "NoteType"
-                       },
-                       "contents": ["C", "D"],
-                       "type": "Note"
-                     }
-                   ]
-                }
-              ]
-            }
-          """
-        }
-    }
-  }
-
-  it("includes notes on the single work endpoint if we pass ?include=notes") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWorkWith(
-          notes = List(GeneralNote("A"), GeneralNote("B")))
-        insertIntoElasticsearch(worksIndex, work)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=notes") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "notes": [
-                 {
-                   "noteType": {
-                     "id": "general-note",
-                     "label": "Notes",
-                     "type": "NoteType"
-                   },
-                   "contents": ["A", "B"],
-                   "type": "Note"
+                   "subjects": [ ${subjects(subjects2)}]
                  }
-              ]
-            }
-          """
-        }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it(
+      "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val subject = List(createSubject)
+          val work = createIdentifiedWorkWith(subjects = subject)
+
+          insertIntoElasticsearch(worksIndex, work)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=subjects") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "subjects": [ ${subjects(subject)}]
+              }
+            """
+          }
+      }
     }
   }
 
-  it("includes collection on the list endpoint if we pass ?include=collection") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val works = List(
-          createIdentifiedWorkWith(
-            canonicalId = "1",
-            collectionPath = Some(
-              CollectionPath(
-                "PP/MI",
-                Some(CollectionLevel.Item),
-                Some("PP/MI")))),
-          createIdentifiedWorkWith(
-            canonicalId = "2",
-            collectionPath = Some(
-              CollectionPath(
-                "CRGH",
-                Some(CollectionLevel.Collection),
-                Some("CRGH")))),
-        )
-        insertIntoElasticsearch(worksIndex, works: _*)
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=collection") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
+  describe("genre includes") {
+    it("includes a list of genres on a list endpoint if we pass ?include=genres") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val genres1 = List(Genre("ornithology", List(Concept("ornithology"))))
+          val genres2 = List(Genre("flying cars", List(Concept("flying cars"))))
+          val work0 =
+            createIdentifiedWorkWith(canonicalId = "1", genres = genres1)
+          val work1 =
+            createIdentifiedWorkWith(canonicalId = "2", genres = genres2)
+
+          insertIntoElasticsearch(worksIndex, work0, work1)
+
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=genres") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
                  {
                    "type": "Work",
-                   "id": "${works.head.canonicalId}",
-                   "title": "${works.head.data.title.get}",
+                   "id": "${work0.canonicalId}",
+                   "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
-                   "collectionPath": {
-                      "label": "PP/MI",
-                      "path": "PP/MI",
-                      "level": "Item",
-                      "type" : "CollectionPath"
-                   }
+                   "genres": [ ${genres(genres1)}]
                  },
                  {
                    "type": "Work",
-                   "id": "${works(1).canonicalId}",
-                   "title": "${works(1).data.title.get}",
+                   "id": "${work1.canonicalId}",
+                   "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
-                   "collectionPath": {
-                      "label": "CRGH",
-                      "path": "CRGH",
-                      "level": "Collection",
-                      "type" : "CollectionPath"
-                   }
-                }
-              ]
-            }
-          """
-        }
+                   "genres": [ ${genres(genres2)}]
+                 }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it(
+      "includes a list of genres on a single work endpoint if we pass ?include=genres") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val genre = List(Genre("ornithology", List(Concept("ornithology"))))
+          val work = createIdentifiedWorkWith(genres = genre)
+
+          insertIntoElasticsearch(worksIndex, work)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=genres") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "genres": [ ${genres(genre)}]
+              }
+            """
+          }
+      }
     }
   }
 
-  it(
-    "includes collection on the single work endpoint if we pass ?include=collection") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWorkWith(
-          collectionPath = Some(
-            CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
-        insertIntoElasticsearch(worksIndex, work)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=collection") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "collectionPath": {
-                "label": "PP/MI",
-                "path": "PP/MI",
-                "level": "Item",
-                "type" : "CollectionPath"
-              },
-              "collection" : {
-                "path" : { "path" : "PP", "type" : "CollectionPath" },
-                "children" : [
-                  {
-                    "path" : {
-                      "label" : "PP/MI",
-                      "level" : "Item",
-                      "path" : "PP/MI",
-                      "type" : "CollectionPath"
-                    },
-                    "work" : {
-                      "id": "${work.canonicalId}",
-                      "title": "${work.data.title.get}",
-                      "alternativeTitles" : [],
-                      "type" : "Work"
-                    },
-                    "children" : []
+  describe("contributor includes") {
+    it(
+      "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val contributors1 =
+            List(Contributor(Person("Ginger Rogers"), roles = Nil))
+          val contributors2 =
+            List(Contributor(Person("Fred Astair"), roles = Nil))
+          val work0 = createIdentifiedWorkWith(
+            canonicalId = "1",
+            contributors = contributors1)
+          val work1 = createIdentifiedWorkWith(
+            canonicalId = "2",
+            contributors = contributors2)
+
+          insertIntoElasticsearch(worksIndex, work0, work1)
+
+          assertJsonResponse(routes, s"/$apiPrefix/works/?include=contributors") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                 {
+                   "type": "Work",
+                   "id": "${work0.canonicalId}",
+                   "title": "${work0.data.title.get}",
+                   "alternativeTitles": [],
+                   "contributors": [ ${contributors(contributors1)}]
+                 },
+                 {
+                   "type": "Work",
+                   "id": "${work1.canonicalId}",
+                   "title": "${work1.data.title.get}",
+                   "alternativeTitles": [],
+                   "contributors": [ ${contributors(contributors2)}]
+                 }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it(
+      "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val contributor =
+            List(Contributor(Person("Ginger Rogers"), roles = Nil))
+          val work = createIdentifiedWorkWith(contributors = contributor)
+
+          insertIntoElasticsearch(worksIndex, work)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=contributors") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "contributors": [ ${contributors(contributor)}]
+              }
+            """
+          }
+      }
+    }
+  }
+
+  describe("production includes") {
+    it(
+      "includes a list of production events on a list endpoint if we pass ?include=production") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val productionEvents1 = createProductionEventList(count = 1)
+          val productionEvents2 = createProductionEventList(count = 2)
+          val work0 = createIdentifiedWorkWith(
+            canonicalId = "1",
+            production = productionEvents1)
+          val work1 = createIdentifiedWorkWith(
+            canonicalId = "2",
+            production = productionEvents2)
+
+          insertIntoElasticsearch(worksIndex, work0, work1)
+
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=production") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                 {
+                   "type": "Work",
+                   "id": "${work0.canonicalId}",
+                   "title": "${work0.data.title.get}",
+                   "alternativeTitles": [],
+                   "production": [ ${production(productionEvents1)}]
+                 },
+                 {
+                   "type": "Work",
+                   "id": "${work1.canonicalId}",
+                   "title": "${work1.data.title.get}",
+                   "alternativeTitles": [],
+                   "production": [ ${production(productionEvents2)}]
+                 }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it(
+      "includes a list of production on a single work endpoint if we pass ?include=production") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val productionEventList = createProductionEventList()
+          val work = createIdentifiedWorkWith(
+            production = productionEventList
+          )
+
+          insertIntoElasticsearch(worksIndex, work)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=production") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "production": [ ${production(productionEventList)}]
+              }
+            """
+          }
+      }
+    }
+  }
+
+  describe("notes includes") {
+    it("includes notes on the list endpoint if we pass ?include=notes") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val works = List(
+            createIdentifiedWorkWith(
+              canonicalId = "A",
+              notes = List(GeneralNote("A"), FundingInformation("B"))),
+            createIdentifiedWorkWith(
+              canonicalId = "B",
+              notes = List(GeneralNote("C"), GeneralNote("D"))),
+          )
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=notes") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                   {
+                     "type": "Work",
+                     "id": "${works(0).canonicalId}",
+                     "title": "${works(0).data.title.get}",
+                     "alternativeTitles": [],
+                     "notes": [
+                       {
+                         "noteType": {
+                           "id": "general-note",
+                           "label": "Notes",
+                           "type": "NoteType"
+                         },
+                         "contents": ["A"],
+                         "type": "Note"
+                       },
+                       {
+                         "noteType": {
+                           "id": "funding-info",
+                           "label": "Funding information",
+                           "type": "NoteType"
+                         },
+                         "contents": ["B"],
+                         "type": "Note"
+                       }
+                     ]
+                   },
+                   {
+                     "type": "Work",
+                     "id": "${works(1).canonicalId}",
+                     "title": "${works(1).data.title.get}",
+                     "alternativeTitles": [],
+                     "notes": [
+                       {
+                         "noteType": {
+                           "id": "general-note",
+                           "label": "Notes",
+                           "type": "NoteType"
+                         },
+                         "contents": ["C", "D"],
+                         "type": "Note"
+                       }
+                     ]
                   }
                 ]
               }
-            }
-          """
-        }
+            """
+          }
+      }
+    }
+
+    it("includes notes on the single work endpoint if we pass ?include=notes") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val work = createIdentifiedWorkWith(
+            notes = List(GeneralNote("A"), GeneralNote("B")))
+          insertIntoElasticsearch(worksIndex, work)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=notes") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "notes": [
+                   {
+                     "noteType": {
+                       "id": "general-note",
+                       "label": "Notes",
+                       "type": "NoteType"
+                     },
+                     "contents": ["A", "B"],
+                     "type": "Note"
+                   }
+                ]
+              }
+            """
+          }
+      }
+    }
+  }
+
+
+  describe("collection includes") {
+    it("includes collection on the list endpoint if we pass ?include=collection") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val works = List(
+            createIdentifiedWorkWith(
+              canonicalId = "1",
+              collectionPath = Some(
+                CollectionPath(
+                  "PP/MI",
+                  Some(CollectionLevel.Item),
+                  Some("PP/MI")))),
+            createIdentifiedWorkWith(
+              canonicalId = "2",
+              collectionPath = Some(
+                CollectionPath(
+                  "CRGH",
+                  Some(CollectionLevel.Collection),
+                  Some("CRGH")))),
+          )
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=collection") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                   {
+                     "type": "Work",
+                     "id": "${works.head.canonicalId}",
+                     "title": "${works.head.data.title.get}",
+                     "alternativeTitles": [],
+                     "collectionPath": {
+                        "label": "PP/MI",
+                        "path": "PP/MI",
+                        "level": "Item",
+                        "type" : "CollectionPath"
+                     }
+                   },
+                   {
+                     "type": "Work",
+                     "id": "${works(1).canonicalId}",
+                     "title": "${works(1).data.title.get}",
+                     "alternativeTitles": [],
+                     "collectionPath": {
+                        "label": "CRGH",
+                        "path": "CRGH",
+                        "level": "Collection",
+                        "type" : "CollectionPath"
+                     }
+                  }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it(
+      "includes collection on the single work endpoint if we pass ?include=collection") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val work = createIdentifiedWorkWith(
+            collectionPath = Some(
+              CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
+          insertIntoElasticsearch(worksIndex, work)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=collection") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "collectionPath": {
+                  "label": "PP/MI",
+                  "path": "PP/MI",
+                  "level": "Item",
+                  "type" : "CollectionPath"
+                },
+                "collection" : {
+                  "path" : { "path" : "PP", "type" : "CollectionPath" },
+                  "children" : [
+                    {
+                      "path" : {
+                        "label" : "PP/MI",
+                        "level" : "Item",
+                        "path" : "PP/MI",
+                        "type" : "CollectionPath"
+                      },
+                      "work" : {
+                        "id": "${work.canonicalId}",
+                        "title": "${work.data.title.get}",
+                        "alternativeTitles" : [],
+                        "type" : "Work"
+                      },
+                      "children" : []
+                    }
+                  ]
+                }
+              }
+            """
+          }
+      }
     }
   }
 
@@ -607,71 +622,73 @@ class WorksIncludesTest
     }
   }
 
-  it(
-    "includes a list of images on the list endpoint if we pass ?include=images") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val works = List(
-          createIdentifiedWorkWith(
-            canonicalId = "A",
-            images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
-          ),
-          createIdentifiedWorkWith(
-            canonicalId = "B",
-            images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+  describe("image includes") {
+    it(
+      "includes a list of images on the list endpoint if we pass ?include=images") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val works = List(
+            createIdentifiedWorkWith(
+              canonicalId = "A",
+              images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+            ),
+            createIdentifiedWorkWith(
+              canonicalId = "B",
+              images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+            )
           )
-        )
 
-        insertIntoElasticsearch(worksIndex, works: _*)
+          insertIntoElasticsearch(worksIndex, works: _*)
 
-        assertJsonResponse(routes, s"/$apiPrefix/works?include=images") {
-          Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${works.head.canonicalId}",
-                  "title": "${works.head.data.title.get}",
-                  "alternativeTitles": [],
-                  "images": [${workImageIncludes(works.head.data.images)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${works(1).canonicalId}",
-                  "title": "${works(1).data.title.get}",
-                  "alternativeTitles": [],
-                  "images": [${workImageIncludes(works(1).data.images)}]
-                }
-              ]
-            }
-          """
-        }
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=images") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = 2)},
+                "results": [
+                  {
+                    "type": "Work",
+                    "id": "${works.head.canonicalId}",
+                    "title": "${works.head.data.title.get}",
+                    "alternativeTitles": [],
+                    "images": [${workImageIncludes(works.head.data.images)}]
+                  },
+                  {
+                    "type": "Work",
+                    "id": "${works(1).canonicalId}",
+                    "title": "${works(1).data.title.get}",
+                    "alternativeTitles": [],
+                    "images": [${workImageIncludes(works(1).data.images)}]
+                  }
+                ]
+              }
+            """
+          }
+      }
     }
-  }
 
-  it(
-    "includes a list of images on a single work endpoint if we pass ?include=images") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
-        val images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
-        val work = createIdentifiedWorkWith(images = images)
+    it(
+      "includes a list of images on a single work endpoint if we pass ?include=images") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          val images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+          val work = createIdentifiedWorkWith(images = images)
 
-        insertIntoElasticsearch(worksIndex, work)
+          insertIntoElasticsearch(worksIndex, work)
 
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${work.canonicalId}?include=images") {
-          Status.OK -> s"""
-            {
-              ${singleWorkResult(apiPrefix)},
-              "id": "${work.canonicalId}",
-              "title": "${work.data.title.get}",
-              "alternativeTitles": [],
-              "images": [${workImageIncludes(images)}]
-            }
-          """
-        }
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.canonicalId}?include=images") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "images": [${workImageIncludes(images)}]
+              }
+            """
+          }
+      }
     }
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -189,7 +189,8 @@ class WorksIncludesTest
   }
 
   describe("genre includes") {
-    it("includes a list of genres on a list endpoint if we pass ?include=genres") {
+    it(
+      "includes a list of genres on a list endpoint if we pass ?include=genres") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           val genres1 = List(Genre("ornithology", List(Concept("ornithology"))))
@@ -495,9 +496,9 @@ class WorksIncludesTest
     }
   }
 
-
   describe("collection includes") {
-    it("includes collection on the list endpoint if we pass ?include=collection") {
+    it(
+      "includes collection on the list endpoint if we pass ?include=collection") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           val works = List(
@@ -557,9 +558,8 @@ class WorksIncludesTest
       "includes collection on the single work endpoint if we pass ?include=collection") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work = createIdentifiedWorkWith(
-            collectionPath = Some(
-              CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
+          val work = createIdentifiedWorkWith(collectionPath = Some(
+            CollectionPath("PP/MI", Some(CollectionLevel.Item), Some("PP/MI"))))
           insertIntoElasticsearch(worksIndex, work)
           assertJsonResponse(
             routes,
@@ -632,11 +632,13 @@ class WorksIncludesTest
           val works = List(
             createIdentifiedWorkWith(
               canonicalId = "A",
-              images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+              images =
+                (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
             ),
             createIdentifiedWorkWith(
               canonicalId = "B",
-              images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+              images =
+                (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
             )
           )
 
@@ -672,7 +674,8 @@ class WorksIncludesTest
       "includes a list of images on a single work endpoint if we pass ?include=images") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+          val images =
+            (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
           val work = createIdentifiedWorkWith(images = images)
 
           insertIntoElasticsearch(worksIndex, work)
@@ -712,12 +715,13 @@ class WorksIncludesTest
       insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
 
     it("includes parts") {
-      withApi { case (ElasticConfig(index, _), routes) =>
-        storeWorks(index)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${workC.canonicalId}?include=parts") {
-          Status.OK -> s"""
+      withApi {
+        case (ElasticConfig(index, _), routes) =>
+          storeWorks(index)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${workC.canonicalId}?include=parts") {
+            Status.OK -> s"""
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
@@ -731,17 +735,18 @@ class WorksIncludesTest
               }]
             }
           """
-        }
+          }
       }
     }
 
     it("includes partOf") {
-      withApi { case (ElasticConfig(index, _), routes) =>
-        storeWorks(index)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${workC.canonicalId}?include=partOf") {
-          Status.OK -> s"""
+      withApi {
+        case (ElasticConfig(index, _), routes) =>
+          storeWorks(index)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${workC.canonicalId}?include=partOf") {
+            Status.OK -> s"""
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
@@ -755,17 +760,18 @@ class WorksIncludesTest
               }]
             }
           """
-        }
+          }
       }
     }
 
     it("includes precededBy") {
-      withApi { case (ElasticConfig(index, _), routes) =>
-        storeWorks(index)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${workC.canonicalId}?include=precededBy") {
-          Status.OK -> s"""
+      withApi {
+        case (ElasticConfig(index, _), routes) =>
+          storeWorks(index)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${workC.canonicalId}?include=precededBy") {
+            Status.OK -> s"""
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
@@ -779,17 +785,18 @@ class WorksIncludesTest
               }]
             }
           """
-        }
+          }
       }
     }
 
     it("includes succeededBy") {
-      withApi { case (ElasticConfig(index, _), routes) =>
-        storeWorks(index)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works/${workC.canonicalId}?include=succeededBy") {
-          Status.OK -> s"""
+      withApi {
+        case (ElasticConfig(index, _), routes) =>
+          storeWorks(index)
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${workC.canonicalId}?include=succeededBy") {
+            Status.OK -> s"""
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
@@ -803,7 +810,7 @@ class WorksIncludesTest
               }]
             }
           """
-        }
+          }
       }
     }
   }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -100,6 +100,22 @@ case class DisplayWork(
     `type` = "List[uk.ac.wellcome.display.models.DisplayImageWorkInclude]",
     description = "Identifiers of images that are sourced from this work"
   ) images: Option[List[DisplayWorkImageInclude]] = None,
+  @Schema(
+    `type` = "List[Work]",
+    description = "Child works."
+  ) parts: Option[List[DisplayWork]] = None,
+  @Schema(
+    `type` = "List[Work]",
+    description = "Ancestor works."
+  ) partOf: Option[List[DisplayWork]] = None,
+  @Schema(
+    `type` = "List[Work]",
+    description = "Sibling works earlier in a series."
+  ) preceededBy: Option[List[DisplayWork]] = None,
+  @Schema(
+    `type` = "List[Work]",
+    description = "Sibling works later in a series."
+  ) suceededBy: Option[List[DisplayWork]] = None,
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Work"
 )
 

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -111,11 +111,11 @@ case class DisplayWork(
   @Schema(
     `type` = "List[Work]",
     description = "Sibling works earlier in a series."
-  ) preceededBy: Option[List[DisplayWork]] = None,
+  ) precededBy: Option[List[DisplayWork]] = None,
   @Schema(
     `type` = "List[Work]",
     description = "Sibling works later in a series."
-  ) suceededBy: Option[List[DisplayWork]] = None,
+  ) succeededBy: Option[List[DisplayWork]] = None,
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Work"
 )
 

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -14,8 +14,8 @@ object WorkInclude {
   case object Images extends WorkInclude
   case object Parts extends WorkInclude
   case object PartOf extends WorkInclude
-  case object PreceededBy extends WorkInclude
-  case object SuceededBy extends WorkInclude
+  case object PrecededBy extends WorkInclude
+  case object SucceededBy extends WorkInclude
 }
 
 case class WorksIncludes(includes: List[WorkInclude]) {
@@ -30,9 +30,9 @@ case class WorksIncludes(includes: List[WorkInclude]) {
   def images = includes.contains(WorkInclude.Images)
   def parts = includes.contains(WorkInclude.Parts)
   def partOf = includes.contains(WorkInclude.PartOf)
-  def preceededBy = includes.contains(WorkInclude.PreceededBy)
-  def suceededBy = includes.contains(WorkInclude.SuceededBy)
-  def anyRelation = parts || partOf || preceededBy || suceededBy
+  def precededBy = includes.contains(WorkInclude.PrecededBy)
+  def succeededBy = includes.contains(WorkInclude.SucceededBy)
+  def anyRelation = parts || partOf || precededBy || succeededBy
 }
 
 object WorksIncludes {
@@ -51,8 +51,8 @@ object WorksIncludes {
     images: Boolean = false,
     parts: Boolean = false,
     partOf: Boolean = false,
-    preceededBy: Boolean = false,
-    suceededBy: Boolean = false,
+    precededBy: Boolean = false,
+    succeededBy: Boolean = false,
   ): WorksIncludes = WorksIncludes(
     List(
       if (identifiers) Some(Identifiers) else None,
@@ -66,8 +66,8 @@ object WorksIncludes {
       if (images) Some(Images) else None,
       if (parts) Some(Parts) else None,
       if (partOf) Some(PartOf) else None,
-      if (preceededBy) Some(PreceededBy) else None,
-      if (suceededBy) Some(SuceededBy) else None,
+      if (precededBy) Some(PrecededBy) else None,
+      if (succeededBy) Some(SucceededBy) else None,
     ).flatten
   )
 

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -12,6 +12,10 @@ object WorkInclude {
   case object Notes extends WorkInclude
   case object Collection extends WorkInclude
   case object Images extends WorkInclude
+  case object Parts extends WorkInclude
+  case object PartOf extends WorkInclude
+  case object PreceededBy extends WorkInclude
+  case object SuceededBy extends WorkInclude
 }
 
 case class WorksIncludes(includes: List[WorkInclude]) {
@@ -24,6 +28,11 @@ case class WorksIncludes(includes: List[WorkInclude]) {
   def notes = includes.contains(WorkInclude.Notes)
   def collection = includes.contains(WorkInclude.Collection)
   def images = includes.contains(WorkInclude.Images)
+  def parts = includes.contains(WorkInclude.Parts)
+  def partOf = includes.contains(WorkInclude.PartOf)
+  def preceededBy = includes.contains(WorkInclude.PreceededBy)
+  def suceededBy = includes.contains(WorkInclude.SuceededBy)
+  def anyRelation = parts || partOf || preceededBy || suceededBy
 }
 
 object WorksIncludes {
@@ -40,6 +49,10 @@ object WorksIncludes {
     notes: Boolean = false,
     collection: Boolean = false,
     images: Boolean = false,
+    parts: Boolean = false,
+    partOf: Boolean = false,
+    preceededBy: Boolean = false,
+    suceededBy: Boolean = false,
   ): WorksIncludes = WorksIncludes(
     List(
       if (identifiers) Some(Identifiers) else None,
@@ -51,10 +64,14 @@ object WorksIncludes {
       if (notes) Some(Notes) else None,
       if (collection) Some(Collection) else None,
       if (images) Some(Images) else None,
+      if (parts) Some(Parts) else None,
+      if (partOf) Some(PartOf) else None,
+      if (preceededBy) Some(PreceededBy) else None,
+      if (suceededBy) Some(SuceededBy) else None,
     ).flatten
   )
 
   def includeAll(): WorksIncludes = WorksIncludes(
-    true, true, true, true, true, true, true, true, true
+    true, true, true, true, true, true, true, true, true, true, true, true, true
   )
 }


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4671

## Description

Uses the `RelatedWorkService` introduced in #695 to expose related works in the API.