### PR TITLE
Remove some Materializer instances that we don't need

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api
 import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
@@ -15,14 +14,11 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import scala.concurrent.{ExecutionContext, Promise}
 
 object Main extends WellcomeTypesafeApp {
-
   runWithConfig { config: Config =>
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     Tracing.init(config)
     val elasticClient = ElasticBuilder.buildElasticClient(config)

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.bigmessaging.typesafe
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import io.circe.{Decoder, Encoder}
@@ -25,7 +24,6 @@ object BigMessagingBuilder {
   def buildMessageStream[T](config: Config)(
     implicit actorSystem: ActorSystem,
     decoderT: Decoder[T],
-    materializer: Materializer,
     codecT: Codec[T]): BigMessageStream[T] = {
 
     implicit val executionContext: ExecutionContext =

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/Main.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/Main.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.mets_adapter
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.scanamo.auto._
@@ -27,8 +26,7 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildExecutionContext()
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     implicit val dynamoClilent: AmazonDynamoDB =
       DynamoBuilder.buildDynamoClient(config)
 
@@ -51,7 +49,6 @@ object Main extends WellcomeTypesafeApp {
   private def buildBagRetriever(config: Config)(
     implicit
     actorSystem: ActorSystem,
-    materializer: Materializer,
     ec: ExecutionContext): BagRetriever =
     new HttpBagRetriever(
       config.requireString("bags.api.url"),

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/BagRetriever.scala
@@ -20,7 +20,6 @@ trait BagRetriever {
 class HttpBagRetriever(baseUrl: String, tokenService: TokenService)(
   implicit
   actorSystem: ActorSystem,
-  materializer: Materializer,
   executionContext: ExecutionContext)
     extends BagRetriever
     with Logging {

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Main.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.idminter
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import io.circe.Json
@@ -24,8 +23,6 @@ object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val identifiersTableConfig = IdentifiersTableBuilder.buildConfig(config)
     RDSBuilder.buildDB(config)

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/Main.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.inference_manager
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.Materializer
 import com.amazonaws.services.s3.AmazonS3
 import software.amazon.awssdk.services.sqs.model.Message
 import com.typesafe.config.Config
@@ -36,8 +35,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 
     implicit val msgStore = S3TypedStore[Output]

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.inference_manager.services
 import akka.Done
 import akka.http.scaladsl.Http.HostConnectionPool
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.stream.Materializer
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Flow
 import software.amazon.awssdk.services.sqs.model.Message
 import grizzled.slf4j.Logging
@@ -21,7 +21,7 @@ class InferenceManagerWorkerService[Destination, Input, Output](
   inferrerClientFlow: Flow[(HttpRequest, (Message, Input)),
                            (Try[HttpResponse], (Message, Input)),
                            HostConnectionPool]
-)(implicit ec: ExecutionContext, materializer: Materializer)
+)(implicit actorSystem: ActorSystem, ec: ExecutionContext)
     extends Runnable
     with Logging {
 

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -31,22 +31,20 @@ trait InferenceManagerWorkerServiceFixture[Input, Output]
         topic,
         bigMessageThreshold = Int.MaxValue) { msgSender =>
         withActorSystem { implicit actorSystem =>
-          withMaterializer(actorSystem) { implicit materializer =>
-            implicit val store: MemoryStore[ObjectLocation, Input] =
-              new MemoryStore[ObjectLocation, Input](Map.empty)
-            withBigMessageStream[Input, R](queue) { msgStream =>
-              val workerService = new InferenceManagerWorkerService(
-                msgStream = msgStream,
-                msgSender = msgSender,
-                inferrerAdapter = adapter,
-                inferrerClientFlow = Http()
-                  .cachedHostConnectionPool[(Message, Input)](
-                    "localhost",
-                    inferrerPort)
-              )
-              workerService.run()
-              testWith(workerService)
-            }
+          implicit val store: MemoryStore[ObjectLocation, Input] =
+            new MemoryStore[ObjectLocation, Input](Map.empty)
+          withBigMessageStream[Input, R](queue) { msgStream =>
+            val workerService = new InferenceManagerWorkerService(
+              msgStream = msgStream,
+              msgSender = msgSender,
+              inferrerAdapter = adapter,
+              inferrerClientFlow = Http()
+                .cachedHostConnectionPool[(Message, Input)](
+                "localhost",
+                inferrerPort)
+            )
+            workerService.run()
+            testWith(workerService)
           }
         }
       }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.images
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
@@ -27,8 +26,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val indexName = config.requireString("es.index")
     val elasticClient = ElasticBuilder.buildElasticClient(config)

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.works
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
@@ -27,8 +26,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val indexName = config.requireString("es.index")
     val elasticClient = ElasticBuilder.buildElasticClient(config)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.matcher
 import java.time.Duration
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
@@ -36,8 +35,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val dynamoClient = DynamoBuilder.buildDynamoClient(config)
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.merger
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
@@ -28,8 +27,7 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     implicit val s3Client =
       S3Builder.buildS3Client(config)
     implicit val workMessageStore = S3TypedStore[BaseWork]

--- a/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
+++ b/pipeline/recorder/src/main/scala/uk/ac/wellcome/platform/recorder/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.recorder
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -12,12 +11,9 @@ import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
 
 object Main extends WellcomeTypesafeApp {
-
   runWithConfig { config: Config =>
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     new RecorderWorkerService(
       store = VHSBuilder.build[TransformedBaseWork](config),

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.calm
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -27,8 +26,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
       AkkaBuilder.buildExecutionContext()
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     implicit val s3Client =
       S3Builder.buildS3Client(config)
     implicit val msgStore =

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.mets
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
@@ -36,8 +35,6 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
       AkkaBuilder.buildExecutionContext()
     implicit val actorSystem: ActorSystem =
       AkkaBuilder.buildActorSystem()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
     implicit val s3Client =
       S3Builder.buildS3Client(config)
     implicit val msgStore =

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.transformer.miro
 
 import scala.concurrent.ExecutionContext
-
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
-
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.miro.services.{
   MiroTransformerWorkerService,
@@ -16,12 +13,10 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.transformer.miro.Implicits._
-
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.messaging.sns.SNSConfig
-
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.storage.streaming.Codec._
@@ -33,8 +28,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
     implicit val s3Client =
       S3Builder.buildS3Client(config)
     implicit val msgStore =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -25,8 +24,7 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     implicit val s3Client =
       S3Builder.buildS3Client(config)
 

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.reindex.reindex_worker
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
@@ -29,8 +28,6 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val dynamoDBClient = DynamoBuilder.buildDynamoClient(config)
     val scanSpecScanner = new ScanSpecScanner(dynamoDBClient)

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Main.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_bib_merger
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
@@ -22,8 +21,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val versionedHybridStore =
       SierraVHSBuilder.buildSierraVHS[SierraTransformable](config)

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Main.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_item_merger
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
@@ -26,8 +25,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val stransformableStore =
       SierraVHSBuilder.buildSierraVHS[SierraTransformable](

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Main.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_items_to_dynamo
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.sierra_adapter.model.Implicits._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -22,8 +21,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
+
     val dynamoInserter = new DynamoInserter(
       SierraVHSBuilder.buildSierraVHS[SierraItemRecord](config))
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Main.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
@@ -21,8 +20,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.sierra_reader.services
 import java.time.Instant
 
 import akka.Done
-import akka.stream.Materializer
+import akka.actor.ActorSystem
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import io.circe.Json
@@ -11,22 +11,12 @@ import io.circe.syntax._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs._
-import uk.ac.wellcome.platform.sierra_reader.config.models.{
-  ReaderConfig,
-  SierraAPIConfig
-}
+import uk.ac.wellcome.platform.sierra_reader.config.models.{ReaderConfig, SierraAPIConfig}
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.{
-  SierraResourceTypes,
-  WindowStatus
-}
+import uk.ac.wellcome.platform.sierra_reader.models.{SierraResourceTypes, WindowStatus}
 import uk.ac.wellcome.platform.sierra_reader.sink.SequentialS3Sink
 import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
-import uk.ac.wellcome.sierra_adapter.model.{
-  AbstractSierraRecord,
-  SierraBibRecord,
-  SierraItemRecord
-}
+import uk.ac.wellcome.sierra_adapter.model.{AbstractSierraRecord, SierraBibRecord, SierraItemRecord}
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.s3.S3Config
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
@@ -41,7 +31,7 @@ class SierraReaderWorkerService(
   s3Config: S3Config,
   readerConfig: ReaderConfig,
   sierraAPIConfig: SierraAPIConfig
-)(implicit ec: ExecutionContext, materializer: Materializer)
+)(implicit actorSystem: ActorSystem, ec: ExecutionContext)
     extends Logging
     with Runnable {
   implicit val s = s3client

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -23,20 +23,18 @@ trait WorkerServiceFixture extends Akka with SQS with S3Fixtures {
                            sierraAPIConfig: SierraAPIConfig = sierraAPIConfig)(
     testWith: TestWith[SierraReaderWorkerService, R]): R =
     withActorSystem { implicit actorSystem =>
-      withMaterializer(actorSystem) { implicit materializer =>
-        withSQSStream[NotificationMessage, R](queue) { sqsStream =>
-          val workerService = new SierraReaderWorkerService(
-            sqsStream = sqsStream,
-            s3client = s3Client,
-            s3Config = createS3ConfigWith(bucket),
-            readerConfig = readerConfig,
-            sierraAPIConfig = sierraAPIConfig
-          )
+      withSQSStream[NotificationMessage, R](queue) { sqsStream =>
+        val workerService = new SierraReaderWorkerService(
+          sqsStream = sqsStream,
+          s3client = s3Client,
+          s3Config = createS3ConfigWith(bucket),
+          readerConfig = readerConfig,
+          sierraAPIConfig = sierraAPIConfig
+        )
 
-          workerService.run()
+        workerService.run()
 
-          testWith(workerService)
-        }
+        testWith(workerService)
       }
     }
 

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_generator
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
@@ -22,8 +21,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val actorSystem: ActorSystem = AkkaBuilder.buildActorSystem()
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
-    implicit val materializer: Materializer =
-      AkkaBuilder.buildMaterializer()
 
     val snapshotService = new SnapshotService(
       akkaS3Settings = AkkaS3Builder.buildAkkaS3Settings(config),
@@ -33,10 +30,7 @@ object Main extends WellcomeTypesafeApp {
 
     new SnapshotGeneratorWorkerService(
       snapshotService = snapshotService,
-      sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)(
-        actorSystem,
-        materializer,
-        executionContext),
+      sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       snsWriter = SNSBuilder.buildSNSMessageSender(
         config,
         subject = s"source: ${this.getClass.getSimpleName}.processMessage",

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.snapshot_generator.services
 import scala.concurrent.{ExecutionContext, Future}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
 import akka.stream.alpakka.s3.{MultipartUploadResult, S3Attributes, S3Settings}
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.{Sink, Source}
@@ -29,7 +28,6 @@ class SnapshotService(akkaS3Settings: S3Settings,
                       elasticClient: ElasticClient,
                       elasticConfig: ElasticConfig)(
   implicit actorSystem: ActorSystem,
-  materializer: Materializer,
   ec: ExecutionContext
 ) extends Logging {
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -109,16 +109,14 @@ class SnapshotGeneratorFeatureTest
   }
 
   def withFixtures[R](
-    testWith: TestWith[(Queue, Topic, Index, Index, Bucket), R]) =
+    testWith: TestWith[(Queue, Topic, Index, Index, Bucket), R]): R =
     withActorSystem { implicit actorSystem =>
-      withMaterializer(actorSystem) { implicit materializer =>
-        withLocalSqsQueue() { queue =>
-          withLocalSnsTopic { topic =>
-            withLocalWorksIndex { worksIndex =>
-              withLocalS3Bucket { bucket =>
-                withWorkerService(queue, topic, worksIndex) { _ =>
-                  testWith((queue, topic, worksIndex, worksIndex, bucket))
-                }
+      withLocalSqsQueue() { queue =>
+        withLocalSnsTopic { topic =>
+          withLocalWorksIndex { worksIndex =>
+            withLocalS3Bucket { bucket =>
+              withWorkerService(queue, topic, worksIndex) { _ =>
+                testWith((queue, topic, worksIndex, worksIndex, bucket))
               }
             }
           }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_generator.fixtures
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import akka.stream.alpakka.s3.S3Settings
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -22,8 +21,7 @@ trait SnapshotServiceFixture extends ElasticsearchFixtures { this: Suite =>
   def withSnapshotService[R](s3AkkaSettings: S3Settings,
                              worksIndex: Index,
                              elasticClient: ElasticClient = elasticClient)(
-    testWith: TestWith[SnapshotService, R])(implicit actorSystem: ActorSystem,
-                                            materializer: Materializer): R = {
+    testWith: TestWith[SnapshotService, R])(implicit actorSystem: ActorSystem): R = {
     val elasticConfig = ElasticConfig(worksIndex, Index(""))
 
     val snapshotService = new SnapshotService(

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.snapshot_generator.fixtures
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import com.sksamuel.elastic4s.Index
 import org.scalatest.Suite
 import uk.ac.wellcome.messaging.sns.{
@@ -24,8 +23,7 @@ trait WorkerServiceFixture
     with SQS { this: Suite =>
   def withWorkerService[R](queue: Queue, topic: Topic, worksIndex: Index)(
     testWith: TestWith[SnapshotGeneratorWorkerService, R])(
-    implicit actorSystem: ActorSystem,
-    materializer: Materializer): R =
+    implicit actorSystem: ActorSystem): R =
     withS3AkkaSettings { s3AkkaClient =>
       withSnapshotService(s3AkkaClient, worksIndex) { snapshotService =>
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/StringToGzipFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/StringToGzipFlowTest.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.file.Paths
 
 import akka.stream.scaladsl.{FileIO, Flow, Keep, Sink, Source}
-import akka.stream.{IOResult, Materializer}
+import akka.stream.IOResult
 import akka.util.ByteString
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
@@ -23,10 +23,7 @@ class StringToGzipFlowTest
     with IntegrationPatience {
 
   it("produces a gzip-compressed file from the lines") {
-    withActorSystem { actorSystem =>
-      implicit val materializer: Materializer =
-        Materializer(actorSystem)
-
+    withActorSystem { implicit actorSystem =>
       val flow = StringToGzipFlow()
 
       val expectedLines = List(

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -24,17 +24,15 @@ class ElasticsearchSourceTest
 
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
-      withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex { index =>
-          val works = createIdentifiedWorks(count = 10)
-          insertIntoElasticsearch(index, works: _*)
+      withLocalWorksIndex { index =>
+        val works = createIdentifiedWorks(count = 10)
+        insertIntoElasticsearch(index, works: _*)
 
-          withSource(index) { source =>
-            val future = source.runWith(Sink.seq)
+        withSource(index) { source =>
+          val future = source.runWith(Sink.seq)
 
-            whenReady(future) { result =>
-              result should contain theSameElementsAs works
-            }
+          whenReady(future) { result =>
+            result should contain theSameElementsAs works
           }
         }
       }
@@ -43,20 +41,18 @@ class ElasticsearchSourceTest
 
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
-      withMaterializer(actorSystem) { implicit materializer =>
-        withLocalWorksIndex { index =>
-          val visibleWorks = createIdentifiedWorks(count = 10)
-          val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
+      withLocalWorksIndex { index =>
+        val visibleWorks = createIdentifiedWorks(count = 10)
+        val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
 
-          val works = visibleWorks ++ invisibleWorks
-          insertIntoElasticsearch(index, works: _*)
+        val works = visibleWorks ++ invisibleWorks
+        insertIntoElasticsearch(index, works: _*)
 
-          withSource(index) { source =>
-            val future = source.runWith(Sink.seq)
+        withSource(index) { source =>
+          val future = source.runWith(Sink.seq)
 
-            whenReady(future) { result =>
-              result should contain theSameElementsAs visibleWorks
-            }
+          whenReady(future) { result =>
+            result should contain theSameElementsAs visibleWorks
           }
         }
       }


### PR DESCRIPTION
Spotted while doing some refactoring for https://github.com/wellcomecollection/platform/issues/4596

In [Akka 2.6](https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html#materializer-changes), you don't need to supply an implicit Materializer if there's an implicit ActorSystem:

> A default materializer is now provided out of the box. For the Java API just pass system when running streams, for Scala an implicit materializer is provided if there is an implicit ActorSystem available. This avoids leaking materializers and simplifies most stream use cases somewhat.

The Materializer instances are often boilerplate that we can delete without losing anything; this highlights places where we *do* need a Materializer (e.g. for Akka flows).