### PR TITLE
More cleanup of tests and MessageSender instances

### DIFF
--- a/calm_adapter/calm_adapter/docker-compose.yml
+++ b/calm_adapter/calm_adapter/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -2,18 +2,20 @@ package uk.ac.wellcome.calm_adapter
 
 import java.time.LocalDate
 
-import scala.concurrent.{ExecutionContext, Future}
 import akka.Done
-import akka.stream.scaladsl._
 import akka.stream.Materializer
+import akka.stream.scaladsl._
 import grizzled.slf4j.Logging
 import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
-import uk.ac.wellcome.typesafe.Runnable
-import uk.ac.wellcome.storage.Version
-import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.bigmessaging.FlowOps
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.typesafe.Runnable
+
+import scala.concurrent.{ExecutionContext, Future}
 
 case class CalmWindow(date: LocalDate)
 
@@ -27,11 +29,12 @@ case class CalmWindow(date: LocalDate)
   *   currently in  the store
   * - Publish the VHS key to SNS
   */
-class CalmAdapterWorkerService(msgStream: SQSStream[NotificationMessage],
-                               msgSender: SNSMessageSender,
-                               calmRetriever: CalmRetriever,
-                               calmStore: CalmStore,
-                               concurrentWindows: Int = 2)(
+class CalmAdapterWorkerService[Destination](
+  msgStream: SQSStream[NotificationMessage],
+  messageSender: MessageSender[Destination],
+  calmRetriever: CalmRetriever,
+  calmStore: CalmStore,
+  concurrentWindows: Int = 2)(
   implicit
   val ec: ExecutionContext,
   materializer: Materializer)
@@ -89,7 +92,7 @@ class CalmAdapterWorkerService(msgStream: SQSStream[NotificationMessage],
     Flow[Result[Option[(Key, CalmRecord)]]]
       .map {
         case Right(Some((key, record))) =>
-          msgSender.sendT(key).toEither.right.map(_ => Some(key -> record))
+          messageSender.sendT(key).toEither.right.map(_ => Some(key -> record))
         case Right(None) => Right(None)
         case err         => err
       }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -34,10 +34,9 @@ class CalmAdapterWorkerService[Destination](
   messageSender: MessageSender[Destination],
   calmRetriever: CalmRetriever,
   calmStore: CalmStore,
-  concurrentWindows: Int = 2)(
-  implicit
-  val ec: ExecutionContext,
-  materializer: Materializer)
+  concurrentWindows: Int = 2)(implicit
+                              val ec: ExecutionContext,
+                              materializer: Materializer)
     extends Runnable
     with FlowOps
     with Logging {

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -139,7 +139,7 @@ class CalmAdapterWorkerServiceTest
               stream,
               messageSender = messageSender,
               retriever,
-              new CalmStore(MemoryVersionedStore(initialEntries = Map.empty))
+              new CalmStore(new MemoryVersionedStore(store))
             )
             calmAdapter.run()
             testWith((calmAdapter, QueuePair(queue, dlq)))

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.memory.{MemoryIndividualMessageSender, MemoryMessageSender}
+import uk.ac.wellcome.messaging.memory.{
+  MemoryIndividualMessageSender,
+  MemoryMessageSender
+}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.Maxima
@@ -105,7 +108,8 @@ class CalmAdapterWorkerServiceTest
     val brokenMessageSender = new MemoryMessageSender() {
       override val underlying: MemoryIndividualMessageSender =
         new MemoryIndividualMessageSender() {
-          override def sendT[T](t: T)(subject: String, destination: String)(implicit encoder: Encoder[T]): Try[Unit] =
+          override def sendT[T](t: T)(subject: String, destination: String)(
+            implicit encoder: Encoder[T]): Try[Unit] =
             if (t.asInstanceOf[Version[String, Int]].id == "B")
               Failure(new Exception("Waaah I couldn't send message"))
             else
@@ -139,7 +143,7 @@ class CalmAdapterWorkerServiceTest
             )
             calmAdapter.run()
             testWith((calmAdapter, QueuePair(queue, dlq)))
-        }
+          }
       }
     }
 

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -1,32 +1,34 @@
 package uk.ac.wellcome.calm_adapter
 
-import scala.util.{Failure, Try}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.language.reflectiveCalls
 import java.time.{Instant, LocalDate}
 
-import org.scalatest.matchers.should.Matchers
+import akka.NotUsed
 import akka.stream.scaladsl._
 import io.circe.Encoder
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
-import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.messaging.memory.{MemoryIndividualMessageSender, MemoryMessageSender}
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.Maxima
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
-import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.reflectiveCalls
+import scala.util.{Failure, Try}
 
 class CalmAdapterWorkerServiceTest
     extends AnyFunSpec
     with Matchers
     with Akka
     with SQS
