### PR TITLE
add new locations model

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.models.work.internal
+
+sealed trait Location {
+  val accessConditions: List[AccessCondition]
+}
+object Location {
+  case class OpenShelves(accessConditions: List[AccessCondition],
+                         shelfmark: String,
+                         sectionName: String)
+      extends Location
+  case class ClosedStores(accessConditions: List[AccessCondition])
+      extends Location
+  case class DigitalResource(accessConditions: List[AccessCondition],
+                             source: DigitalSource)
+      extends Location
+}
+
+sealed trait DigitalSource {
+  val url: String
+  val license: Option[License]
+  val credit: Option[String]
+}
+
+object DigitalSource {
+  case class IIIFPresentation(url: String,
+                              license: Option[License],
+                              credit: Option[String])
+      extends DigitalSource
+  case class IIIFImage(url: String,
+                       license: Option[License],
+                       credit: Option[String])
+      extends DigitalSource
+  case class ExternalSource(url: String,
+                            license: Option[License],
+                            credit: Option[String])
+      extends DigitalSource
+}


### PR DESCRIPTION
ref #817 

We're moving towards a location model that is focussed on the question "Where/how can I access this?".

Having three different `Location`s seems to cover the bases, and removing the `DigitalLocation` and `PhysicalLocation` as they aren't useful. If we found a use for them they would be a property of the `Location` e.g.
```scala
trait LocationType
object LocationType {
  case object Physical
  case object Digital
}
trait Location
case class OpenShelves() extends Location { type Format: LocationType.Physical }
case class DigitalResource() extends Location { type Format: LocationType.Digital }
```

This will then allow for `?items.locations.type=OpenShelves,DigitalResource` and to be able to facet on that. As we're not storing the label of an item in ES, I might have to have a think about how those are constructed.

The spacing is all a bit strange, thanks `scalafmt`.