### PR TITLE
Don't include unnested ancestors in partOf

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkService.scala
@@ -78,17 +78,9 @@ class RelatedWorkService(elasticsearchService: ElasticsearchService)(
       case Nil => None
     }
 
-    // For backwards compatability we include the unnested ancestors ordered
-    // from root to parent, with the parent additionally containing the nested
-    // data
-    val partOf: List[RelatedWork] = ancestors
-      .sortBy(tokenizePath)
-      .dropRight(1)
-      .map(RelatedWork(_)) ::: parent.toList
-
     RelatedWorks(
       parts = Some(children.sortBy(tokenizePath).map(RelatedWork(_))),
-      partOf = Some(partOf),
+      partOf = Some(parent.toList),
       precededBy = Some(precededBy.map(RelatedWork(_))),
       succeededBy = Some(succeededBy.map(RelatedWork(_)))
     )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -77,8 +77,6 @@ class RelatedWorkServiceTest
             parts = Some(Nil),
             partOf = Some(
               List(
-                RelatedWork(workA),
-                RelatedWork(work2),
                 RelatedWork(
                   workE,
                   RelatedWorks.partOf(
@@ -133,7 +131,6 @@ class RelatedWorkServiceTest
             parts = Some(Nil),
             partOf = Some(
               List(
-                RelatedWork(workA),
                 RelatedWork(
                   workE,
                   RelatedWorks.partOf(
@@ -166,7 +163,6 @@ class RelatedWorkServiceTest
           RelatedWorks(
             parts = Some(Nil),
             partOf = Some(List(
-              RelatedWork(workP.withData(_.copy(items = Nil))),
               RelatedWork(
                 workQ.withData(_.copy(notes = Nil)),
                 RelatedWorks.partOf(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -162,17 +162,18 @@ class RelatedWorkServiceTest
         result shouldBe Right(
           RelatedWorks(
             parts = Some(Nil),
-            partOf = Some(List(
-              RelatedWork(
-                workQ.withData(_.copy(notes = Nil)),
-                RelatedWorks.partOf(
-                  RelatedWork(
-                    workP.withData(_.copy(items = Nil)),
-                    RelatedWorks(partOf = Some(Nil))
+            partOf = Some(
+              List(
+                RelatedWork(
+                  workQ.withData(_.copy(notes = Nil)),
+                  RelatedWorks.partOf(
+                    RelatedWork(
+                      workP.withData(_.copy(items = Nil)),
+                      RelatedWorks(partOf = Some(Nil))
+                    )
                   )
-                )
-              ),
-            )),
+                ),
+              )),
             precededBy = Some(Nil),
             succeededBy = Some(Nil),
           )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -627,12 +627,6 @@ class WorksIncludesTest
               "alternativeTitles": [],
               "partOf": [
                 {
-                  "id": "${work0.canonicalId}",
-                  "title": "0",
-                  "alternativeTitles": [],
-                  "type": "Work"
-                },
-                {
                   "id": "${workA.canonicalId}",
                   "title": "0/a",
                   "alternativeTitles": [],


### PR DESCRIPTION
This was previously included for backwards compatibility, but not required since https://github.com/wellcomecollection/wellcomecollection.org/pull/5504