### PR TITLE
add minimum_should_match to bool query with filter

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -43,7 +43,7 @@ case object WorksMultiMatcher {
           ("data.notes.content", None),
         ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
       )
-    )
+    ).minimumShouldMatch(1)
   }
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.common.Operator.AND
+import com.sksamuel.elastic4s.requests.common.Operator.{AND, OR}
 import com.sksamuel.elastic4s.requests.searches.queries.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.{
   BEST_FIELDS,
@@ -15,35 +15,46 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
 
 case object WorksMultiMatcher {
   def apply(q: String): BoolQuery = {
-    boolQuery().should(
-      prefixQuery("data.title.keyword", q).boost(1000),
-      MultiMatchQuery(
-        q,
-        `type` = Some(BEST_FIELDS),
-        operator = Some(AND),
-        fields = Seq(
-          ("canonicalId.text", Some(1000)),
-          ("sourceIdentifier.value.text", Some(1000)),
-          ("data.otherIdentifiers.value.text", Some(1000)),
-          ("data.items.id.canonicalId.text", Some(1000)),
-          ("data.items.id.sourceIdentifier.value.text", Some(1000)),
-          ("data.items.id.otherIdentifiers.value.text", Some(1000)),
-          ("data.title", Some(100)),
-          ("data.title.english", Some(100)),
-          ("data.title.shingles", Some(100)),
-          ("data.alternativeTitles", Some(100)),
-          ("data.subjects.concepts.label", Some(10)),
-          ("data.genres.concepts.label", Some(10)),
-          ("data.contributors.agent.label", Some(10)),
-          ("data.production.*.label", Some(10)),
-          ("data.description", None),
-          ("data.physicalDescription", None),
-          ("data.language.label", None),
-          ("data.edition", None),
-          ("data.notes.content", None),
-        ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
+    boolQuery()
+      .should(
+        MultiMatchQuery(
+          q,
+          `type` = Some(BEST_FIELDS),
+          operator = Some(OR),
+          fields = Seq(
+            ("canonicalId.text", Some(1000)),
+            ("sourceIdentifier.value.text", Some(1000)),
+            ("data.otherIdentifiers.value.text", Some(1000)),
+            ("data.items.id.canonicalId.text", Some(1000)),
+            ("data.items.id.sourceIdentifier.value.text", Some(1000)),
+            ("data.items.id.otherIdentifiers.value.text", Some(1000)),
+          ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
+        ),
+        prefixQuery("data.title.keyword", q).boost(1000),
+        MultiMatchQuery(
+          q,
+          `type` = Some(BEST_FIELDS),
+          operator = Some(AND),
+          fields = Seq(
+            ("data.title", Some(100)),
+            ("data.title.english", Some(100)),
+            ("data.title.shingles", Some(100)),
+            ("data.alternativeTitles", Some(100)),
+            ("data.subjects.concepts.label", Some(10)),
+            ("data.genres.concepts.label", Some(10)),
+            ("data.contributors.agent.label", Some(10)),
+            ("data.production.*.label", Some(10)),
+            ("data.description", None),
+            ("data.physicalDescription", None),
+            ("data.language.label", None),
+            ("data.edition", None),
+            ("data.notes.content", None),
+            ("data.collectionPath.path", None),
+            ("data.collectionPath.label", None),
+          ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
+        )
       )
-    ).minimumShouldMatch(1)
+      .minimumShouldMatch(1)
   }
 }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -312,20 +312,6 @@ class WorksQueryTest
     }
   }
 
-  it("Shouldn't return all the results if queried") {
-    withLocalWorksIndex { index =>
-      val matchingWork = createIdentifiedWorkWith(
-        title = Some("Matching")
-      )
-      val notMatchingWork = createIdentifiedWorkWith(
-        title = Some("No thanks")
-      )
-      val query = "Matching"
-      insertIntoElasticsearch(index, matchingWork, notMatchingWork)
-      assertResultsMatchForAllowedQueryTypes(index, query, List(matchingWork))
-    }
-  }
-
   private def assertResultsMatchForAllowedQueryTypes(
     index: Index,
     query: String,


### PR DESCRIPTION
> If the bool query includes at least one should clause and no must or filter clauses, the default value is 1. Otherwise, the default value is 0.

--  [The docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html)

Adding a minimum should match to the query so we don't return all the results as is currently happening.