### PR TITLE
Use the new Location models throughout the catalogue repo

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageReader.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageReader.scala
@@ -2,19 +2,20 @@ package uk.ac.wellcome.bigmessaging
 
 import grizzled.slf4j.Logging
 import io.circe.Decoder
-import uk.ac.wellcome.json.JsonUtil.fromJson
 import uk.ac.wellcome.bigmessaging.message.{
   InlineNotification,
   MessageNotification,
   RemoteNotification
 }
-import uk.ac.wellcome.storage.{Identified, NotFoundError, ObjectLocation}
+import uk.ac.wellcome.json.JsonUtil.fromJson
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
+import uk.ac.wellcome.storage.{Identified, NotFoundError}
 
 import scala.util.{Failure, Success, Try}
 
 trait BigMessageReader[T] extends Logging {
-  val store: Store[ObjectLocation, T]
+  val store: Store[S3ObjectLocation, T]
 
   implicit val decoder: Decoder[T]
 

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/BigMessageSender.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.bigmessaging
 
-import uk.ac.wellcome.messaging.{IndividualMessageSender, MessageSender}
+import uk.ac.wellcome.messaging.MessageSender
 
 class BigMessageSender[Destination](
-  val underlying: IndividualMessageSender[Destination],
+  val underlying: IndividualBigMessageSender[Destination],
   val subject: String,
   val destination: Destination
 ) extends MessageSender[Destination]

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/IndividualBigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/IndividualBigMessageSender.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.bigmessaging.message.{
 }
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.IndividualMessageSender
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 
 import scala.util.{Failure, Success, Try}
@@ -20,7 +20,7 @@ trait IndividualBigMessageSender[Destination]
     extends IndividualMessageSender[Destination]
     with Logging {
   val underlying: IndividualMessageSender[Destination]
-  val store: Store[ObjectLocation, String]
+  val store: Store[S3ObjectLocation, String]
   val maxMessageSize: Int
   val namespace: String
 
@@ -61,7 +61,7 @@ trait IndividualBigMessageSender[Destination]
   private def createRemoteNotification(
     body: String,
     destination: Destination): Try[RemoteNotification] = {
-    val location = ObjectLocation(namespace, getKey(destination))
+    val location = S3ObjectLocation(namespace, getKey(destination))
 
     val notification =
       for {

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -23,7 +23,7 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
 class VHSInternalStore[T](
   prefix: S3ObjectLocationPrefix,
   indexStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String,
-                                                                      Int],
+                                                                        Int],
   dataStore: TypedStore[S3ObjectLocation, T]
 ) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
 

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -2,36 +2,37 @@ package uk.ac.wellcome.bigmessaging
 
 import java.util.UUID
 
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.{
   HybridStoreWithMaxima,
   Store,
   TypedStore,
   VersionedHybridStore
 }
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, Version}
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.Maxima
 
 class VHS[T](val hybridStore: VHSInternalStore[T])
     extends VersionedHybridStore[
       String,
       Int,
-      ObjectLocation,
+      S3ObjectLocation,
       T,
     ](hybridStore)
 
 class VHSInternalStore[T](
-  prefix: ObjectLocationPrefix,
-  indexStore: Store[Version[String, Int], ObjectLocation] with Maxima[String,
+  prefix: S3ObjectLocationPrefix,
+  indexStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String,
                                                                       Int],
-  dataStore: TypedStore[ObjectLocation, T]
-) extends HybridStoreWithMaxima[String, Int, ObjectLocation, T] {
+  dataStore: TypedStore[S3ObjectLocation, T]
+) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
 
   override val indexedStore
-    : Store[Version[String, Int], ObjectLocation] with Maxima[String, Int] =
+    : Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Int] =
     indexStore
