### PR TITLE
Fix staging api Terraform module name

### DIFF
--- a/api/terraform/catalogue_api_staging_20200721/main.tf
+++ b/api/terraform/catalogue_api_staging_20200721/main.tf
@@ -1,4 +1,4 @@
-module "catalogue_api_prod_20200520" {
+module "catalogue_api_staging_20200520" {
   source = "../modules/stack"
 
   environment        = local.environment


### PR DESCRIPTION
I can't apply the changes from https://github.com/wellcomecollection/catalogue/pull/828 because the staging and prod modules have the same name.

I also realised the dates in the module names don't match the directory/namespace but I don't really want to mess around with `state mv`ing to sort that for prod without downtime...