### PR TITLE
make elastic index creator more sensible

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexCreator.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticsearchIndexCreator.scala
@@ -3,18 +3,11 @@ package uk.ac.wellcome.elasticsearch
 import com.sksamuel.elastic4s.ElasticApi.createIndex
 import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.analysis.Analysis
-import com.sksamuel.elastic4s.requests.indexes.{
-  CreateIndexResponse,
-  PutMappingResponse
-}
-import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.elasticsearch.elastic4s.searchtemplate.PutSearchTemplateRequest
 import uk.ac.wellcome.elasticsearch.elastic4s.WecoElasticDsl._
 import uk.ac.wellcome.elasticsearch.model.SearchTemplate
-
 import scala.concurrent.{ExecutionContext, Future}
 
 class ElasticsearchIndexCreator(
@@ -23,18 +16,29 @@ class ElasticsearchIndexCreator(
   config: IndexConfig)(implicit ec: ExecutionContext)
     extends Logging {
 
-  def create: Future[Unit] = {
-    create(
-      index = index,
-      mapping = config.mapping,
-      config.analysis,
-      config.searchTemplate)
+  def create: Future[Unit] = createOrUpdate
+
+  val mapping = config.mapping
+  val analysis = config.analysis
+  val searchTemplate = config.searchTemplate
+
+  private def exists = elasticClient.execute(indexExists(index.name))
+
+  private def createOrUpdate: Future[Unit] = {
+    for {
+      existsResp <- exists
+      createResp <- if (existsResp.result.isExists) {
+        update
+      } else {
+        put
+      }
+      resp <- searchTemplate
+        .map(template => putSearchTemplate(template))
+        .getOrElse(Future.successful(createResp))
+    } yield { handleEsError(resp) }
   }
 
-  private def create(index: Index,
-                     mapping: MappingDefinition,
-                     analysis: Analysis,
-                     searchTemplate: Option[SearchTemplate]): Future[Unit] =
+  private def put =
     elasticClient
       .execute {
         createIndex(index.name)
@@ -58,62 +62,25 @@ class ElasticsearchIndexCreator(
           // they end up having more than 1000 fields, so we increase them to 2000
           .settings(Map("mapping.total_fields.limit" -> 2000))
       }
-      .flatMap { response: Response[CreateIndexResponse] =>
-        if (response.isError) {
-          if (response.error.`type` == "resource_already_exists_exception" || response.error.`type` == "index_already_exists_exception") {
-            info(s"Index $index already exists")
-            update(index, mappingDefinition = mapping)
-          } else {
-            Future.failed(
-              throw new RuntimeException(
-                s"Failed creating index $index: ${response.error}"
-              )
-            )
-          }
-        } else {
-          searchTemplate.map { template =>
-            elasticClient.execute {
-              // We use an index namespace on templates to know
-              // which index they will work against
-              PutSearchTemplateRequest(
-                s"${index.name}__${template.id}",
-                template.query)
-            } map { response =>
-              if (response.isError) {
-                Future.failed(
-                  throw new RuntimeException(
-                    s"Failed creating search template ${template.id}: ${response.error}"
-                  )
-                )
-              }
-            }
-          } getOrElse Future.successful(response)
-        }
-      }
-      .map { _ =>
-        info("Index updated successfully")
-      }
 
-  private def update(index: Index,
-                     mappingDefinition: MappingDefinition): Future[Unit] =
+  private def putSearchTemplate(template: SearchTemplate) =
+    elasticClient.execute {
+      // We use an index namespace on templates to know
+      // which index they will work against
+      PutSearchTemplateRequest(s"${index.name}__${template.id}", template.query)
+    }
+
+  private def update =
     elasticClient
-      .execute {
+      .execute(
         putMapping(index.name)
-          .dynamic(mappingDefinition.dynamic.getOrElse(DynamicMapping.Strict))
-          .as(mappingDefinition.fields)
-      }
-      .recover {
-        case e: Throwable =>
-          error(s"Failed updating index $index", e)
-          throw e
-      }
-      .map { response: Response[PutMappingResponse] =>
-        if (response.isError) {
-          throw new RuntimeException(s"Failed updating index: $response")
-        }
-        response
-      }
-      .map { _ =>
-        info("Successfully applied new mapping")
-      }
+          .dynamic(mapping.dynamic.getOrElse(DynamicMapping.Strict))
+          .as(mapping.fields)
+      )
+
+  private def handleEsError[T](resp: Response[T]) =
+    if (resp.isError) {
+      throw new RuntimeException(
+        s"Index creation error on index:${index.name} resp: $resp")
+    }
 }


### PR DESCRIPTION
Could probably have done some fancy bits and bobs with a `EitherT[Future, Error, Response[T]]` but started to feel overkill where a for comprehension might achieve the same thing.

The logic is also slightly different
* Check if the index exists
* If not => try create it
* If so => try update it
* Then add the search template

This seemed more logical as almost always the index will exist, allowed us to remove the custom error checking, and, I suspect, we might gain some tiny tiny improvements as a `PUT` that returns a fail is probably slower than a `HEAD` request.

This fixes the fact that if the search template changes and the index already exists, it doesn't update.