-  override val typedStore: TypedStore[ObjectLocation, T] = dataStore
+  override val typedStore: TypedStore[S3ObjectLocation, T] = dataStore
 
   override protected def createTypeStoreId(
-    id: Version[String, Int]): ObjectLocation =
+    id: Version[String, Int]): S3ObjectLocation =
     prefix.asLocation(id.id, id.version.toString, UUID.randomUUID().toString)
 }

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/BigMessageStream.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.{SQSConfig, SQSStream}
 import uk.ac.wellcome.monitoring.Metrics
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -24,11 +24,11 @@ class BigMessageStream[T](sqsClient: SqsAsyncClient,
   implicit
   actorSystem: ActorSystem,
   decoderT: Decoder[T],
-  storeT: Store[ObjectLocation, T],
+  storeT: Store[S3ObjectLocation, T],
   ec: ExecutionContext) {
 
   private val bigMessageReader = new BigMessageReader[T] {
-    override val store: Store[ObjectLocation, T] = storeT
+    override val store: Store[S3ObjectLocation, T] = storeT
     override implicit val decoder: Decoder[T] = decoderT
   }
 

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageNotification.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/message/MessageNotification.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.bigmessaging.message
 
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 /** Most of our inter-application messages are fairly small, and can be
   * sent inline on SNS/SQS.  But occasionally, we have an unusually large
   * message that can't be sent this way.  In that case, we store a copy
-  * of the message in S3, and send an ObjectLocation telling the consumer
+  * of the message in S3, and send an S3ObjectLocation telling the consumer
   * where to find the main message.
   *
   * This trait is the base for the two notification classes -- so we
@@ -14,7 +14,7 @@ import uk.ac.wellcome.storage.ObjectLocation
   */
 sealed trait MessageNotification
 
-case class RemoteNotification(location: ObjectLocation)
+case class RemoteNotification(location: S3ObjectLocation)
     extends MessageNotification
 
 case class InlineNotification(jsonString: String) extends MessageNotification

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/s3/S3IndividualBigMessageSender.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/s3/S3IndividualBigMessageSender.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.bigmessaging.IndividualBigMessageSender
 import uk.ac.wellcome.messaging.IndividualMessageSender
 import uk.ac.wellcome.messaging.sns.{SNSConfig, SNSIndividualMessageSender}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
@@ -17,7 +17,7 @@ class S3IndividualBigMessageSender(
 ) extends IndividualBigMessageSender[SNSConfig] {
   override val underlying: IndividualMessageSender[SNSConfig] = snsMessageSender
 
-  override val store: Store[ObjectLocation, String] = S3TypedStore[String]
+  override val store: Store[S3ObjectLocation, String] = S3TypedStore[String]
 
   override val namespace: String = bucketName
 }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageIntegrationTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageIntegrationTest.scala
@@ -11,8 +11,8 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec
@@ -41,7 +41,7 @@ class BigMessageIntegrationTest
       )
 
       val reader = new BigMessageReader[Shape] {
-        override val store: Store[ObjectLocation, Shape] =
+        override val store: Store[S3ObjectLocation, Shape] =
           S3TypedStore[Shape]
         override implicit val decoder: Decoder[Shape] = decoderS
       }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageReaderTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageReaderTest.scala
@@ -79,6 +79,6 @@ class BigMessageReaderTest
     result shouldBe a[Failure[_]]
     val err = result.failed.get
     err shouldBe a[Throwable]
-    err.getMessage shouldBe "Nothing at does-not/exist"
+    err.getMessage shouldBe "Nothing at s3://does-not/exist"
   }
 }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageReaderTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageReaderTest.scala