-    with SNS
     with Eventually
     with IntegrationPatience {
 
@@ -43,8 +45,10 @@ class CalmAdapterWorkerServiceTest
   it("should process an incoming window, storing records and publishing keys") {
     val store = dataStore()
     val retriever = calmRetriever(List(recordA, recordB, recordC))
-    withCalmAdapterWorkerService(retriever, store) {
-      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+    val messageSender = new MemoryMessageSender()
+
+    withCalmAdapterWorkerService(retriever, store, messageSender) {
+      case (_, QueuePair(queue, dlq)) =>
         sendNotificationToSQS(queue, CalmWindow(queryDate))
         eventually {
           store.entries shouldBe Map(
@@ -59,7 +63,8 @@ class CalmAdapterWorkerServiceTest
             CalmQuery.ModifiedDate(queryDate))
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          getMessages(topic) shouldBe List(
+
+          messageSender.getMessages[Version[String, Int]] shouldBe List(
             Version("A", 0),
             Version("B", 0),
             Version("C", 0)
@@ -71,21 +76,23 @@ class CalmAdapterWorkerServiceTest
   it("should complete successfully when no records returned from the query") {
     val store = dataStore()
     val retriever = calmRetriever(Nil)
-    withCalmAdapterWorkerService(retriever, store) {
-      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+    val messageSender = new MemoryMessageSender()
+
+    withCalmAdapterWorkerService(retriever, store, messageSender) {
+      case (_, QueuePair(queue, dlq)) =>
         sendNotificationToSQS(queue, CalmWindow(queryDate))
         Thread.sleep(1500)
         store.entries shouldBe Map.empty
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
-        getMessages(topic) shouldBe Nil
+
+        messageSender.messages shouldBe empty
     }
   }
 
   it("should send the message to the DLQ if publishing of any record fails") {
-    val store = dataStore()
     val retriever = new CalmRetriever {
-      def apply(query: CalmQuery) = {
+      def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
         val timestamp = Instant.now
         val records = List(
           CalmRecord("A", Map.empty, timestamp),
@@ -95,65 +102,51 @@ class CalmAdapterWorkerServiceTest
         Source.fromIterator(() => records.toIterator)
       }
     }
-    val createBrokenMsgSender = (topic: SNS.Topic) =>
-      new SNSMessageSender(
-        snsClient = snsClient,
-        snsConfig = createSNSConfigWith(topic),
-        subject = "BrokenSNSMessageSender"
-      ) {
-        override def sendT[T](item: T)(
-          implicit encoder: Encoder[T]): Try[Unit] = {
-          if (item.asInstanceOf[Version[String, Int]].id == "B")
-            Failure(new Exception("Waaah I couldn't send message"))
-          else
-            super.sendT(item)
+    val brokenMessageSender = new MemoryMessageSender() {
+      override val underlying: MemoryIndividualMessageSender =
+        new MemoryIndividualMessageSender() {
+          override def sendT[T](t: T)(subject: String, destination: String)(implicit encoder: Encoder[T]): Try[Unit] =
+            if (t.asInstanceOf[Version[String, Int]].id == "B")
+              Failure(new Exception("Waaah I couldn't send message"))
+            else
+              super.sendT(t)(subject, destination)
         }
     }
-    withCalmAdapterWorkerService(retriever, store, createBrokenMsgSender(_)) {
-      case (calmAdapter, QueuePair(queue, dlq), topic) =>
+
+    withCalmAdapterWorkerService(retriever, messageSender = brokenMessageSender) {
+      case (_, QueuePair(queue, dlq)) =>
         sendNotificationToSQS(queue, CalmWindow(queryDate))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
-        assertQueueHasSize(dlq, 1)
+        assertQueueHasSize(dlq, size = 1)
     }
   }
 
   def withCalmAdapterWorkerService[R](
     retriever: CalmRetriever,
-    store: MemoryStore[Key, CalmRecord] with Maxima[String, Int],
-    createMsgSender: SNS.Topic => SNSMessageSender = createMsgSender(_))(
-    testWith: TestWith[(CalmAdapterWorkerService, QueuePair, SNS.Topic), R]) =
+    store: MemoryStore[Key, CalmRecord] with Maxima[String, Int] = dataStore(),
+    messageSender: MemoryMessageSender = new MemoryMessageSender())(
+    testWith: TestWith[(CalmAdapterWorkerService[String], QueuePair), R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSnsTopic { topic =>
-        withLocalSqsQueuePair() {
-          case QueuePair(queue, dlq) =>
-            withSQSStream[NotificationMessage, R](queue) { stream =>
-              withMaterializer { implicit materializer =>
-                val calmAdapter = new CalmAdapterWorkerService(
-                  stream,
-                  createMsgSender(topic),
-                  retriever,
-                  new CalmStore(new MemoryVersionedStore(store))
-                )
-                calmAdapter.run()
-                testWith((calmAdapter, QueuePair(queue, dlq), topic))
-              }
-            }
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withSQSStream[NotificationMessage, R](queue) { stream =>
+            val calmAdapter = new CalmAdapterWorkerService(
+              stream,
+              messageSender = messageSender,
+              retriever,
+              new CalmStore(MemoryVersionedStore(initialEntries = Map.empty))
+            )
+            calmAdapter.run()
+            testWith((calmAdapter, QueuePair(queue, dlq)))
         }
       }
     }
 
-  def createMsgSender(topic: SNS.Topic) =
-    new SNSMessageSender(
-      snsClient = snsClient,
-      snsConfig = createSNSConfigWith(topic),
-      subject = "SNSMessageSender"
-    )
-
   def calmRetriever(records: List[CalmRecord]) =
     new CalmRetriever {
       var previousQuery: Option[CalmQuery] = None
-      def apply(query: CalmQuery) = {
+      def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
         previousQuery = Some(query)
         Source.fromIterator(() => records.toIterator)
       }
@@ -161,9 +154,4 @@ class CalmAdapterWorkerServiceTest
 
   def dataStore(entries: (Key, CalmRecord)*) =
     new MemoryStore(entries.toMap) with MemoryMaxima[String, CalmRecord]
-
-  def getMessages(topic: SNS.Topic) =
-    listMessagesReceivedFromSNS(topic)
-      .map(msgInfo => fromJson[Version[String, Int]](msgInfo.message).get)
-      .toList
 }

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -26,7 +26,9 @@ class VHSInternalStore[T](
   dataStore: TypedStore[ObjectLocation, T]
 ) extends HybridStoreWithMaxima[String, Int, ObjectLocation, T] {
 
-  override val indexedStore: Store[Version[String, Int], ObjectLocation] with Maxima[String, Int] = indexStore
+  override val indexedStore
+    : Store[Version[String, Int], ObjectLocation] with Maxima[String, Int] =
+    indexStore
   override val typedStore: TypedStore[ObjectLocation, T] = dataStore
 
   override protected def createTypeStoreId(

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -26,8 +26,8 @@ class VHSInternalStore[T](
   dataStore: TypedStore[ObjectLocation, T]
 ) extends HybridStoreWithMaxima[String, Int, ObjectLocation, T] {
 
-  override val indexedStore = indexStore;
-  override val typedStore = dataStore;
+  override val indexedStore: Store[Version[String, Int], ObjectLocation] with Maxima[String, Int] = indexStore
+  override val typedStore: TypedStore[ObjectLocation, T] = dataStore
 
   override protected def createTypeStoreId(
     id: Version[String, Int]): ObjectLocation =

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
@@ -97,11 +97,11 @@ trait BigMessagingFixture
       testWith(sender)
     }
 
-  def withSnsMessageSender[R](topic: Topic, snsClient: SnsClient = snsClient)(
+  private def withSnsMessageSender[R](topic: Topic, senderSnsClient: SnsClient)(
     testWith: TestWith[MessageSender[SNSConfig], R]): R =
     testWith(
       new SNSMessageSender(
-        snsClient = snsClient,
+        snsClient = senderSnsClient,
         snsConfig = createSNSConfigWith(topic),
         subject = "Sent in BigMessagingFixture"
       )

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/VHSFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/VHSFixture.scala
@@ -6,10 +6,8 @@ import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
-import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 
-trait VHSFixture[T] extends BigMessagingFixture {
-
+trait VHSFixture[T] {
   type VHS = VersionedStore[String, Int, T]
 
   type InternalStore =
@@ -33,9 +31,4 @@ trait VHSFixture[T] extends BigMessagingFixture {
 
   def withBrokenVHS[R](testWith: TestWith[VHS, R]): R =
     testWith(new BrokenMemoryVHS())
-
-  def withMemoryMessageSender[R](
-    testWith: TestWith[MemoryMessageSender, R]): R = {
-    testWith(new MemoryMessageSender())
-  }
 }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
@@ -23,7 +23,7 @@ class BigMessageStreamTest
     with Matchers
     with BigMessagingFixture {
 
-  def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject) = {
+  def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject): Future[Unit] = {
     list.add(o)
     Future.successful(())
   }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStreamTest.scala
@@ -23,7 +23,8 @@ class BigMessageStreamTest
     with Matchers
     with BigMessagingFixture {
 
-  def process(list: ConcurrentLinkedQueue[ExampleObject])(o: ExampleObject): Future[Unit] = {
+  def process(list: ConcurrentLinkedQueue[ExampleObject])(
+    o: ExampleObject): Future[Unit] = {
     list.add(o)
     Future.successful(())
   }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -150,6 +150,9 @@ class IdMinterFeatureTest
     // TODO Write this test using dead letter queues once https://github.com/adamw/elasticmq/issues/69 is closed
     Thread.sleep(2000)
 
-    getQueueAttribute(queue, attributeName = QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
+    getQueueAttribute(
+      queue,
+      attributeName =
+        QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
   }
 }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -3,10 +3,7 @@ package uk.ac.wellcome.platform.idminter
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.services.sqs.model.{
-  GetQueueAttributesRequest,
-  QueueAttributeName
-}
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
@@ -14,8 +11,6 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.platform.idminter.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.models.Implicits._
-
-import scala.collection.JavaConverters._
 
 class IdMinterFeatureTest
     extends AnyFunSpec
@@ -161,14 +156,6 @@ class IdMinterFeatureTest
     // TODO Write this test using dead letter queues once https://github.com/adamw/elasticmq/issues/69 is closed
     Thread.sleep(2000)
 
-    sqsClient
-      .getQueueAttributes { builder: GetQueueAttributesRequest.Builder =>
-        builder
-          .queueUrl(queue.url)
-          .attributeNames(List(
-            QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE).asJava)
-      }
-      .attributes()
-      .get(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
+    getQueueAttribute(queue, attributeName = QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
   }
 }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -4,8 +4,6 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -14,13 +12,9 @@ import uk.ac.wellcome.models.Implicits._
 
 class IdMinterFeatureTest
     extends AnyFunSpec
-    with SQS
-    with SNS
-    with BigMessagingFixture
-    with fixtures.IdentifiersDatabase
+    with Matchers
     with IntegrationPatience
     with Eventually
-    with Matchers
     with WorkerServiceFixture
     with WorksGenerators {
 

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
@@ -21,7 +21,8 @@ trait WorkerServiceFixture
     with BigMessagingFixture {
   def withWorkerService[R](bucket: Bucket,
                            topic: Topic,
-                           queue: Queue = Queue("url://q", "arn::q", visibilityTimeout = 1),
+                           queue: Queue =
+                             Queue("url://q", "arn::q", visibilityTimeout = 1),
                            identifiersDao: IdentifiersDao,
                            identifiersTableConfig: IdentifiersTableConfig)(
     testWith: TestWith[IdMinterWorkerService[SNSConfig], R]): R =

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/fixtures/WorkerServiceFixture.scala
@@ -21,7 +21,7 @@ trait WorkerServiceFixture
     with BigMessagingFixture {
   def withWorkerService[R](bucket: Bucket,
                            topic: Topic,
-                           queue: Queue,
+                           queue: Queue = Queue("url://q", "arn::q", visibilityTimeout = 1),
                            identifiersDao: IdentifiersDao,
                            identifiersTableConfig: IdentifiersTableConfig)(
     testWith: TestWith[IdMinterWorkerService[SNSConfig], R]): R =

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerServiceTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerServiceTest.scala
@@ -1,27 +1,17 @@
 package uk.ac.wellcome.platform.idminter.services
 
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc._
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.platform.idminter.database.{
   FieldDescription,
   IdentifiersDao
 }
-import uk.ac.wellcome.platform.idminter.fixtures
 import uk.ac.wellcome.platform.idminter.fixtures.WorkerServiceFixture
 
 class IdMinterWorkerServiceTest
     extends AnyFunSpec
-    with SQS
-    with SNS
-    with BigMessagingFixture
-    with fixtures.IdentifiersDatabase
-    with Eventually
-    with IntegrationPatience
     with Matchers
     with MockitoSugar
     with WorkerServiceFixture {

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
@@ -115,7 +115,10 @@ class IngestorWorkerServiceTest
           Thread.sleep(2000)
 
           eventually {
-            getQueueAttribute(queue, attributeName = QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
+            getQueueAttribute(
+              queue,
+              attributeName =
+                QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
           }
         }
       }

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
@@ -5,10 +5,7 @@ import com.sksamuel.elastic4s.http.JavaClient
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import org.scalatest.funspec.AnyFunSpec
-import software.amazon.awssdk.services.sqs.model.{
-  GetQueueAttributesRequest,
-  QueueAttributeName
-}
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.elasticsearch.{
   ElasticCredentials,
   ElasticsearchIndexCreator
@@ -118,18 +115,7 @@ class IngestorWorkerServiceTest
           Thread.sleep(2000)
 
           eventually {
-            sqsClient
-              .getQueueAttributes {
-                builder: GetQueueAttributesRequest.Builder =>
-                  builder
-                    .queueUrl(queue.url)
-                    .attributeNames(
-                      QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE)
-              }
-              .attributes()
-              .get(
-                QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE
-              ) shouldBe "1"
+            getQueueAttribute(queue, attributeName = QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE) shouldBe "1"
           }
         }
       }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -4,10 +4,7 @@ import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 import uk.ac.wellcome.elasticsearch.WorksIndexConfig
-import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
@@ -18,11 +15,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class IngestorWorkerServiceTest
     extends AnyFunSpec
-    with ScalaFutures
     with Matchers
-    with BigMessagingFixture
-    with ElasticsearchFixtures
-    with SQS
+    with ScalaFutures
     with IngestorFixtures
     with WorksGenerators {
 

--- a/pipeline/matcher/docker-compose.yml
+++ b/pipeline/matcher/docker-compose.yml
@@ -10,7 +10,3 @@ s3:
   image: scality/s3server:mem-latest
   ports:
     - "33333:8000"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -5,13 +5,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode
-}
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.{Identified, Version}
@@ -25,97 +21,92 @@ class MatcherFeatureTest
     with WorksGenerators {
 
   it("processes a message with a simple UnidentifiedWork with no linked works") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            val work = createUnidentifiedWork
+    val messageSender = new MemoryMessageSender()
 
-            sendWork(work, vhs, queue)
+    withLocalSqsQueue() { queue =>
+      withVHS { vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          val work = createUnidentifiedWork
 
-            eventually {
-              val snsMessages = listMessagesReceivedFromSNS(topic)
-              snsMessages.size should be >= 1
+          val expectedResult = MatcherResult(
+            Set(
+              MatchedIdentifiers(
+                identifiers = Set(WorkIdentifier(work))
+              )
+            )
+          )
 
-              snsMessages.map { snsMessage =>
-                val identifiersList =
-                  fromJson[MatcherResult](snsMessage.message).get
+          sendWork(work, vhs, queue)
 
-                identifiersList shouldBe
-                  MatcherResult(
-                    Set(MatchedIdentifiers(
-                      Set(WorkIdentifier(work))
-                    )))
-              }
-            }
+          eventually {
+            messageSender.getMessages[MatcherResult].distinct shouldBe Seq(expectedResult)
           }
         }
       }
     }
   }
 
-  it(
-    "does not process a message if the work version is older than that already stored in the graph store") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorkGraphTable { graphTable =>
-            withVHS { vhs =>
-              withWorkerService(vhs, queue, topic, graphTable) { _ =>
-                val existingWorkVersion = 2
-                val updatedWorkVersion = 1
+  it("skips a message if the graph store already has a newer version") {
+    val messageSender = new MemoryMessageSender()
 
-                val workAv1 = createUnidentifiedWorkWith(
-                  version = updatedWorkVersion
-                )
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorkGraphTable { graphTable =>
+          withVHS { vhs =>
+            withWorkerService(vhs, queue, messageSender, graphTable) { _ =>
+              val existingWorkVersion = 2
+              val updatedWorkVersion = 1
 
-                val existingWorkAv2 = WorkNode(
-                  id = workAv1.sourceIdentifier.toString,
-                  version = Some(existingWorkVersion),
-                  linkedIds = Nil,
-                  componentId = workAv1.sourceIdentifier.toString
-                )
-                put(dynamoClient, graphTable.name)(existingWorkAv2)
+              val workAv1 = createUnidentifiedWorkWith(
+                version = updatedWorkVersion
+              )
 
-                sendWork(workAv1, vhs, queue)
+              val existingWorkAv2 = WorkNode(
+                id = workAv1.sourceIdentifier.toString,
+                version = Some(existingWorkVersion),
+                linkedIds = Nil,
+                componentId = workAv1.sourceIdentifier.toString
+              )
+              put(dynamoClient, graphTable.name)(existingWorkAv2)
 
-                eventually {
-                  noMessagesAreWaitingIn(queue)
-                  noMessagesAreWaitingIn(dlq)
-                }
-                listMessagesReceivedFromSNS(topic).size shouldBe 0
+              sendWork(workAv1, vhs, queue)
+
+              eventually {
+                noMessagesAreWaitingIn(queue)
+                noMessagesAreWaitingIn(dlq)
               }
+
+              messageSender.messages shouldBe empty
             }
           }
       }
     }
   }
 
-  it(
-    "does not process a message if the work version is older than that already stored in vhs") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorkGraphTable { graphTable =>
-            withVHS { vhs: VHS =>
-              withWorkerService(vhs, queue, topic, graphTable) { _ =>
-                val workv2 = createUnidentifiedWorkWith(version = 2)
+  it("skips a message if VHS already has a newer version") {
+    val messageSender = new MemoryMessageSender()
 
-                val key = vhs.put(
-                  Version(workv2.sourceIdentifier.toString, workv2.version))(
-                  workv2) match {
-                  case Left(err) =>
-                    throw new Exception(s"Failed storing work in VHS: $err")
-                  case Right(Identified(key, _)) => key
-                }
-                sendNotificationToSQS(queue, Version(key.id, 1))
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorkGraphTable { graphTable =>
+          withVHS { vhs: VHS =>
+            withWorkerService(vhs, queue, messageSender, graphTable) { _ =>
+              val workv2 = createUnidentifiedWorkWith(version = 2)
 
-                eventually {
-                  assertQueueEmpty(queue)
-                  assertQueueEmpty(dlq)
-                }
-                listMessagesReceivedFromSNS(topic).size shouldBe 0
+              val key = vhs.put(
+                Version(workv2.sourceIdentifier.toString, workv2.version))(
+                workv2) match {
+                case Left(err) =>
+                  throw new Exception(s"Failed storing work in VHS: $err")
+                case Right(Identified(key, _)) => key
               }
+              sendNotificationToSQS(queue, Version(key.id, 1))
+
+              eventually {
+                assertQueueEmpty(queue)
+                assertQueueEmpty(dlq)
+              }
+              messageSender.messages shouldBe empty
             }
           }
       }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -7,7 +7,12 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.{Identified, Version}
@@ -39,7 +44,8 @@ class MatcherFeatureTest
           sendWork(work, vhs, queue)
 
           eventually {
-            messageSender.getMessages[MatcherResult].distinct shouldBe Seq(expectedResult)
+            messageSender.getMessages[MatcherResult].distinct shouldBe Seq(
+              expectedResult)
           }
         }
       }
@@ -79,7 +85,7 @@ class MatcherFeatureTest
               messageSender.messages shouldBe empty
             }
           }
-      }
+        }
     }
   }
 
@@ -109,7 +115,7 @@ class MatcherFeatureTest
               messageSender.messages shouldBe empty
             }
           }
-      }
+        }
     }
   }
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -17,7 +17,11 @@ import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, WorkNode}
 import uk.ac.wellcome.platform.matcher.services.MatcherWorkerService
-import uk.ac.wellcome.platform.matcher.storage.{WorkGraphStore, WorkNodeDao, WorkStore}
+import uk.ac.wellcome.platform.matcher.storage.{
+  WorkGraphStore,
+  WorkNodeDao,
+  WorkStore
+}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
@@ -25,7 +29,11 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
-import uk.ac.wellcome.storage.locking.dynamo.{DynamoLockDaoFixtures, DynamoLockingService, ExpiringLock}
+import uk.ac.wellcome.storage.locking.dynamo.{
+  DynamoLockDaoFixtures,
+  DynamoLockingService,
+  ExpiringLock
+}
 import uk.ac.wellcome.storage.Identified
 
 trait MatcherFixtures
@@ -49,11 +57,11 @@ trait MatcherFixtures
       testWith(table)
     }
 
-  def withWorkerService[R](vhs: VHS,
-                           queue: SQS.Queue,
-                           messageSender: MemoryMessageSender,
-                           graphTable: Table)(
-    testWith: TestWith[MatcherWorkerService[String], R]): R =
+  def withWorkerService[R](
+    vhs: VHS,
+    queue: SQS.Queue,
+    messageSender: MemoryMessageSender,
+    graphTable: Table)(testWith: TestWith[MatcherWorkerService[String], R]): R =
     withLockTable { lockTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
         withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
@@ -73,7 +81,9 @@ trait MatcherFixtures
       }
     }
 
-  def withWorkerService[R](vhs: VHS, queue: SQS.Queue, messageSender: MemoryMessageSender)(
+  def withWorkerService[R](vhs: VHS,
+                           queue: SQS.Queue,
+                           messageSender: MemoryMessageSender)(
     testWith: TestWith[MatcherWorkerService[String], R]): R =
     withWorkGraphTable { graphTable =>
       withWorkerService(vhs, queue, messageSender, graphTable) { service =>

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -7,7 +7,11 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
+import uk.ac.wellcome.models.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier
+}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -40,7 +44,9 @@ class MatcherWorkerServiceTest
     withLocalSqsQueue() { implicit queue =>
       withVHS { implicit vhs =>
         withWorkerService(vhs, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(updatedWork, expectedResult = expectedMatchedWorks)
+          processAndAssertMatchedWorkIs(
+            updatedWork,
+            expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -61,7 +67,9 @@ class MatcherWorkerServiceTest
     withLocalSqsQueue() { implicit queue =>
       withVHS { implicit vhs =>
         withWorkerService(vhs, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(invisibleWork, expectedResult = expectedMatchedWorks)
+          processAndAssertMatchedWorkIs(
+            invisibleWork,
+            expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -89,13 +97,14 @@ class MatcherWorkerServiceTest
       )
     )
 
-
     implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
     withLocalSqsQueue() { implicit queue =>
       withVHS { implicit vhs =>
         withWorkerService(vhs, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(workAv1, expectedResult = expectedMatchedWorks)
+          processAndAssertMatchedWorkIs(
+            workAv1,
+            expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -110,7 +119,8 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 1))
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/A", version = 1))
         )
       )
     )
@@ -122,7 +132,8 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/B", version = 1))
         )
       )
     )
@@ -152,7 +163,8 @@ class MatcherWorkerServiceTest
       MatcherResult(
         Set(
           MatchedIdentifiers(
-            identifiers = Set(WorkIdentifier("sierra-system-number/C", version = 1))
+            identifiers =
+              Set(WorkIdentifier("sierra-system-number/C", version = 1))
           )
         )
       )
@@ -201,7 +213,8 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 1))
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/A", version = 1))
         )
       )
     )
@@ -215,7 +228,8 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/B", version = 1))
         )
       )
     )
@@ -249,10 +263,12 @@ class MatcherWorkerServiceTest
       MatcherResult(
         Set(
           MatchedIdentifiers(
-            identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 3))
+            identifiers =
+              Set(WorkIdentifier("sierra-system-number/A", version = 3))
           ),
           MatchedIdentifiers(
-            identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+            identifiers =
+              Set(WorkIdentifier("sierra-system-number/B", version = 1))
           )
         )
       )
@@ -264,8 +280,12 @@ class MatcherWorkerServiceTest
         withWorkerService(vhs, queue, messageSender) { _ =>
           processAndAssertMatchedWorkIs(workAv1, expectedMatchedWorksAv1)
           processAndAssertMatchedWorkIs(workBv1, expectedMatchedWorksBv1)
-          processAndAssertMatchedWorkIs(workAv2MatchedToB, expectedMatchedWorksAv2MatchedToB)
-          processAndAssertMatchedWorkIs(workAv3WithNoMatchingWorks, expectedMatchedWorksAv3)
+          processAndAssertMatchedWorkIs(
+            workAv2MatchedToB,
+            expectedMatchedWorksAv2MatchedToB)
+          processAndAssertMatchedWorkIs(
+            workAv3WithNoMatchingWorks,
+            expectedMatchedWorksAv3)
         }
       }
     }
@@ -280,36 +300,40 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 2))
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/A", version = 2))
         )
       )
     )
 
     implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      implicit val q: SQS.Queue = queue
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        implicit val q: SQS.Queue = queue
 
