### PR TITLE
Reduce staging desired task count to 1

### DIFF
--- a/api/terraform/catalogue_api_staging_20200721/main.tf
+++ b/api/terraform/catalogue_api_staging_20200721/main.tf
@@ -4,7 +4,7 @@ module "catalogue_api_prod_20200520" {
   environment        = local.environment
   instance           = "20200721"
   listener_port      = 1235
-  desired_task_count = 3
+  desired_task_count = 1
 
   namespace   = local.namespace
   vpc_id      = local.vpc_id


### PR DESCRIPTION
afaict we don't want/need 3 instances of the staging API (?)