### PR TITLE
use lowercase keywords for ID search

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -32,14 +32,14 @@ case object ImagesMultiMatcher {
     } map (FieldWithOptionalBoost(_, None))
 
     val sourceWorkIdFields = Seq(
-      "id.canonicalId.text",
-      "id.sourceIdentifier.value.text",
-      "id.otherIdentifiers.value.text"
+      "id.canonicalId",
+      "id.sourceIdentifier.value",
+      "id.otherIdentifiers.value"
     )
 
     val idFields = (Seq(
-      "id.canonicalId.text",
-      "id.sourceIdentifier.value.text",
+      "id.canonicalId",
+      "id.sourceIdentifier.value",
     ) ++ sourceWorkIdFields
       .flatMap(
         subField =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -12,6 +12,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   FieldWithOptionalBoost,
   MultiMatchQuery
 }
+import uk.ac.wellcome.elasticsearch.WorksAnalysis.whitespaceAnalyzer
 
 case object WorksMultiMatcher {
   def apply(q: String): BoolQuery = {
@@ -21,6 +22,7 @@ case object WorksMultiMatcher {
           q,
           `type` = Some(BEST_FIELDS),
           operator = Some(OR),
+          analyzer = Some(whitespaceAnalyzer.name),
           fields = Seq(
             ("canonicalId", Some(1000)),
             ("sourceIdentifier.value", Some(1000)),
@@ -98,7 +100,8 @@ case object WorksPhraserBeam {
         MultiMatchQuery(
           fields = idFields,
           text = q,
-          `type` = Some(CROSS_FIELDS)
+          `type` = Some(CROSS_FIELDS),
+          analyzer = Some(whitespaceAnalyzer.name),
         ),
         MultiMatchQuery(
           text = q,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -22,12 +22,12 @@ case object WorksMultiMatcher {
           `type` = Some(BEST_FIELDS),
           operator = Some(OR),
           fields = Seq(
-            ("canonicalId.text", Some(1000)),
-            ("sourceIdentifier.value.text", Some(1000)),
-            ("data.otherIdentifiers.value.text", Some(1000)),
-            ("data.items.id.canonicalId.text", Some(1000)),
-            ("data.items.id.sourceIdentifier.value.text", Some(1000)),
-            ("data.items.id.otherIdentifiers.value.text", Some(1000)),
+            ("canonicalId", Some(1000)),
+            ("sourceIdentifier.value", Some(1000)),
+            ("data.otherIdentifiers.value", Some(1000)),
+            ("data.items.id.canonicalId", Some(1000)),
+            ("data.items.id.sourceIdentifier.value", Some(1000)),
+            ("data.items.id.otherIdentifiers.value", Some(1000)),
           ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
         ),
         prefixQuery("data.title.keyword", q).boost(1000),
@@ -77,12 +77,12 @@ case object WorksPhraserBeam {
     ).map(FieldWithOptionalBoost(_, None))
 
     val idFields = Seq(
-      "canonicalId.text",
-      "sourceIdentifier.value.text",
-      "data.otherIdentifiers.value.text",
-      "data.items.id.canonicalId.text",
-      "data.items.id.sourceIdentifier.value.text",
-      "data.items.id.otherIdentifiers.value.text",
+      "canonicalId",
+      "sourceIdentifier.value",
+      "data.otherIdentifiers.value",
+      "data.items.id.canonicalId",
+      "data.items.id.sourceIdentifier.value",
+      "data.items.id.otherIdentifiers.value",
     ).map(FieldWithOptionalBoost(_, None))
 
     boolQuery().must(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -195,6 +195,53 @@ class WorksQueryTest
       }
     }
 
+    it("matches multiple IDs") {
+      withLocalWorksIndex { index =>
+        val work1 = createIdentifiedWorkWith(
+          canonicalId = "AbCDeF1234"
+        )
+        val work2 = createIdentifiedWorkWith(
+          canonicalId = "rstYui786"
+        )
+        val nonMatchingWork = createIdentifiedWorkWith(
+          canonicalId = "bloopybloop"
+        )
+        val query = "abcdef1234 rstyui786"
+
+        insertIntoElasticsearch(index, work1, work2, nonMatchingWork)
+
+        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
+      }
+    }
+
+    it("doesn't match partially matching IDs") {
+      withLocalWorksIndex { index =>
+        val work1 = createIdentifiedWorkWith(
+          canonicalId = "AbCDeF1234"
+        )
+        val work2 = createIdentifiedWorkWith(
+          canonicalId = "rstYui786"
+        )
+        val nonMatchingWork1 = createIdentifiedWorkWith(
+          canonicalId = "bloopybloop"
+        )
+        // We've put spaces in this as some Miro IDs are sentences
+        val nonMatchingWork2 = createIdentifiedWorkWith(
+          canonicalId = "Oxford english dictionary"
+        )
+        val query = "abcdef1234 rstyui786 Oxford"
+
+        insertIntoElasticsearch(
+          index,
+          work1,
+          work2,
+          nonMatchingWork1,
+          nonMatchingWork2)
+
+        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
+      }
+    }
+
     it("Searches for contributors") {
       withLocalWorksIndex { index =>
         val matchingWork = createIdentifiedWorkWith(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -166,35 +166,16 @@ class WorksQueryTest
       }
     }
 
-    it("matches when searching for multiple IDs") {
-      withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "abc123"
-        )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "123abc"
-        )
-        val query = "abc123 123abc"
-
-        insertIntoElasticsearch(index, work1, work2)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
-      }
-    }
-
     it("doesn't match on partial IDs") {
       withLocalWorksIndex { index =>
         val work1 = createIdentifiedWorkWith(
-          canonicalId = "abcdefg"
-        )
-        val work2 = createIdentifiedWorkWith(
           canonicalId = "1234567"
         )
-        val query = "123 abcdefg"
+        val query = "123"
 
-        insertIntoElasticsearch(index, work1, work2)
+        insertIntoElasticsearch(index, work1)
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1))
+        assertResultsMatchForAllowedQueryTypes(index, query, List())
       }
     }
 
@@ -203,30 +184,14 @@ class WorksQueryTest
         val work1 = createIdentifiedWorkWith(
           canonicalId = "AbCDeF1234"
         )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "12345Ef"
+        val nonMatchingWork = createIdentifiedWorkWith(
+          canonicalId = "bloopybloop"
         )
-        val query = "abcdef1234 12345ef"
+        val query = "abcdef1234"
 
-        insertIntoElasticsearch(index, work1, work2)
+        insertIntoElasticsearch(index, work1, nonMatchingWork)
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
-      }
-    }
-
-    it("matches IDs that are part of a query") {
-      withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "AbCDeF1234"
-        )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "12345Ef"
-        )
-        val query = "abcdef1234 12345ef hats, dogs and dolomites"
-
-        insertIntoElasticsearch(index, work1, work2)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
+        assertResultsMatchForAllowedQueryTypes(index, query, List(work1))
       }
     }
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.ElasticDsl.{
 }
 import com.sksamuel.elastic4s.requests.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
