### PR TITLE
Embiggen matcher timeouts

### DIFF
--- a/pipeline/matcher/src/main/resources/application.conf
+++ b/pipeline/matcher/src/main/resources/application.conf
@@ -3,6 +3,7 @@ aws.metrics.namespace=${?metrics_namespace}
 aws.sns.topic.arn=${?topic_arn}
 aws.dynamo.tableName=${?dynamo_table}
 aws.dynamo.tableIndex=${?dynamo_index}
+aws.locking.service.dynamo.timeout=${?dynamo_lock_timeout}
 aws.locking.service.dynamo.tableName=${?dynamo_lock_table}
 aws.locking.service.dynamo.tableIndex=${?dynamo_lock_table_index}
 aws.vhs.dynamo.tableName=${?vhs_recorder_dynamo_table_name}

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -26,6 +26,7 @@ import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockingService
 }
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.ExecutionContext
 
@@ -49,7 +50,12 @@ object Main extends WellcomeTypesafeApp {
       dynamoClient,
       DynamoLockDaoConfig(
         DynamoBuilder.buildDynamoConfig(config, namespace = "locking.service"),
-        Duration.ofSeconds(180)
+        Duration.ofSeconds(
+          config
+            .getIntOption("aws.locking.service.dynamo.timeout")
+            .getOrElse(180)
+            .toLong
+        )
       )
     )
 


### PR DESCRIPTION
In the ongoing struggle with the matcher - caused by it needing to extract _huge_ sets of linked works for archives - it appears that this helps things to (eventually) go through