### PR TITLE
RelatedWorksService

### DIFF
--- a/.sbt_metadata/relation_embedder.json
+++ b/.sbt_metadata/relation_embedder.json
@@ -2,6 +2,7 @@
   "id" : "relation_embedder",
   "folder" : "pipeline/relation_embedder",
   "dependencyIds" : [
-    "internal_model"
+    "internal_model",
+    "elasticsearch",
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val merger = setupProject(
 lazy val relation_embedder = setupProject(
   project,
   "pipeline/relation_embedder",
-  localDependencies = Seq(internal_model),
+  localDependencies = Seq(internal_model, elasticsearch),
   externalDependencies = CatalogueDependencies.relationEmbedderDependencies)
 
 lazy val recorder = setupProject(

--- a/pipeline/relation_embedder/docker-compose.yml
+++ b/pipeline/relation_embedder/docker-compose.yml
@@ -2,3 +2,15 @@ sqs:
  image: s12v/elasticmq
  ports:
    - "9324:9324"
+
+elasticsearch:
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.6.1"
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  environment:
+    - "http.host=0.0.0.0"
+    - "transport.host=0.0.0.0"
+    - "cluster.name=wellcome"
+    - "logger.level=DEBUG"
+    - "discovery.type=single-node"

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
@@ -1,0 +1,113 @@
+package uk.ac.wellcome.relation_embedder
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  SearchRequest
+}
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+
+case class RelatedWorkRequestBuilder(index: Index,
+                                     path: String,
+                                     maxRelatedWorks: Int = 1000) {
+
+  // To reduce response size and improve Elasticsearch performance we only
+  // return core fields
+  val fieldWhitelist = List(
+    "canonicalId",
+    "version",
+    "ontologyType",
+    "sourceIdentifier.identifierType.id",
+    "sourceIdentifier.identifierType.label",
+    "sourceIdentifier.identifierType.ontologyType",
+    "sourceIdentifier.value",
+    "sourceIdentifier.ontologyType",
+    "data.title",
+    "data.alternativeTitles",
+    "data.collectionPath.path",
+    "data.collectionPath.level.type",
+    "data.collectionPath.label",
+    "data.ontologyType",
+  )
+
+  lazy val request: MultiSearchRequest =
+    multi(
+      childrenRequest,
+      siblingsRequest,
+      ancestorsRequest
+    )
+
+  /**
+    * Query all direct children of the node with the given path.
+    */
+  lazy val childrenRequest: SearchRequest =
+    relatedWorksRequest(
+      pathQuery(path, depth + 1)
+    )
+
+  /**
+    * Query all siblings of the node with the given path.
+    */
+  lazy val siblingsRequest: SearchRequest =
+    relatedWorksRequest(
+      ancestors.lastOption match {
+        case Some(parent) =>
+          must(
+            pathQuery(parent, depth),
+            not(termQuery(field = "data.collectionPath.path", value = path))
+          )
+        case None => matchNoneQuery()
+      }
+    )
+
+  /**
+    * Query all ancestors of the node with the given path.
+    */
+  lazy val ancestorsRequest: SearchRequest =
+    relatedWorksRequest(
+      ancestors match {
+        case Nil => matchNoneQuery()
+        case ancestors =>
+          should(
+            ancestors.map(ancestor => pathQuery(ancestor, pathDepth(ancestor)))
+          )
+      }
+    )
+
+  lazy val ancestors: List[String] =
+    pathAncestors(path)
+
+  lazy val depth: Int =
+    ancestors.length + 1
+
+  def pathQuery(path: String, depth: Int) =
+    must(
+      termQuery(field = "data.collectionPath.path", value = path),
+      termQuery(field = "data.collectionPath.depth", value = depth),
+    )
+
+  def relatedWorksRequest(query: Query): SearchRequest =
+    search(index)
+      .query(query)
+      .from(0)
+      .limit(maxRelatedWorks)
+      .sourceInclude(fieldWhitelist)
+
+  def pathAncestors(path: String): List[String] =
+    tokenize(path) match {
+      case head :+ tail :+ _ =>
+        val ancestor = join(head :+ tail)
+        pathAncestors(ancestor) :+ ancestor
+      case _ => Nil
+    }
+
+  def pathDepth(path: String): Int =
+    tokenize(path).length
+
+  def tokenize(path: String): List[String] =
+    path.split("/").toList
+
+  def join(tokens: List[String]): String =
+    tokens.mkString("/")
+}

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
@@ -1,0 +1,168 @@
+package uk.ac.wellcome.relation_embedder
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.annotation.tailrec
+import scala.util.Try
+
+import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index, Response}
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  MultiSearchResponse,
+  SearchResponse
+}
+import com.sksamuel.elastic4s.requests.searches.SearchHit
+import com.sksamuel.elastic4s.ElasticDsl._
+
+import uk.ac.wellcome.models.work.internal._
+
+import uk.ac.wellcome.models.work.internal.result._
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.json.JsonUtil.fromJson
+
+case class RelatedWork(id: String)
+
+case class RelatedWorks(
+  parts: List[RelatedWork],
+  partOf: List[RelatedWork],
+  precededBy: List[RelatedWork],
+  succeededBy: List[RelatedWork],
+)
+
+trait RelatedWorksService {
+
+  def apply(work: IdentifiedWork): Future[RelatedWorks]
+}
+
+class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
+  implicit ec: ExecutionContext) extends RelatedWorksService {
+
+  type PathToken = Either[Int, String]
+
+  type TokenizedPath = List[PathToken]
+
+  def apply(work: IdentifiedWork): Future[RelatedWorks] =
+    work.data.collectionPath match {
+      case None => Future.successful(RelatedWorks(Nil, Nil, Nil, Nil))
+      case Some(CollectionPath(path, _, _)) =>
+        executeMultiSearchRequest(
+          RelatedWorkRequestBuilder(index, path).request
+        ).flatMap { result =>
+          val works = result.left
+            .map(_.asException)
+            .flatMap { searchResponses =>
+              searchResponses.map { resp =>
+                resp.hits.hits.toList.map(toWork).toResult
+              }.toResult
+            }
+          val relatedWorks = works.flatMap {
+            case List(children, siblings, ancestors) =>
+              Right(toRelatedWorks(path, children, siblings, ancestors))
+            case works =>
+              Left(
+                new Exception(
+                  "Expected multisearch response containing 3 items")
+              )
+          }
+          relatedWorks match {
+            case Right(relatedWorks) => Future.successful(relatedWorks)
+            case Left(err)           => Future.failed(err)
+          }
+        }
+    }
+
+  def executeMultiSearchRequest(request: MultiSearchRequest)
+    : Future[Either[ElasticError, List[SearchResponse]]] =
+    elasticClient
+      .execute(request)
+      .map(toEither)
+      .map { response =>
+        response.right.flatMap {
+          case MultiSearchResponse(items) =>
+            val results = items.map(_.response)
+            val error = results.collectFirst { case Left(err) => err }
+            error match {
+              case Some(err) => Left(err)
+              case None =>
+                Right(
+                  results.collect { case Right(resp) => resp }.toList
+                )
+            }
+        }
+      }
+
+  def toEither[T](response: Response[T]): Either[ElasticError, T] =
+    if (response.isError)
+      Left(response.error)
+    else
+      Right(response.result)
+
+  def toWork(hit: SearchHit): Result[IdentifiedWork] =
+    fromJson[IdentifiedWork](hit.sourceAsString).toEither
+
+  def toRelatedWorks(path: String,
+                     children: List[IdentifiedWork],
+                     siblings: List[IdentifiedWork],
+                     ancestors: List[IdentifiedWork]): RelatedWorks = {
+    val mainPath = tokenizePath(path)
+    val (precededBy, succeededBy) = siblings.sortBy(tokenizePath).partition {
+      work =>
+        tokenizePath(work) match {
+          case None => true
+          case Some(workPath) =>
+            tokenizedPathOrdering.compare(mainPath, workPath) >= 0
+        }
+    }
+    RelatedWorks(
+      parts = children.sortBy(tokenizePath).toRelatedWorks,
+      partOf = ancestors.sortBy(tokenizePath).toRelatedWorks,
+      precededBy = precededBy.toRelatedWorks,
+      succeededBy = succeededBy.toRelatedWorks
+    )
+  }
+
+  def tokenizePath(path: String): TokenizedPath =
+    path.split("/").toList.map { str =>
+      Try(str.toInt).map(Left(_)).getOrElse(Right(str))
+    }
+
+  private def tokenizePath(work: IdentifiedWork): Option[TokenizedPath] =
+    work.data.collectionPath
+      .map { collectionPath =>
+        tokenizePath(collectionPath.path)
+      }
+
+  implicit val tokenizedPathOrdering: Ordering[TokenizedPath] =
+    new Ordering[TokenizedPath] {
+      @tailrec
+      override def compare(a: TokenizedPath, b: TokenizedPath): Int =
+        (a, b) match {
+          case (Nil, Nil) => 0
+          case (Nil, _)   => -1
+          case (_, Nil)   => 1
+          case (xHead :: xTail, yHead :: yTail) =>
+            if (xHead == yHead)
+              compare(xTail, yTail)
+            else
+              pathTokenOrdering.compare(xHead, yHead)
+        }
+    }
+
+  implicit val pathTokenOrdering: Ordering[PathToken] =
+    new Ordering[PathToken] {
+      override def compare(a: PathToken, b: PathToken): Int =
+        (a, b) match {
+          case (Left(a), Left(b))   => a.compareTo(b)
+          case (Right(a), Right(b)) => a.compareTo(b)
+          case (Left(_), _)         => -1
+          case _                    => 1
+        }
+    }
+
+  implicit class WorkListOps(works: List[IdentifiedWork]) {
+
+    def toRelatedWorks: List[RelatedWork] =
+      works.map { work =>
+        RelatedWork(work.sourceIdentifier.toString)
+      }
+  }
+}


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4672

## Description

This introduces a `RelatedWorksService` in `relation_embedder` (similar to what exists in the API code), to get the IDs of related works for any particular work. The current implementation queries the collection path in ElasticSearch. A future implementation may traverse a graph store rather than using paths.