### PR TITLE
Remove the backwards-compatible ObjectLocation

### DIFF
--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiver.scala
@@ -21,10 +21,8 @@ import uk.ac.wellcome.storage.Identified
 case class HybridRecord(
   id: String,
   version: Int,
-  location: BackwardsCompatObjectLocation
+  location: S3ObjectLocation
 )
-
-case class BackwardsCompatObjectLocation(namespace: String, key: String)
 
 class MiroVHSRecordReceiver[MsgDestination](
   messageSender: MessageSender[MsgDestination],
@@ -62,12 +60,8 @@ class MiroVHSRecordReceiver[MsgDestination](
   }
 
   private def getRecord(record: HybridRecord): Try[MiroRecord] =
-    record match {
-      case HybridRecord(_, _, BackwardsCompatObjectLocation(bucket, key)) =>
-        store.get(S3ObjectLocation(bucket, key)) match {
-          case Right(Identified(_, miroRecord)) =>
-            Success(miroRecord)
-          case Left(error) => Failure(error.e)
-        }
+    store.get(record.location) match {
+      case Right(Identified(_, miroRecord)) => Success(miroRecord)
+      case Left(error)                      => Failure(error.e)
     }
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/fixtures/MiroVHSRecordReceiverFixture.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.services.{
-  BackwardsCompatObjectLocation,
   HybridRecord,
   MiroVHSRecordReceiver
 }
@@ -60,10 +59,7 @@ trait MiroVHSRecordReceiverFixture extends MiroRecordGenerators with SQS {
     val location = S3ObjectLocation(namespace, id)
 
     store.put(location)(miroRecord)
-    HybridRecord(
-      id = id,
-      version = version,
-      location = BackwardsCompatObjectLocation(location.bucket, location.key)
-    )
+
+    HybridRecord(id = id, version = version, location = location)
   }
 }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4692

The Miro VHS table now has a bucket/key model that's more consistent with what we use elsewhere. It has all three of namespace/bucket/key as a compatibility thing, so we can do away with one of these shims. I added the "bucket" column to the table while doing some refactoring for the new Location models.