### PR TITLE
use TransformedBaseWork type param on sendT for proper serialisation

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -7,10 +7,7 @@ import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
-import uk.ac.wellcome.models.work.internal.{
-  TransformedBaseWork,
-  UnidentifiedInvisibleWork
-}
+import uk.ac.wellcome.models.work.internal.TransformedBaseWork
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -53,6 +53,8 @@ class MetsTransformerWorkerService[Destination](
       metsLocation <- getMetsLocation(key)
       metsData <- xmlTransformer.transform(metsLocation)
       work <- metsData.toWork(key.version)
+      // We send the generic type param to `sendT` so it serialises uses the
+      // discriminator `type` when read by the recorder.
       _ <- messageSender.sendT[TransformedBaseWork](work).toEither
     } yield ()
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -7,6 +7,10 @@ import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
+import uk.ac.wellcome.models.work.internal.{
+  TransformedBaseWork,
+  UnidentifiedInvisibleWork
+}
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
@@ -49,7 +53,7 @@ class MetsTransformerWorkerService[Destination](
       metsLocation <- getMetsLocation(key)
       metsData <- xmlTransformer.transform(metsLocation)
       work <- metsData.toWork(key.version)
-      _ <- messageSender.sendT(work).toEither
+      _ <- messageSender.sendT[TransformedBaseWork](work).toEither
     } yield ()
 
   private def getMetsLocation(key: Version[String, Int]): Result[MetsLocation] =

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
@@ -85,6 +85,22 @@ class MetsTransformerWorkerServiceTest
     }
   }
 
+  it("sends messages that can be decoded as a TransformedBaseWork") {
+
+    val identifier = randomAlphanumeric(10)
+    val version = randomInt(1, 10)
+    val str = metsXmlWith(identifier, Some(License.CCBYNC))
+
+    withWorkerService {
+      case (QueuePair(queue, _), metsBucket, messageSender, dynamoStore) =>
+        sendWork(str, "mets.xml", dynamoStore, metsBucket, queue, version)
+        eventually {
+          val works = messageSender.getMessages[TransformedBaseWork]
+          works.head shouldBe expectedWork(identifier, version)
+        }
+    }
+  }
+
   private def expectedWork(identifier: String, version: Int): InvisibleWork = {
     val expectedUrl =
       s"https://wellcomelibrary.org/iiif/$identifier/manifest"


### PR DESCRIPTION
I've gone through the codebase and it's not used anywhere else with anything bar a `TransformedBaseWork`.
Not sure where to write the test, might try get the fix in and do that.

Chaars @warrd and @alexwlchan for the explanations on this.