### PR TITLE
Filter by colour

### DIFF
--- a/api/api/src/main/resources/application.conf
+++ b/api/api/src/main/resources/application.conf
@@ -7,3 +7,4 @@ api.host=${?api_host}
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
+images.palette.bin-sizes=${?palette_bin_sizes}

--- a/api/api/src/main/resources/application.conf
+++ b/api/api/src/main/resources/application.conf
@@ -7,4 +7,3 @@ api.host=${?api_host}
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
-images.palette.bin-sizes=${?palette_bin_sizes}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.Http
 import com.typesafe.config.Config
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
-import uk.ac.wellcome.platform.api.models.ApiConfig
+import uk.ac.wellcome.platform.api.models.{ApiConfig, QueryConfig}
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -43,7 +43,17 @@ object Main extends WellcomeTypesafeApp {
           .getOrElse("context.json"),
       )
 
-    val router = new Router(elasticClient, elasticConfig, apiConfig)
+    val queryConfig = QueryConfig(
+      paletteBinSizes = config
+        .getStringOption("images.palette.bin-sizes")
+        .map { commaSeparated =>
+          commaSeparated.split(",").toSeq.map(_.toInt)
+        }
+        .getOrElse(Seq(4, 6, 8))
+    )
+
+    val router =
+      new Router(elasticClient, elasticConfig, queryConfig, apiConfig)
 
     () =>
       Http()

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -43,14 +43,8 @@ object Main extends WellcomeTypesafeApp {
           .getOrElse("context.json"),
       )
 