-      withVHS { implicit vhs =>
-        withWorkerService(vhs, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
+        withVHS { implicit vhs =>
+          withWorkerService(vhs, queue, messageSender) { _ =>
+            processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
-          // Work V1 is sent but not matched
-          val workAv1 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            version = 1
-          )
+            // Work V1 is sent but not matched
+            val workAv1 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              version = 1
+            )
 
-          sendWork(workAv1, vhs, queue)
-          eventually {
-            noMessagesAreWaitingIn(queue)
-            noMessagesAreWaitingIn(dlq)
+            sendWork(workAv1, vhs, queue)
+            eventually {
+              noMessagesAreWaitingIn(queue)
+              noMessagesAreWaitingIn(dlq)
 
-            messageSender.getMessages[MatcherResult].last shouldBe expectedMatchedWorkAv2
+              messageSender
+                .getMessages[MatcherResult]
+                .last shouldBe expectedMatchedWorkAv2
+            }
+
           }
-
         }
-      }
     }
   }
 
@@ -322,40 +346,40 @@ class MatcherWorkerServiceTest
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
         MatchedIdentifiers(
-          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 2)
-          )
+          identifiers =
+            Set(WorkIdentifier("sierra-system-number/A", version = 2))
         )
       )
     )
 
     implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      implicit val q: SQS.Queue = queue
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        implicit val q: SQS.Queue = queue
 
