### PR TITLE
remove check on non-partial folder names for travis run_job

### DIFF
--- a/.travis/sbt_dependency_tree.py
+++ b/.travis/sbt_dependency_tree.py
@@ -64,7 +64,7 @@ class Repository:
         """Which project, if any, is this path associated with?"""
         for project in self.projects.values():
             """We check with a / at the end to make sure we don't match partial folder names"""
-            if path.startswith(f'{project.folder}/'):
+            if path.startswith(f"{project.folder}/"):
                 return project
         else:
             raise KeyError("No project associated with %r!" % path)

--- a/.travis/sbt_dependency_tree.py
+++ b/.travis/sbt_dependency_tree.py
@@ -63,7 +63,8 @@ class Repository:
     def lookup_path(self, path):
         """Which project, if any, is this path associated with?"""
         for project in self.projects.values():
-            if path.startswith(project.folder):
+            """We check with a / at the end to make sure we don't match partial folder names"""
+            if path.startswith(f'{project.folder}/'):
                 return project
         else:
             raise KeyError("No project associated with %r!" % path)

--- a/.travis/test_run_job.py
+++ b/.travis/test_run_job.py
@@ -20,6 +20,10 @@ def repo():
         ("id_minter", ["common/Makefile", "pipeline/Makefile"], True),
         ("elasticsearch", ["common/Makefile"], True),
         ("elasticsearch", ["common/Makefile", "pipeline/Makefile"], True),
+        ("elasticsearch", ["common/Makefile", "pipeline/Makefile"], True),
+        ("big_messaging_typesafe", ["common/big_messaging/file.scala"], False),
+        ("merger", ["common/big_messaging/file.scala"], False),
+        ("merger", ["common/big_messaging_typesafe/file.scala"], True),
     ],
 )
 def test_should_run_sbt_project(repo, project_name, changed_paths, should_run_project):


### PR DESCRIPTION
`big_messaging` was  being selected as the project for a file changing in `big_messaging_typesafe` as we are currently matching without checking it's the end of the folder name.