### PR TITLE
WorkData ID modelling

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -17,7 +17,7 @@ case class DateRangeFilter(fromDate: Option[LocalDate],
                            toDate: Option[LocalDate])
     extends WorkFilter
 
-case object StandardWorkFilter extends WorkFilter
+case object VisibleWorkFilter extends WorkFilter
 
 case class LanguageFilter(languageIds: Seq[String]) extends WorkFilter
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -82,7 +82,7 @@ class FiltersAndAggregationsBuilder(
     case _: ItemLocationTypeFilter => None
     case _: WorkTypeFilter         => Some(AggregationRequest.WorkType)
     case _: DateRangeFilter        => None
-    case StandardWorkFilter        => None
+    case VisibleWorkFilter         => None
     case _: LanguageFilter         => Some(AggregationRequest.Language)
     case _: GenreFilter            => Some(AggregationRequest.Genre)
     case _: SubjectFilter          => Some(AggregationRequest.Subject)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -117,13 +117,13 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
       }
       .getOrElse { boolQuery }
       .filter {
-        (StandardWorkFilter :: filteredAggregationBuilder.unpairedFilters)
+        (VisibleWorkFilter :: filteredAggregationBuilder.unpairedFilters)
           .map(buildWorkFilterQuery)
       }
 
   private def buildWorkFilterQuery(workFilter: WorkFilter): Query =
     workFilter match {
-      case StandardWorkFilter =>
+      case VisibleWorkFilter =>
         termQuery(field = "type", value = "Standard")
       case ItemLocationTypeFilter(itemLocationTypeIds) =>
         termsQuery(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -19,13 +19,13 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       val languageFilter = LanguageFilter(Seq("en"))
       val sut = new FiltersAndAggregationsBuilder(
         List(AggregationRequest.WorkType, AggregationRequest.License),
-        List(workTypeFilter, languageFilter, StandardWorkFilter),
+        List(workTypeFilter, languageFilter, VisibleWorkFilter),
         requestToAggregation,
         filterToQuery
       )
 
       sut.pairedFilters should contain only workTypeFilter
-      sut.unpairedFilters should contain only (languageFilter, StandardWorkFilter)
+      sut.unpairedFilters should contain only (languageFilter, VisibleWorkFilter)
     }
 
     it("handles the case where all filters are unpaired") {
@@ -33,13 +33,13 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       val languageFilter = LanguageFilter(Seq("en"))
       val sut = new FiltersAndAggregationsBuilder(
         List(AggregationRequest.License),
-        List(workTypeFilter, languageFilter, StandardWorkFilter),
+        List(workTypeFilter, languageFilter, VisibleWorkFilter),
         requestToAggregation,
         filterToQuery
       )
 
       sut.pairedFilters should have length 0
-      sut.unpairedFilters should contain only (languageFilter, workTypeFilter, StandardWorkFilter)
+      sut.unpairedFilters should contain only (languageFilter, workTypeFilter, VisibleWorkFilter)
     }
 
     it("handles the case where all filters are paired") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -155,8 +155,7 @@ class RelatedWorkServiceTest
   it("Only returns core fields on related works") {
     withLocalWorksIndex { index =>
       val workP = work("p", CollectionLevel.Collection) withData (
-        _.copy[DataState.Identified](
-          items = List(createIdentifiedItem))
+        _.copy[DataState.Identified](items = List(createIdentifiedItem))
       )
       val workQ = work("p/q", CollectionLevel.Series) withData (
         _.copy[DataState.Identified](notes = List(GeneralNote("hi")))

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -155,11 +155,11 @@ class RelatedWorkServiceTest
   it("Only returns core fields on related works") {
     withLocalWorksIndex { index =>
       val workP = work("p", CollectionLevel.Collection) withData (
-        _.copy[Identified, IdState.Identified](
+        _.copy[DataState.Identified](
           items = List(createIdentifiedItem))
       )
       val workQ = work("p/q", CollectionLevel.Series) withData (
-        _.copy[Identified, IdState.Identified](notes = List(GeneralNote("hi")))
+        _.copy[DataState.Identified](notes = List(GeneralNote("hi")))
       )
       val workR = work("p/q/r", CollectionLevel.Item)
       storeWorks(index, List(workP, workQ, workR))

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models
 
 import io.circe.generic.extras.JsonKey
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.ac.wellcome.models.work.internal.{IdState, ImageSource, WorkState}
+import uk.ac.wellcome.models.work.internal._
 
 @Schema(
   name = "ImageSource",
@@ -20,7 +20,7 @@ case class DisplayImageSource(
 
 object DisplayImageSource {
 
-  def apply(imageSource: ImageSource[IdState.Identified, WorkState.Identified])
+  def apply(imageSource: ImageSource[DataState.Identified])
     : DisplayImageSource =
     new DisplayImageSource(
       id = imageSource.id.canonicalId,

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -20,8 +20,8 @@ case class DisplayImageSource(
 
 object DisplayImageSource {
 
-  def apply(imageSource: ImageSource[DataState.Identified])
-    : DisplayImageSource =
+  def apply(
+    imageSource: ImageSource[DataState.Identified]): DisplayImageSource =
     new DisplayImageSource(
       id = imageSource.id.canonicalId,
       ontologyType = imageSource.ontologyType

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkImageInclude.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkImageInclude.scala
@@ -14,7 +14,7 @@ case class DisplayWorkImageInclude(
 )
 
 object DisplayWorkImageInclude {
-  def apply(image: UnmergedImage[DataState.Identified])
-    : DisplayWorkImageInclude =
+  def apply(
+    image: UnmergedImage[DataState.Identified]): DisplayWorkImageInclude =
     new DisplayWorkImageInclude(id = image.id.canonicalId)
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkImageInclude.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWorkImageInclude.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.display.models
 
 import io.circe.generic.extras.JsonKey
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.ac.wellcome.models.work.internal.{IdState, UnmergedImage, WorkState}
+import uk.ac.wellcome.models.work.internal._
 
 @Schema(
   name = "Image",
@@ -14,7 +14,7 @@ case class DisplayWorkImageInclude(
 )
 
 object DisplayWorkImageInclude {
-  def apply(image: UnmergedImage[IdState.Identified, WorkState.Identified])
+  def apply(image: UnmergedImage[DataState.Identified])
     : DisplayWorkImageInclude =
     new DisplayWorkImageInclude(id = image.id.canonicalId)
 }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -216,8 +216,7 @@ trait DisplaySerialisationTestBase {
   def production(production: List[ProductionEvent[IdState.Minted]]) =
     production.map(productionEvent).mkString(",")
 
-  def workImageInclude(
-    image: UnmergedImage[DataState.Identified]) =
+  def workImageInclude(image: UnmergedImage[DataState.Identified]) =
     s"""
        {
          "id": "${image.id.canonicalId}",
@@ -225,8 +224,7 @@ trait DisplaySerialisationTestBase {
        }
     """.stripMargin
 
-  def workImageIncludes(
-    images: List[UnmergedImage[DataState.Identified]]) =
+  def workImageIncludes(images: List[UnmergedImage[DataState.Identified]]) =
     images.map(workImageInclude).mkString(",")
 
   def productionEvent(event: ProductionEvent[IdState.Minted]): String =

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -217,7 +217,7 @@ trait DisplaySerialisationTestBase {
     production.map(productionEvent).mkString(",")
 
   def workImageInclude(
-    image: UnmergedImage[IdState.Identified, WorkState.Identified]) =
+    image: UnmergedImage[DataState.Identified]) =
     s"""
        {
          "id": "${image.id.canonicalId}",
@@ -226,7 +226,7 @@ trait DisplaySerialisationTestBase {
     """.stripMargin
 
   def workImageIncludes(
-    images: List[UnmergedImage[IdState.Identified, WorkState.Identified]]) =
+    images: List[UnmergedImage[DataState.Identified]]) =
     images.map(workImageInclude).mkString(",")
 
   def productionEvent(event: ProductionEvent[IdState.Minted]): String =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -83,16 +83,16 @@ object Implicits {
   implicit val _dec40: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
   implicit val _dec41
-    : Decoder[UnmergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Decoder[UnmergedImage[MinterState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _dec42
-    : Decoder[UnmergedImage[IdState.Identified, WorkState.Identified]] =
+    : Decoder[UnmergedImage[MinterState.Minted]] =
     deriveConfiguredDecoder
   implicit val _dec43
-    : Decoder[WorkData[WorkState.Unidentified, IdState.Identifiable]] =
+    : Decoder[WorkData[MinterState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _dec44
-    : Decoder[WorkData[WorkState.Identified, IdState.Identified]] =
+    : Decoder[WorkData[MinterState.Minted]] =
     deriveConfiguredDecoder
   implicit val _dec45: Decoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredDecoder
@@ -111,17 +111,17 @@ object Implicits {
   implicit val _dec52: Decoder[Work[WorkState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec53
-    : Decoder[MergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Decoder[MergedImage[MinterState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _dec54
-    : Decoder[MergedImage[IdState.Identified, WorkState.Identified]] =
+    : Decoder[MergedImage[MinterState.Minted]] =
     deriveConfiguredDecoder
   implicit val _dec55: Decoder[AugmentedImage] = deriveConfiguredDecoder
   implicit val _dec56
-    : Decoder[BaseImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Decoder[BaseImage[MinterState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _dec57
-    : Decoder[BaseImage[IdState.Identified, WorkState.Identified]] =
+    : Decoder[BaseImage[MinterState.Minted]] =
     deriveConfiguredDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
@@ -188,16 +188,16 @@ object Implicits {
   implicit val _enc40: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
   implicit val _enc41
-    : Encoder[UnmergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Encoder[UnmergedImage[MinterState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _enc42
-    : Encoder[UnmergedImage[IdState.Identified, WorkState.Identified]] =
+    : Encoder[UnmergedImage[MinterState.Minted]] =
     deriveConfiguredEncoder
   implicit val _enc43
-    : Encoder[WorkData[WorkState.Unidentified, IdState.Identifiable]] =
+    : Encoder[WorkData[MinterState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _enc44
-    : Encoder[WorkData[WorkState.Identified, IdState.Identified]] =
+    : Encoder[WorkData[MinterState.Minted]] =
     deriveConfiguredEncoder
   implicit val _enc45: Encoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredEncoder
@@ -216,16 +216,16 @@ object Implicits {
   implicit val _enc52: Encoder[Work[WorkState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc53
-    : Encoder[MergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Encoder[MergedImage[MinterState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _enc54
-    : Encoder[MergedImage[IdState.Identified, WorkState.Identified]] =
+    : Encoder[MergedImage[MinterState.Minted]] =
     deriveConfiguredEncoder
   implicit val _enc55: Encoder[AugmentedImage] = deriveConfiguredEncoder
   implicit val _enc56
-    : Encoder[BaseImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : Encoder[BaseImage[MinterState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _enc57
-    : Encoder[BaseImage[IdState.Identified, WorkState.Identified]] =
+    : Encoder[BaseImage[MinterState.Minted]] =
     deriveConfiguredEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -83,16 +83,16 @@ object Implicits {
   implicit val _dec40: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
   implicit val _dec41
-    : Decoder[UnmergedImage[MinterState.Unminted]] =
+    : Decoder[UnmergedImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec42
-    : Decoder[UnmergedImage[MinterState.Minted]] =
+    : Decoder[UnmergedImage[DataState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec43
-    : Decoder[WorkData[MinterState.Unminted]] =
+    : Decoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec44
-    : Decoder[WorkData[MinterState.Minted]] =
+    : Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec45: Decoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredDecoder
@@ -111,17 +111,17 @@ object Implicits {
   implicit val _dec52: Decoder[Work[WorkState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec53
-    : Decoder[MergedImage[MinterState.Unminted]] =
+    : Decoder[MergedImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec54
-    : Decoder[MergedImage[MinterState.Minted]] =
+    : Decoder[MergedImage[DataState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec55: Decoder[AugmentedImage] = deriveConfiguredDecoder
   implicit val _dec56
-    : Decoder[BaseImage[MinterState.Unminted]] =
+    : Decoder[BaseImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec57
-    : Decoder[BaseImage[MinterState.Minted]] =
+    : Decoder[BaseImage[DataState.Identified]] =
     deriveConfiguredDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
@@ -188,16 +188,16 @@ object Implicits {
   implicit val _enc40: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
   implicit val _enc41
-    : Encoder[UnmergedImage[MinterState.Unminted]] =
+    : Encoder[UnmergedImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc42
-    : Encoder[UnmergedImage[MinterState.Minted]] =
+    : Encoder[UnmergedImage[DataState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc43
-    : Encoder[WorkData[MinterState.Unminted]] =
+    : Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc44
-    : Encoder[WorkData[MinterState.Minted]] =
+    : Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc45: Encoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredEncoder
@@ -216,16 +216,16 @@ object Implicits {
   implicit val _enc52: Encoder[Work[WorkState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc53
-    : Encoder[MergedImage[MinterState.Unminted]] =
+    : Encoder[MergedImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc54
-    : Encoder[MergedImage[MinterState.Minted]] =
+    : Encoder[MergedImage[DataState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc55: Encoder[AugmentedImage] = deriveConfiguredEncoder
   implicit val _enc56
-    : Encoder[BaseImage[MinterState.Unminted]] =
+    : Encoder[BaseImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc57
-    : Encoder[BaseImage[MinterState.Minted]] =
+    : Encoder[BaseImage[DataState.Identified]] =
     deriveConfiguredEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -82,17 +82,13 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec40: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec41
-    : Decoder[UnmergedImage[DataState.Unidentified]] =
+  implicit val _dec41: Decoder[UnmergedImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
-  implicit val _dec42
-    : Decoder[UnmergedImage[DataState.Identified]] =
+  implicit val _dec42: Decoder[UnmergedImage[DataState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec43
-    : Decoder[WorkData[DataState.Unidentified]] =
+  implicit val _dec43: Decoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredDecoder
-  implicit val _dec44
-    : Decoder[WorkData[DataState.Identified]] =
+  implicit val _dec44: Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec45: Decoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredDecoder
@@ -110,18 +106,14 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec52: Decoder[Work[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec53
-    : Decoder[MergedImage[DataState.Unidentified]] =
+  implicit val _dec53: Decoder[MergedImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
-  implicit val _dec54
-    : Decoder[MergedImage[DataState.Identified]] =
+  implicit val _dec54: Decoder[MergedImage[DataState.Identified]] =
     deriveConfiguredDecoder
   implicit val _dec55: Decoder[AugmentedImage] = deriveConfiguredDecoder
-  implicit val _dec56
-    : Decoder[BaseImage[DataState.Unidentified]] =
+  implicit val _dec56: Decoder[BaseImage[DataState.Unidentified]] =
     deriveConfiguredDecoder
-  implicit val _dec57
-    : Decoder[BaseImage[DataState.Identified]] =
+  implicit val _dec57: Decoder[BaseImage[DataState.Identified]] =
     deriveConfiguredDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
@@ -187,17 +179,13 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc40: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc41
-    : Encoder[UnmergedImage[DataState.Unidentified]] =
+  implicit val _enc41: Encoder[UnmergedImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
-  implicit val _enc42
-    : Encoder[UnmergedImage[DataState.Identified]] =
+  implicit val _enc42: Encoder[UnmergedImage[DataState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc43
-    : Encoder[WorkData[DataState.Unidentified]] =
+  implicit val _enc43: Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
-  implicit val _enc44
-    : Encoder[WorkData[DataState.Identified]] =
+  implicit val _enc44: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc45: Encoder[Work.Standard[WorkState.Unidentified]] =
     deriveConfiguredEncoder
@@ -215,17 +203,13 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc52: Encoder[Work[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc53
-    : Encoder[MergedImage[DataState.Unidentified]] =
+  implicit val _enc53: Encoder[MergedImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
-  implicit val _enc54
-    : Encoder[MergedImage[DataState.Identified]] =
+  implicit val _enc54: Encoder[MergedImage[DataState.Identified]] =
     deriveConfiguredEncoder
   implicit val _enc55: Encoder[AugmentedImage] = deriveConfiguredEncoder
-  implicit val _enc56
-    : Encoder[BaseImage[DataState.Unidentified]] =
+  implicit val _enc56: Encoder[BaseImage[DataState.Unidentified]] =
     deriveConfiguredEncoder
-  implicit val _enc57
-    : Encoder[BaseImage[DataState.Identified]] =
+  implicit val _enc57: Encoder[BaseImage[DataState.Identified]] =
     deriveConfiguredEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DataState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DataState.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.models.work.internal
+
+/** Container type for IdState types, that is used by WorkData / ImageData
+  * with two associated types:
+  *
+  * - Id (references an ID type, always with a source identifier)
+  * - MaybeId (references an ID type, potentially with a source identifier)
+  */
+sealed trait DataState {
+  type Id
+  type MaybeId
+}
+
+object DataState {
+  case class Unidentified() extends DataState {
+    type Id = IdState.Identifiable
+    type MaybeId = IdState.Unminted
+  }
+
+  case class Identified() extends DataState {
+    type Id = IdState.Identified
+    type MaybeId = IdState.Minted
+  }
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
@@ -59,6 +59,27 @@ object IdState {
   }
 }
 
+/* Container type for IdState types with two associated types:
+ * * Id (references an ID type, always with a source identifier)
+ * * MaybeId (references an ID type, potentially with a source identifier)
+ */
+sealed trait MinterState {
+  type Id <: IdState.WithSourceIdentifier
+  type MaybeId <: IdState
+}
+
+object MinterState {
+  case class Unminted() extends MinterState {
+    type Id = IdState.Identifiable
+    type MaybeId = IdState.Unminted
+  }
+
+  case class Minted() extends MinterState {
+    type Id = IdState.Identified
+    type MaybeId = IdState.Minted
+  }
+}
+
 /** A trait assigned to all objects that contain some ID value. */
 trait HasId[+T] {
   val id: T

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/IdState.scala
@@ -17,9 +17,6 @@ sealed trait IdState {
 
 object IdState {
 
-  /* Parent trait for all IDs that contain a sourceIdentifier */
-  sealed trait WithSourceIdentifier extends IdState
-
   /* Parent trait for an ID of an object that is pre minter. */
   sealed trait Unminted extends IdState
 
@@ -32,8 +29,7 @@ object IdState {
     canonicalId: String,
     sourceIdentifier: SourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
-  ) extends Minted
-      with WithSourceIdentifier {
+  ) extends Minted {
     def maybeCanonicalId = Some(canonicalId)
     def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
   }
@@ -44,8 +40,7 @@ object IdState {
     sourceIdentifier: SourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
     identifiedType: String = classOf[Identified].getSimpleName,
-  ) extends Unminted
-      with WithSourceIdentifier {
+  ) extends Unminted {
     def maybeCanonicalId = None
     def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
   }
@@ -56,27 +51,6 @@ object IdState {
   case object Unidentifiable extends Unminted with Minted {
     def maybeCanonicalId = None
     def allSourceIdentifiers = Nil
-  }
-}
-
-/* Container type for IdState types with two associated types:
- * * Id (references an ID type, always with a source identifier)
- * * MaybeId (references an ID type, potentially with a source identifier)
- */
-sealed trait MinterState {
-  type Id <: IdState.WithSourceIdentifier
-  type MaybeId <: IdState
-}
-
-object MinterState {
-  case class Unminted() extends MinterState {
-    type Id = IdState.Identifiable
-    type MaybeId = IdState.Unminted
-  }
-
-  case class Minted() extends MinterState {
-    type Id = IdState.Identified
-    type MaybeId = IdState.Minted
   }
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait BaseImage[+State <: DataState]
-    extends HasId[State#Id] {
+sealed trait BaseImage[+State <: DataState] extends HasId[State#Id] {
   val id: State#Id
   val location: DigitalLocationDeprecated
 }
@@ -12,8 +11,7 @@ case class UnmergedImage[State <: DataState](
   location: DigitalLocationDeprecated
 ) extends BaseImage[State] {
   def mergeWith(canonicalWork: SourceWork[State],
-                redirectedWork: Option[SourceWork[State]])
-    : MergedImage[State] =
+                redirectedWork: Option[SourceWork[State]]): MergedImage[State] =
     MergedImage[State](
       id = id,
       version = version,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait BaseImage[+State <: MinterState]
+sealed trait BaseImage[+State <: DataState]
     extends HasId[State#Id] {
   val id: State#Id
   val location: DigitalLocationDeprecated
 }
 
-case class UnmergedImage[State <: MinterState](
+case class UnmergedImage[State <: DataState](
   id: State#Id,
   version: Int,
   location: DigitalLocationDeprecated
@@ -22,7 +22,7 @@ case class UnmergedImage[State <: MinterState](
     )
 }
 
-case class MergedImage[State <: MinterState](
+case class MergedImage[State <: DataState](
   id: State#Id,
   version: Int,
   location: DigitalLocationDeprecated,
@@ -38,7 +38,7 @@ case class MergedImage[State <: MinterState](
 
 object MergedImage {
   implicit class IdentifiedMergedImageOps(
-    mergedImage: MergedImage[MinterState.Minted]) {
+    mergedImage: MergedImage[DataState.Identified]) {
     def augment(inferredData: => Option[InferredData]): AugmentedImage =
       AugmentedImage(
         id = mergedImage.id,
@@ -54,9 +54,9 @@ case class AugmentedImage(
   id: IdState.Identified,
   version: Int,
   location: DigitalLocationDeprecated,
-  source: ImageSource[MinterState.Minted],
+  source: ImageSource[DataState.Identified],
   inferredData: Option[InferredData] = None
-) extends BaseImage[MinterState.Minted]
+) extends BaseImage[DataState.Identified]
 
 case class InferredData(
   // We split the feature vector so that it can fit into
@@ -75,8 +75,8 @@ object UnmergedImage {
   def apply(sourceIdentifier: SourceIdentifier,
             version: Int,
             location: DigitalLocationDeprecated)
-    : UnmergedImage[MinterState.Unminted] =
-    UnmergedImage[MinterState.Unminted](
+    : UnmergedImage[DataState.Unidentified] =
+    UnmergedImage[DataState.Unidentified](
       id = IdState.Identifiable(sourceIdentifier),
       version = version,
       location

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -1,24 +1,24 @@
 package uk.ac.wellcome.models.work.internal
 
 sealed trait ImageSource[
-  ImageId <: IdState.WithSourceIdentifier, State <: WorkState] {
+  ImageId <: IdState.WithSourceIdentifier, MaybeId <: IdState] {
   val id: ImageId
   val ontologyType: String
 }
 
 case class SourceWorks[ImageId <: IdState.WithSourceIdentifier,
-                       State <: WorkState](
-  canonicalWork: SourceWork[ImageId, State],
-  redirectedWork: Option[SourceWork[ImageId, State]]
-) extends ImageSource[ImageId, State] {
+                       MaybeId <: IdState](
+  canonicalWork: SourceWork[ImageId, MaybeId],
+  redirectedWork: Option[SourceWork[ImageId, MaybeId]]
+) extends ImageSource[ImageId, MaybeId] {
   override val id = canonicalWork.id
   override val ontologyType: String = canonicalWork.ontologyType
 }
 
 case class SourceWork[ImageId <: IdState.WithSourceIdentifier,
-                      State <: WorkState](
+                      MaybeId <: IdState](
   id: ImageId,
-  data: WorkData[State, ImageId],
+  data: WorkData[MaybeId, ImageId],
   ontologyType: String = "Work",
 )
 
@@ -27,7 +27,7 @@ object SourceWork {
   implicit class UnidentifiedWorkToSourceWork(
     work: Work[WorkState.Unidentified]) {
 
-    def toSourceWork: SourceWork[IdState.Identifiable, WorkState.Unidentified] =
+    def toSourceWork: SourceWork[IdState.Identifiable, IdState.Unminted] =
       SourceWork(
         id = IdState.Identifiable(work.state.sourceIdentifier),
         data = work.data
@@ -36,7 +36,7 @@ object SourceWork {
 
   implicit class IdentifiedWorkToSourceWork(work: Work[WorkState.Identified]) {
 
-    def toSourceWork: SourceWork[IdState.Identified, WorkState.Identified] =
+    def toSourceWork: SourceWork[IdState.Identified, IdState.Minted] =
       SourceWork(
         id = IdState.Identified(
           sourceIdentifier = work.state.sourceIdentifier,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -1,24 +1,21 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait ImageSource[
-  ImageId <: IdState.WithSourceIdentifier, MaybeId <: IdState] {
-  val id: ImageId
+sealed trait ImageSource[State <: MinterState] {
+  val id: State#Id
   val ontologyType: String
 }
 
-case class SourceWorks[ImageId <: IdState.WithSourceIdentifier,
-                       MaybeId <: IdState](
-  canonicalWork: SourceWork[ImageId, MaybeId],
-  redirectedWork: Option[SourceWork[ImageId, MaybeId]]
-) extends ImageSource[ImageId, MaybeId] {
+case class SourceWorks[State <: MinterState](
+  canonicalWork: SourceWork[State],
+  redirectedWork: Option[SourceWork[State]]
+) extends ImageSource[State] {
   override val id = canonicalWork.id
   override val ontologyType: String = canonicalWork.ontologyType
 }
 
-case class SourceWork[ImageId <: IdState.WithSourceIdentifier,
-                      MaybeId <: IdState](
-  id: ImageId,
-  data: WorkData[MaybeId, ImageId],
+case class SourceWork[State <: MinterState](
+  id: State#Id,
+  data: WorkData[State],
   ontologyType: String = "Work",
 )
 
@@ -27,8 +24,8 @@ object SourceWork {
   implicit class UnidentifiedWorkToSourceWork(
     work: Work[WorkState.Unidentified]) {
 
-    def toSourceWork: SourceWork[IdState.Identifiable, IdState.Unminted] =
-      SourceWork(
+    def toSourceWork: SourceWork[MinterState.Unminted] =
+      SourceWork[MinterState.Unminted](
         id = IdState.Identifiable(work.state.sourceIdentifier),
         data = work.data
       )
@@ -36,8 +33,8 @@ object SourceWork {
 
   implicit class IdentifiedWorkToSourceWork(work: Work[WorkState.Identified]) {
 
-    def toSourceWork: SourceWork[IdState.Identified, IdState.Minted] =
-      SourceWork(
+    def toSourceWork: SourceWork[MinterState.Minted] =
+      SourceWork[MinterState.Minted](
         id = IdState.Identified(
           sourceIdentifier = work.state.sourceIdentifier,
           canonicalId = work.state.canonicalId

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait ImageSource[State <: MinterState] {
+sealed trait ImageSource[State <: DataState] {
   val id: State#Id
   val ontologyType: String
 }
 
-case class SourceWorks[State <: MinterState](
+case class SourceWorks[State <: DataState](
   canonicalWork: SourceWork[State],
   redirectedWork: Option[SourceWork[State]]
 ) extends ImageSource[State] {
@@ -13,7 +13,7 @@ case class SourceWorks[State <: MinterState](
   override val ontologyType: String = canonicalWork.ontologyType
 }
 
-case class SourceWork[State <: MinterState](
+case class SourceWork[State <: DataState](
   id: State#Id,
   data: WorkData[State],
   ontologyType: String = "Work",
@@ -24,8 +24,8 @@ object SourceWork {
   implicit class UnidentifiedWorkToSourceWork(
     work: Work[WorkState.Unidentified]) {
 
-    def toSourceWork: SourceWork[MinterState.Unminted] =
-      SourceWork[MinterState.Unminted](
+    def toSourceWork: SourceWork[DataState.Unidentified] =
+      SourceWork[DataState.Unidentified](
         id = IdState.Identifiable(work.state.sourceIdentifier),
         data = work.data
       )
@@ -33,8 +33,8 @@ object SourceWork {
 
   implicit class IdentifiedWorkToSourceWork(work: Work[WorkState.Identified]) {
 
-    def toSourceWork: SourceWork[MinterState.Minted] =
-      SourceWork[MinterState.Minted](
+    def toSourceWork: SourceWork[DataState.Identified] =
+      SourceWork[DataState.Identified](
         id = IdState.Identified(
           sourceIdentifier = work.state.sourceIdentifier,
           canonicalId = work.state.canonicalId

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -9,7 +9,7 @@ sealed trait Work[State <: WorkState] {
 
   val version: Int
   val state: State
-  val data: WorkData[State#MaybeId, State#Id]
+  val data: WorkData[State#MintState]
 
   def sourceIdentifier: SourceIdentifier = state.sourceIdentifier
 
@@ -17,7 +17,7 @@ sealed trait Work[State <: WorkState] {
     sourceIdentifier :: data.otherIdentifiers
 
   def withData(
-    f: WorkData[State#MaybeId, State#Id] => WorkData[State#MaybeId, State#Id])
+    f: WorkData[State#MintState] => WorkData[State#MintState])
     : Work[State] =
     this match {
       case Work.Standard(version, data, state) =>
@@ -33,22 +33,22 @@ object Work {
 
   case class Standard[State <: WorkState](
     version: Int,
-    data: WorkData[State#MaybeId, State#Id],
+    data: WorkData[State#MintState],
     state: State,
   ) extends Work[State]
 
   case class Redirected[State <: WorkState](
     version: Int,
-    redirect: State#Id,
+    redirect: State#MintState#Id,
     state: State,
   ) extends Work[State] {
 
-    val data = WorkData[State#MaybeId, State#Id]()
+    val data = WorkData[State#MintState]()
   }
 
   case class Invisible[State <: WorkState](
     version: Int,
-    data: WorkData[State#MaybeId, State#Id],
+    data: WorkData[State#MintState],
     state: State,
     invisibilityReasons: List[InvisibilityReason] = Nil,
   ) extends Work[State]
@@ -57,7 +57,7 @@ object Work {
 /** WorkData contains data common to all types of works that can exist at any
   * stage of the pipeline.
   */
-case class WorkData[MaybeId <: IdState, Id <: IdState.WithSourceIdentifier](
+case class WorkData[State <: MinterState](
   title: Option[String] = None,
   otherIdentifiers: List[SourceIdentifier] = Nil,
   mergeCandidates: List[MergeCandidate] = Nil,
@@ -66,20 +66,20 @@ case class WorkData[MaybeId <: IdState, Id <: IdState.WithSourceIdentifier](
   description: Option[String] = None,
   physicalDescription: Option[String] = None,
   lettering: Option[String] = None,
-  createdDate: Option[Period[MaybeId]] = None,
-  subjects: List[Subject[MaybeId]] = Nil,
-  genres: List[Genre[MaybeId]] = Nil,
-  contributors: List[Contributor[MaybeId]] = Nil,
+  createdDate: Option[Period[State#MaybeId]] = None,
+  subjects: List[Subject[State#MaybeId]] = Nil,
+  genres: List[Genre[State#MaybeId]] = Nil,
+  contributors: List[Contributor[State#MaybeId]] = Nil,
   thumbnail: Option[LocationDeprecated] = None,
-  production: List[ProductionEvent[MaybeId]] = Nil,
+  production: List[ProductionEvent[State#MaybeId]] = Nil,
   language: Option[Language] = None,
   edition: Option[String] = None,
   notes: List[Note] = Nil,
   duration: Option[Int] = None,
-  items: List[Item[MaybeId]] = Nil,
+  items: List[Item[State#MaybeId]] = Nil,
   merged: Boolean = false,
   collectionPath: Option[CollectionPath] = None,
-  images: List[UnmergedImage[Id, MaybeId]] = Nil
+  images: List[UnmergedImage[State]] = Nil
 )
 
 /** WorkState represents the state of the work in the pipeline, and contains
@@ -111,9 +111,7 @@ case class WorkData[MaybeId <: IdState, Id <: IdState.WithSourceIdentifier](
   */
 sealed trait WorkState {
 
-  type MaybeId <: IdState
-
-  type Id <: IdState.WithSourceIdentifier
+  type MintState <: MinterState
 
   val sourceIdentifier: SourceIdentifier
 }
@@ -127,9 +125,7 @@ object WorkState {
     sourceIdentifier: SourceIdentifier
   ) extends WorkState {
 
-    type MaybeId = IdState.Unminted
-
-    type Id = IdState.Identifiable
+    type MintState = MinterState.Unminted
   }
 
   case class Identified(
@@ -137,8 +133,6 @@ object WorkState {
     canonicalId: String,
   ) extends WorkState {
 
-    type MaybeId = IdState.Minted
-
-    type Id = IdState.Identified
+    type MintState = MinterState.Minted
   }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -9,7 +9,7 @@ sealed trait Work[State <: WorkState] {
 
   val version: Int
   val state: State
-  val data: WorkData[State, State#Id]
+  val data: WorkData[State#MaybeId, State#Id]
 
   def sourceIdentifier: SourceIdentifier = state.sourceIdentifier
 
@@ -17,7 +17,7 @@ sealed trait Work[State <: WorkState] {
     sourceIdentifier :: data.otherIdentifiers
 
   def withData(
-    f: WorkData[State, State#Id] => WorkData[State, State#Id])
+    f: WorkData[State#MaybeId, State#Id] => WorkData[State#MaybeId, State#Id])
     : Work[State] =
     this match {
       case Work.Standard(version, data, state) =>
@@ -33,7 +33,7 @@ object Work {
 
   case class Standard[State <: WorkState](
     version: Int,
-    data: WorkData[State, State#Id],
+    data: WorkData[State#MaybeId, State#Id],
     state: State,
   ) extends Work[State]
 
@@ -43,12 +43,12 @@ object Work {
     state: State,
   ) extends Work[State] {
 
-    val data = WorkData[State, State#Id]()
+    val data = WorkData[State#MaybeId, State#Id]()
   }
 
   case class Invisible[State <: WorkState](
     version: Int,
-    data: WorkData[State, State#Id],
+    data: WorkData[State#MaybeId, State#Id],
     state: State,
     invisibilityReasons: List[InvisibilityReason] = Nil,
   ) extends Work[State]
@@ -57,7 +57,7 @@ object Work {
 /** WorkData contains data common to all types of works that can exist at any
   * stage of the pipeline.
   */
-case class WorkData[State <: WorkState, Id <: IdState.WithSourceIdentifier](
+case class WorkData[MaybeId <: IdState, Id <: IdState.WithSourceIdentifier](
   title: Option[String] = None,
   otherIdentifiers: List[SourceIdentifier] = Nil,
   mergeCandidates: List[MergeCandidate] = Nil,
@@ -66,20 +66,20 @@ case class WorkData[State <: WorkState, Id <: IdState.WithSourceIdentifier](
   description: Option[String] = None,
   physicalDescription: Option[String] = None,
   lettering: Option[String] = None,
-  createdDate: Option[Period[State#MaybeId]] = None,
-  subjects: List[Subject[State#MaybeId]] = Nil,
-  genres: List[Genre[State#MaybeId]] = Nil,
-  contributors: List[Contributor[State#MaybeId]] = Nil,
+  createdDate: Option[Period[MaybeId]] = None,
+  subjects: List[Subject[MaybeId]] = Nil,
+  genres: List[Genre[MaybeId]] = Nil,
+  contributors: List[Contributor[MaybeId]] = Nil,
   thumbnail: Option[LocationDeprecated] = None,
-  production: List[ProductionEvent[State#MaybeId]] = Nil,
+  production: List[ProductionEvent[MaybeId]] = Nil,
   language: Option[Language] = None,
   edition: Option[String] = None,
   notes: List[Note] = Nil,
   duration: Option[Int] = None,
-  items: List[Item[State#MaybeId]] = Nil,
+  items: List[Item[MaybeId]] = Nil,
   merged: Boolean = false,
   collectionPath: Option[CollectionPath] = None,
-  images: List[UnmergedImage[Id, State]] = Nil
+  images: List[UnmergedImage[Id, MaybeId]] = Nil
 )
 
 /** WorkState represents the state of the work in the pipeline, and contains

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -45,8 +45,7 @@ trait ImageGenerators
     parentWork: Work.Standard[WorkState.Unidentified] =
       createUnidentifiedSierraWorkWith(),
     redirectedWork: Option[Work[WorkState.Unidentified]] = Some(
-      createMiroWorkWith(Nil)))
-    : MergedImage[DataState.Unidentified] =
+      createMiroWorkWith(Nil))): MergedImage[DataState.Unidentified] =
     createUnmergedImageWith(location, version, identifierType = identifierType) mergeWith (
       parentWork.toSourceWork,
       redirectedWork.map(_.toSourceWork)
@@ -63,8 +62,7 @@ trait ImageGenerators
     parentWork: Work.Standard[WorkState.Identified] =
       createIdentifiedSierraWorkWith(),
     redirectedWork: Option[Work[WorkState.Identified]] = Some(
-      createIdentifiedSierraWorkWith()))
-    : MergedImage[DataState.Identified] =
+      createIdentifiedSierraWorkWith())): MergedImage[DataState.Identified] =
     MergedImage[DataState.Identified](
       imageId,
       version,
@@ -144,8 +142,8 @@ trait ImageGenerators
 
   implicit class UnmergedImageIdOps(
     val image: UnmergedImage[DataState.Unidentified]) {
-    def toIdentifiedWith(id: String = createCanonicalId)
-      : UnmergedImage[DataState.Identified] =
+    def toIdentifiedWith(
+      id: String = createCanonicalId): UnmergedImage[DataState.Identified] =
       UnmergedImage[DataState.Identified](
         id = IdState.Identified(
           canonicalId = id,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -13,7 +13,7 @@ trait ImageGenerators
     version: Int = 1,
     identifierValue: String = randomAlphanumeric(10),
     identifierType: IdentifierType = IdentifierType("miro-image-number")
-  ): UnmergedImage[IdState.Identifiable, WorkState.Unidentified] =
+  ): UnmergedImage[DataState.Unidentified] =
     UnmergedImage(
       sourceIdentifier = createSourceIdentifierWith(
         identifierType = identifierType,
@@ -22,8 +22,7 @@ trait ImageGenerators
       location = location
     )
 
-  def createUnmergedImage
-    : UnmergedImage[IdState.Identifiable, WorkState.Unidentified] =
+  def createUnmergedImage: UnmergedImage[DataState.Unidentified] =
     createUnmergedImageWith()
 
   def createUnmergedMiroImage = createUnmergedImageWith(
@@ -47,14 +46,13 @@ trait ImageGenerators
       createUnidentifiedSierraWorkWith(),
     redirectedWork: Option[Work[WorkState.Unidentified]] = Some(
       createMiroWorkWith(Nil)))
-    : MergedImage[IdState.Identifiable, WorkState.Unidentified] =
+    : MergedImage[DataState.Unidentified] =
     createUnmergedImageWith(location, version, identifierType = identifierType) mergeWith (
       parentWork.toSourceWork,
       redirectedWork.map(_.toSourceWork)
     )
 
-  def createMergedImage
-    : MergedImage[IdState.Identifiable, WorkState.Unidentified] =
+  def createMergedImage: MergedImage[DataState.Unidentified] =
     createMergedImageWith()
 
   def createIdentifiedMergedImageWith(
@@ -66,8 +64,8 @@ trait ImageGenerators
       createIdentifiedSierraWorkWith(),
     redirectedWork: Option[Work[WorkState.Identified]] = Some(
       createIdentifiedSierraWorkWith()))
-    : MergedImage[IdState.Identified, WorkState.Identified] =
-    MergedImage(
+    : MergedImage[DataState.Identified] =
+    MergedImage[DataState.Identified](
       imageId,
       version,
       location,
@@ -145,10 +143,10 @@ trait ImageGenerators
   }
 
   implicit class UnmergedImageIdOps(
-    val image: UnmergedImage[IdState.Identifiable, WorkState.Unidentified]) {
+    val image: UnmergedImage[DataState.Unidentified]) {
     def toIdentifiedWith(id: String = createCanonicalId)
-      : UnmergedImage[IdState.Identified, WorkState.Identified] =
-      UnmergedImage(
+      : UnmergedImage[DataState.Identified] =
+      UnmergedImage[DataState.Identified](
         id = IdState.Identified(
           canonicalId = id,
           sourceIdentifier = image.id.allSourceIdentifiers.head
@@ -157,7 +155,7 @@ trait ImageGenerators
         location = image.location
       )
 
-    val toIdentified: UnmergedImage[IdState.Identified, WorkState.Identified] =
+    val toIdentified: UnmergedImage[DataState.Identified] =
       toIdentifiedWith()
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -45,13 +45,13 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
 
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    items: List[Item[Unidentified#MaybeId]] = Nil,
-    images: List[UnmergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    items: List[Item[IdState.Unminted]] = Nil,
+    images: List[UnmergedImage[DataState.Unidentified]] =
       Nil,
   ): Work.Invisible[Unidentified] =
     Work.Invisible[Unidentified](
       state = Unidentified(sourceIdentifier),
-      data = WorkData[Unidentified, IdState.Identifiable](
+      data = WorkData[DataState.Unidentified](
         items = items,
         images = images,
       ),
@@ -102,12 +102,12 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     edition: Option[String] = None,
     duration: Option[Int] = None,
     items: List[Item[IdState.Unminted]] = Nil,
-    images: List[UnmergedImage[IdState.Identifiable, Unidentified]] = Nil)
+    images: List[UnmergedImage[DataState.Unidentified]] = Nil)
     : Work.Standard[Unidentified] =
     Work.Standard[Unidentified](
       state = Unidentified(sourceIdentifier),
       version = version,
-      data = WorkData[Unidentified, IdState.Identifiable](
+      data = WorkData[DataState.Unidentified](
         otherIdentifiers = otherIdentifiers,
         mergeCandidates = mergeCandidates,
         title = title,
@@ -156,7 +156,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     language: Option[Language] = None,
     duration: Option[Int] = None,
     items: List[Item[IdState.Minted]] = Nil,
-    images: List[UnmergedImage[IdState.Identified, Identified]] = Nil,
+    images: List[UnmergedImage[DataState.Identified]] = Nil,
     version: Int = 1,
     merged: Boolean = false,
     collectionPath: Option[CollectionPath] = None,
@@ -166,9 +166,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       state = Identified(
         canonicalId = canonicalId,
         sourceIdentifier = sourceIdentifier,
-      ),
-      version = version,
-      data = WorkData[Identified, IdState.Identified](
+      ), version = version,
+      data = WorkData[DataState.Identified](
         otherIdentifiers = otherIdentifiers,
         mergeCandidates = mergeCandidates,
         title = title,
@@ -229,8 +228,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     )
 
   def createUnidentifiedCalmWorkWith(
-    data: WorkData[Unidentified, IdState.Identifiable] =
-      WorkData[Unidentified, IdState.Identifiable](
+    data: WorkData[DataState.Unidentified] =
+      WorkData[DataState.Unidentified](
         items = List(createCalmItem)
       ),
     id: String = randomAlphanumeric(6),
@@ -251,7 +250,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
   def createUnidentifiedInvisibleMetsWorkWith(
     sourceIdentifier: SourceIdentifier = createMetsSourceIdentifier,
     items: List[Item[IdState.Unminted]] = List(createDigitalItem),
-    images: List[UnmergedImage[IdState.Identifiable, Unidentified]])
+    images: List[UnmergedImage[DataState.Unidentified]])
     : Work.Invisible[Unidentified] =
     createUnidentifiedInvisibleWorkWith(
       sourceIdentifier = sourceIdentifier,
@@ -294,7 +293,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     createUnidentifiedSierraWorkWith(items = items)
 
   def createMiroWorkWith(
-    images: List[UnmergedImage[IdState.Identifiable, Unidentified]],
+    images: List[UnmergedImage[DataState.Unidentified]],
     otherIdentifiers: List[SourceIdentifier] = Nil,
     sourceIdentifier: SourceIdentifier = createMiroSourceIdentifier)
     : Work.Standard[Unidentified] =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -46,8 +46,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     items: List[Item[IdState.Unminted]] = Nil,
-    images: List[UnmergedImage[DataState.Unidentified]] =
-      Nil,
+    images: List[UnmergedImage[DataState.Unidentified]] = Nil,
   ): Work.Invisible[Unidentified] =
     Work.Invisible[Unidentified](
       state = Unidentified(sourceIdentifier),
@@ -166,7 +165,8 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
       state = Identified(
         canonicalId = canonicalId,
         sourceIdentifier = sourceIdentifier,
-      ), version = version,
+      ),
+      version = version,
       data = WorkData[DataState.Identified](
         otherIdentifiers = otherIdentifiers,
         mergeCandidates = mergeCandidates,
@@ -228,10 +228,9 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     )
 
   def createUnidentifiedCalmWorkWith(
-    data: WorkData[DataState.Unidentified] =
-      WorkData[DataState.Unidentified](
-        items = List(createCalmItem)
-      ),
+    data: WorkData[DataState.Unidentified] = WorkData[DataState.Unidentified](
+      items = List(createCalmItem)
+    ),
     id: String = randomAlphanumeric(6),
     version: Int = 0): Work.Standard[Unidentified] =
     Work.Standard[Unidentified](
@@ -292,10 +291,10 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
     : Work.Standard[Unidentified] =
     createUnidentifiedSierraWorkWith(items = items)
 
-  def createMiroWorkWith(
-    images: List[UnmergedImage[DataState.Unidentified]],
-    otherIdentifiers: List[SourceIdentifier] = Nil,
-    sourceIdentifier: SourceIdentifier = createMiroSourceIdentifier)
+  def createMiroWorkWith(images: List[UnmergedImage[DataState.Unidentified]],
+                         otherIdentifiers: List[SourceIdentifier] = Nil,
+                         sourceIdentifier: SourceIdentifier =
+                           createMiroSourceIdentifier)
     : Work.Standard[Unidentified] =
     createUnidentifiedWorkWith(
       sourceIdentifier = sourceIdentifier,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -45,7 +45,7 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
 
   def createUnidentifiedInvisibleWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    items: List[Item[Unidentified#DataId]] = Nil,
+    items: List[Item[Unidentified#MaybeId]] = Nil,
     images: List[UnmergedImage[IdState.Identifiable, WorkState.Unidentified]] =
       Nil,
   ): Work.Invisible[Unidentified] =

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/package.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/package.scala
@@ -7,8 +7,7 @@ import uk.ac.wellcome.models.work.internal._
 import scala.util.Try
 
 package object services {
-  type MergedIdentifiedImage =
-    MergedImage[IdState.Identified, WorkState.Identified]
+  type MergedIdentifiedImage = MergedImage[DataState.Identified]
 
   // Because request pool flows cannot be FlowWithContexts, we have to manually
   // attach both the "usual" context object (the RequestCtx) and the context from

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -36,23 +36,22 @@ trait InferenceManagerWorkerServiceFixture
     testWith: TestWith[InferenceManagerWorkerService[String], R])(
     implicit decoder: Decoder[MergedIdentifiedImage]): R =
     withActorSystem { implicit actorSystem =>
-      withBigMessageStream[
-        MergedImage[DataState.Identified],
-        R](queue) { msgStream =>
-        val workerService = new InferenceManagerWorkerService(
-          msgStream = msgStream,
-          messageSender = messageSender,
-          inferrerAdapters = adapters,
-          imageDownloader = new ImageDownloader(
-            root = fileRoot,
-            fileWriter = fileWriter,
-            requestPool = imageRequestPool),
-          requestPool = inferrerRequestPool
-        )
+      withBigMessageStream[MergedImage[DataState.Identified], R](queue) {
+        msgStream =>
+          val workerService = new InferenceManagerWorkerService(
+            msgStream = msgStream,
+            messageSender = messageSender,
+            inferrerAdapters = adapters,
+            imageDownloader = new ImageDownloader(
+              root = fileRoot,
+              fileWriter = fileWriter,
+              requestPool = imageRequestPool),
+            requestPool = inferrerRequestPool
+          )
 
-        workerService.run()
+          workerService.run()
 
-        testWith(workerService)
+          testWith(workerService)
       }
     }
 

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -37,7 +37,7 @@ trait InferenceManagerWorkerServiceFixture
     implicit decoder: Decoder[MergedIdentifiedImage]): R =
     withActorSystem { implicit actorSystem =>
       withBigMessageStream[
-        MergedImage[IdState.Identified, WorkState.Identified],
+        MergedImage[DataState.Identified],
         R](queue) { msgStream =>
         val workerService = new InferenceManagerWorkerService(
           msgStream = msgStream,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/logging/MergerLogging.scala
@@ -15,13 +15,10 @@ trait MergerLogging extends Logging {
   def describeWorks(works: NonEmptyList[Work[Unidentified]]): String =
     describeWorks(works.toList)
 
-  def describeImage(
-    image: BaseImage[IdState.Identifiable, Unidentified]): String =
+  def describeImage(image: BaseImage[DataState.Unidentified]): String =
     s"(id=${image.id})"
 
-  def describeImages(
-    images: Seq[BaseImage[IdState.Identifiable, WorkState.Unidentified]])
-    : String =
+  def describeImages(images: Seq[BaseImage[DataState.Unidentified]]): String =
     s"[${images.map(describeImage).mkString(",")}]"
 
   def describeMergeSet(target: Work[Unidentified],

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
@@ -7,6 +7,5 @@ import WorkState.Unidentified
  * MergeResult holds the resultant target after all fields have been merged,
  * and the images that were created in the process
  */
-case class MergeResult(
-  mergedTarget: Work[Unidentified],
-  images: Seq[MergedImage[DataState.Unidentified]])
+case class MergeResult(mergedTarget: Work[Unidentified],
+                       images: Seq[MergedImage[DataState.Unidentified]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
@@ -9,4 +9,4 @@ import WorkState.Unidentified
  */
 case class MergeResult(
   mergedTarget: Work[Unidentified],
-  images: Seq[MergedImage[IdState.Identifiable, Unidentified]])
+  images: Seq[MergedImage[DataState.Unidentified]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -7,6 +7,5 @@ import WorkState.Unidentified
  * MergerOutcome is the final output of the merger:
  * all merged, redirected, and remaining works, as well as all merged images
  */
-case class MergerOutcome(
-  works: Seq[Work[Unidentified]],
-  images: Seq[MergedImage[DataState.Unidentified]])
+case class MergerOutcome(works: Seq[Work[Unidentified]],
+                         images: Seq[MergedImage[DataState.Unidentified]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -9,4 +9,4 @@ import WorkState.Unidentified
  */
 case class MergerOutcome(
   works: Seq[Work[Unidentified]],
-  images: Seq[MergedImage[IdState.Identifiable, Unidentified]])
+  images: Seq[MergedImage[DataState.Unidentified]])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -12,7 +12,7 @@ object ImagesRule extends FieldMergeRule {
   import WorkPredicates._
 
   type FieldData =
-    List[MergedImage[IdState.Identifiable, WorkState.Unidentified]]
+    List[MergedImage[DataState.Unidentified]]
 
   override def merge(
     target: Work.Standard[Unidentified],
@@ -58,7 +58,7 @@ object ImagesRule extends FieldMergeRule {
   trait FlatImageMergeRule extends PartialRule {
     final override def rule(target: Work.Standard[Unidentified],
                             sources: NonEmptyList[Work[Unidentified]])
-      : List[MergedImage[IdState.Identifiable, WorkState.Unidentified]] = {
+      : List[MergedImage[DataState.Unidentified]] = {
       val works = sources.prepend(target).toList
       works flatMap {
         _.data.images.map {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -123,7 +123,7 @@ object PlatformMerger extends Merger {
       } yield
         MergeResult(
           mergedTarget = target.withData { data =>
-            data.copy[Unidentified, IdState.Identifiable](
+            data.copy[DataState.Unidentified](
               merged = true,
               items = items,
               thumbnail = thumbnail,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
@@ -27,10 +27,9 @@ class ImagesRuleTest
       result should have length 1
       result.head.location should be(miroWork.data.images.head.location)
       val source = result.head.source
-      source shouldBe a[SourceWorks[_, _]]
+      source shouldBe a[SourceWorks[_]]
       val sourceWorks =
-        source.asInstanceOf[SourceWorks[IdState.Identifiable,
-                                        WorkState.Unidentified]]
+        source.asInstanceOf[SourceWorks[DataState.Unidentified]]
       sourceWorks.canonicalWork.id.sourceIdentifier should be(
         miroWork.sourceIdentifier)
       sourceWorks.redirectedWork should be(None)
@@ -50,8 +49,7 @@ class ImagesRuleTest
       result.foreach { image =>
         val imageSource =
           image.source
-            .asInstanceOf[SourceWorks[IdState.Identifiable,
-                                      WorkState.Unidentified]]
+            .asInstanceOf[SourceWorks[DataState.Unidentified]]
         val identifier = imageSource.canonicalWork.id.sourceIdentifier
         identifier shouldBe sierraWork.sourceIdentifier
         imageSource.redirectedWork shouldBe defined
@@ -75,8 +73,7 @@ class ImagesRuleTest
         metsWork.data.images.map(_.location)
       result.map { image =>
         image.source
-          .asInstanceOf[SourceWorks[IdState.Identifiable,
-                                    WorkState.Unidentified]]
+          .asInstanceOf[SourceWorks[DataState.Unidentified]]
           .canonicalWork
           .id
           .sourceIdentifier
@@ -100,8 +97,7 @@ class ImagesRuleTest
           miroWorks.map(_.data.images.head.location)
       result.map { image =>
         image.source
-          .asInstanceOf[SourceWorks[IdState.Identifiable,
-                                    WorkState.Unidentified]]
+          .asInstanceOf[SourceWorks[DataState.Unidentified]]
           .canonicalWork
           .id
           .sourceIdentifier
@@ -121,8 +117,7 @@ class ImagesRuleTest
         miroWorks.map(_.data.images.head.location)
       result.map { image =>
         image.source
-          .asInstanceOf[SourceWorks[IdState.Identifiable,
-                                    WorkState.Unidentified]]
+          .asInstanceOf[SourceWorks[DataState.Unidentified]]
           .canonicalWork
           .id
           .sourceIdentifier
@@ -147,8 +142,7 @@ class ImagesRuleTest
       val sources = (1 to 5).map(_ => createMiroWork)
       forAll(testRule.apply(target, sources).get) {
         _.source
-          .asInstanceOf[SourceWorks[IdState.Identifiable,
-                                    WorkState.Unidentified]]
+          .asInstanceOf[SourceWorks[DataState.Unidentified]]
           .canonicalWork
           .id
           .sourceIdentifier should be(target.sourceIdentifier)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -57,7 +57,7 @@ class MergerTest
       } yield
         MergeResult(
           mergedTarget = target withData { data =>
-            data.copy[Unidentified, IdState.Identifiable](
+            data.copy[DataState.Unidentified](
               items = items,
               otherIdentifiers = otherIdentifiers
             )
@@ -72,7 +72,7 @@ class MergerTest
     mergedWorks.works should contain(
       inputWorks.head.asInstanceOf[Work.Standard[Unidentified]] withData {
         data =>
-          data.copy[Unidentified, IdState.Identifiable](
+          data.copy[DataState.Unidentified](
             items = mergedTargetItems,
             otherIdentifiers = mergedOtherIdentifiers
           )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -236,8 +236,7 @@ class MergerWorkerServiceTest
 
           val imagesSent =
             senders.images
-              .getMessages[MergedImage[IdState.Identifiable,
-                                       WorkState.Unidentified]]
+              .getMessages[MergedImage[DataState.Unidentified]]
               .distinct
           imagesSent should have size 1
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -117,8 +117,7 @@ object CalmTransformer
         !nonSuppressedStatuses.contains(status.toLowerCase.trim)
       }
 
-  def workData(
-    record: CalmRecord): Result[WorkData[DataState.Unidentified]] =
+  def workData(record: CalmRecord): Result[WorkData[DataState.Unidentified]] =
     for {
       accessStatus <- accessStatus(record)
       title <- title(record)

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -51,7 +51,7 @@ object CalmTransformer
           state = Unidentified(sourceIdentifier(record)),
           version = version,
           data = workData(record)
-            .getOrElse(WorkData[Unidentified, IdState.Identifiable]()),
+            .getOrElse(WorkData[DataState.Unidentified]()),
           invisibilityReasons = List(SuppressedFromSource("Calm"))
         )
       )
@@ -118,7 +118,7 @@ object CalmTransformer
       }
 
   def workData(
-    record: CalmRecord): Result[WorkData[Unidentified, IdState.Identifiable]] =
+    record: CalmRecord): Result[WorkData[DataState.Unidentified]] =
     for {
       accessStatus <- accessStatus(record)
       title <- title(record)
@@ -126,7 +126,7 @@ object CalmTransformer
       collectionPath <- collectionPath(record, collectionLevel)
       language <- language(record)
     } yield
-      WorkData[Unidentified, IdState.Identifiable](
+      WorkData[DataState.Unidentified](
         title = Some(title),
         otherIdentifiers = otherIdentifiers(record),
         workType = Some(workType(collectionLevel)),

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -30,7 +30,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
             identifierType = CalmIdentifierTypes.recordId
           )
         ),
-        data = WorkData[Unidentified, IdState.Identifiable](
+        data = WorkData[DataState.Unidentified](
           title = Some("abc"),
           workType = Some(WorkType.ArchiveCollection),
           collectionPath = Some(
@@ -488,7 +488,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
           )
         ),
         version = version,
-        data = WorkData[Unidentified, IdState.Identifiable](
+        data = WorkData[DataState.Unidentified](
           title = Some("Should suppress"),
           workType = Some(WorkType.ArchiveSection),
           collectionPath = Some(

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -28,7 +28,7 @@ case class MetsData(
       Work.Invisible[Unidentified](
         version = version,
         state = Unidentified(sourceIdentifier),
-        data = WorkData[Unidentified, IdState.Identifiable](
+        data = WorkData[DataState.Unidentified](
           items = List(item),
           mergeCandidates = List(mergeCandidate),
           thumbnail = thumbnail(sourceIdentifier.value, license, accessStatus),
@@ -138,7 +138,7 @@ case class MetsData(
   private def images(version: Int,
                      license: Option[License],
                      accessStatus: Option[AccessStatus])
-    : List[UnmergedImage[IdState.Identifiable, WorkState.Unidentified]] =
+    : List[UnmergedImage[DataState.Unidentified]] =
     if (accessStatus.forall(shouldCreateDigitalLocation)) {
       fileReferences
         .filter(ImageUtils.isImage)

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerServiceTest.scala
@@ -125,7 +125,7 @@ class MetsTransformerWorkerServiceTest
           value = identifier
         )
       ),
-      data = WorkData[Unidentified, IdState.Identifiable](
+      data = WorkData[DataState.Unidentified](
         items = List(expectedItem),
         mergeCandidates = List(
           MergeCandidate(

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -34,7 +34,7 @@ class MetsDataTest
     metsData.toWork(version).right.get shouldBe Work.Invisible[Unidentified](
       version = version,
       state = Unidentified(expectedSourceIdentifier),
-      data = WorkData[Unidentified, IdState.Identifiable](
+      data = WorkData[DataState.Unidentified](
         items = List(unidentifiableItem),
         mergeCandidates = List(
           MergeCandidate(
@@ -72,7 +72,7 @@ class MetsDataTest
     metsData.toWork(version).right.get shouldBe Work.Invisible[Unidentified](
       version = version,
       state = Unidentified(expectedSourceIdentifier),
-      data = WorkData[Unidentified, IdState.Identifiable](
+      data = WorkData[DataState.Unidentified](
         items = List(unidentifiableItem),
         mergeCandidates = List(
           MergeCandidate(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -71,7 +71,7 @@ class MiroRecordTransformer
 
       val (title, description) = getTitleAndDescription(miroRecord)
 
-      val data = WorkData[WorkState.Unidentified, IdState.Identifiable](
+      val data = WorkData[DataState.Unidentified](
         otherIdentifiers = getOtherIdentifiers(miroRecord),
         title = Some(title),
         workType = getWorkType,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
@@ -5,9 +5,8 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 trait MiroImage extends MiroLocation {
 
-  def getImage(
-    miroRecord: MiroRecord,
-    version: Int): UnmergedImage[DataState.Unidentified] =
+  def getImage(miroRecord: MiroRecord,
+               version: Int): UnmergedImage[DataState.Unidentified] =
     UnmergedImage(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("miro-image-number"),

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
@@ -1,19 +1,13 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
-import uk.ac.wellcome.models.work.internal.{
-  IdState,
-  IdentifierType,
-  SourceIdentifier,
-  UnmergedImage,
-  WorkState
-}
+import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 
 trait MiroImage extends MiroLocation {
 
   def getImage(
     miroRecord: MiroRecord,
-    version: Int): UnmergedImage[IdState.Identifiable, WorkState.Unidentified] =
+    version: Int): UnmergedImage[DataState.Unidentified] =
     UnmergedImage(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType("miro-image-number"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformableTransformer.scala
@@ -97,7 +97,7 @@ class SierraTransformableTransformer(sierraTransformable: SierraTransformable,
   }
 
   def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
-    WorkData[WorkState.Unidentified, IdState.Identifiable](
+    WorkData[DataState.Unidentified](
       otherIdentifiers = SierraIdentifiers(bibId, bibData),
       mergeCandidates = SierraMergeCandidates(bibId, bibData),
       title = SierraTitle(bibId, bibData),


### PR DESCRIPTION
This changes `WorkData` and the image types so not dependent on a `WorkState` type parameter, each having a single `DataState` parameter. This is required for decoupling the `Work` model from the image models, in preparation for adding new work states (`Source`, `Merged`, `Denormalised`, `Identified`), and also makes the code more readable than having two type parameters which essentially indicate the same thing (i.e. that the piece of data is pre or post `id_minter`)

Also the `StandardWorkFilter` is renamed to `VisibleWorkFilter`, as the fact it is a standard work is not the important factor as far as the API filtering is concerned.