### PR TITLE
Remove an unused Terraform remote state block

### DIFF
--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -33,17 +33,6 @@ data "terraform_remote_state" "catalogue_infra_critical" {
   }
 }
 
-data "terraform_remote_state" "catalogue_pipeline_data" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue_pipeline_data.tfstate"
-    region   = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 


### PR DESCRIPTION
There's nothing in the pipeline Terraform that actually reads from this state.