### PR TITLE
Relation embedder core logic

### DIFF
--- a/.sbt_metadata/relation_embedder.json
+++ b/.sbt_metadata/relation_embedder.json
@@ -3,6 +3,7 @@
   "folder" : "pipeline/relation_embedder",
   "dependencyIds" : [
     "internal_model",
-    "elasticsearch"
+    "elasticsearch",
+    "pipeline_storage"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val merger = setupProject(
 lazy val relation_embedder = setupProject(
   project,
   "pipeline/relation_embedder",
-  localDependencies = Seq(internal_model, elasticsearch),
+  localDependencies = Seq(internal_model, elasticsearch, pipeline_storage),
   externalDependencies = CatalogueDependencies.relationEmbedderDependencies
 )
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala
@@ -1,5 +1,8 @@
 package uk.ac.wellcome.models.work.internal
 
+import scala.util.Try
+import scala.annotation.tailrec
+
 /** Holds relations for a particular work. This is a recursive data structure,
   * so related works can in turn hold their relations. An Option[List[_]] is
   * used to represent cases both where the work has no relations and where the
@@ -15,6 +18,11 @@ case class RelatedWorks(
   partOf: Option[List[RelatedWork]] = None,
   precededBy: Option[List[RelatedWork]] = None,
   succeededBy: Option[List[RelatedWork]] = None,
+)
+
+case class RelatedWork(
+  work: IdentifiedWork,
+  relatedWorks: RelatedWorks
 )
 
 object RelatedWorks {
@@ -42,12 +50,110 @@ object RelatedWorks {
       precededBy = default,
       succeededBy = default
     )
-}
 
-case class RelatedWork(
-  work: IdentifiedWork,
-  relatedWorks: RelatedWorks
-)
+  type TokenizedPath = List[PathToken]
+  type PathToken = List[PathTokenPart]
+  type PathTokenPart = Either[Int, String]
+
+  /** Creates RelatedWorks from unnested and unsorted data.
+    *
+    * @param path Children of the work
+    * @param children Direct descendents of the work
+    * @param siblings Siblings of the work
+    * @param ancestors Ancestors of the work
+    */
+  def apply(path: String,
+            children: List[IdentifiedWork],
+            siblings: List[IdentifiedWork],
+            ancestors: List[IdentifiedWork]): RelatedWorks = {
+    val mainPath = tokenizePath(path)
+    val (precededBy, succeededBy) = siblings.sortBy(tokenizePath).partition {
+      work =>
+        tokenizePath(work) match {
+          case None => true
+          case Some(workPath) =>
+            tokenizedPathOrdering.compare(mainPath, workPath) >= 0
+        }
+    }
+    val parent = ancestors.sortBy(tokenizePath) match {
+      case head :: tail =>
+        Some(
+          tail.foldLeft(RelatedWork(head, RelatedWorks(partOf = Some(Nil)))) {
+            case (relatedWork, work) =>
+              RelatedWork(work, RelatedWorks.partOf(relatedWork))
+          }
+        )
+      case Nil => None
+    }
+
+    RelatedWorks(
+      parts = Some(children.sortBy(tokenizePath).map(RelatedWork(_))),
+      partOf = Some(parent.toList),
+      precededBy = Some(precededBy.map(RelatedWork(_))),
+      succeededBy = Some(succeededBy.map(RelatedWork(_)))
+    )
+  }
+
+  private def tokenizePath(path: String): TokenizedPath =
+    path.split("/").toList.map { str =>
+      """\d+|\D+""".r
+        .findAllIn(str)
+        .toList
+        .map { token =>
+          Try(token.toInt).map(Left(_)).getOrElse(Right(token))
+        }
+    }
+
+  private def tokenizePath(work: IdentifiedWork): Option[TokenizedPath] =
+    work.data.collectionPath
+      .map { collectionPath =>
+        tokenizePath(collectionPath.path)
+      }
+
+  implicit val tokenizedPathOrdering: Ordering[TokenizedPath] =
+    new Ordering[TokenizedPath] {
+      @tailrec
+      override def compare(a: TokenizedPath, b: TokenizedPath): Int =
+        (a, b) match {
+          case (Nil, Nil) => 0
+          case (Nil, _)   => -1
+          case (_, Nil)   => 1
+          case (xHead :: xTail, yHead :: yTail) =>
+            if (xHead == yHead)
+              compare(xTail, yTail)
+            else
+              pathTokenOrdering.compare(xHead, yHead)
+        }
+    }
+
+  implicit val pathTokenOrdering: Ordering[PathToken] =
+    new Ordering[PathToken] {
+      @tailrec
+      override def compare(a: PathToken, b: PathToken): Int =
+        (a, b) match {
+          case (Nil, Nil) => 0
+          case (Nil, _)   => 1
+          case (_, Nil)   => -1
+          case (aHead :: aTail, bHead :: bTail) =>
+            val comparison = pathTokenPartOrdering.compare(aHead, bHead)
+            if (comparison == 0)
+              compare(aTail, bTail)
+            else
+              comparison
+        }
+    }
+
+  implicit val pathTokenPartOrdering: Ordering[PathTokenPart] =
+    new Ordering[PathTokenPart] {
+      override def compare(a: PathTokenPart, b: PathTokenPart): Int =
+        (a, b) match {
+          case (Left(a), Left(b))   => a.compareTo(b)
+          case (Right(a), Right(b)) => a.compareTo(b)
+          case (Left(_), _)         => -1
+          case _                    => 1
+        }
+    }
+}
 
 object RelatedWork {
   def apply(work: IdentifiedWork): RelatedWork =

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
@@ -18,7 +18,9 @@ object Main extends WellcomeTypesafeApp {
 
     new RelationEmbedderWorkerService(
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      msgSender = ???
+      msgSender = ???,
+      workRetriever = ???,
+      relatedWorksService = ???
     )
   }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
@@ -20,7 +20,8 @@ object Main extends WellcomeTypesafeApp {
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       msgSender = ???,
       workRetriever = ???,
-      relatedWorksService = ???
+      workIndexer = ???,
+      relatedWorksService = ???,
     )
   }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
@@ -97,7 +97,7 @@ case class RelatedWorkRequestBuilder(index: Index,
     */
   lazy val parentQuery: Query =
     ancestors.lastOption match {
-      case None => matchNoneQuery()
+      case None         => matchNoneQuery()
       case Some(parent) => pathQuery(parent, depth - 1)
     }
 

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorkRequestBuilder.scala
@@ -14,7 +14,7 @@ case class RelatedWorkRequestBuilder(index: Index,
 
   // To reduce response size and improve Elasticsearch performance we only
   // return core fields
-  val fieldWhitelist = List(
+  val relationsFieldWhitelist = List(
     "canonicalId",
     "version",
     "ontologyType",
@@ -31,48 +31,83 @@ case class RelatedWorkRequestBuilder(index: Index,
     "data.ontologyType",
   )
 
-  lazy val request: MultiSearchRequest =
+  // To reduce response size and improve Elasticsearch performance we only
+  // return core fields
+  val otherAffectedWorksFieldWhitelist = List(
+    "sourceIdentifier.identifierType.id",
+    "sourceIdentifier.identifierType.label",
+    "sourceIdentifier.identifierType.ontologyType",
+    "sourceIdentifier.value",
+    "sourceIdentifier.ontologyType",
+  )
+
+  lazy val relationsRequest: MultiSearchRequest =
     multi(
-      childrenRequest,
-      siblingsRequest,
-      ancestorsRequest
+      relatedWorksRequest(childrenQuery),
+      relatedWorksRequest(siblingsQuery),
+      relatedWorksRequest(ancestorsQuery)
     )
+
+  lazy val otherAffectedWorksRequest: SearchRequest =
+    search(index)
+      .query {
+        should(
+          siblingsQuery,
+          parentQuery,
+          descendentsQuery
+        )
+      }
+      .from(0)
+      .limit(maxRelatedWorks)
+      .sourceInclude(otherAffectedWorksFieldWhitelist)
 
   /**
     * Query all direct children of the node with the given path.
     */
-  lazy val childrenRequest: SearchRequest =
-    relatedWorksRequest(
-      pathQuery(path, depth + 1)
-    )
+  lazy val childrenQuery: Query =
+    pathQuery(path, depth + 1)
 
   /**
     * Query all siblings of the node with the given path.
     */
-  lazy val siblingsRequest: SearchRequest =
-    relatedWorksRequest(
-      ancestors.lastOption match {
-        case Some(parent) =>
-          must(
-            pathQuery(parent, depth),
-            not(termQuery(field = "data.collectionPath.path", value = path))
-          )
-        case None => matchNoneQuery()
-      }
-    )
+  lazy val siblingsQuery: Query =
+    ancestors.lastOption match {
+      case Some(parent) =>
+        must(
+          pathQuery(parent, depth),
+          not(termQuery(field = "data.collectionPath.path", value = path))
+        )
+      case None => matchNoneQuery()
+    }
 
   /**
     * Query all ancestors of the node with the given path.
     */
-  lazy val ancestorsRequest: SearchRequest =
-    relatedWorksRequest(
-      ancestors match {
-        case Nil => matchNoneQuery()
-        case ancestors =>
-          should(
-            ancestors.map(ancestor => pathQuery(ancestor, pathDepth(ancestor)))
-          )
-      }
+  lazy val ancestorsQuery: Query =
+    ancestors match {
+      case Nil => matchNoneQuery()
+      case ancestors =>
+        should(
+          ancestors.map(ancestor => pathQuery(ancestor, pathDepth(ancestor)))
+        )
+    }
+
+  /**
+    * Query the parent of the node with the given path.
+    */
+  lazy val parentQuery: Query =
+    ancestors.lastOption match {
+      case None => matchNoneQuery()
+      case Some(parent) => pathQuery(parent, depth - 1)
+    }
+
+  /**
+    * Query all descendents of the node with the given path.
+    */
+  lazy val descendentsQuery: Query =
+    must(
+      termQuery(field = "data.collectionPath.path", value = path),
+      not(termQuery(field = "data.collectionPath.depth", value = depth)),
     )
 
   lazy val ancestors: List[String] =
@@ -92,7 +127,7 @@ case class RelatedWorkRequestBuilder(index: Index,
       .query(query)
       .from(0)
       .limit(maxRelatedWorks)
-      .sourceInclude(fieldWhitelist)
+      .sourceInclude(relationsFieldWhitelist)
 
   def pathAncestors(path: String): List[String] =
     tokenize(path) match {

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelatedWorksService.scala
@@ -6,8 +6,8 @@ import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index, Response}
 import com.sksamuel.elastic4s.requests.searches.{
   MultiSearchRequest,
   MultiSearchResponse,
-  SearchResponse,
-  SearchRequest
+  SearchRequest,
+  SearchResponse
 }
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.sksamuel.elastic4s.ElasticDsl._
@@ -28,7 +28,8 @@ trait RelatedWorksService {
     * @param work The work
     * @return The IDs of the other works to denormalise
     */
-  def getOtherAffectedWorks(work: IdentifiedBaseWork): Future[List[SourceIdentifier]]
+  def getOtherAffectedWorks(
+    work: IdentifiedBaseWork): Future[List[SourceIdentifier]]
 
   /** For a given work return all its relations.
     *
@@ -42,7 +43,8 @@ class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
   implicit ec: ExecutionContext)
     extends RelatedWorksService {
 
-  def getOtherAffectedWorks(work: IdentifiedBaseWork): Future[List[SourceIdentifier]] =
+  def getOtherAffectedWorks(
+    work: IdentifiedBaseWork): Future[List[SourceIdentifier]] =
     work match {
       case work: IdentifiedWork =>
         work.data.collectionPath match {
@@ -51,19 +53,19 @@ class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
             executeSearchRequest(
               RelatedWorkRequestBuilder(index, path).otherAffectedWorksRequest
             ).flatMap { result =>
-              val works = result
-                .left
+              val works = result.left
                 .map(_.asException)
                 .flatMap { resp =>
                   resp.hits.hits.toList.map(toAffectedWork).toResult
                 }
               works match {
-                case Right(works) => Future.successful(works.map(_.sourceIdentifier))
-                case Left(err)    => Future.failed(err)
+                case Right(works) =>
+                  Future.successful(works.map(_.sourceIdentifier))
+                case Left(err) => Future.failed(err)
               }
             }
         }
-        case _ => Future.successful(Nil)
+      case _ => Future.successful(Nil)
     }
 
   def getRelations(work: IdentifiedBaseWork): Future[RelatedWorks] =
@@ -97,12 +99,12 @@ class PathQueryRelatedWorksService(elasticClient: ElasticClient, index: Index)(
               }
             }
         }
-        case _ => Future.successful(RelatedWorks.nil)
+      case _ => Future.successful(RelatedWorks.nil)
     }
 
   private def executeSearchRequest(
     request: SearchRequest): Future[Either[ElasticError, SearchResponse]] =
-      elasticClient.execute(request).map(toEither)
+    elasticClient.execute(request).map(toEither)
 
   private def executeMultiSearchRequest(request: MultiSearchRequest)
     : Future[Either[ElasticError, List[SearchResponse]]] =

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -1,14 +1,16 @@
 package uk.ac.wellcome.relation_embedder
 
-import akka.Done
-
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import akka.Done
+import akka.stream.scaladsl._
+import akka.stream.Materializer
 
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.pipeline_storage.Retriever
+import uk.ac.wellcome.pipeline_storage.{Indexer, Retriever}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.json.JsonUtil._
 
@@ -16,14 +18,38 @@ class RelationEmbedderWorkerService[MsgDestination](
   sqsStream: SQSStream[NotificationMessage],
   msgSender: MessageSender[MsgDestination],
   workRetriever: Retriever[IdentifiedBaseWork],
+  workIndexer: Indexer[IdentifiedBaseWork],
   relatedWorksService: RelatedWorksService,
-)(implicit ec: ExecutionContext) extends Runnable {
-
+  batchSize: Int = 20,
+  flushInterval: FiniteDuration = 3 seconds
+)(implicit ec: ExecutionContext, materializer: Materializer) extends Runnable { 
   def run(): Future[Done] =
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
   def processMessage(message: NotificationMessage): Future[Unit] =
-    for {
-      work <- workRetriever(message.body)
-    } yield ()
+    Source.future(workRetriever(message.body))
+      .mapAsync(1) { work =>
+        relatedWorksService
+          .getOtherAffectedWorks(work)
+          .map(work.sourceIdentifier :: _)
+      }
+      .mapConcat(sourceIdentifier => sourceIdentifier)
+      .mapAsync(3) { sourceIdentifier =>
+        workRetriever(sourceIdentifier.toString)
+      }
+      .mapAsync(3) { work =>
+        relatedWorksService.getRelations(work).map(relations => (work, relations))
+      }
+      .map { case (work, relations) =>
+        // TODO: here we should add the relations to the work model for storage.
+        // This requires model changes which have not been made yet
+        val denormalisedWork: IdentifiedBaseWork = ???
+        denormalisedWork
+      }
+      .groupedWithin(batchSize, flushInterval)
+      .map { works =>
+        workIndexer.index(works)
+      }
+      .runForeach(_ => ())
+      .map(_ => ())
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -2,17 +2,28 @@ package uk.ac.wellcome.relation_embedder
 
 import akka.Done
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
+
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.pipeline_storage.Retriever
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.json.JsonUtil._
 
 class RelationEmbedderWorkerService[MsgDestination](
   sqsStream: SQSStream[NotificationMessage],
-  msgSender: MessageSender[MsgDestination]
-) extends Runnable {
+  msgSender: MessageSender[MsgDestination],
+  workRetriever: Retriever[IdentifiedBaseWork],
+  relatedWorksService: RelatedWorksService,
+)(implicit ec: ExecutionContext) extends Runnable {
 
   def run(): Future[Done] =
-    ???
+    sqsStream.foreach(this.getClass.getSimpleName, processMessage)
+
+  def processMessage(message: NotificationMessage): Future[Unit] =
+    for {
+      work <- workRetriever(message.body)
+    } yield ()
 }

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -51,9 +51,6 @@ class RelatedWorksServiceTest
   val works =
     List(workA, workB, workC, workD, workE, workF, work4, work3, work2, work1)
 
-  def relatedWork(work: IdentifiedWork) =
-    RelatedWork(work.sourceIdentifier.toString)
-
   it(
     "Retrieves a related works for the given path with children and siblings sorted correctly") {
     withLocalWorksIndex { index =>
@@ -61,10 +58,10 @@ class RelatedWorksServiceTest
       whenReady(service(index)(work2)) { result =>
         result shouldBe
           RelatedWorks(
-            parts = List(relatedWork(workD), relatedWork(workE)),
-            partOf = List(relatedWork(workA)),
-            precededBy = List(relatedWork(work1)),
-            succeededBy = List(relatedWork(work3), relatedWork(work4)),
+            parts = Some(List(RelatedWork(workD), RelatedWork(workE))),
+            partOf = Some(List(RelatedWork(workA, RelatedWorks(partOf = Some(Nil))))),
+            precededBy = Some(List(RelatedWork(work1))),
+            succeededBy = Some(List(RelatedWork(work3), RelatedWork(work4))),
           )
       }
     }
@@ -77,11 +74,28 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workF)) { relatedWorks =>
         relatedWorks shouldBe
           RelatedWorks(
-            parts = Nil,
-            partOf =
-              List(relatedWork(workA), relatedWork(work2), relatedWork(workE)),
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(Nil),
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workE,
+                  RelatedWorks.partOf(
+                    RelatedWork(
+                      work2,
+                      RelatedWorks(
+                        partOf = Some(
+                          List(
+                            RelatedWork(workA, RelatedWorks(partOf = Some(Nil)))
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
       }
     }
@@ -93,14 +107,14 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workA)) { relatedWorks =>
         relatedWorks shouldBe
           RelatedWorks(
-            parts = List(
-              relatedWork(work1),
-              relatedWork(work2),
-              relatedWork(work3),
-              relatedWork(work4)),
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil
+            parts = Some(List(
+              RelatedWork(work1),
+              RelatedWork(work2),
+              RelatedWork(work3),
+              RelatedWork(work4))),
+            partOf = Some(Nil),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil)
           )
       }
     }
@@ -112,10 +126,23 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workF)) { result =>
         result shouldBe
           RelatedWorks(
-            parts = Nil,
-            partOf = List(relatedWork(workA), relatedWork(workE)),
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(Nil),
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workE,
+                  RelatedWorks(
+                    partOf = Some(
+                      List(
+                        RelatedWork(workA, RelatedWorks(partOf = Some(Nil)))
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
       }
     }
@@ -128,10 +155,10 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workX)) { result =>
         result shouldBe
           RelatedWorks(
-            parts = Nil,
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil
+            parts = Some(Nil),
+            partOf = Some(Nil),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil)
           )
       }
     }
@@ -147,13 +174,13 @@ class RelatedWorksServiceTest
       whenReady(service(index)(workA)) { result =>
         result shouldBe
           RelatedWorks(
-            parts = List(
-              relatedWork(workB1),
-              relatedWork(workB2),
-              relatedWork(workB10)),
-            partOf = Nil,
-            precededBy = Nil,
-            succeededBy = Nil,
+            parts = Some(List(
+              RelatedWork(workB1),
+              RelatedWork(workB2),
+              RelatedWork(workB10))),
+            partOf = Some(Nil),
+            precededBy = Some(Nil),
+            succeededBy = Some(Nil),
           )
       }
     }

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -78,7 +78,7 @@ class RelatedWorksServiceTest
       }
     }
 
-    it("Returns no affectedd works when work is not part of a collection") {
+    it("Returns no affected works when work is not part of a collection") {
       withLocalWorksIndex { index =>
         val workX = createIdentifiedWork
         storeWorks(index, List(workA, work1, workX))

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -55,7 +55,7 @@ class RelatedWorksServiceTest
     "Retrieves a related works for the given path with children and siblings sorted correctly") {
     withLocalWorksIndex { index =>
       storeWorks(index)
-      whenReady(service(index)(work2)) { result =>
+      whenReady(service(index).getRelations(work2)) { result =>
         result shouldBe
           RelatedWorks(
             parts = Some(List(RelatedWork(workD), RelatedWork(workE))),
@@ -71,7 +71,7 @@ class RelatedWorksServiceTest
     "Retrieves a related works for the given path with ancestors sorted correctly") {
     withLocalWorksIndex { index =>
       storeWorks(index)
-      whenReady(service(index)(workF)) { relatedWorks =>
+      whenReady(service(index).getRelations(workF)) { relatedWorks =>
         relatedWorks shouldBe
           RelatedWorks(
             parts = Some(Nil),
@@ -104,7 +104,7 @@ class RelatedWorksServiceTest
   it("Retrieves relations correctly from root position") {
     withLocalWorksIndex { index =>
       storeWorks(index)
-      whenReady(service(index)(workA)) { relatedWorks =>
+      whenReady(service(index).getRelations(workA)) { relatedWorks =>
         relatedWorks shouldBe
           RelatedWorks(
             parts = Some(List(
@@ -123,7 +123,7 @@ class RelatedWorksServiceTest
   it("Ignores missing ancestors") {
     withLocalWorksIndex { index =>
       storeWorks(index, List(workA, workB, workC, workD, workE, workF))
-      whenReady(service(index)(workF)) { result =>
+      whenReady(service(index).getRelations(workF)) { result =>
         result shouldBe
           RelatedWorks(
             parts = Some(Nil),
@@ -152,7 +152,7 @@ class RelatedWorksServiceTest
     withLocalWorksIndex { index =>
       val workX = createIdentifiedWork
       storeWorks(index, List(workA, work1, workX))
-      whenReady(service(index)(workX)) { result =>
+      whenReady(service(index).getRelations(workX)) { result =>
         result shouldBe
           RelatedWorks(
             parts = Some(Nil),
@@ -171,7 +171,7 @@ class RelatedWorksServiceTest
       val workB2 = work("a/B2")
       val workB10 = work("a/B10")
       storeWorks(index, List(workA, workB2, workB1, workB10))
-      whenReady(service(index)(workA)) { result =>
+      whenReady(service(index).getRelations(workA)) { result =>
         result shouldBe
           RelatedWorks(
             parts = Some(List(

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -65,7 +65,8 @@ class RelatedWorksServiceTest
       }
     }
 
-    it("Retrieves the whole remaining tree when getting affected works from root position") {
+    it(
+      "Retrieves the whole remaining tree when getting affected works from root position") {
       withLocalWorksIndex { index =>
         storeWorks(index)
         whenReady(service(index).getOtherAffectedWorks(workA)) { result =>
@@ -97,7 +98,8 @@ class RelatedWorksServiceTest
           result shouldBe
             RelatedWorks(
               parts = Some(List(RelatedWork(workD), RelatedWork(workE))),
-              partOf = Some(List(RelatedWork(workA, RelatedWorks(partOf = Some(Nil))))),
+              partOf = Some(
+                List(RelatedWork(workA, RelatedWorks(partOf = Some(Nil))))),
               precededBy = Some(List(RelatedWork(work1))),
               succeededBy = Some(List(RelatedWork(work3), RelatedWork(work4))),
             )
@@ -123,7 +125,9 @@ class RelatedWorksServiceTest
                         RelatedWorks(
                           partOf = Some(
                             List(
-                              RelatedWork(workA, RelatedWorks(partOf = Some(Nil)))
+                              RelatedWork(
+                                workA,
+                                RelatedWorks(partOf = Some(Nil)))
                             )
                           )
                         )
@@ -145,11 +149,12 @@ class RelatedWorksServiceTest
         whenReady(service(index).getRelations(workA)) { relatedWorks =>
           relatedWorks shouldBe
             RelatedWorks(
-              parts = Some(List(
-                RelatedWork(work1),
-                RelatedWork(work2),
-                RelatedWork(work3),
-                RelatedWork(work4))),
+              parts = Some(
+                List(
+                  RelatedWork(work1),
+                  RelatedWork(work2),
+                  RelatedWork(work3),
+                  RelatedWork(work4))),
               partOf = Some(Nil),
               precededBy = Some(Nil),
               succeededBy = Some(Nil)
@@ -212,10 +217,11 @@ class RelatedWorksServiceTest
         whenReady(service(index).getRelations(workA)) { result =>
           result shouldBe
             RelatedWorks(
-              parts = Some(List(
-                RelatedWork(workB1),
-                RelatedWork(workB2),
-                RelatedWork(workB10))),
+              parts = Some(
+                List(
+                  RelatedWork(workB1),
+                  RelatedWork(workB2),
+                  RelatedWork(workB10))),
               partOf = Some(Nil),
               precededBy = Some(Nil),
               succeededBy = Some(Nil),


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4672

## Description

Includes the main logic for the relation embedder:

* Given some work at the input, query for all works in the tree that will require denormalisation
* In turn fetch each work from the store, and query for their relations
* Add the relation data to the works and store them in the output index

NOTE: model changes to `Work` are required for this with have not yet been made, so there is no tests yet for the `RelationEmbedderWorkerService`