### PR TITLE
partOf should contain nested ancestors

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -14,7 +14,6 @@ import uk.ac.wellcome.platform.api.services.{
   CollectionService,
   ElasticsearchService,
   RelatedWorkService,
-  RelatedWorks,
   WorksService
 }
 import uk.ac.wellcome.platform.api.Tracing
@@ -136,32 +135,16 @@ class WorksController(
     complete(
       ResultResponse(
         context = contextUri,
-        result = DisplayWork(work, includes).copy(
-          collection = tree.map {
-            case (tree, expandedPaths) =>
-              DisplayCollection(tree, expandedPaths)
-          },
-          parts =
-            if (includes.parts)
-              relatedWorks.map { relatedWorks =>
-                relatedWorks.parts.map(DisplayWork(_))
-              } else None,
-          partOf =
-            if (includes.partOf)
-              relatedWorks.map { relatedWorks =>
-                relatedWorks.partOf.map(DisplayWork(_))
-              } else None,
-          precededBy =
-            if (includes.precededBy)
-              relatedWorks.map { relatedWorks =>
-                relatedWorks.precededBy.map(DisplayWork(_))
-              } else None,
-          succeededBy =
-            if (includes.succeededBy)
-              relatedWorks.map { relatedWorks =>
-                relatedWorks.succeededBy.map(DisplayWork(_))
-              } else None,
-        )
+        result = relatedWorks
+          .map(DisplayWork(work, includes, _))
+          .getOrElse(
+            DisplayWork(work, includes).copy(
+              collection = tree.map {
+                case (tree, expandedPaths) =>
+                  DisplayCollection(tree, expandedPaths)
+              }
+            )
+          )
       )
     )
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
@@ -77,9 +77,18 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
         )
       case Nil => None
     }