-import uk.ac.wellcome.elasticsearch.WorksAnalysis.asciifoldingAnalyzer
+import uk.ac.wellcome.elasticsearch.WorksAnalysis._
 trait IndexConfig {
   val mapping: MappingDefinition
   val analysis: Analysis
@@ -34,6 +34,9 @@ trait IndexConfig {
     textField(name).fields(
       textField("english").analyzer("english")
     )
+
+  def lowercaseKeyword(name: String) =
+    keywordField(name).normalizer(lowercaseNormalizer.name)
 
   def asciifoldingTextFieldWithKeyword(name: String) =
     textWithKeyword(name)
@@ -87,8 +90,8 @@ trait IndexConfig {
 
   val label = asciifoldingTextFieldWithKeyword("label")
 
-  val sourceIdentifierValue = keywordWithText("value")
+  val sourceIdentifierValue = lowercaseKeyword("value")
 
-  val canonicalId = keywordWithText("canonicalId")
+  val canonicalId = lowercaseKeyword("canonicalId")
   val version = intField("version")
 }

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
@@ -3,6 +3,7 @@ import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.analysis.{
   Analysis,
   CustomAnalyzer,
+  CustomNormalizer,
   PathHierarchyTokenizer,
   ShingleTokenFilter,
   StemmerTokenFilter,
@@ -54,6 +55,12 @@ object WorksAnalysis {
     charFilters = Nil
   )
 
+  val lowercaseNormalizer = CustomNormalizer(
+    "lowercase_normalizer",
+    tokenFilters = List("lowercase", asciiFoldingTokenFilter.name),
+    charFilters = Nil
+  )
+
   val englishAnalyzer = CustomAnalyzer(
     "english_analyzer",
     tokenizer = "standard",
@@ -86,7 +93,8 @@ object WorksAnalysis {
         shingleTokenFilter,
         englishStemmerTokenFilter,
         englishPossessiveStemmerTokenFilter),
-      tokenizers = List(pathTokenizer)
+      tokenizers = List(pathTokenizer),
+      normalizers = List(lowercaseNormalizer)
     )
 
   }

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
@@ -55,12 +55,6 @@ object WorksAnalysis {
     charFilters = Nil
   )
 
-  val lowercaseNormalizer = CustomNormalizer(
-    "lowercase_normalizer",
-    tokenFilters = List("lowercase", asciiFoldingTokenFilter.name),
-    charFilters = Nil
-  )
-
   val englishAnalyzer = CustomAnalyzer(
     "english_analyzer",
     tokenizer = "standard",
@@ -80,13 +74,27 @@ object WorksAnalysis {
     charFilters = Nil
   )
 
+  val whitespaceAnalyzer = CustomAnalyzer(
+    "whitespace_analyzer",
+    tokenizer = "whitespace",
+    tokenFilters = Nil,
+    charFilters = Nil,
+  )
+
+  val lowercaseNormalizer = CustomNormalizer(
+    "lowercase_normalizer",
+    tokenFilters = List("lowercase", asciiFoldingTokenFilter.name),
+    charFilters = Nil
+  )
+
   def apply(): Analysis = {
     Analysis(
       analyzers = List(
         pathAnalyzer,
         asciifoldingAnalyzer,
         shingleAsciifoldingAnalyzer,
-        englishAnalyzer
+        englishAnalyzer,
+        whitespaceAnalyzer,
       ),
       tokenFilters = List(
         asciiFoldingTokenFilter,

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksAnalysis.scala
@@ -83,7 +83,7 @@ object WorksAnalysis {
 
   val lowercaseNormalizer = CustomNormalizer(
     "lowercase_normalizer",
-    tokenFilters = List("lowercase", asciiFoldingTokenFilter.name),
+    tokenFilters = List("lowercase"),
     charFilters = Nil
   )
 

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/IndexerTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/IndexerTest.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.ingestor.common
 
-import com.sksamuel.elastic4s.requests.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.{Index, Indexable}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.elasticsearch.IndexConfig
+import uk.ac.wellcome.elasticsearch.{IndexConfig, WorksAnalysis}
 import uk.ac.wellcome.elasticsearch.model.{CanonicalId, Version}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
@@ -156,7 +155,7 @@ class IndexerTest
   object StrictWithNoDataIndexConfig extends IndexConfig {
     import com.sksamuel.elastic4s.ElasticDsl._
 
-    val analysis = Analysis(analyzers = List())
+    val analysis = WorksAnalysis()
 
     val title = textField("title")
     val data = objectField("data")


### PR DESCRIPTION
Fixes #713 

Makes ID search across keywords, lowercase normalized

Affects:
- If you aggregate, you get the lowercased versions
- ~We lose multi ID search~ We now use a `whitespace` analyser when querying the ID field, meaning it will split the query into keywords split on ` ` and run as an `OR`

☝️ Neither of these have been identified as needed, and if they are we can approach them then.