### PR TITLE
Palette inferrer fixes

### DIFF
--- a/pipeline/inferrer/feature_inferrer/app/main.py
+++ b/pipeline/inferrer/feature_inferrer/app/main.py
@@ -65,6 +65,6 @@ def on_startup():
 
 
 @app.on_event("shutdown")
-def on_shutdown():
-    http.close_persistent_client_session()
+async def on_shutdown():
+    await http.close_persistent_client_session()
     batch_inferrer_queue.stop_worker()

--- a/pipeline/inferrer/feature_inferrer/requirements.in
+++ b/pipeline/inferrer/feature_inferrer/requirements.in
@@ -8,4 +8,4 @@ scikit-learn[alldeps]==0.19.2
 torch==1.4.0
 torchvision==0.5.0
 uvicorn==0.11.3
-weco_datascience==0.1.3
+weco_datascience==0.1.4

--- a/pipeline/inferrer/feature_inferrer/requirements.txt
+++ b/pipeline/inferrer/feature_inferrer/requirements.txt
@@ -47,7 +47,7 @@ urllib3==1.25.8           # via botocore, requests
 uvicorn==0.11.3           # via -r requirements.in
 uvloop==0.14.0            # via uvicorn
 websockets==8.1           # via uvicorn
-weco_datascience==0.1.3   # via -r requirements.in
+weco_datascience==0.1.4   # via -r requirements.in
 yarl==1.4.2               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -78,7 +78,7 @@ class ManagerInferrerIntegrationTest
                   features2 should have length 2048
                   forAll(features1 ++ features2) { _.isNaN shouldBe false }
                   every(lshEncodedFeatures) should fullyMatch regex """(\d+)-(\d+)"""
-                  every(palette) should fullyMatch regex """\d+"""
+                  every(palette) should fullyMatch regex """\d+/\d+"""
               }
           }
         }

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -10,7 +10,7 @@ logger = get_logger(__name__)
 
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
-palette_encoder = PaletteEncoder(palette_size=5, bin_sizes=[4, 6, 8])
+palette_encoder = PaletteEncoder(palette_size=5, bin_sizes=[5, 7, 11])
 
 # initialise API
 logger.info("Starting API")

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -10,9 +10,7 @@ logger = get_logger(__name__)
 
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
-palette_encoder = PaletteEncoder(
-    palette_size=5, palette_weights=[2, 2, 1, 1, 1], bin_sizes=[4, 6, 8]
-)
+palette_encoder = PaletteEncoder(palette_weights=[2, 2, 1, 1, 1], bin_sizes=[4, 6, 8])
 
 # initialise API
 logger.info("Starting API")

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -10,7 +10,11 @@ logger = get_logger(__name__)
 
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
-palette_encoder = PaletteEncoder(palette_size=5, bin_sizes=[5, 7, 11])
+palette_encoder = PaletteEncoder(
+    palette_size=5,
+    palette_weights=[1, 2, 2, 3, 3],
+    bin_sizes=[5, 7, 11]
+)
 
 # initialise API
 logger.info("Starting API")

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -12,8 +12,8 @@ logger = get_logger(__name__)
 logger.info("Initialising PaletteEncoder model")
 palette_encoder = PaletteEncoder(
     palette_size=5,
-    palette_weights=[1, 2, 2, 3, 3],
-    bin_sizes=[5, 7, 11]
+    palette_weights=[1, 1, 1, 2, 2],
+    bin_sizes=[4, 6, 8]
 )
 
 # initialise API

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -10,7 +10,7 @@ logger = get_logger(__name__)
 
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
-palette_encoder = PaletteEncoder(palette_size=5, precision_levels=[4, 6, 8])
+palette_encoder = PaletteEncoder(palette_size=5, bin_sizes=[4, 6, 8])
 
 # initialise API
 logger.info("Starting API")

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -51,6 +51,6 @@ def on_startup():
 
 
 @app.on_event("shutdown")
-def on_shutdown():
-    http.close_persistent_client_session()
+async def on_shutdown():
+    await http.close_persistent_client_session()
     batch_inferrer_queue.stop_worker()

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 logger.info("Initialising PaletteEncoder model")
 palette_encoder = PaletteEncoder(
     palette_size=5,
-    palette_weights=[1, 1, 1, 2, 2],
+    palette_weights=[2, 2, 1, 1, 1],
     bin_sizes=[4, 6, 8]
 )
 

--- a/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
+++ b/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
@@ -5,14 +5,13 @@ from joblib import Parallel, delayed
 
 
 class PaletteEncoder:
-    def __init__(self, palette_size, palette_weights, bin_sizes):
+    def __init__(self, palette_weights, bin_sizes):
         """
-        Instantiate a palette encoder that looks for palette_size colours,
+        Instantiate a palette encoder that looks for len(palette_weights) colours,
         weighted by palette_weights in descending order of cluster cardinality,
         and quantises the resultant colors across bin_sizes bins, respectively.
         """
