### PR TITLE
Correctly sort archive items containing a mixture of alphanumeric tokens

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
@@ -83,8 +83,7 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
 
   private def tokenizePath(path: String): TokenizedPath =
     path.split("/").toList.map { str =>
-      """\d+|\D+"""
-        .r
+      """\d+|\D+""".r
         .findAllIn(str)
         .toList
         .map { token =>
@@ -119,7 +118,7 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
       @tailrec
       override def compare(a: PathToken, b: PathToken): Int =
         (a, b) match {
-          case (Nil, Nil)   => 0
+          case (Nil, Nil) => 0
           case (Nil, _)   => 1
           case (_, Nil)   => -1
           case (aHead :: aTail, bHead :: bTail) =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -155,4 +155,25 @@ class RelatedWorkServiceTest
       }
     }
   }
+
+  it(
+    "Sorts works consisting of paths with an alphanumeric mixture of tokens") {
+    withLocalWorksIndex { index =>
+      val workA = work("a", CollectionLevel.Collection)
+      val workB1 = work("a/B1", CollectionLevel.Series)
+      val workB2 = work("a/B2", CollectionLevel.Item)
+      val workB10 = work("a/B10", CollectionLevel.Item)
+      storeWorks(index, List(workA, workB2, workB1, workB10))
+      whenReady(service.retrieveRelatedWorks(index, workA)) { result =>
+        result shouldBe Right(
+          RelatedWorks(
+            parts = List(workB1, workB2, workB10),
+            partOf = Nil,
+            precededBy = Nil,
+            succeededBy = Nil,
+          )
+        )
+      }
+    }
+  }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -156,8 +156,7 @@ class RelatedWorkServiceTest
     }
   }
 
-  it(
-    "Sorts works consisting of paths with an alphanumeric mixture of tokens") {
+  it("Sorts works consisting of paths with an alphanumeric mixture of tokens") {
     withLocalWorksIndex { index =>
       val workA = work("a", CollectionLevel.Collection)
       val workB1 = work("a/B1", CollectionLevel.Series)

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
@@ -123,8 +123,7 @@ class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
 
   private def tokenizePath(path: String): TokenizedPath =
     path.split("/").toList.map { str =>
-      """\d+|\D+"""
-        .r
+      """\d+|\D+""".r
         .findAllIn(str)
         .toList
         .map { token =>
@@ -159,7 +158,7 @@ class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
       @tailrec
       override def compare(a: PathToken, b: PathToken): Int =
         (a, b) match {
-          case (Nil, Nil)   => 0
+          case (Nil, Nil) => 0
           case (Nil, _)   => 1
           case (_, Nil)   => -1
           case (aHead :: aTail, bHead :: bTail) =>

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -137,8 +137,7 @@ class RelatedWorksServiceTest
     }
   }
 
-  it(
-    "Sorts works consisting of paths with an alphanumeric mixture of tokens") {
+  it("Sorts works consisting of paths with an alphanumeric mixture of tokens") {
     withLocalWorksIndex { index =>
       val workA = work("a")
       val workB1 = work("a/B1")
@@ -148,7 +147,10 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workA)) { result =>
         result shouldBe
           RelatedWorks(
-            parts = List(relatedWork(workB1), relatedWork(workB2), relatedWork(workB10)),
+            parts = List(
+              relatedWork(workB1),
+              relatedWork(workB2),
+              relatedWork(workB10)),
             partOf = Nil,
             precededBy = Nil,
             succeededBy = Nil,

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -136,4 +136,24 @@ class RelatedWorksServiceTest
       }
     }
   }
+
+  it(
+    "Sorts works consisting of paths with an alphanumeric mixture of tokens") {
+    withLocalWorksIndex { index =>
+      val workA = work("a")
+      val workB1 = work("a/B1")
+      val workB2 = work("a/B2")
+      val workB10 = work("a/B10")
+      storeWorks(index, List(workA, workB2, workB1, workB10))
+      whenReady(service(index)(workA)) { result =>
+        result shouldBe
+          RelatedWorks(
+            parts = List(relatedWork(workB1), relatedWork(workB2), relatedWork(workB10)),
+            partOf = Nil,
+            precededBy = Nil,
+            succeededBy = Nil,
+          )
+      }
+    }
+  }
 }


### PR DESCRIPTION
https://github.com/wellcomecollection/platform/issues/4762

[This](https://wellcomecollection.org/works/xvgk6ws8) works children, for example, are sorted incorrectly. Should be:

```
SA/FPA/A1
SA/FPA/A2
SA/FPA/A3
...
SA/FPA/A10
SA/FPA/A11
...
```