@@ -10,8 +10,8 @@ import uk.ac.wellcome.bigmessaging.message.{
 }
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 
@@ -21,24 +21,24 @@ class BigMessageReaderTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with ObjectLocationGenerators {
+    with S3ObjectLocationGenerators {
   case class Shape(colour: String, sides: Int)
 
   val blueTriangle = Shape(colour = "blue", sides = 3)
 
-  def createReader(shapeStore: Store[ObjectLocation, Shape] = new MemoryStore(
+  def createReader(shapeStore: Store[S3ObjectLocation, Shape] = new MemoryStore(
                      Map.empty))(
     implicit decoderS: Decoder[Shape]): BigMessageReader[Shape] =
     new BigMessageReader[Shape] {
-      override val store: Store[ObjectLocation, Shape] =
+      override val store: Store[S3ObjectLocation, Shape] =
         shapeStore
       override implicit val decoder: Decoder[Shape] = decoderS
     }
 
   it("reads a large message from the object store") {
-    val store = new MemoryStore(Map.empty[ObjectLocation, Shape])
+    val store = new MemoryStore(Map.empty[S3ObjectLocation, Shape])
     val reader = createReader(store)
-    val objectLocation = createObjectLocation
+    val objectLocation = createS3ObjectLocation
 
     store.put(objectLocation)(blueTriangle)
 
@@ -71,7 +71,7 @@ class BigMessageReaderTest
     val reader = createReader()
 
     val notification = RemoteNotification(
-      location = ObjectLocation("does-not", "exist")
+      location = S3ObjectLocation("does-not", "exist")
     )
 
     val result = reader.read(notification)

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageSenderTest.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/BigMessageSenderTest.scala
@@ -112,7 +112,7 @@ class BigMessageSenderTest
               fromJson[RemoteNotification](msg.message).get
             }
 
-        messages.head.location.namespace shouldBe bucket.name
+        messages.head.location.bucket shouldBe bucket.name
       }
     }
   }

--- a/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
+++ b/common/big_messaging/src/test/scala/uk/ac/wellcome/bigmessaging/fixtures/BigMessagingFixture.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 
@@ -26,8 +26,8 @@ trait BigMessagingFixture extends SQS {
     implicit
     actorSystem: ActorSystem,
     decoderT: Decoder[T],
-    storeT: Store[ObjectLocation, T] =
-      new MemoryStore[ObjectLocation, T](Map.empty)): R = {
+    storeT: Store[S3ObjectLocation, T] =
+      new MemoryStore[S3ObjectLocation, T](initialEntries = Map.empty)): R = {
     val stream = new BigMessageStream[T](
       sqsClient = sqsClient,
       sqsConfig = createSQSConfigWith(queue),

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/BigMessagingBuilder.scala
@@ -11,8 +11,7 @@ import uk.ac.wellcome.bigmessaging.s3.S3BigMessageSender
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.s3.S3Config
+import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec
@@ -32,7 +31,7 @@ object BigMessagingBuilder {
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 
-    implicit val store: Store[ObjectLocation, T] = S3TypedStore[T]
+    implicit val store: Store[S3ObjectLocation, T] = S3TypedStore[T]
 
     new BigMessageStream[T](
       sqsClient = SQSBuilder.buildSQSAsyncClient(config),

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -4,22 +4,22 @@ import org.scanamo.auto._
 import com.typesafe.config.Config
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, Version}
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 import uk.ac.wellcome.storage.streaming.Codec
 import uk.ac.wellcome.bigmessaging.{VHS, VHSInternalStore}
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 object VHSBuilder {
 
   type IndexStore =
-    Store[Version[String, Int], ObjectLocation] with Maxima[String, Int]
+    Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Int]
 
   def build[T](config: Config, namespace: String = "vhs")(
     implicit codec: Codec[T]): VHS[T] =
@@ -30,7 +30,7 @@ object VHSBuilder {
       S3Builder.buildS3Client(config)
     )
 
-  def build[T](objectLocationPrefix: ObjectLocationPrefix,
+  def build[T](objectLocationPrefix: S3ObjectLocationPrefix,
                dynamoConfig: DynamoConfig,
                dynamoClient: AmazonDynamoDB,
                s3Client: AmazonS3)(implicit codec: Codec[T]): VHS[T] = {
@@ -44,10 +44,10 @@ object VHSBuilder {
   }
 
   private def buildObjectLocationPrefix(config: Config, namespace: String) =
-    ObjectLocationPrefix(
-      namespace = config
+    S3ObjectLocationPrefix(
+      bucket = config
         .requireString(s"aws.${namespace}.s3.bucketName"),
-      path = config
+      keyPrefix = config
         .getStringOption(s"aws.${namespace}.s3.globalPrefix")
         .getOrElse("")
     )
@@ -55,6 +55,6 @@ object VHSBuilder {
   private def createIndexStore(dynamoClient: AmazonDynamoDB,
                                dynamoConfig: DynamoConfig): IndexStore = {
     implicit val dynamo = dynamoClient;
-    new DynamoHashStore[String, Int, ObjectLocation](dynamoConfig)
+    new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig)
   }
 }

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsLocation.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/MetsLocation.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.mets_adapter.models
 
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 /** METS location data to send onwards to the transformer.
   */
@@ -11,8 +11,8 @@ case class MetsLocation(bucket: String,
                         manifestations: List[String] = Nil) {
 
   def xmlLocation =
-    ObjectLocation(bucket, s"${path}/${file}")
+    S3ObjectLocation(bucket, s"${path}/${file}")
 
   def manifestationLocations =
-    manifestations.map(file => ObjectLocation(bucket, s"${path}/${file}"))
+    manifestations.map(file => S3ObjectLocation(bucket, s"${path}/${file}"))
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -8,8 +8,9 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
+import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
@@ -18,7 +19,7 @@ class MetsTransformerWorkerService[Destination](
   msgStream: SQSStream[NotificationMessage],
   messageSender: MessageSender[Destination],
   adapterStore: VersionedStore[String, Int, MetsLocation],
-  metsXmlStore: Readable[ObjectLocation, String]
+  metsXmlStore: Readable[S3ObjectLocation, String]
 ) extends Runnable
     with Logging {
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/store/TemporaryCredentialsStore.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/store/TemporaryCredentialsStore.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.transformer.mets.store
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.transformer.mets.client.AssumeRoleClientProvider
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, StoreReadError}
+import uk.ac.wellcome.storage.{Identified, StoreReadError}
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec
@@ -10,14 +11,14 @@ import uk.ac.wellcome.storage.streaming.Codec
 class TemporaryCredentialsStore[T](
   assumeRoleClientProvider: AssumeRoleClientProvider[AmazonS3])(
   implicit codec: Codec[T])
-    extends Readable[ObjectLocation, T] {
+    extends Readable[S3ObjectLocation, T] {
 
-  def get(objectLocation: ObjectLocation): ReadEither = {
+  def get(S3ObjectLocation: S3ObjectLocation): ReadEither = {
     for {
       client <- assumeRoleClientProvider.getClient.left
         .map(StoreReadError(_))
       result <- S3TypedStore[T](codec, client)
-        .get(objectLocation)
+        .get(S3ObjectLocation)
     } yield {
       result match {
         case Identified(key, data) => Identified(key, data)

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
@@ -7,13 +7,13 @@ import org.scalatest.funspec.AnyFunSpec
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
+import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.generators.RandomStrings
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.mets.client.ClientFactory
@@ -24,10 +24,11 @@ import uk.ac.wellcome.platform.transformer.mets.fixtures.{
 }
 import uk.ac.wellcome.platform.transformer.mets.store.TemporaryCredentialsStore
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.VersionedStore
-import uk.ac.wellcome.storage.{Identified, ObjectLocation, Version}
+import uk.ac.wellcome.storage.{Identified, Version}
 
 class MetsTransformerWorkerServiceTest
     extends AnyFunSpec
@@ -166,7 +167,7 @@ class MetsTransformerWorkerServiceTest
     val rootPath = "data"
     val key = for {
       _ <- S3TypedStore[String].put(
-        ObjectLocation(metsBucket.name, s"$rootPath/$name"))(mets)
+        S3ObjectLocation(metsBucket.name, key = s"$rootPath/$name"))(mets)
       entry = MetsLocation(metsBucket.name, rootPath, 1, name, List())
       key <- dynamoStore.put(Version(name, version))(entry)
     } yield key

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/store/TemporaryCredentialsStoreTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/store/TemporaryCredentialsStoreTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.transformer.mets.fixtures.{
   LocalStackS3Fixtures,
   STSFixtures
 }
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
+import uk.ac.wellcome.storage.Identified
 
 import scala.util.Right
 
@@ -20,7 +20,7 @@ class TemporaryCredentialsStoreTest
   it("gets a file from s3 using temporary credentials") {
     withActorSystem { implicit actorSystem =>
       withLocalStackS3Bucket { bucket =>
-        val location = ObjectLocation(bucket.name, "file.txt")
+        val location = createS3ObjectLocationWith(bucket)
         val content = "Rudolph the red node reindeer"
         localStackS3Store.put(location)(content)
         withAssumeRoleClientProvider(roleArn)(testS3ClientBuilder) {

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -6,8 +6,8 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
 import uk.ac.wellcome.models.work.internal.License
 import uk.ac.wellcome.platform.transformer.mets.fixtures.MetsGenerators
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStore
-import uk.ac.wellcome.storage.ObjectLocation
 
 class MetsXmlTransformerTest
     extends AnyFunSpec
@@ -96,7 +96,7 @@ class MetsXmlTransformerTest
       (manifestations ++ root
         .map(content => "root.xml" -> Some(content))).collect {
         case (file, Some(content)) =>
-          ObjectLocation("bucket", s"path/$file") -> content
+          S3ObjectLocation("bucket", key = s"path/$file") -> content
       }
     )
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -11,8 +11,9 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
+import uk.ac.wellcome.storage.Identified
 
 // In future we should just receive the ID and version from the adapter as the
 // S3 specific `location` field is an implementation detail we should not be
@@ -27,7 +28,7 @@ case class BackwardsCompatObjectLocation(namespace: String, key: String)
 
 class MiroVHSRecordReceiver[MsgDestination](
   messageSender: MessageSender[MsgDestination],
-  store: Store[ObjectLocation, MiroRecord])(implicit ec: ExecutionContext)
+  store: Store[S3ObjectLocation, MiroRecord])(implicit ec: ExecutionContext)
     extends Logging {
 
   def receiveMessage(message: NotificationMessage,
@@ -62,8 +63,8 @@ class MiroVHSRecordReceiver[MsgDestination](
 
   private def getRecord(record: HybridRecord): Try[MiroRecord] =
     record match {
-      case HybridRecord(_, _, BackwardsCompatObjectLocation(namespace, path)) =>
-        store.get(ObjectLocation(namespace, path)) match {
+      case HybridRecord(_, _, BackwardsCompatObjectLocation(bucket, key)) =>
+        store.get(S3ObjectLocation(bucket, key)) match {
           case Right(Identified(_, miroRecord)) =>
             Success(miroRecord)
           case Left(error) => Failure(error.e)

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.platform.transformer.miro.services.{
   MiroVHSRecordReceiver
 }
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 
@@ -21,9 +21,9 @@ import scala.util.Random
 
 trait MiroVHSRecordReceiverFixture extends MiroRecordGenerators with SQS {
 
-  type MiroStore = Store[ObjectLocation, MiroRecord]
+  type MiroStore = Store[S3ObjectLocation, MiroRecord]
 
-  private val store: MiroStore = new MemoryStore(Map.empty)
+  private val store: MiroStore = new MemoryStore(initialEntries = Map.empty)
 
   def createRecordReceiverWith(
     messageSender: MemoryMessageSender): MiroVHSRecordReceiver[String] =
@@ -57,14 +57,14 @@ trait MiroVHSRecordReceiverFixture extends MiroRecordGenerators with SQS {
     version: Int = 1,
     namespace: String = "test",
     id: String = Random.alphanumeric take 10 mkString): HybridRecord = {
-    val location = ObjectLocation(namespace, id)
+    val location = S3ObjectLocation(namespace, id)
 
     store.put(location)(miroRecord)
     HybridRecord(
       id = id,
       version = version,
       location =
-        BackwardsCompatObjectLocation(location.namespace, location.path)
+        BackwardsCompatObjectLocation(location.bucket, location.key)
     )
   }
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -63,8 +63,7 @@ trait MiroVHSRecordReceiverFixture extends MiroRecordGenerators with SQS {
     HybridRecord(
       id = id,
       version = version,
-      location =
-        BackwardsCompatObjectLocation(location.bucket, location.key)
+      location = BackwardsCompatObjectLocation(location.bucket, location.key)
     )
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "14.0.0"
+  val defaultVersion = "19.1.0"
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -27,8 +27,8 @@ import uk.ac.wellcome.sierra_adapter.model.{
   SierraBibRecord,
   SierraItemRecord
 }
-import uk.ac.wellcome.storage.{Identified, ObjectLocation}
-import uk.ac.wellcome.storage.s3.S3Config
+import uk.ac.wellcome.storage.Identified
+import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -68,7 +68,7 @@ class SierraReaderWorkerService(
 
   private def runSierraStream(
     window: String,
-    windowStatus: WindowStatus): Future[Identified[ObjectLocation, String]] = {
+    windowStatus: WindowStatus): Future[Identified[S3ObjectLocation, String]] = {
 
     info(s"Running the stream with window=$window and status=$windowStatus")
 
@@ -110,7 +110,7 @@ class SierraReaderWorkerService(
 
       Future.fromTry(
         S3TypedStore[String]
-          .put(ObjectLocation(s3Config.bucketName, key))("")
+          .put(S3ObjectLocation(bucket = s3Config.bucketName, key = key))("")
           .left
           .map { _.e }
           .toTry)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -66,9 +66,8 @@ class SierraReaderWorkerService(
       _ <- runSierraStream(window = window, windowStatus = windowStatus)
     } yield ()
 
-  private def runSierraStream(
-    window: String,
-    windowStatus: WindowStatus): Future[Identified[S3ObjectLocation, String]] = {
+  private def runSierraStream(window: String, windowStatus: WindowStatus)
+    : Future[Identified[S3ObjectLocation, String]] = {
 
     info(s"Running the stream with window=$window and status=$windowStatus")
 

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3Sink.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3Sink.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.sierra_reader.sink
 import akka.Done
 import akka.stream.scaladsl.Sink
 import io.circe.Json
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
 import scala.concurrent.Future
@@ -19,7 +19,7 @@ object SequentialS3Sink {
         // e.g. "1" ~> "0001", "25" ~> "0025"
         val key = f"$keyPrefix${index + offset}%04d.json"
         store
-          .put(ObjectLocation(bucketName, key))(json.noSpaces)
+          .put(S3ObjectLocation(bucketName, key))(json.noSpaces)
           .left
           .map(_.e)
           .toTry

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -9,9 +9,9 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.platform.sierra_reader.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.sierra_adapter.model.{SierraBibRecord, SierraItemRecord}
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 class SierraReaderWorkerServiceTest
     extends AnyFunSpec
@@ -157,12 +157,12 @@ class SierraReaderWorkerServiceTest
   private def getBibRecordsFromS3(bucket: Bucket,
                                   key: String): List[SierraBibRecord] =
     getObjectFromS3[List[SierraBibRecord]](
-      ObjectLocation(namespace = bucket.name, path = key))
+      S3ObjectLocation(bucket = bucket.name, key = key))
 
   private def getItemRecordsFromS3(bucket: Bucket,
                                    key: String): List[SierraItemRecord] =
     getObjectFromS3[List[SierraItemRecord]](
-      ObjectLocation(namespace = bucket.name, path = key))
+      S3ObjectLocation(bucket = bucket.name, key = key))
 
   it("returns a SierraReaderException if it receives an invalid message") {
     val body =

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -11,9 +11,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 
 import scala.concurrent.Future
@@ -118,5 +118,5 @@ class SequentialS3SinkTest
   }
 
   def getJsonFromS3(bucket: Bucket, key: String): Json =
-    getJsonFromS3(ObjectLocation(bucket.name, key))
+    getJsonFromS3(S3ObjectLocation(bucket.name, key))
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4596 (finally)

Context for people who primarily work on the catalogue:

As part of adding support for Azure to the storage service, we had to add new implementations of everything in the shared storage library. As we were doing it, we split the `ObjectLocation` model into `S3ObjectLocation` and `AzureBlobLocation` – so you can't accidentally ask S3 for an object in Azure, or vice versa. This also allows us to use more provider-specific terminology where appropriate:

Before:

```scala
ObjectLocation(namespace: String, path: String)
```

After:

```scala
S3ObjectLocation(bucket: String, key: String)
AzureBlobLocation(container: String, name: String)
```

The shared libraries include JSON decoders and Dynamo formats for the S3ObjectLocation class that mean it should be backwards-compatible – if it reads JSON/Dynamo rows written by the old model, it will read them in the new models.

This is what that enormous big-messaging patch was laying the groundwork for; to be able to make this patch super simple.