-        assert len(palette_weights) == palette_size
-        self.palette_size = palette_size
+        self.palette_size = len(palette_weights)
         self.palette_weights = palette_weights
         self.bin_sizes = bin_sizes
         self.delayed_process_image = delayed(self.process_image)

--- a/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
+++ b/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
@@ -6,6 +6,11 @@ from joblib import Parallel, delayed
 
 class PaletteEncoder:
     def __init__(self, palette_size, palette_weights, bin_sizes):
+        """
+        Instantiate a palette encoder that looks for palette_size colours,
+        weighted by palette_weights in descending order of cluster cardinality,
+        and quantises the resultant colors across bin_sizes bins, respectively.
+        """
         assert len(palette_weights) == palette_size
         self.palette_size = palette_size
         self.palette_weights = palette_weights
@@ -17,18 +22,13 @@ class PaletteEncoder:
         """
         extract n significant colours from the image pixels by taking the
         centres of n kmeans clusters of the image's pixels arranged in colour
-        space. Returns tuples of (colour, weight) where the weights are integers.
-        The biggest cluster is weighted at n^p, the second largest (n-1)^p
-        times, ..., and the smallest has weight 1.
+        space. Returns colours in descending order of cluster cardinality.
         """
         pixels = np.array(image).reshape(-1, 3)
-        print(np.array(image).shape)
-        print(pixels.shape)
 
         # Only cluster distinct colours but weight them by their frequency
         # As per https://arxiv.org/pdf/1101.0395.pdf
         distinct_colours, distinct_colour_freqs = np.unique(pixels, axis=0, return_counts=True)
-        print(len(distinct_colours))
         clusters = KMeans(n_clusters=n).fit(distinct_colours, sample_weight=distinct_colour_freqs)
 
         # Sort clusters by the sum of the weights they contain

--- a/pipeline/inferrer/palette_inferrer/requirements.in
+++ b/pipeline/inferrer/palette_inferrer/requirements.in
@@ -4,4 +4,4 @@ joblib==0.16.0
 numpy==1.18.1
 scikit-learn[alldeps]==0.23.2
 uvicorn==0.11.7
-weco-datascience==0.1.3
+weco-datascience==0.1.4

--- a/pipeline/inferrer/palette_inferrer/requirements.in
+++ b/pipeline/inferrer/palette_inferrer/requirements.in
@@ -2,6 +2,6 @@ fastapi==0.54.1
 gunicorn==20.0.4
 joblib==0.16.0
 numpy==1.18.1
-scikit-learn[alldeps]==0.19.2
+scikit-learn[alldeps]==0.23.2
 uvicorn==0.11.7
 weco-datascience==0.1.3

--- a/pipeline/inferrer/palette_inferrer/requirements.txt
+++ b/pipeline/inferrer/palette_inferrer/requirements.txt
@@ -27,7 +27,7 @@ h11==0.9.0                # via uvicorn
 httptools==0.1.1          # via uvicorn
 idna==2.9                 # via requests, yarl
 jmespath==0.9.5           # via boto3, botocore
-joblib==0.16.0            # via -r requirements.in
+joblib==0.16.0            # via -r requirements.in, scikit-learn
 multidict==4.7.5          # via aiohttp, yarl
 numpy==1.18.1             # via -r requirements.in, scikit-learn, scipy
 piffle==0.3.0             # via weco-datascience
@@ -38,10 +38,11 @@ pydantic==1.4             # via fastapi
 python-dateutil==2.8.1    # via botocore
 requests==2.23.0          # via piffle
 s3transfer==0.3.3         # via boto3
-scikit-learn[alldeps]==0.19.2  # via -r requirements.in
+scikit-learn[alldeps]==0.23.2  # via -r requirements.in
 scipy==1.5.2              # via scikit-learn
 six==1.14.0               # via piffle, python-dateutil
 starlette==0.13.2         # via fastapi
+threadpoolctl==2.1.0      # via scikit-learn
 urllib3==1.25.8           # via botocore, requests
 uvicorn==0.11.7           # via -r requirements.in
 uvloop==0.14.0            # via uvicorn

--- a/pipeline/inferrer/palette_inferrer/requirements.txt
+++ b/pipeline/inferrer/palette_inferrer/requirements.txt
@@ -47,7 +47,7 @@ urllib3==1.25.8           # via botocore, requests
 uvicorn==0.11.7           # via -r requirements.in
 uvloop==0.14.0            # via uvicorn
 websockets==8.1           # via uvicorn
-weco-datascience==0.1.3   # via -r requirements.in
+weco-datascience==0.1.4   # via -r requirements.in
 yarl==1.4.2               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This fixes 2 bugs:
- One of the clusters was always being discarded (weighted at 0)
- Cluster weights were being applied inconsistently (centroids were not ordered)

It also includes a few changes:
- Only distinct colours are clustered but they are weighted by their frequencies. This offers a speedup of up to 40%.
- Binning/quantisation is now done directly without the overhead of calculating a histogram.
- Cluster weights are specified directly rather than via a parameter `p` used in `int(index ** p)`.