-      withVHS { implicit vhs =>
-        withWorkerService(vhs, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
+        withVHS { implicit vhs =>
+          withWorkerService(vhs, queue, messageSender) { _ =>
+            processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
-          // Work V1 is sent but not matched
-          val differentWorkAv2 = createUnidentifiedWorkWith(
-            sourceIdentifier = identifierA,
-            mergeCandidates = List(MergeCandidate(identifierB)),
-            version = 2)
+            // Work V1 is sent but not matched
+            val differentWorkAv2 = createUnidentifiedWorkWith(
+              sourceIdentifier = identifierA,
+              mergeCandidates = List(MergeCandidate(identifierB)),
+              version = 2)
 
-          sendWork(differentWorkAv2, vhs, queue)
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueHasSize(dlq, 1)
+            sendWork(differentWorkAv2, vhs, queue)
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueHasSize(dlq, 1)
+            }
           }
         }
-      }
     }
   }
 
-  private def processAndAssertMatchedWorkIs(
-    workToMatch: TransformedBaseWork,
-    expectedResult: MatcherResult)(
+  private def processAndAssertMatchedWorkIs(workToMatch: TransformedBaseWork,
+                                            expectedResult: MatcherResult)(
     implicit
     vhs: VHS,
     queue: SQS.Queue,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -1,17 +1,13 @@
 package uk.ac.wellcome.platform.matcher.services
 
+import org.scalatest.Assertion
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.json.JsonUtil.fromJson
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.models.matcher.{
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier
-}
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier}
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -30,23 +26,21 @@ class MatcherWorkerServiceTest
   private val identifierC = createSierraSystemSourceIdentifierWith(value = "C")
 
   it("creates a work without identifiers") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            // Work Av1 created without any matched works
-            val updatedWork = createUnidentifiedSierraWork
-            val expectedMatchedWorks =
-              MatcherResult(
-                Set(MatchedIdentifiers(Set(WorkIdentifier(updatedWork)))))
+    // Work Av1 created without any matched works
+    val updatedWork = createUnidentifiedSierraWork
+    val expectedMatchedWorks =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(identifiers = Set(WorkIdentifier(updatedWork)))
+        )
+      )
 
-            processAndAssertMatchedWorkIs(
-              updatedWork,
-              expectedMatchedWorks,
-              vhs,
-              queue,
-              topic)
-          }
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
+
+    withLocalSqsQueue() { implicit queue =>
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(updatedWork, expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -54,27 +48,20 @@ class MatcherWorkerServiceTest
 
   it(
     "sends an invisible work as a single matched result with no other matched identifiers") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            val invisibleWork = createUnidentifiedInvisibleWork
-            val expectedMatchedWorks =
-              MatcherResult(
-                Set(
-                  MatchedIdentifiers(
-                    Set(WorkIdentifier(invisibleWork))
-                  ))
-              )
+    val invisibleWork = createUnidentifiedInvisibleWork
+    val expectedMatchedWorks =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(identifiers = Set(WorkIdentifier(invisibleWork)))
+        )
+      )
 
-            processAndAssertMatchedWorkIs(
-              workToMatch = invisibleWork,
-              expectedMatchedWorks = expectedMatchedWorks,
-              vhs = vhs,
-              queue = queue,
-              topic = topic
-            )
-          }
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
+
+    withLocalSqsQueue() { implicit queue =>
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(invisibleWork, expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -82,31 +69,33 @@ class MatcherWorkerServiceTest
 
   it(
     "work A with one link to B and no existing works returns a single matched work") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            // Work Av1
-            val workAv1 =
-              createUnidentifiedWorkWith(
-                sourceIdentifier = identifierA,
-                mergeCandidates = List(MergeCandidate(identifierB)))
-            // Work Av1 matched to B (before B exists hence version is None)
-            // need to match to works that do not exist to support
-            // bi-directionally matched works without deadlocking (A->B, B->A)
-            val expectedMatchedWorks = MatcherResult(
-              Set(
-                MatchedIdentifiers(Set(
-                  WorkIdentifier("sierra-system-number/A", Some(1)),
-                  WorkIdentifier("sierra-system-number/B", None)))))
+    // Work Av1
+    val workAv1 =
+      createUnidentifiedWorkWith(
+        sourceIdentifier = identifierA,
+        mergeCandidates = List(MergeCandidate(identifierB)))
 
-            processAndAssertMatchedWorkIs(
-              workAv1,
-              expectedMatchedWorks,
-              vhs,
-              queue,
-              topic)
-          }
+    // Work Av1 matched to B (before B exists hence version is None)
+    // need to match to works that do not exist to support
+    // bi-directionally matched works without deadlocking (A->B, B->A)
+    val expectedMatchedWorks = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(
+            WorkIdentifier("sierra-system-number/A", version = Some(1)),
+            WorkIdentifier("sierra-system-number/B", version = None)
+          )
+        )
+      )
+    )
+
+
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
+
+    withLocalSqsQueue() { implicit queue =>
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(workAv1, expectedResult = expectedMatchedWorks)
         }
       }
     }
@@ -114,271 +103,266 @@ class MatcherWorkerServiceTest
 
   it(
     "matches a work with one link then matches the combined work to a new work") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            // Work Av1
-            val workAv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = identifierA)
+    // Work Av1
+    val workAv1 =
+      createUnidentifiedWorkWith(sourceIdentifier = identifierA)
 
-            val expectedMatchedWorks = MatcherResult(
-              Set(
-                MatchedIdentifiers(Set(
-                  WorkIdentifier("sierra-system-number/A", 1)
-                ))))
+    val expectedMatchedWorksAv1 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 1))
+        )
+      )
+    )
 
-            processAndAssertMatchedWorkIs(
-              workAv1,
-              expectedMatchedWorks,
-              vhs,
-              queue,
-              topic)
+    // Work Bv1
+    val workBv1 =
+      createUnidentifiedWorkWith(sourceIdentifier = identifierB)
 
-            // Work Bv1
-            val workBv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = identifierB)
+    val expectedMatchedWorksBv1 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+        )
+      )
+    )
 
-            processAndAssertMatchedWorkIs(
-              workBv1,
-              MatcherResult(Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/B", 1))))),
-              vhs,
-              queue,
-              topic)
+    // Work Av1 matched to B
+    val workAv2 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 2,
+      mergeCandidates = List(MergeCandidate(identifierB)))
 
