### PR TITLE
Give the images ingestor more memory

### DIFF
--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -21,6 +21,8 @@ module "ingestor_images" {
   cluster_name = aws_ecs_cluster.cluster.name
   cluster_arn  = aws_ecs_cluster.cluster.arn
 
+  memory = 4096
+
   env_vars = {
     metrics_namespace   = "${local.namespace_hyphen}_ingestor_images"
     es_index            = var.es_images_index


### PR DESCRIPTION
It's throwing OutOfMemoryErrors from the enormous archive-related documents