### PR TITLE
add the keyword field back to title

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -108,7 +108,7 @@ case object WorksIndexConfig extends IndexConfig {
   def items(fieldName: String) = objectField(fieldName).fields(
     id(),
     location(),
-    englishTextKeywordField("title"),
+    title,
     keywordField("ontologyType")
   )
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -108,7 +108,7 @@ case object WorksIndexConfig extends IndexConfig {
   def items(fieldName: String) = objectField(fieldName).fields(
     id(),
     location(),
-    title,
+    englishTextKeywordField("title"),
     keywordField("ontologyType")
   )
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -37,6 +37,7 @@ case object WorksIndexConfig extends IndexConfig {
 
   val title = asciifoldingTextFieldWithKeyword("title")
     .fields(
+      keywordField("keyword"),
       textField("english").analyzer(englishAnalyzer.name),
       textField("shingles").analyzer(shingleAsciifoldingAnalyzer.name)
     )


### PR DESCRIPTION
Nicely picked up by rank_eval, but need to put this into the build to catch it earlier. Tests not written as it's relevancy work.

[Used here](https://github.com/wellcomecollection/catalogue/blob/master/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala#L31)

Adds the title mapping to `items` as it'll be needed when we start searching that.