### PR TITLE
Fix/weco deploy version

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -119,4 +119,5 @@ catalogue_api:
           role_arn: arn:aws:iam::756629837203:role/catalogue-ci
   name: Catalogue API
   role_arn: arn:aws:iam::760097843905:role/platform-ci
+  aws_region_name: eu-west-1
   github_repository: wellcometrust/catalogue

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -82,7 +82,7 @@ endef
 define publish_service_ssm
 	$(ROOT)/docker_run.py \
     	    --aws --dind -- \
-                wellcome/weco-deploy:4.1.0 \
+                wellcome/weco-deploy:5.0.2 \
                 --project-id="$(2)" \
                 --verbose \
                 publish \


### PR DESCRIPTION
Seems this was breaking the build as the defaults weren't set. Bumped the version while we're at it.