### PR TITLE
Remove container-level memory limits from single-container services

### DIFF
--- a/infrastructure/modules/worker/main.tf
+++ b/infrastructure/modules/worker/main.tf
@@ -59,9 +59,6 @@ module "app_container" {
   name  = var.name
   image = var.image
 
-  cpu    = var.app_cpu
-  memory = var.app_memory
-
   environment = var.env_vars
   secrets     = var.secret_env_vars
 

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -58,16 +58,6 @@ variable "memory" {
   default = 1024
 }
 
-variable "app_cpu" {
-  type    = number
-  default = 512
-}
-
-variable "app_memory" {
-  type    = number
-  default = 1024
-}
-
 variable "use_fargate_spot" {
   type    = bool
   default = false


### PR DESCRIPTION
Because these limits were unspecified in the higher-level modules, they were stuck as their defaults and so task/Fargate-level resource allocations weren't able to be used by the application