### PR TITLE
Simulate an immediately returning Fault in BagRetriever tests

### DIFF
--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/BagRetrieverTest.scala
@@ -106,7 +106,10 @@ class BagRetrieverTest
             .willReturn(
               aResponse()
                 .withStatus(200)
-                .withFault(Fault.CONNECTION_RESET_BY_PEER)))
+                // Simulate an immediately returning Fault
+                // Fault.CONNECTION_RESET_BY_PEER can cause an extended wait
+                // which can cause this test to fail in some environments
+                .withFault(Fault.RANDOM_DATA_THEN_CLOSE)))
         whenReady(getBag(bagRetriever, "digitised", "this-will-fault").failed) {
           _ shouldBe a[Throwable]
         }


### PR DESCRIPTION
This test fails in some environments (my machine, Buildkite) as it can take longer than the timeout (15s) to complete. 