+
+    // For backwards compatability we include the unnested ancestors ordered
+    // from root to parent, with the parent additionally containing the nested
+    // data
+    val partOf: List[RelatedWork] = ancestors
+      .sortBy(tokenizePath)
+      .dropRight(1)
+      .map(RelatedWork(_)) ::: parent.toList
+
     RelatedWorks(
       parts = Some(children.sortBy(tokenizePath).map(RelatedWork(_))),
-      partOf = Some(parent.toList),
+      partOf = Some(partOf),
       precededBy = Some(precededBy.map(RelatedWork(_))),
       succeededBy = Some(succeededBy.map(RelatedWork(_)))
     )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -77,6 +77,8 @@ class RelatedWorkServiceTest
             parts = Some(Nil),
             partOf = Some(
               List(
+                RelatedWork(workA),
+                RelatedWork(work2),
                 RelatedWork(
                   workE,
                   RelatedWorks.partOf(
@@ -133,6 +135,7 @@ class RelatedWorkServiceTest
             parts = Some(Nil),
             partOf = Some(
               List(
+                RelatedWork(workA),
                 RelatedWork(
                   workE,
                   RelatedWorks.partOf(
@@ -166,6 +169,7 @@ class RelatedWorkServiceTest
             parts = Some(Nil),
             partOf = Some(
               List(
+                RelatedWork(workP.withData(_.copy(items = Nil))),
                 RelatedWork(
                   workQ.withData(_.copy(notes = Nil)),
                   RelatedWorks.partOf(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -57,27 +57,47 @@ class RelatedWorkServiceTest
       whenReady(service.retrieveRelatedWorks(index, work2)) { result =>
         result shouldBe Right(
           RelatedWorks(
-            parts = List(workD, workE),
-            partOf = List(workA),
-            precededBy = List(work1),
-            succeededBy = List(work3, work4),
+            parts = Some(List(RelatedWork(workD), RelatedWork(workE))),
+            partOf =
+              Some(List(RelatedWork(workA, RelatedWorks(partOf = Some(Nil))))),
+            precededBy = Some(List(RelatedWork(work1))),
+            succeededBy = Some(List(RelatedWork(work3), RelatedWork(work4))),
           )
         )
       }
     }
   }
 
-  it(
-    "Retrieves a related works for the given path with ancestors sorted correctly") {
+  it("Retrieves a related works for the given path with nested ancestors") {
     withLocalWorksIndex { index =>
       storeWorks(index)
       whenReady(service.retrieveRelatedWorks(index, workF)) { result =>
         result shouldBe Right(
           RelatedWorks(
-            parts = Nil,
-            partOf = List(workA, work2, workE),
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(Nil),
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workE,
+                  RelatedWorks.partOf(
+                    RelatedWork(
+                      work2,
+                      RelatedWorks(
+                        partOf = Some(
+                          List(
+                            RelatedWork(
+                              workA,
+                              RelatedWorks(partOf = Some(Nil)))
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
         )
       }
@@ -90,10 +110,15 @@ class RelatedWorkServiceTest
       whenReady(service.retrieveRelatedWorks(index, workA)) { result =>
         result.right.get shouldBe
           RelatedWorks(
-            parts = List(work1, work2, work3, work4),
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil
+            parts = Some(
+              List(
+                RelatedWork(work1),
+                RelatedWork(work2),
+                RelatedWork(work3),
+                RelatedWork(work4))),
+            partOf = Some(Nil),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil)
           )
       }
     }
@@ -105,10 +130,22 @@ class RelatedWorkServiceTest
       whenReady(service.retrieveRelatedWorks(index, workF)) { result =>
         result shouldBe Right(
           RelatedWorks(
-            parts = Nil,
-            partOf = List(workA, workE),
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(Nil),
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workE,
+                  RelatedWorks.partOf(
+                    RelatedWork(
+                      workA,
+                      RelatedWorks(partOf = Some(Nil))
+                    )
+                  )
+                )
+              )
+            ),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
         )
       }
@@ -126,13 +163,21 @@ class RelatedWorkServiceTest
       whenReady(service.retrieveRelatedWorks(index, workR)) { result =>
         result shouldBe Right(
           RelatedWorks(
-            parts = Nil,
-            partOf = List(
-              workP.withData(_.copy(items = Nil)),
-              workQ.withData(_.copy(notes = Nil)),
-            ),
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(Nil),
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workQ.withData(_.copy(notes = Nil)),
+                  RelatedWorks.partOf(
+                    RelatedWork(
+                      workP.withData(_.copy(items = Nil)),
+                      RelatedWorks(partOf = Some(Nil))
+                    )
+                  )
+                ),
+              )),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
         )
       }
@@ -144,14 +189,7 @@ class RelatedWorkServiceTest
       val workX = createIdentifiedWork
       storeWorks(index, List(workA, work1, workX))
       whenReady(service.retrieveRelatedWorks(index, workX)) { result =>
-        result shouldBe Right(
-          RelatedWorks(
-            parts = Nil,
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil
-          )
-        )
+        result shouldBe Right(RelatedWorks.nil)
       }
     }
   }
@@ -166,10 +204,14 @@ class RelatedWorkServiceTest
       whenReady(service.retrieveRelatedWorks(index, workA)) { result =>
         result shouldBe Right(
           RelatedWorks(
-            parts = List(workB1, workB2, workB10),
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(
+              List(
+                RelatedWork(workB1),
+                RelatedWork(workB2),
+                RelatedWork(workB10))),
+            partOf = Some(Nil),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
         )
       }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -87,9 +87,7 @@ class RelatedWorkServiceTest
                       RelatedWorks(
                         partOf = Some(
                           List(
-                            RelatedWork(
-                              workA,
-                              RelatedWorks(partOf = Some(Nil)))
+                            RelatedWork(workA, RelatedWorks(partOf = Some(Nil)))
                           )
                         )
                       )
@@ -167,19 +165,18 @@ class RelatedWorkServiceTest
         result shouldBe Right(
           RelatedWorks(
             parts = Some(Nil),
-            partOf = Some(
-              List(
-                RelatedWork(workP.withData(_.copy(items = Nil))),
-                RelatedWork(
-                  workQ.withData(_.copy(notes = Nil)),
-                  RelatedWorks.partOf(
-                    RelatedWork(
-                      workP.withData(_.copy(items = Nil)),
-                      RelatedWorks(partOf = Some(Nil))
-                    )
+            partOf = Some(List(
+              RelatedWork(workP.withData(_.copy(items = Nil))),
+              RelatedWork(
+                workQ.withData(_.copy(notes = Nil)),
+                RelatedWorks.partOf(
+                  RelatedWork(
+                    workP.withData(_.copy(items = Nil)),
+                    RelatedWorks(partOf = Some(Nil))
                   )
-                ),
-              )),
+                )
+              ),
+            )),
             precededBy = Some(Nil),
             succeededBy = Some(Nil),
           )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -710,14 +710,15 @@ class WorksIncludesTest
         sourceIdentifier = createSourceIdentifierWith(value = path)
       )
 
-    val workA = work("a")
-    val workB = work("a/b")
-    val workC = work("a/c")
-    val workD = work("a/d")
-    val workE = work("a/c/e")
+    val work0 = work("0")
+    val workA = work("0/a")
+    val workB = work("0/a/b")
+    val workC = work("0/a/c")
+    val workD = work("0/a/d")
+    val workE = work("0/a/c/e")
 
     def storeWorks(index: Index) =
-      insertIntoElasticsearch(index, workA, workB, workC, workD, workE)
+      insertIntoElasticsearch(index, work0, workA, workB, workC, workD, workE)
 
     it("includes parts") {
       withApi {
@@ -730,11 +731,11 @@ class WorksIncludesTest
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
-              "title": "a/c",
+              "title": "0/a/c",
               "alternativeTitles": [],
               "parts": [{
                 "id": "${workE.canonicalId}",
-                "title": "a/c/e",
+                "title": "0/a/c/e",
                 "alternativeTitles": [],
                 "type": "Work"
               }]
@@ -755,13 +756,20 @@ class WorksIncludesTest
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
-              "title": "a/c",
+              "title": "0/a/c",
               "alternativeTitles": [],
               "partOf": [{
                 "id": "${workA.canonicalId}",
-                "title": "a",
+                "title": "0/a",
                 "alternativeTitles": [],
-                "type": "Work"
+                "type": "Work",
+                "partOf": [{
+                  "id": "${work0.canonicalId}",
+                  "title": "0",
+                  "alternativeTitles": [],
+                  "type": "Work",
+                  "partOf": []
+                }]
               }]
             }
           """
@@ -780,11 +788,11 @@ class WorksIncludesTest
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
-              "title": "a/c",
+              "title": "0/a/c",
               "alternativeTitles": [],
               "precededBy": [{
                 "id": "${workB.canonicalId}",
-                "title": "a/b",
+                "title": "0/a/b",
                 "alternativeTitles": [],
                 "type": "Work"
               }]
@@ -805,11 +813,11 @@ class WorksIncludesTest
             {
               ${singleWorkResult(apiPrefix)},
               "id": "${workC.canonicalId}",
-              "title": "a/c",
+              "title": "0/a/c",
               "alternativeTitles": [],
               "succeededBy": [{
                 "id": "${workD.canonicalId}",
-                "title": "a/d",
+                "title": "0/a/d",
                 "alternativeTitles": [],
                 "type": "Work"
               }]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -758,18 +758,26 @@ class WorksIncludesTest
               "id": "${workC.canonicalId}",
               "title": "0/a/c",
               "alternativeTitles": [],
-              "partOf": [{
-                "id": "${workA.canonicalId}",
-                "title": "0/a",
-                "alternativeTitles": [],
-                "type": "Work",
-                "partOf": [{
+              "partOf": [
+                {
                   "id": "${work0.canonicalId}",
                   "title": "0",
                   "alternativeTitles": [],
+                  "type": "Work"
+                },
+                {
+                  "id": "${workA.canonicalId}",
+                  "title": "0/a",
+                  "alternativeTitles": [],
                   "type": "Work",
-                  "partOf": []
-                }]
+                  "partOf": [{
+                    "id": "${work0.canonicalId}",
+                    "title": "0",
+                    "alternativeTitles": [],
+                    "type": "Work",
+                    "partOf": []
+                  }
+                ]
               }]
             }
           """

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.display.models
 
 import io.circe.generic.extras.JsonKey
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.ac.wellcome.models.work.internal.IdentifiedWork
+import uk.ac.wellcome.models.work.internal.{
+  IdentifiedWork,
+  RelatedWork,
+  RelatedWorks
+}
 
 @Schema(
   name = "Work",
@@ -187,4 +191,42 @@ case object DisplayWork {
 
   def apply(work: IdentifiedWork): DisplayWork =
     DisplayWork(work = work, includes = WorksIncludes())
+
+  def apply(work: IdentifiedWork,
+            includes: WorksIncludes,
+            relatedWorks: RelatedWorks): DisplayWork =
+    DisplayWork(work, includes).copy(
+      parts =
+        if (includes.parts)
+          relatedWorks.parts.map { parts =>
+            parts.map {
+              case RelatedWork(work, related) =>
+                DisplayWork(work, includes, related)
+            }
+          } else None,
+      partOf =
+        if (includes.partOf)
+          relatedWorks.partOf.map { partOf =>
+            partOf.map {
+              case RelatedWork(work, related) =>
+                DisplayWork(work, includes, related)
+            }
+          } else None,
+      precededBy =
+        if (includes.precededBy)
+          relatedWorks.precededBy.map { precededBy =>
+            precededBy.map {
+              case RelatedWork(work, related) =>
+                DisplayWork(work, includes, related)
+            }
+          } else None,
+      succeededBy =
+        if (includes.succeededBy)
+          relatedWorks.succeededBy.map { succeededBy =>
+            succeededBy.map {
+              case RelatedWork(work, related) =>
+                DisplayWork(work, includes, related)
+            }
+          } else None,
+    )
 }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -442,4 +442,65 @@ class DisplayWorkTest
       }
     }
   }
+
+  describe("related works") {
+    val work = createIdentifiedWork
+    val workA = createIdentifiedWork
+    val workB = createIdentifiedWork
+    val workC = createIdentifiedWork
+    val workD = createIdentifiedWork
+    val workE = createIdentifiedWork
+    val workF = createIdentifiedWork
+
+    val relatedWorks = RelatedWorks(
+      partOf = Some(
+        List(
+          RelatedWork(
+            workB,
+            RelatedWorks.partOf(RelatedWork(workA))
+          )
+        )
+      ),
+      parts = Some(List(RelatedWork(workE), RelatedWork(workF))),
+      precededBy = Some(List(RelatedWork(workC))),
+      succeededBy = Some(List(RelatedWork(workD))),
+    )
+
+    it("includes nested partOf") {
+      val displayWork =
+        DisplayWork(work, WorksIncludes(partOf = true), relatedWorks)
+      displayWork.partOf.isEmpty shouldBe false
+      val partOf: List[DisplayWork] = displayWork.partOf.get
+      partOf.map(_.id) shouldBe List(workB.canonicalId)
+      partOf(0).partOf shouldBe Some(List(DisplayWork(workA)))
+    }
+
+    it("includes parts") {
+      val displayWork =
+        DisplayWork(work, WorksIncludes(parts = true), relatedWorks)
+      displayWork.parts shouldBe Some(
+        List(DisplayWork(workE), DisplayWork(workF))
+      )
+    }
+
+    it("includes precededBy") {
+      val displayWork =
+        DisplayWork(work, WorksIncludes(precededBy = true), relatedWorks)
+      displayWork.precededBy shouldBe Some(List(DisplayWork(workC)))
+    }
+
+    it("includes succeededBy") {
+      val displayWork =
+        DisplayWork(work, WorksIncludes(succeededBy = true), relatedWorks)
+      displayWork.succeededBy shouldBe Some(List(DisplayWork(workD)))
+    }
+
+    it("does not include relations when not requested") {
+      val displayWork = DisplayWork(work, WorksIncludes(), relatedWorks)
+      displayWork.parts shouldBe None
+      displayWork.partOf shouldBe None
+      displayWork.precededBy shouldBe None
+      displayWork.succeededBy shouldBe None
+    }
+  }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.models.work.internal
+
+/** Holds relations for a particular work. This is a recursive data structure,
+  * so related works can in turn hold their relations. An Option[List[_]] is
+  * used to represent cases both where the work has no relations and where the
+  * relations are not currently known.
+  * 
+  * @param parts Children of the work
+  * @param partOf Parents of the work
+  * @param precededBy Siblings preceding the work
+  * @param succeededBy Siblings following the work
+  */
+case class RelatedWorks(
+  parts: Option[List[RelatedWork]] = None,
+  partOf: Option[List[RelatedWork]] = None,
+  precededBy: Option[List[RelatedWork]] = None,
+  succeededBy: Option[List[RelatedWork]] = None,
+)
+
+object RelatedWorks {
+  def unknown: RelatedWorks =
+    RelatedWorks(
+      parts = None,
+      partOf = None,
+      precededBy = None,
+      succeededBy = None
+    )
+
+  def nil: RelatedWorks =
+    RelatedWorks(
+      parts = Some(Nil),
+      partOf = Some(Nil),
+      precededBy = Some(Nil),
+      succeededBy = Some(Nil)
+    )
+
+  def partOf(relatedWork: RelatedWork,
+             default: Option[List[RelatedWork]] = None): RelatedWorks =
+    RelatedWorks(
+      parts = default,
+      partOf = Some(List(relatedWork)),
+      precededBy = default,
+      succeededBy = default
+    )
+}
+
+case class RelatedWork(
+  work: IdentifiedWork,
+  relatedWorks: RelatedWorks
+)
+
+object RelatedWork {
+  def apply(work: IdentifiedWork): RelatedWork =
+    RelatedWork(work, RelatedWorks.unknown)
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
@@ -4,7 +4,7 @@ package uk.ac.wellcome.models.work.internal
   * so related works can in turn hold their relations. An Option[List[_]] is
   * used to represent cases both where the work has no relations and where the
   * relations are not currently known.
-  * 
+  *
   * @param parts Children of the work
   * @param partOf Parents of the work
   * @param precededBy Siblings preceding the work


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4671

## Description

The `partOf` field currently incorrectly contains an array of all ancestors, but should contain only direct parents, with early ancestors nested within.

Here we allow relation fields to be nested, currently with only `partOf` containing nesting.

NOTE:  For backwards compatibility we include the unnested ancestors ordered from root to parent, with the parent additionally containing the nested data. This will be removed once the front end is switched over.