-            // Work Av1 matched to B
-            val workAv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 2,
-              mergeCandidates = List(MergeCandidate(identifierB)))
+    val expectedMatchedWorksAv2 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(
+            WorkIdentifier("sierra-system-number/A", version = 2),
+            WorkIdentifier("sierra-system-number/B", version = 1)
+          )
+        )
+      )
+    )
 
-            processAndAssertMatchedWorkIs(
-              workAv2,
-              MatcherResult(
-                Set(
-                  MatchedIdentifiers(Set(
-                    WorkIdentifier("sierra-system-number/A", 2),
-                    WorkIdentifier("sierra-system-number/B", 1))))),
-              vhs,
-              queue,
-              topic
+    // Work Cv1
+    val workCv1 =
+      createUnidentifiedWorkWith(sourceIdentifier = identifierC)
+
+    val expectedMatcherWorksCv1 =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(
+            identifiers = Set(WorkIdentifier("sierra-system-number/C", version = 1))
+          )
+        )
+      )
+
+    // Work Bv2 matched to C
+    val workBv2 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierB,
+      version = 2,
+      mergeCandidates = List(MergeCandidate(identifierC)))
+
+    val expectedMatchedWorksBv2 =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(
+            identifiers = Set(
+              WorkIdentifier("sierra-system-number/A", version = 2),
+              WorkIdentifier("sierra-system-number/B", version = 2),
+              WorkIdentifier("sierra-system-number/C", version = 1)
             )
+          )
+        )
+      )
 
-            // Work Cv1
-            val workCv1 =
-              createUnidentifiedWorkWith(sourceIdentifier = identifierC)
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-            processAndAssertMatchedWorkIs(
-              workCv1,
-              MatcherResult(Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/C", 1))))),
-              vhs,
-              queue,
-              topic)
-
-            // Work Bv2 matched to C
-            val workBv2 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierB,
-              version = 2,
-              mergeCandidates = List(MergeCandidate(identifierC)))
-
-            processAndAssertMatchedWorkIs(
-              workBv2,
-              MatcherResult(
-                Set(
-                  MatchedIdentifiers(
-                    Set(
-                      WorkIdentifier("sierra-system-number/A", 2),
-                      WorkIdentifier("sierra-system-number/B", 2),
-                      WorkIdentifier("sierra-system-number/C", 1))))),
-              vhs,
-              queue,
-              topic
-            )
-          }
+    withLocalSqsQueue() { implicit queue =>
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(workAv1, expectedMatchedWorksAv1)
+          processAndAssertMatchedWorkIs(workBv1, expectedMatchedWorksBv1)
+          processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorksAv2)
+          processAndAssertMatchedWorkIs(workCv1, expectedMatcherWorksCv1)
+          processAndAssertMatchedWorkIs(workBv2, expectedMatchedWorksBv2)
         }
       }
     }
   }
 
   it("breaks matched works into individual works") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueue() { queue =>
-        withVHS { vhs =>
-          withWorkerService(vhs, queue, topic) { _ =>
-            // Work Av1
-            val workAv1 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 1)
+    // Work Av1
+    val workAv1 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 1
+    )
 
-            processAndAssertMatchedWorkIs(
-              workAv1,
-              MatcherResult(Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/A", 1))))),
-              vhs,
-              queue,
-              topic)
+    val expectedMatchedWorksAv1 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 1))
+        )
+      )
+    )
 
-            // Work Bv1
-            val workBv1 = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierB,
-              version = 1)
+    // Work Bv1
+    val workBv1 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierB,
+      version = 1
+    )
 
-            processAndAssertMatchedWorkIs(
-              workBv1,
-              MatcherResult(Set(MatchedIdentifiers(
-                Set(WorkIdentifier("sierra-system-number/B", 1))))),
-              vhs,
-              queue,
-              topic)
+    val expectedMatchedWorksBv1 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+        )
+      )
+    )
 
-            // Match Work A to Work B
-            val workAv2MatchedToB = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 2,
-              mergeCandidates = List(MergeCandidate(identifierB)))
+    // Match Work A to Work B
+    val workAv2MatchedToB = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 2,
+      mergeCandidates = List(MergeCandidate(identifierB))
+    )
 
-            processAndAssertMatchedWorkIs(
-              workAv2MatchedToB,
-              MatcherResult(
-                Set(
-                  MatchedIdentifiers(Set(
-                    WorkIdentifier("sierra-system-number/A", 2),
-                    WorkIdentifier("sierra-system-number/B", 1))))),
-              vhs,
-              queue,
-              topic
+    val expectedMatchedWorksAv2MatchedToB =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(
+            identifiers = Set(
+              WorkIdentifier("sierra-system-number/A", version = 2),
+              WorkIdentifier("sierra-system-number/B", version = 1)
             )
+          )
+        )
+      )
 
-            // A no longer matches B
-            val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
-              sourceIdentifier = identifierA,
-              version = 3)
+    // A no longer matches B
+    val workAv3WithNoMatchingWorks = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 3
+    )
 
-            processAndAssertMatchedWorkIs(
-              workAv3WithNoMatchingWorks,
-              MatcherResult(
-                Set(
-                  MatchedIdentifiers(
-                    Set(WorkIdentifier("sierra-system-number/A", 3))),
-                  MatchedIdentifiers(
-                    Set(WorkIdentifier("sierra-system-number/B", 1))))),
-              vhs,
-              queue,
-              topic
-            )
-          }
+    val expectedMatchedWorksAv3 =
+      MatcherResult(
+        Set(
+          MatchedIdentifiers(
+            identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 3))
+          ),
+          MatchedIdentifiers(
+            identifiers = Set(WorkIdentifier("sierra-system-number/B", version = 1))
+          )
+        )
+      )
+
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
+
+    withLocalSqsQueue() { implicit queue =>
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(workAv1, expectedMatchedWorksAv1)
+          processAndAssertMatchedWorkIs(workBv1, expectedMatchedWorksBv1)
+          processAndAssertMatchedWorkIs(workAv2MatchedToB, expectedMatchedWorksAv2MatchedToB)
+          processAndAssertMatchedWorkIs(workAv3WithNoMatchingWorks, expectedMatchedWorksAv3)
         }
       }
     }
   }
 
   it("does not match a lower version") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withVHS { vhs =>
-            withWorkerService(vhs, queue, topic) { _ =>
-              val workAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = identifierA,
-                version = 2
-              )
+    val workAv2 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 2
+    )
 
-              val expectedMatchedWorkAv2 = MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
+    val expectedMatchedWorkAv2 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 2))
+        )
+      )
+    )
 
-              processAndAssertMatchedWorkIs(
-                workAv2,
-                expectedMatchedWorkAv2,
-                vhs,
-                queue,
-                topic)
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-              // Work V1 is sent but not matched
-              val workAv1 = createUnidentifiedWorkWith(
-                sourceIdentifier = identifierA,
-                version = 1)
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      implicit val q: SQS.Queue = queue
 
-              sendWork(workAv1, vhs, queue)
-              eventually {
-                noMessagesAreWaitingIn(queue)
-                noMessagesAreWaitingIn(dlq)
-                assertLastMatchedResultIs(
-                  topic = topic,
-                  expectedMatcherResult = expectedMatchedWorkAv2
-                )
-              }
-            }
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
+
+          // Work V1 is sent but not matched
+          val workAv1 = createUnidentifiedWorkWith(
+            sourceIdentifier = identifierA,
+            version = 1
+          )
+
+          sendWork(workAv1, vhs, queue)
+          eventually {
+            noMessagesAreWaitingIn(queue)
+            noMessagesAreWaitingIn(dlq)
+
+            messageSender.getMessages[MatcherResult].last shouldBe expectedMatchedWorkAv2
           }
+
+        }
       }
     }
   }
 
   it("does not match an existing version with different information") {
-    withLocalSnsTopic { topic =>
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withVHS { vhs =>
-            withWorkerService(vhs, queue, topic) { _ =>
-              val workAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = identifierA,
-                version = 2
-              )
+    val workAv2 = createUnidentifiedWorkWith(
+      sourceIdentifier = identifierA,
+      version = 2
+    )
 
-              val expectedMatchedWorkAv2 = MatcherResult(
-                Set(MatchedIdentifiers(
-                  Set(WorkIdentifier("sierra-system-number/A", 2)))))
+    val expectedMatchedWorkAv2 = MatcherResult(
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier("sierra-system-number/A", version = 2)
+          )
+        )
+      )
+    )
 
-              processAndAssertMatchedWorkIs(
-                workAv2,
-                expectedMatchedWorkAv2,
-                vhs,
-                queue,
-                topic)
+    implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-              // Work V1 is sent but not matched
-              val differentWorkAv2 = createUnidentifiedWorkWith(
-                sourceIdentifier = identifierA,
-                mergeCandidates = List(MergeCandidate(identifierB)),
-                version = 2)
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      implicit val q: SQS.Queue = queue
 
-              sendWork(differentWorkAv2, vhs, queue)
-              eventually {
-                assertQueueEmpty(queue)
-                assertQueueHasSize(dlq, 1)
-              }
-            }
+      withVHS { implicit vhs =>
+        withWorkerService(vhs, queue, messageSender) { _ =>
+          processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
+
+          // Work V1 is sent but not matched
+          val differentWorkAv2 = createUnidentifiedWorkWith(
+            sourceIdentifier = identifierA,
+            mergeCandidates = List(MergeCandidate(identifierB)),
+            version = 2)
+
+          sendWork(differentWorkAv2, vhs, queue)
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueHasSize(dlq, 1)
           }
+        }
       }
     }
   }
 
