### PR TITLE
Parse Miro IDs that have a suffix

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MiroIdParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MiroIdParser.scala
@@ -1,24 +1,25 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
-import java.lang.Character._
-
 import org.apache.commons.lang3.StringUtils.leftPad
+
+import scala.util.matching.Regex
 
 trait MiroIdParser {
   val miroIdPadToDigits = 7
 
-  def parse089MiroId(miroId: String) = {
-    val strippedMiroId: String = miroId.replace(" ", "")
-    strippedMiroId.toList match {
-      case (head: Char) :: (tail: List[Char])
-          if isLetter(head) && tail.forall(isDigit) =>
-        Some(formatMiroId(head, tail))
-      case _ =>
-        None
+  // Miro IDs start with a prefix letter, followed by a sequence of digits,
+  // and optionally end in a suffix of letters
+  lazy val miroIdRegex: Regex = "^([a-zA-Z])([0-9]+)([a-zA-Z]*)$".r
+
+  def parse089MiroId(miroId: String): Option[String] = {
+    val strippedMiroId = miroId.replace(" ", "")
+    strippedMiroId match {
+      case miroIdRegex(prefix, digits, suffix) =>
+        Some(formatMiroId(prefix.charAt(0), digits, suffix))
+      case _ => None
     }
   }
 
-  private def formatMiroId(head: Char, tail: List[Char]) = {
-    s"$head${leftPad(tail.mkString, miroIdPadToDigits, '0')}"
-  }
+  private def formatMiroId(prefix: Char, digits: String, suffix: String) =
+    s"$prefix${leftPad(digits, miroIdPadToDigits, '0')}$suffix"
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MiroIdParserTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MiroIdParserTest.scala
@@ -14,7 +14,8 @@ class MiroIdParserTest extends AnyFunSpec with Matchers with MiroIdParser {
         ("V 1234567", "V1234567"),
         ("V 1", "V0000001"),
         ("V 12345", "V0012345"),
-        ("L 12345", "L0012345")
+        ("L 12345", "L0012345"),
+        ("V 12345 ER", "V0012345ER")
       )) { (miroId, expectedParsedId) =>
       parse089MiroId(miroId) shouldBe Some(expectedParsedId)
     }


### PR DESCRIPTION
Turns out some Miro IDs have suffixes, and we still want to merge them