-    val queryConfig = QueryConfig(
-      paletteBinSizes = config
-        .getStringOption("images.palette.bin-sizes")
-        .map { commaSeparated =>
-          commaSeparated.split(",").toSeq.map(_.toInt)
-        }
-        .getOrElse(Seq(4, 6, 8))
-    )
+    val queryConfig =
+      QueryConfig.fetchFromIndex(elasticClient, elasticConfig.imagesIndex)
 
     val router =
       new Router(elasticClient, elasticConfig, queryConfig, apiConfig)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -19,6 +19,7 @@ import uk.ac.wellcome.platform.api.services.ElasticsearchService
 
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,
+             queryConfig: QueryConfig,
              implicit val apiConfig: ApiConfig)(implicit ec: ExecutionContext)
     extends CustomDirectives {
 
@@ -84,7 +85,11 @@ class Router(elasticClient: ElasticClient,
     new WorksController(elasticsearchService, apiConfig, elasticConfig)
 
   lazy val imagesController =
-    new ImagesController(elasticsearchService, apiConfig, elasticConfig)
+    new ImagesController(
+      elasticsearchService,
+      apiConfig,
+      elasticConfig,
+      queryConfig)
 
   def swagger: Route = get {
     complete(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -1,19 +1,35 @@
 package uk.ac.wellcome.platform.api.elasticsearch
 
-class ColorQuery(binSizes: Seq[Int], repetitions: Int) {
+import com.sksamuel.elastic4s.ElasticApi._
+import com.sksamuel.elastic4s.requests.searches.queries.MoreLikeThisQuery
+import uk.ac.wellcome.platform.api.elasticsearch.ColorQuery.hexToRgb
 
-  def getColorSignature(color: ColorQuery.Rgb): Seq[String] =
+class ColorQuery(binSizes: Seq[Int]) {
+
+  def apply(field: String, hexColors: Seq[String]): MoreLikeThisQuery =
+    moreLikeThisQuery(field)
+      .likeTexts(getColorsSignature(hexColors.map(hexToRgb)))
+      .copy(
+        minTermFreq = Some(1),
+        minDocFreq = Some(1),
+        maxQueryTerms = Some(1000),
+        minShouldMatch = Some("1")
+      )
+
+  private def getColorsSignature(colors: Seq[ColorQuery.Rgb]): Seq[String] =
     binSizes
       .flatMap { nBins =>
         val idx = componentIndex(nBins) _
-        val indices = (idx(color._1), idx(color._2), idx(color._3))
+        val colorIndices = colors.map { color =>
+          (idx(color._1), idx(color._2), idx(color._3))
+        }
         val d = nBins - 1
-        Seq.fill(repetitions)(
+        colorIndices.map { indices =>
           (indices._1 + d * indices._2 + d * d * indices._3, nBins)
-        )
+        }
       }
       .map {
-        case (index, nBins) => s"${index}/${nBins}"
+        case (index, nBins) => s"$index/$nBins"
       }
 
   private def componentIndex(nBins: Int)(i: Int): Int =
@@ -23,12 +39,6 @@ class ColorQuery(binSizes: Seq[Int], repetitions: Int) {
 
 object ColorQuery {
   type Rgb = (Int, Int, Int)
-
-  def getSignatureParams(sample: Seq[String]): (Seq[Int], Int) = {
-    val binSizes = sample.map(_.split("/").last.toInt).distinct
-    val repetitions = sample.count(_.endsWith(binSizes.head.toString))
-    (binSizes, repetitions)
-  }
 
   def hexToRgb(hex: String): Rgb = {
     val n = Integer.parseInt(hex, 16)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -6,9 +6,11 @@ import uk.ac.wellcome.platform.api.elasticsearch.ColorQuery.hexToRgb
 
 class ColorQuery(binSizes: Seq[Int]) {
 
-  def apply(field: String, hexColors: Seq[String]): MoreLikeThisQuery =
+  def apply(field: String,
+            hexColors: Seq[String],
+            binIndices: Seq[Int] = binSizes.indices): MoreLikeThisQuery =
     moreLikeThisQuery(field)
-      .likeTexts(getColorsSignature(hexColors.map(hexToRgb)))
+      .likeTexts(getColorsSignature(hexColors.map(hexToRgb), binIndices))
       .copy(
         minTermFreq = Some(1),
         minDocFreq = Some(1),
@@ -16,8 +18,10 @@ class ColorQuery(binSizes: Seq[Int]) {
         minShouldMatch = Some("1")
       )
 
-  private def getColorsSignature(colors: Seq[ColorQuery.Rgb]): Seq[String] =
-    binSizes
+  private def getColorsSignature(colors: Seq[ColorQuery.Rgb],
+                                 binIndices: Seq[Int]): Seq[String] =
+    binIndices
+      .map(binSizes)
       .flatMap { d =>
         val idx = componentIndex(d) _
         colors.map { color =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.platform.api.elasticsearch
+
+class ColorQuery(binSizes: Seq[Int], repetitions: Int) {
+
+  def getColorSignature(color: ColorQuery.Rgb): Seq[String] =
+    binSizes
+      .flatMap { nBins =>
+        val idx = componentIndex(nBins) _
+        val indices = (idx(color._1), idx(color._2), idx(color._3))
+        val d = nBins - 1
+        Seq.fill(repetitions)(
+          (indices._1 + d * indices._2 + d * d * indices._3, nBins)
+        )
+      }
+      .map {
+        case (index, nBins) => s"${index}/${nBins}"
+      }
+
+  private def componentIndex(nBins: Int)(i: Int): Int =
+    math.floor(nBins * i / 256d).toInt
+
+}
+
+object ColorQuery {
+  type Rgb = (Int, Int, Int)
+
+  def getSignatureParams(sample: Seq[String]): (Seq[Int], Int) = {
+    val binSizes = sample.map(_.split("/").last.toInt).distinct
+    val repetitions = sample.count(_.endsWith(binSizes.head.toString))
+    (binSizes, repetitions)
+  }
+
+  def hexToRgb(hex: String): Rgb = {
+    val n = Integer.parseInt(hex, 16)
+    (
+      (n >> 16) & 0xFF,
+      (n >> 8) & 0xFF,
+      n & 0xFF
+    )
+  }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -18,18 +18,15 @@ class ColorQuery(binSizes: Seq[Int]) {
 
   private def getColorsSignature(colors: Seq[ColorQuery.Rgb]): Seq[String] =
     binSizes
-      .flatMap { nBins =>
-        val idx = componentIndex(nBins) _
-        val colorIndices = colors.map { color =>
-          (idx(color._1), idx(color._2), idx(color._3))
-        }
-        val d = nBins - 1
-        colorIndices.map { indices =>
-          (indices._1 + d * indices._2 + d * d * indices._3, nBins)
+      .flatMap { d =>
+        val idx = componentIndex(d) _
+        colors.map { color =>
+          val indices = (idx(color._1), idx(color._2), idx(color._3))
+          (indices._1 + d * indices._2 + d * d * indices._3, d)
         }
       }
       .map {
-        case (index, nBins) => s"$index/$nBins"
+        case (index, d) => s"$index/$d"
       }
 
   private def componentIndex(nBins: Int)(i: Int): Int =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -38,3 +38,5 @@ case class CollectionDepthFilter(depth: Int) extends WorkFilter
 case class AccessStatusFilter(includes: List[AccessStatus],
                               excludes: List[AccessStatus])
     extends WorkFilter
+
+case class ColorFilter(hexColors: Seq[String]) extends ImageFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.models.Implicits._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 case class QueryConfig(
   paletteBinSizes: Seq[Int]
@@ -54,11 +54,14 @@ object QueryConfig {
             .left
             .map(_.asException)
             .toTry
-            .map {
-              case Some(bins) => bins
+            .flatMap {
+              case Some(bins) => Success(bins)
               case None =>
-                throw new RuntimeException(
-                  "Could not extract palette parameters from data in index")
+                Failure(
+                  new RuntimeException(
+                    "Could not extract palette parameters from data in index"
+                  )
+                )
             }
         }
       }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api.models
 
-import com.sksamuel.elastic4s.ElasticApi.search
+import com.sksamuel.elastic4s.ElasticApi.{existsQuery, search}
 import com.sksamuel.elastic4s.ElasticDsl.SearchHandler
 import com.sksamuel.elastic4s.circe._
 import com.sksamuel.elastic4s.{ElasticClient, Index}
@@ -34,7 +34,9 @@ object QueryConfig {
     index: Index)(implicit ec: ExecutionContext): Future[Seq[Int]] =
     elasticClient
       .execute(
-        search(index).matchAllQuery().size(1)
+        search(index).query(
+          existsQuery("inferredData.palette")
+        )
       )
       .flatMap { result =>
         Future.fromTry {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
@@ -1,5 +1,63 @@
 package uk.ac.wellcome.platform.api.models
 
+import com.sksamuel.elastic4s.ElasticApi.search
+import com.sksamuel.elastic4s.ElasticDsl.SearchHandler
+import com.sksamuel.elastic4s.circe._
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import uk.ac.wellcome.models.work.internal.AugmentedImage
+import uk.ac.wellcome.models.Implicits._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
+
 case class QueryConfig(
   paletteBinSizes: Seq[Int]
 )
+
+object QueryConfig {
+  def fetchFromIndex(elasticClient: ElasticClient, imagesIndex: Index)(
+    implicit ec: ExecutionContext): QueryConfig =
+    QueryConfig(
+      paletteBinSizes = Try(
+        Await.result(
+          getPaletteBinSizesFromIndex(elasticClient, imagesIndex),
+          5 seconds
+        )
+      ).getOrElse(defaultPaletteBinSizes)
+    )
+
+  val defaultPaletteBinSizes = Seq(4, 6, 8)
+
+  private def getPaletteBinSizesFromIndex(
+    elasticClient: ElasticClient,
+    index: Index)(implicit ec: ExecutionContext): Future[Seq[Int]] =
+    elasticClient
+      .execute(
+        search(index).matchAllQuery().size(1)
+      )
+      .flatMap { result =>
+        Future.fromTry {
+          result.toEither
+            .map { response =>
+              response.hits.hits.headOption
+                .flatMap(_.to[AugmentedImage].inferredData.map(_.palette))
+                .map { palette =>
+                  palette
+                    .flatMap(_.split("/").lastOption)
+                    .distinct
+                    .map(_.toInt)
+                }
+            }
+            .left
+            .map(_.asException)
+            .toTry
+            .map {
+              case Some(bins) => bins
+              case None =>
+                throw new RuntimeException(
+                  "Could not extract palette parameters from data in index")
+            }
+        }
+      }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/QueryConfig.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.api.models
+
+case class QueryConfig(
+  paletteBinSizes: Seq[Int]
+)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.Implicits._
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.Tracing
-import uk.ac.wellcome.platform.api.models.{ApiConfig, SimilarityMetric}
+import uk.ac.wellcome.platform.api.models.{
+  ApiConfig,
+  QueryConfig,
+  SimilarityMetric
+}
 import uk.ac.wellcome.platform.api.services.{
   ElasticsearchService,
   ImagesService
@@ -16,10 +20,10 @@ import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ImagesController(
-  elasticsearchService: ElasticsearchService,
-  implicit val apiConfig: ApiConfig,
-  elasticConfig: ElasticConfig)(implicit ec: ExecutionContext)
+class ImagesController(elasticsearchService: ElasticsearchService,
+                       implicit val apiConfig: ApiConfig,
+                       elasticConfig: ElasticConfig,
+                       queryConfig: QueryConfig)(implicit ec: ExecutionContext)
     extends CustomDirectives
     with Tracing
     with FailFastCirceSupport {
@@ -100,5 +104,6 @@ class ImagesController(
       })
       .getOrElse(Nil)
 
-  private lazy val imagesService = new ImagesService(elasticsearchService)
+  private lazy val imagesService =
+    new ImagesService(elasticsearchService, queryConfig)
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -32,6 +32,7 @@ case class MultipleImagesParams(
   pageSize: Option[Int],
   query: Option[String],
   license: Option[LicenseFilter],
+  colors: Option[ColorFilter],
   _index: Option[String]
 ) extends QueryParams
     with Paginated {
@@ -58,10 +59,14 @@ object MultipleImagesParams extends QueryParamsUtils {
         "pageSize".as[Int].?,
         "query".as[String].?,
         "locations.license".as[LicenseFilter].?,
+        "colors".as[ColorFilter].?,
         "_index".as[String].?
       )
     ).tflatMap { args =>
       val params = (MultipleImagesParams.apply _).tupled(args)
       validated(params.paginationErrors, params)
     }
+
+  implicit val colorFilter: Decoder[ColorFilter] =
+    decodeCommaSeparated.emap(strs => Right(ColorFilter(strs)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -32,7 +32,7 @@ case class MultipleImagesParams(
   pageSize: Option[Int],
   query: Option[String],
   license: Option[LicenseFilter],
-  colors: Option[ColorFilter],
+  color: Option[ColorFilter],
   _index: Option[String]
 ) extends QueryParams
     with Paginated {
@@ -48,7 +48,7 @@ case class MultipleImagesParams(
   private def filters: List[ImageFilter] =
     List(
       license,
-      colors
+      color
     ).flatten
 }
 
@@ -62,7 +62,7 @@ object MultipleImagesParams extends QueryParamsUtils {
         "pageSize".as[Int].?,
         "query".as[String].?,
         "locations.license".as[LicenseFilter].?,
-        "colors".as[ColorFilter].?,
+        "color".as[ColorFilter].?,
         "_index".as[String].?
       )
     ).tflatMap { args =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -46,7 +46,10 @@ case class MultipleImagesParams(
     )
 
   private def filters: List[ImageFilter] =
-    license.toList
+    List(
+      license,
+      colors
+    ).flatten
 }
 
 object MultipleImagesParams extends QueryParamsUtils {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -5,7 +5,6 @@ import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.sort._
-import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.platform.api.elasticsearch.{
   ColorQuery,
   ImageSimilarity,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -2,13 +2,12 @@ package uk.ac.wellcome.platform.api.services
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.{ElasticError, Hit, Index}
 import com.sksamuel.elastic4s.circe._
+import com.typesafe.config.Config
 import io.circe.Decoder
-
 import uk.ac.wellcome.display.models.SortingOrder
 import uk.ac.wellcome.models.work.internal.AugmentedImage
 import uk.ac.wellcome.models.Implicits._
@@ -26,11 +25,12 @@ case class ImagesSearchOptions(
   pageNumber: Int = 1
 ) extends PaginatedSearchOptions
 
-class ImagesService(searchService: ElasticsearchService)(
-  implicit ec: ExecutionContext)
+class ImagesService(searchService: ElasticsearchService,
+                    queryConfig: QueryConfig)(implicit ec: ExecutionContext)
     extends Tracing {
 
   private val nVisuallySimilarImages = 5
+  private val imagesRequestBuilder = new ImagesRequestBuilder(queryConfig)
 
   def findImageById(id: String)(
     index: Index): Future[Either[ElasticError, Option[AugmentedImage]]] =
@@ -50,7 +50,7 @@ class ImagesService(searchService: ElasticsearchService)(
     searchService
       .executeSearch(
         queryOptions = toElasticsearchQueryOptions(searchOptions),
-        requestBuilder = ImagesRequestBuilder,
+        requestBuilder = imagesRequestBuilder,
         index = index
       )
       .map { _.map(createResultList) }
@@ -64,11 +64,11 @@ class ImagesService(searchService: ElasticsearchService)(
       .executeSearchRequest({
         val requestBuilder = similarityMetric match {
           case SimilarityMetric.Blended =>
-            ImagesRequestBuilder.requestWithBlendedSimilarity
+            imagesRequestBuilder.requestWithBlendedSimilarity
           case SimilarityMetric.Features =>
-            ImagesRequestBuilder.requestWithSimilarFeatures
+            imagesRequestBuilder.requestWithSimilarFeatures
           case SimilarityMetric.Colors =>
-            ImagesRequestBuilder.requestWithSimilarColors
+            imagesRequestBuilder.requestWithSimilarColors
         }
         requestBuilder(index, image.id.canonicalId, nVisuallySimilarImages)
       })

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -6,7 +6,6 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.{ElasticError, Hit, Index}
 import com.sksamuel.elastic4s.circe._
-import com.typesafe.config.Config
 import io.circe.Decoder
 import uk.ac.wellcome.display.models.SortingOrder
 import uk.ac.wellcome.models.work.internal.AugmentedImage

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -218,6 +218,12 @@ trait MultipleImagesSwagger {
         required = false
       ),
       new Parameter(
+        name = "colors",
+        in = ParameterIn.QUERY,
+        description = "Filter the images by colors.",
+        required = false
+      ),
+      new Parameter(
         name = "page",
         in = ParameterIn.QUERY,
         description = "The page to return from the result list",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQueryTest.scala
@@ -1,0 +1,50 @@
+package uk.ac.wellcome.platform.api.elasticsearch
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ColorQueryTest extends AnyFunSpec with Matchers {
+  val colorQuery = new ColorQuery(binSizes = Seq(4, 6, 8))
+
+  it("converts hex colors to rgb tuples") {
+    val hexes = Seq("ff0000", "00ff00", "0000ff", "00fa9a")
+    val tuples = hexes.map(ColorQuery.hexToRgb)
+
+    tuples shouldBe Seq(
+      (255, 0, 0),
+      (0, 255, 0),
+      (0, 0, 255),
+      (0, 250, 154),
+    )
+  }
+
+  it("creates queries for signatures with given bin sizes") {
+    val hexCode = "ffff00"
+    val q = colorQuery("colorField", Seq(hexCode))
+
+    q.fields should contain only "colorField"
+    q.likeTexts shouldBe Seq(
+      "15/4",
+      "35/6",
+      "63/8"
+    )
+  }
+
+  it("creates queries for multiple colors") {
+    val hexCodes = Seq("ff0000", "00ff00", "0000ff")
+    val q = colorQuery("colorField", hexCodes)
+
+    q.fields should contain only "colorField"
+    q.likeTexts shouldBe Seq(
+      "3/4",
+      "12/4",
+      "48/4",
+      "5/6",
+      "30/6",
+      "180/6",
+      "7/8",
+      "56/8",
+      "448/8"
+    )
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQueryTest.scala
@@ -30,6 +30,14 @@ class ColorQueryTest extends AnyFunSpec with Matchers {
     )
   }
 
+  it("creates queries for signatures with only some bins used") {
+    val hexCode = "ffff00"
+    val q = colorQuery("colorField", Seq(hexCode), binIndices = Seq(2))
+
+    q.fields should contain only "colorField"
+    q.likeTexts shouldBe Seq("63/8")
+  }
+
   it("creates queries for multiple colors") {
     val hexCodes = Seq("ff0000", "00ff00", "0000ff")
     val q = colorQuery("colorField", hexCodes)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.api.Router
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.platform.api.models.ApiConfig
+import uk.ac.wellcome.platform.api.models.{ApiConfig, QueryConfig}
 
 trait ApiFixture
     extends AnyFunSpec
@@ -34,13 +34,14 @@ trait ApiFixture
       val router = new Router(
         elasticClient,
         elasticConfig,
+        QueryConfig(paletteBinSizes = Seq(4, 6, 8)),
         ApiConfig(
           host = apiHost,
           scheme = apiScheme,
           defaultPageSize = 10,
           pathPrefix = apiName,
           contextSuffix = "context.json"
-        )
+        ),
       )
       testWith((elasticConfig, router.routes))
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -79,7 +79,7 @@ class ImagesFiltersTest extends ApiImagesTestBase {
       withApi {
         case (ElasticConfig(_, imagesIndex), routes) =>
           insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
-          assertJsonResponse(routes, f"/$apiPrefix/images?colors=ff0000") {
+          assertJsonResponse(routes, f"/$apiPrefix/images?color=ff0000") {
             Status.OK -> imagesListResponse(
               images = Seq(redImage)
             )
@@ -93,7 +93,7 @@ class ImagesFiltersTest extends ApiImagesTestBase {
           insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
           assertJsonResponse(
             routes,
-            f"/$apiPrefix/images?colors=ff0000,0000ff",
+            f"/$apiPrefix/images?color=ff0000,0000ff",
             unordered = true) {
             Status.OK -> imagesListResponse(
               images = Seq(blueImage, redImage)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -22,4 +22,84 @@ class ImagesFiltersTest extends ApiImagesTestBase {
       }
     }
   }
+
+  describe("filtering images by color") {
+    val redImage = createAugmentedImageWith(
+      inferredData = createInferredData.map(
+        _.copy(
+          palette = List(
+            "3/4",
+            "3/4",
+            "6/4",
+            "6/4",
+            "30/4",
+            "18/4",
+            "1/4",
+            "4/6",
+            "4/6",
+            "34/6",
+            "34/6",
+            "130/6",
+            "70/6",
+            "2/6",
+            "6/8",
+            "6/8",
+            "69/8",
+            "69/8",
+            "301/8",
+            "181/8",
+            "2/8"
+          ))))
+    val blueImage = createAugmentedImageWith(
+      inferredData = createInferredData.map(_.copy(palette = List(
+        "48/4",
+        "48/4",
+        "5/4",
+        "5/4",
+        "26/4",
+        "32/4",
+        "16/4",
+        "180/6",
+        "180/6",
+        "50/6",
+        "50/6",
+        "93/6",
+        "144/6",
+        "36/6",
+        "448/8",
+        "448/8",
+        "83/8",
+        "83/8",
+        "164/8",
+        "320/8",
+        "128/8"
+      ))))
+
+    it("filters by color") {
+      withApi {
+        case (ElasticConfig(_, imagesIndex), routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
+          assertJsonResponse(routes, f"/$apiPrefix/images?colors=ff0000") {
+            Status.OK -> imagesListResponse(
+              images = Seq(redImage)
+            )
+          }
+      }
+    }
+
+    it("filters by multiple colors") {
+      withApi {
+        case (ElasticConfig(_, imagesIndex), routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
+          assertJsonResponse(
+            routes,
+            f"/$apiPrefix/images?colors=ff0000,0000ff",
+            unordered = true) {
+            Status.OK -> imagesListResponse(
+              images = Seq(blueImage, redImage)
+            )
+          }
+      }
+    }
+  }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
@@ -65,5 +65,15 @@ class QueryConfigTest
         result.paletteBinSizes shouldBe QueryConfig.defaultPaletteBinSizes
       }
     }
+
+    it("returns the default config if the data is not found") {
+      withLocalImagesIndex { index =>
+        val image = createAugmentedImageWith(inferredData = None)
+        insertImagesIntoElasticsearch(index, image)
+
+        val result = QueryConfig.fetchFromIndex(elasticClient, index)
+        result.paletteBinSizes shouldBe QueryConfig.defaultPaletteBinSizes
+      }
+    }
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
@@ -1,0 +1,69 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.sksamuel.elastic4s.Index
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.elasticsearch.ElasticClientBuilder
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.generators.ImageGenerators
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class QueryConfigTest
+    extends AnyFunSpec
+    with Matchers
+    with ElasticsearchFixtures
+    with ImageGenerators {
+  describe("fetchFromIndex") {
+
+    it("fetches query config from a given index") {
+      withLocalImagesIndex { index =>
+        val binSizes = Seq(10, 11, 12)
+        val image = createAugmentedImageWith(
+          inferredData = createInferredData.map(
+            _.copy(
+              palette = randomColorVector(binSizes = binSizes).toList
+            ))
+        )
+        insertImagesIntoElasticsearch(index, image)
+
+        val result = QueryConfig.fetchFromIndex(elasticClient, index)
+        result.paletteBinSizes shouldBe binSizes
+      }
+    }
+
+    it("returns the default config if the index doesn't exist") {
+      val result =
+        QueryConfig.fetchFromIndex(elasticClient, Index("not-an-index"))
+      result.paletteBinSizes shouldBe QueryConfig.defaultPaletteBinSizes
+    }
+
+    it("returns the default config if ES can't be connected to") {
+      val badClient = ElasticClientBuilder.create(
+        hostname = "not-a-host",
+        port = 123456,
+        protocol = "http",
+        username = "not-good",
+        password = "very-bad"
+      )
+      val result =
+        QueryConfig.fetchFromIndex(badClient, Index("not-an-index"))
+      result.paletteBinSizes shouldBe QueryConfig.defaultPaletteBinSizes
+    }
+
+    it("returns the default config if the data is not in the expected format") {
+      withLocalImagesIndex { index =>
+        val image = createAugmentedImageWith(
+          inferredData = createInferredData.map(
+            _.copy(
+              palette = List("123", "hello", "bad data")
+            ))
+        )
+        insertImagesIntoElasticsearch(index, image)
+
+        val result = QueryConfig.fetchFromIndex(elasticClient, index)
+        result.paletteBinSizes shouldBe QueryConfig.defaultPaletteBinSizes
+      }
+    }
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{EitherValues, OptionValues}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.ImageGenerators
-import uk.ac.wellcome.platform.api.models.SimilarityMetric
+import uk.ac.wellcome.platform.api.models.{QueryConfig, SimilarityMetric}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -21,7 +21,8 @@ class ImagesServiceTest
   val elasticsearchService = new ElasticsearchService(elasticClient)
 
   val imagesService = new ImagesService(
-    elasticsearchService
+    elasticsearchService,
+    QueryConfig(paletteBinSizes = Seq(4, 6, 8))
   )
 
   describe("findImageById") {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -70,13 +70,13 @@ trait ImageGenerators
     val features = randomVector(4096)
     val (features1, features2) = features.splitAt(features.size / 2)
     val lshEncodedFeatures = simHasher4096.lsh(features)
-    val palette = randomSortedIntegerVector(20, maxComponent = 1000)
+    val palette = randomColorVector()
     Some(
       InferredData(
         features1 = features1.toList,
         features2 = features2.toList,
         lshEncodedFeatures = lshEncodedFeatures.toList,
-        palette = palette.map(_.toString).toList
+        palette = palette.toList
       )
     )
   }
@@ -116,9 +116,9 @@ trait ImageGenerators
       similarVectors(4096, n)
     } else { (1 to n).map(_ => randomVector(4096, maxR = 10.0f)) }
     val palettes = if (similarPalette) {
-      similarSortedIntegerVectors(30, n)
+      similarColorVectors(n)
     } else {
-      (1 to n).map(_ => randomSortedIntegerVector(30, maxComponent = 1000))
+      (1 to n).map(_ => randomColorVector())
     }
     (features zip palettes).map {
       case (features, palette) =>

--- a/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
+++ b/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
@@ -51,9 +51,8 @@ class PaletteEncoder:
         return consistently_indexed_centroids[labels_by_weight]
 
     @staticmethod
-    def get_bin_index(colour, n_bins):
-        indices = np.floor(n_bins * colour / 256).astype(int)
-        d = n_bins - 1
+    def get_bin_index(colour, d):
+        indices = np.floor(d * colour / 256).astype(int)
         return indices[0] + d * indices[1] + d * d * indices[2]
 
     @staticmethod


### PR DESCRIPTION
This allows API users to pass a comma-separated list of colours (well, `color`s) to filter by. As such there is no scoring of colour similarity but it's likely we'll tackle that next. It also fixes a [very silly off-by-one error](https://github.com/wellcomecollection/catalogue/pull/867/files#diff-33b0eaf9b9d3a3a798032a703417da0aL56) that I introduced in https://github.com/wellcomecollection/catalogue/pull/864.

In order to construct the colour queries the API needs to know some of the parameters (bin sizes) that were used in the creation of the colour signature tokens (ie by the palette inferrer). The change in https://github.com/wellcomecollection/catalogue/pull/864 encoded the parameters in the signatures themselves, and this PR includes the functionality to extract these from the index at API startup.

I initially made this a parameter that could be passed as an environment variable, but actually finding a way of sharing that between the pipeline and api stacks _and_ respecting differing co-existing environments and indices proved quite tricky and no less ugly than this solution - but I'm open to discussion on this. I did add a few tests to try to ensure that a failure of this mechanism wouldn't bork the whole API.