-  private def processAndAssertMatchedWorkIs(workToMatch: TransformedBaseWork,
-                                            expectedMatchedWorks: MatcherResult,
-                                            vhs: VHS,
-                                            queue: SQS.Queue,
-                                            topic: Topic) = {
+  private def processAndAssertMatchedWorkIs(
+    workToMatch: TransformedBaseWork,
+    expectedResult: MatcherResult)(
+    implicit
+    vhs: VHS,
+    queue: SQS.Queue,
+    messageSender: MemoryMessageSender): Assertion = {
     sendWork(workToMatch, vhs, queue)
     eventually {
-      assertLastMatchedResultIs(
-        topic = topic,
-        expectedMatcherResult = expectedMatchedWorks
-      )
+      messageSender.getMessages[MatcherResult].last shouldBe expectedResult
     }
-  }
-
-  private def assertLastMatchedResultIs(
-    topic: Topic,
-    expectedMatcherResult: MatcherResult) = {
-
-    val snsMessages = listMessagesReceivedFromSNS(topic)
-    snsMessages.size should be >= 1
-
-    val actualMatcherResults = snsMessages.map { snsMessage =>
-      fromJson[MatcherResult](snsMessage.message).get
-    }
-    actualMatcherResults.last shouldBe expectedMatcherResult
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -1,16 +1,14 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
 import org.scalatest.Assertion
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-
-import uk.ac.wellcome.models.work.internal.TransformedBaseWork
+import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.storage.Identified
 
 trait LocalWorksVhs
     extends VHSFixture[TransformedBaseWork]
-    with Eventually
-    with ScalaFutures {
+    with Matchers {
 
   def givenStoredInVhs(vhs: VHS, works: TransformedBaseWork*): Seq[Assertion] =
     works.map { work =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/LocalWorksVhs.scala
@@ -6,9 +6,7 @@ import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.storage.Identified
 
-trait LocalWorksVhs
-    extends VHSFixture[TransformedBaseWork]
-    with Matchers {
+trait LocalWorksVhs extends VHSFixture[TransformedBaseWork] with Matchers {
 
   def givenStoredInVhs(vhs: VHS, works: TransformedBaseWork*): Seq[Assertion] =
     works.map { work =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -19,7 +20,7 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.monitoring.Metrics
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 
-trait WorkerServiceFixture extends LocalWorksVhs {
+trait WorkerServiceFixture extends LocalWorksVhs with BigMessagingFixture {
 
   def withWorkerService[R](vhs: VHS,
                            queue: Queue,

--- a/pipeline/recorder/docker-compose.yml
+++ b/pipeline/recorder/docker-compose.yml
@@ -10,8 +10,3 @@ s3:
   image: scality/s3server:mem-latest
   ports:
     - "33333:8000"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
-

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -40,9 +40,7 @@ class RecorderIntegrationTest
       withLocalS3Bucket { bucket =>
         withLocalDynamoDbTable { table =>
           val vhs = VHSBuilder.build[TransformedBaseWork](
-            ObjectLocationPrefix(
-              namespace = bucket.name,
-              path = "recorder"),
+            ObjectLocationPrefix(namespace = bucket.name, path = "recorder"),
             DynamoConfig(table.name, table.index),
             dynamoClient,
             s3Client,

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -11,17 +11,20 @@ import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
 
-trait WorkerServiceFixture extends VHSFixture[TransformedBaseWork] with BigMessagingFixture {
-  def withWorkerService[R](
-    queue: Queue,
-    vhs: VHS,
-    messageSender: MemoryMessageSender = new MemoryMessageSender())(
+trait WorkerServiceFixture
+    extends VHSFixture[TransformedBaseWork]
+    with BigMessagingFixture {
+  def withWorkerService[R](queue: Queue,
+                           vhs: VHS,
+                           messageSender: MemoryMessageSender =
+                             new MemoryMessageSender())(
     testWith: TestWith[RecorderWorkerService[String], R]): R =
     withActorSystem { implicit actorSystem =>
       implicit val store =
         new MemoryStore[ObjectLocation, TransformedBaseWork](Map.empty)
       withBigMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
-        val workerService = new RecorderWorkerService(vhs, msgStream, messageSender)
+        val workerService =
+          new RecorderWorkerService(vhs, msgStream, messageSender)
         workerService.run()
         testWith(workerService)
       }
@@ -38,7 +41,8 @@ trait WorkerServiceFixture extends VHSFixture[TransformedBaseWork] with BigMessa
     Version(id, expectedVhsVersion)
   }
 
-  def assertWorkNotStored[T <: TransformedBaseWork](vhs: VHS, work: T): Assertion = {
+  def assertWorkNotStored[T <: TransformedBaseWork](vhs: VHS,
+                                                    work: T): Assertion = {
     val id = work.sourceIdentifier.toString
     vhs.getLatest(id) shouldBe a[Left[_, _]]
   }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/fixtures/WorkerServiceFixture.scala
@@ -1,28 +1,27 @@
 package uk.ac.wellcome.platform.recorder.fixtures
 
+import org.scalatest.Assertion
+import uk.ac.wellcome.bigmessaging.fixtures.{BigMessagingFixture, VHSFixture}
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.recorder.services.RecorderWorkerService
-
-import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.messaging.MessageSender
-
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
 import uk.ac.wellcome.storage.store.memory.MemoryStore
+import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
 
-trait WorkerServiceFixture extends VHSFixture[TransformedBaseWork] {
-
-  def withWorkerService[R, D](queue: Queue,
-                              vhs: VHS,
-                              msgSender: MessageSender[D])(
-    testWith: TestWith[RecorderWorkerService[D], R]): R =
+trait WorkerServiceFixture extends VHSFixture[TransformedBaseWork] with BigMessagingFixture {
+  def withWorkerService[R](
+    queue: Queue,
+    vhs: VHS,
+    messageSender: MemoryMessageSender = new MemoryMessageSender())(
+    testWith: TestWith[RecorderWorkerService[String], R]): R =
     withActorSystem { implicit actorSystem =>
       implicit val store =
         new MemoryStore[ObjectLocation, TransformedBaseWork](Map.empty)
       withBigMessageStream[TransformedBaseWork, R](queue = queue) { msgStream =>
-        val workerService = new RecorderWorkerService(vhs, msgStream, msgSender)
+        val workerService = new RecorderWorkerService(vhs, msgStream, messageSender)
         workerService.run()
         testWith(workerService)
       }
@@ -39,8 +38,7 @@ trait WorkerServiceFixture extends VHSFixture[TransformedBaseWork] {
     Version(id, expectedVhsVersion)
   }
 
-  def assertWorkNotStored[T <: TransformedBaseWork](vhs: VHS, work: T) = {
-
+  def assertWorkNotStored[T <: TransformedBaseWork](vhs: VHS, work: T): Assertion = {
     val id = work.sourceIdentifier.toString
     vhs.getLatest(id) shouldBe a[Left[_, _]]
   }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -117,7 +117,8 @@ class RecorderWorkerServiceTest
           eventually {
             val id = work.sourceIdentifier.toString
 
-            messageSender.getMessages[Version[String, Int]] shouldBe Seq(Version(id, 0))
+            messageSender.getMessages[Version[String, Int]] shouldBe Seq(
+              Version(id, 0))
           }
         }
       }

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -1,38 +1,32 @@
 package uk.ac.wellcome.platform.recorder.services
 
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
-import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+import uk.ac.wellcome.storage.Version
 
 class RecorderWorkerServiceTest
     extends AnyFunSpec
     with Matchers
-    with ScalaFutures
-    with BigMessagingFixture
-    with IntegrationPatience
     with WorkerServiceFixture
     with JsonAssertions
     with WorksGenerators {
 
   it("records an UnidentifiedWork") {
     withLocalSqsQueue() { queue =>
-      withMemoryMessageSender { msgSender =>
-        withVHS { vhs =>
-          withWorkerService(queue, vhs, msgSender) { service =>
-            val work = createUnidentifiedWork
-            sendMessage[TransformedBaseWork](queue = queue, obj = work)
-            eventually {
-              assertWorkStored(vhs, work)
-            }
+      withVHS { vhs =>
+        withWorkerService(queue, vhs) { _ =>
+          val work = createUnidentifiedWork
+          sendMessage[TransformedBaseWork](queue = queue, obj = work)
+          eventually {
+            assertWorkStored(vhs, work)
           }
         }
       }
@@ -41,14 +35,12 @@ class RecorderWorkerServiceTest
 
   it("stores UnidentifiedInvisibleWorks") {
     withLocalSqsQueue() { queue =>
-      withMemoryMessageSender { msgSender =>
-        withVHS { vhs =>
-          withWorkerService(queue, vhs, msgSender) { service =>
-            val invisibleWork = createUnidentifiedInvisibleWork
-            sendMessage[TransformedBaseWork](queue = queue, invisibleWork)
-            eventually {
-              assertWorkStored(vhs, invisibleWork)
-            }
+      withVHS { vhs =>
+        withWorkerService(queue, vhs) { _ =>
+          val invisibleWork = createUnidentifiedInvisibleWork
+          sendMessage[TransformedBaseWork](queue = queue, invisibleWork)
+          eventually {
+            assertWorkStored(vhs, invisibleWork)
           }
         }
       }
@@ -57,19 +49,17 @@ class RecorderWorkerServiceTest
 
   it("doesn't overwrite a newer work with an older work") {
     withLocalSqsQueue() { queue =>
-      withMemoryMessageSender { msgSender =>
-        withVHS { vhs =>
-          withWorkerService(queue, vhs, msgSender) { service =>
-            val olderWork = createUnidentifiedWork
-            val newerWork = olderWork
-              .copy(version = 10)
-              .withData(data => data.copy(title = Some("A nice new thing")))
-            sendMessage[TransformedBaseWork](queue = queue, newerWork)
-            eventually { assertWorkStored(vhs, newerWork) }
-            sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
-            eventually { assertQueueEmpty(queue) }
-            assertWorkStored(vhs, newerWork, 1)
-          }
+      withVHS { vhs =>
+        withWorkerService(queue, vhs) { _ =>
+          val olderWork = createUnidentifiedWork
+          val newerWork = olderWork
+            .copy(version = 10)
+            .withData(data => data.copy(title = Some("A nice new thing")))
+          sendMessage[TransformedBaseWork](queue = queue, newerWork)
+          eventually { assertWorkStored(vhs, newerWork) }
+          sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+          eventually { assertQueueEmpty(queue) }
+          assertWorkStored(vhs, newerWork, 1)
         }
       }
     }
@@ -77,20 +67,18 @@ class RecorderWorkerServiceTest
 
   it("overwrites an older work with an newer work") {
     withLocalSqsQueue() { queue =>
-      withMemoryMessageSender { msgSender =>
-        withVHS { vhs =>
-          withWorkerService(queue, vhs, msgSender) { service =>
-            val olderWork = createUnidentifiedWork
-            val newerWork = olderWork
-              .copy(version = 10)
-              .withData(data => data.copy(title = Some("A nice new thing")))
-            sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+      withVHS { vhs =>
+        withWorkerService(queue, vhs) { _ =>
+          val olderWork = createUnidentifiedWork
+          val newerWork = olderWork
+            .copy(version = 10)
+            .withData(data => data.copy(title = Some("A nice new thing")))
+          sendMessage[TransformedBaseWork](queue = queue, obj = olderWork)
+          eventually {
+            assertWorkStored(vhs, olderWork)
+            sendMessage[TransformedBaseWork](queue = queue, obj = newerWork)
             eventually {
-              assertWorkStored(vhs, olderWork)
-              sendMessage[TransformedBaseWork](queue = queue, obj = newerWork)
-              eventually {
-                assertWorkStored(vhs, newerWork, expectedVhsVersion = 1)
-              }
+              assertWorkStored(vhs, newerWork, expectedVhsVersion = 1)
             }
           }
         }
@@ -99,19 +87,19 @@ class RecorderWorkerServiceTest
   }
 
   it("fails if saving to the store fails") {
+    val messageSender = new MemoryMessageSender()
+
     withLocalSqsQueuePair() {
       case SQS.QueuePair(queue, dlq) =>
-        withMemoryMessageSender { msgSender =>
-          withBrokenVHS { vhs =>
-            withWorkerService(queue, vhs, msgSender) { service =>
-              val work = createUnidentifiedWork
-              sendMessage[TransformedBaseWork](queue = queue, obj = work)
-              eventually {
-                assertQueueEmpty(queue)
-                assertQueueHasSize(dlq, 1)
-                assertWorkNotStored(vhs, work)
-                msgSender.getMessages[ObjectLocation].toList shouldBe Nil
-              }
+        withBrokenVHS { vhs =>
+          withWorkerService(queue, vhs, messageSender) { _ =>
+            val work = createUnidentifiedWork
+            sendMessage[TransformedBaseWork](queue = queue, obj = work)
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueHasSize(dlq, 1)
+              assertWorkNotStored(vhs, work)
+              messageSender.messages shouldBe empty
             }
           }
         }
@@ -119,22 +107,17 @@ class RecorderWorkerServiceTest
   }
 
   it("sends the VHS key to the queue") {
+    val messageSender = new MemoryMessageSender()
+
     withLocalSqsQueue() { queue =>
-      withMemoryMessageSender { msgSender =>
-        withVHS { vhs =>
-          withWorkerService(queue, vhs, msgSender) { service =>
-            val work = createUnidentifiedWork
-            sendMessage[TransformedBaseWork](queue = queue, obj = work)
-            eventually {
-              val id = work.sourceIdentifier.toString
-              val expected = s"""
-                |{
-                |  "id": "$id",
-                |  "version": 0
-                |}""".stripMargin
-              val actual = msgSender.messages.map(_.body).head
-              assertJsonStringsAreEqual(actual, expected)
-            }
+      withVHS { vhs =>
+        withWorkerService(queue, vhs, messageSender) { _ =>
+          val work = createUnidentifiedWork
+          sendMessage[TransformedBaseWork](queue = queue, obj = work)
+          eventually {
+            val id = work.sourceIdentifier.toString
+
+            messageSender.getMessages[Version[String, Int]] shouldBe Seq(Version(id, 0))
           }
         }
       }

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorksGenerators
-import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedWork
+}
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
@@ -53,30 +56,32 @@ class TransformerWorkerTest
       Version("C", 3) -> ValidTestData
     )
 
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      withWorker(queue, records = records) { _ =>
-        sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorker(queue, records = records) { _ =>
+          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
+          sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
+          sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
 
-        Thread.sleep(500)
+          Thread.sleep(500)
 
-        assertQueueEmpty(dlq)
-        assertQueueEmpty(queue)
-      }
+          assertQueueEmpty(dlq)
+          assertQueueEmpty(queue)
+        }
     }
   }
 
   it("sends failed messages to the DLQ if it can't read from store") {
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      withWorker(queue, records = Map.empty) { _ =>
-        sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorker(queue, records = Map.empty) { _ =>
+          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
 
-        Thread.sleep(2000)
+          Thread.sleep(2000)
 
-        assertQueueHasSize(dlq, size = 1)
-        assertQueueEmpty(queue)
-      }
+          assertQueueHasSize(dlq, size = 1)
+          assertQueueEmpty(queue)
+        }
     }
   }
 
@@ -87,17 +92,18 @@ class TransformerWorkerTest
       Version("C", 3) -> InvalidTestData
     )
 
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      withWorker(queue, records = records) { _ =>
-        sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorker(queue, records = records) { _ =>
+          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
+          sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
+          sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
 
-        Thread.sleep(2000)
+          Thread.sleep(2000)
 
-        assertQueueHasSize(dlq, size = 1)
-        assertQueueEmpty(queue)
-      }
+          assertQueueHasSize(dlq, size = 1)
+          assertQueueEmpty(queue)
+        }
     }
   }
 

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -1,55 +1,33 @@
 package uk.ac.wellcome.transformer.common.worker
 
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.bigmessaging.memory.MemoryBigMessageSender
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
+import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.internal.{
-  IdentifierType,
-  SourceIdentifier,
-  TransformedBaseWork,
-  UnidentifiedWork,
-  WorkData
-}
-import uk.ac.wellcome.monitoring.memory.MemoryMetrics
+import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.internal.{TransformedBaseWork, UnidentifiedWork}
 import uk.ac.wellcome.storage.Version
-import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.VersionedStore
-import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 trait TestData
 case object ValidTestData extends TestData
 case object InvalidTestData extends TestData
 
-object TestTransformer extends Transformer[TestData] {
-  def apply(data: TestData, version: Int) =
+object TestTransformer extends Transformer[TestData] with WorksGenerators {
+  def apply(data: TestData, version: Int): Either[Exception, UnidentifiedWork] =
     data match {
-      case ValidTestData =>
-        Right(
-          UnidentifiedWork(
-            sourceIdentifier = SourceIdentifier(
-              value = "id",
-              identifierType = IdentifierType("miro-image-number"),
-              ontologyType = "IdentifierType"),
-            version = version,
-            data = WorkData()
-          )
-        )
-
+      case ValidTestData   => Right(createUnidentifiedWork)
       case InvalidTestData => Left(new Exception("No No No"))
     }
-
 }
 
 class TestTransformerWorker(
@@ -57,13 +35,7 @@ class TestTransformerWorker(
   val sender: MemoryBigMessageSender[TransformedBaseWork],
   val store: VersionedStore[String, Int, TestData]
 ) extends TransformerWorker[TestData, String] {
-  val transformer = TestTransformer
-}
-
-trait TestJsonCodecs {
-  implicit val versionEnc: Encoder[Version[String, Int]] = deriveEncoder
-  implicit val notificationMessageEnc: Decoder[NotificationMessage] =
-    deriveDecoder
+  val transformer: Transformer[TestData] = TestTransformer
 }
 
 class TransformerWorkerTest
@@ -72,19 +44,17 @@ class TransformerWorkerTest
     with Matchers
     with Akka
     with SQS
-    with SNS
-    with TestJsonCodecs {
+    with SNS {
 
-  it("Should have an empty queue and DLQ if it can process all messages") {
+  it("empties the queue if it can process everything") {
+    val records = Map(
+      Version("A", 1) -> ValidTestData,
+      Version("B", 2) -> ValidTestData,
+      Version("C", 3) -> ValidTestData
+    )
 
-    withTransformerWorker(
-      records = Map(
-        Version("A", 1) -> ValidTestData,
-        Version("B", 2) -> ValidTestData,
-        Version("C", 3) -> ValidTestData
-      )
-    ) {
-      case (transformerWorker, QueuePair(queue, dlq), metrics) =>
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withWorker(queue, records = records) { _ =>
         sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
         sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
         sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
@@ -93,78 +63,59 @@ class TransformerWorkerTest
 
         assertQueueEmpty(dlq)
         assertQueueEmpty(queue)
+      }
     }
   }
 
-  it(
-    "Send failed messages to the DLQ and send to metrics if it can't read from store") {
-
-    withTransformerWorker(
-      records = Map(
-        Version("A", 1) -> ValidTestData,
-        Version("B", 2) -> ValidTestData,
-        Version("C", 3) -> ValidTestData
-      )
-    ) {
-      case (transformerWorker, QueuePair(queue, dlq), metrics) =>
+  it("sends failed messages to the DLQ if it can't read from store") {
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withWorker(queue, records = Map.empty) { _ =>
         sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
-        sendNotificationToSQS[Version[String, Int]](queue, Version("D", 4))
 
         Thread.sleep(2000)
 
-        assertQueueHasSize(dlq, 1)
+        assertQueueHasSize(dlq, size = 1)
         assertQueueEmpty(queue)
+      }
     }
   }
 
-  it(
-    "Send failed messages to the DLQ if it receives an error from the transformer") {
+  it("sends failed messages to the DLQ if the transformer errors") {
+    val records = Map(
+      Version("A", 1) -> ValidTestData,
+      Version("B", 2) -> ValidTestData,
+      Version("C", 3) -> InvalidTestData
+    )
 
-    withTransformerWorker(
-      records = Map(
-        Version("A", 1) -> ValidTestData,
-        Version("B", 2) -> ValidTestData,
-        Version("C", 3) -> InvalidTestData
-      )
-    ) {
-      case (transformerWorker, QueuePair(queue, dlq), metrics) =>
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withWorker(queue, records = records) { _ =>
         sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
         sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
         sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
 
         Thread.sleep(2000)
 
-        assertQueueHasSize(dlq, 1)
+        assertQueueHasSize(dlq, size = 1)
         assertQueueEmpty(queue)
+      }
     }
   }
 
-  def withTransformerWorker[R](records: Map[Version[String, Int], TestData])(
-    testWith: TestWith[(TestTransformerWorker,
-                        SQS.QueuePair,
-                        MemoryMetrics[StandardUnit]),
-                       R]) =
+  def withWorker[R](queue: Queue, records: Map[Version[String, Int], TestData])(
+    testWith: TestWith[Unit, R]
+  ): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          val metrics = new MemoryMetrics[StandardUnit]()
-          withSQSStream[NotificationMessage, R](queue, metrics) { stream =>
-            val sender = new MemoryBigMessageSender[TransformedBaseWork]()
-            val data
-              : MemoryStore[Version[String, Int], TestData] with Maxima[String,
-                                                                        Int] =
-              new MemoryStore(records) with MemoryMaxima[String, TestData]
-            val store = new MemoryVersionedStore[String, TestData](data)
+      withSQSStream[NotificationMessage, R](queue) { stream =>
+        val store = MemoryVersionedStore[String, TestData](records)
 
-            val transformerWorker =
-              new TestTransformerWorker(stream, sender, store)
+        val worker = new TestTransformerWorker(
+          stream = stream,
+          sender = new MemoryBigMessageSender[TransformedBaseWork](),
+          store = store
+        )
 
-            transformerWorker.run()
-            testWith((transformerWorker, QueuePair(queue, dlq), metrics))
-          }
-
+        worker.run()
+        testWith(())
       }
     }
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
@@ -134,8 +134,7 @@ class MetsTransformerWorkerServiceTest
                   withSQSStream[NotificationMessage, R](queue) { sqsStream =>
                     withSqsBigMessageSender[TransformedBaseWork, R](
                       messagingBucket,
-                      topic,
-                      snsClient) { messageSender =>
+                      topic) { messageSender =>
                       withAssumeRoleClientProvider(roleArn)(
                         BypassCredentialsClientFactory) {
                         assumeRoleclientProvider =>

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -78,8 +78,7 @@ class MiroTransformerFeatureTest
     val miroHybridRecordMessage2 =
       createHybridRecordNotificationWith(
         createMiroRecordWith(
-          title = Some(
-            "Greenfield Sluder, Tonsillectomy..., use of guillotine"),
+          title = Some("Greenfield Sluder, Tonsillectomy..., use of guillotine"),
           description = Some("Use of the guillotine"),
           copyrightCleared = Some("Y"),
           imageNumber = "L0023034",

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.miro
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
@@ -16,13 +15,10 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
 
 class MiroTransformerFeatureTest
     extends AnyFunSpec
     with Matchers
-    with Akka
-    with BigMessagingFixture
     with Eventually
     with IntegrationPatience
     with MiroRecordGenerators

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -38,7 +38,7 @@ trait MiroVHSRecordReceiverFixture
 
   def withMiroVHSRecordReceiver[R](topic: Topic, bucket: Bucket)(
     testWith: TestWith[MiroVHSRecordReceiver[SNSConfig], R]): R = {
-    withSqsBigMessageSender[TransformedBaseWork, R](bucket, topic, snsClient) {
+    withSqsBigMessageSender[TransformedBaseWork, R](bucket, topic) {
       msgSender =>
         val recordReceiver = new MiroVHSRecordReceiver(msgSender, store)
         testWith(recordReceiver)

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -64,6 +64,9 @@ trait MiroVHSRecordReceiverFixture
     )
   }
 
+  def createHybridRecordNotification: NotificationMessage =
+    createHybridRecordNotificationWith()
+
   def createHybridRecordWith(
     miroRecord: MiroRecord = createMiroRecord,
     miroMetadata: MiroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -44,7 +44,7 @@ class MiroVHSRecordReceiverTest
   it("receives a message and sends it to SNS client") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message = createHybridRecordNotificationWith()
+        val message = createHybridRecordNotification
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future = recordReceiver.receiveMessage(message, transformToWork)
@@ -94,7 +94,7 @@ class MiroVHSRecordReceiverTest
   ignore("returns a failed future if there's no MiroMetadata") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val incompleteMessage = createHybridRecordNotificationWith()
+        val incompleteMessage = createHybridRecordNotification
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
@@ -130,8 +130,7 @@ class MiroVHSRecordReceiverTest
   it("fails if it's unable to perform a transformation") {
     withLocalSnsTopic { topic =>
       withLocalS3Bucket { bucket =>
-        val message =
-          createHybridRecordNotificationWith()
+        val message = createHybridRecordNotification
 
         withMiroVHSRecordReceiver(topic, bucket) { recordReceiver =>
           val future =
@@ -147,7 +146,7 @@ class MiroVHSRecordReceiverTest
 
   it("fails if it's unable to publish the work") {
     withLocalS3Bucket { bucket =>
-      val message = createHybridRecordNotificationWith()
+      val message = createHybridRecordNotification
 
       withMiroVHSRecordReceiver(Topic("no-such-topic"), bucket) {
         recordReceiver =>

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -1,12 +1,9 @@
 package uk.ac.wellcome.platform.transformer.miro.services
 
-import scala.util.Try
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Try
 import uk.ac.wellcome.models.work.generators.WorksGenerators
 import uk.ac.wellcome.models.work.internal.{
   TransformedBaseWork,
@@ -20,16 +17,14 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+
+import scala.util.Try
 
 class MiroVHSRecordReceiverTest
     extends AnyFunSpec
     with Matchers
-    with BigMessagingFixture
-    with Eventually
     with MiroVHSRecordReceiverFixture
     with IntegrationPatience
-    with MockitoSugar
     with ScalaFutures
     with MiroRecordGenerators
     with WorksGenerators {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -136,8 +136,8 @@ class MiroVHSRecordReceiverTest
           val future =
             recordReceiver.receiveMessage(message, failingTransformToWork)
 
-          whenReady(future.failed) { x =>
-            x shouldBe a[TestException]
+          whenReady(future.failed) {
+            _ shouldBe a[TestException]
           }
         }
       }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerServiceTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerServiceTest.scala
@@ -135,7 +135,7 @@ class SierraTransformerWorkerServiceTest
         val store = createStore[SierraTransformable]()
         val sender = new MemoryBigMessageSender[TransformedBaseWork]()
         sendNotificationToSQS(queue, Version(randomAlphanumeric, 1))
-        withWorkerService(store, sender, queue) { recordReceiver =>
+        withWorkerService(store, sender, queue) { _ =>
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -155,7 +155,7 @@ class SierraTransformerWorkerServiceTest
           """{
           |"not a key": true
           |}""".stripMargin)
-        withWorkerService(store, sender, queue) { recordReceiver =>
+        withWorkerService(store, sender, queue) { _ =>
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -173,7 +173,7 @@ class SierraTransformerWorkerServiceTest
     withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
         sendNotificationToSQS(queue, key)
-        withBrokenWorkerService(store, sender, queue) { recordReceiver =>
+        withBrokenWorkerService(store, sender, queue) { _ =>
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -194,7 +194,7 @@ class SierraTransformerWorkerServiceTest
     withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
         sendNotificationToSQS(queue, key)
-        withWorkerService(store, sender, queue) { recordReceiver =>
+        withWorkerService(store, sender, queue) { _ =>
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, 1)
@@ -242,7 +242,7 @@ class SierraTransformerWorkerServiceTest
       }
     }
 
-  private def brokenStore = {
+  private def brokenStore: MemoryVersionedStore[String, SierraTransformable] = {
     new MemoryVersionedStore[String, SierraTransformable](
       new MemoryStore(Map[Version[String, Int], SierraTransformable]())
       with MemoryMaxima[String, SierraTransformable]) {


### PR DESCRIPTION
Some more refactoring found spun out of https://github.com/wellcomecollection/catalogue/pull/700; part of https://github.com/wellcomecollection/platform/issues/4596

None of them are enormously significant – missing type hints, cleaning up helpers, using MemoryMessageSender instead of SNSMessageSender to save us pulling an extra Docker image. High line noise, low value, so I wanted them out of the big refactoring PRs.