### PR TITLE
API type filter

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.api.models
 
-import uk.ac.wellcome.models.work.internal.AccessStatus
-
+import uk.ac.wellcome.models.work.internal.{AccessStatus, WorkType}
 import java.time.LocalDate
 
 sealed trait DocumentFilter
@@ -13,7 +12,7 @@ case class ItemLocationTypeFilter(locationTypeIds: Seq[String])
 
 case class FormatFilter(formatIds: Seq[String]) extends WorkFilter
 
-case class WorkTypeFilter(types: Seq[String]) extends WorkFilter
+case class WorkTypeFilter(types: List[WorkType]) extends WorkFilter
 
 case class DateRangeFilter(fromDate: Option[LocalDate],
                            toDate: Option[LocalDate])

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -13,6 +13,8 @@ case class ItemLocationTypeFilter(locationTypeIds: Seq[String])
 
 case class FormatFilter(formatIds: Seq[String]) extends WorkFilter
 
+case class WorkTypeFilter(types: Seq[String]) extends WorkFilter
+
 case class DateRangeFilter(fromDate: Option[LocalDate],
                            toDate: Option[LocalDate])
     extends WorkFilter
@@ -29,7 +31,7 @@ case class LicenseFilter(licenseIds: Seq[String])
     extends WorkFilter
     with ImageFilter
 
-case class IdentifiersFilter(values: List[String]) extends WorkFilter
+case class IdentifiersFilter(values: Seq[String]) extends WorkFilter
 
 case class CollectionPathFilter(path: String) extends WorkFilter
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -66,6 +66,7 @@ case class MultipleWorksParams(
   query: Option[String],
   identifiers: Option[IdentifiersFilter],
   `items.locations.accessConditions.status`: Option[AccessStatusFilter],
+  `type`: Option[WorkTypeFilter],
   _queryType: Option[SearchQueryType],
   _index: Option[String],
 ) extends QueryParams
@@ -94,7 +95,8 @@ case class MultipleWorksParams(
       `subjects.label`,
       identifiers,
       `items.locations.accessConditions.status`,
-      license
+      license,
+      `type`
     ).flatten
 
   private def dateFilter: Option[DateRangeFilter] =
@@ -133,6 +135,7 @@ object MultipleWorksParams extends QueryParamsUtils {
         "query".as[String].?,
         "identifiers".as[IdentifiersFilter].?,
         "items.locations.accessConditions.status".as[AccessStatusFilter].?,
+        "type".as[WorkTypeFilter].?,
         "_queryType".as[SearchQueryType].?,
         "_index".as[String].?,
       )
@@ -142,13 +145,16 @@ object MultipleWorksParams extends QueryParamsUtils {
     }
 
   implicit val formatFilter: Decoder[FormatFilter] =
-    decodeCommaSeparated.emap(strs => Right(FormatFilter(strs)))
+    stringListFilter(FormatFilter)
+
+  implicit val workTypeFilter: Decoder[WorkTypeFilter] =
+    stringListFilter(WorkTypeFilter)
 
   implicit val itemLocationTypeFilter: Decoder[ItemLocationTypeFilter] =
-    decodeCommaSeparated.emap(strs => Right(ItemLocationTypeFilter(strs)))
+    stringListFilter(ItemLocationTypeFilter)
 
   implicit val languageFilter: Decoder[LanguageFilter] =
-    decodeCommaSeparated.emap(strs => Right(LanguageFilter(strs)))
+    stringListFilter(LanguageFilter)
 
   implicit val genreFilter: Decoder[GenreFilter] =
     Decoder.decodeString.emap(str => Right(GenreFilter(str)))
@@ -157,7 +163,7 @@ object MultipleWorksParams extends QueryParamsUtils {
     Decoder.decodeString.emap(str => Right(SubjectFilter(str)))
 
   implicit val identifiersFilter: Decoder[IdentifiersFilter] =
-    decodeCommaSeparated.emap(strs => Right(IdentifiersFilter(strs)))
+    stringListFilter(IdentifiersFilter)
 
   implicit val accessStatusFilter: Decoder[AccessStatusFilter] =
     decodeIncludesAndExcludes(
@@ -198,4 +204,7 @@ object MultipleWorksParams extends QueryParamsUtils {
       SearchQueryType.default,
       "MultiMatcher" -> SearchQueryType.MultiMatcher,
     )
+
+  private def stringListFilter[T](applyFilter: Seq[String] => T): Decoder[T] =
+    decodeCommaSeparated.emap(strs => Right(applyFilter(strs)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -6,7 +6,7 @@ import io.circe.Decoder
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.platform.api.services.WorksSearchOptions
-import uk.ac.wellcome.models.work.internal.AccessStatus
+import uk.ac.wellcome.models.work.internal.{AccessStatus, WorkType}
 
 case class SingleWorkParams(
   include: Option[WorksIncludes],
@@ -148,7 +148,11 @@ object MultipleWorksParams extends QueryParamsUtils {
     stringListFilter(FormatFilter)
 
   implicit val workTypeFilter: Decoder[WorkTypeFilter] =
-    stringListFilter(WorkTypeFilter)
+    decodeOneOfCommaSeparated(
+      "Collection" -> WorkType.Collection,
+      "Series" -> WorkType.Series,
+      "Section" -> WorkType.Section
+    ).emap(values => Right(WorkTypeFilter(values)))
 
   implicit val itemLocationTypeFilter: Decoder[ItemLocationTypeFilter] =
     stringListFilter(ItemLocationTypeFilter)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -81,6 +81,7 @@ class FiltersAndAggregationsBuilder(
     filter: WorkFilter): Option[AggregationRequest] = filter match {
     case _: ItemLocationTypeFilter => None
     case _: FormatFilter           => Some(AggregationRequest.Format)
+    case _: WorkTypeFilter         => None
     case _: DateRangeFilter        => None
     case VisibleWorkFilter         => None
     case _: LanguageFilter         => Some(AggregationRequest.Language)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -131,6 +131,8 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
           values = itemLocationTypeIds)
       case FormatFilter(formatIds) =>
         termsQuery(field = "data.format.id", values = formatIds)
+      case WorkTypeFilter(types) =>
+        termsQuery(field = "data.workType", values = types)
       case DateRangeFilter(fromDate, toDate) =>
         val (gte, lte) =
           (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -6,9 +6,9 @@ import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs._
 import com.sksamuel.elastic4s.requests.searches.queries._
 import com.sksamuel.elastic4s.requests.searches.sort._
-
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.models._
+import uk.ac.wellcome.models.work.internal.WorkType
 
 object WorksRequestBuilder extends ElasticsearchRequestBuilder {
 
@@ -132,7 +132,9 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
       case FormatFilter(formatIds) =>
         termsQuery(field = "data.format.id", values = formatIds)
       case WorkTypeFilter(types) =>
-        termsQuery(field = "data.workType", values = types)
+        termsQuery(
+          field = "data.workType",
+          values = types.map(WorkType.getName))
       case DateRangeFilter(fromDate, toDate) =>
         val (gte, lte) =
           (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -332,7 +332,7 @@ trait MultipleWorksSwagger {
         description = "Filter by the type of the searched works",
         required = false,
         schema = new Schema(
-          allowableValues = Array("Work", "Collection", "Series", "Section")
+          allowableValues = Array("Standard", "Collection", "Series", "Section")
         )
       ),
       new Parameter(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -332,7 +332,7 @@ trait MultipleWorksSwagger {
         description = "Filter by the type of the searched works",
         required = false,
         schema = new Schema(
-          allowableValues = Array("Standard", "Collection", "Series", "Section")
+          allowableValues = Array("Collection", "Series", "Section")
         )
       ),
       new Parameter(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -327,6 +327,15 @@ trait MultipleWorksSwagger {
         required = false
       ),
       new Parameter(
+        name = "type",
+        in = ParameterIn.QUERY,
+        description = "Filter by the type of the searched works",
+        required = false,
+        schema = new Schema(
+          allowableValues = Array("Work", "Collection", "Series", "Section")
+        )
+      ),
+      new Parameter(
         name = "aggregations",
         in = ParameterIn.QUERY,
         description =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -210,6 +210,70 @@ class WorksFiltersTest extends ApiWorksTestBase {
     }
   }
 
+  describe("filtering works by type") {
+    val standardWork = createIdentifiedWork
+    val collectionWork =
+      createIdentifiedWorkWith(
+        title = Some("rats"),
+        workType = WorkType.Collection)
+    val seriesWork = createIdentifiedWorkWith(
+      title = Some("rats rats"),
+      workType = WorkType.Series)
+    val sectionWork = createIdentifiedWorkWith(
+      title = Some("rats rats bats"),
+      workType = WorkType.Section)
+
+    val works = Seq(standardWork, collectionWork, seriesWork, sectionWork)
+
+    it("when listing works") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+
+          assertJsonResponse(routes, s"/$apiPrefix/works?type=Collection") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(collectionWork)
+            )
+          }
+      }
+    }
+
+    it("filters by multiple types") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works?type=Collection,Standard",
+            unordered = true) {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(standardWork, collectionWork)
+            )
+          }
+      }
+    }
+
+    it("when searching works") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works?query=rats&type=Series,Section",
+            unordered = true) {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(seriesWork, sectionWork)
+            )
+          }
+      }
+    }
+  }
+
   describe("filtering works by date range") {
     val (work1, work2, work3) = (
       createDatedWork("1709", canonicalId = "a"),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -211,7 +211,6 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by type") {
-    val standardWork = createIdentifiedWork
     val collectionWork =
       createIdentifiedWorkWith(
         title = Some("rats"),
@@ -223,7 +222,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
       title = Some("rats rats bats"),
       workType = WorkType.Section)
 
-    val works = Seq(standardWork, collectionWork, seriesWork, sectionWork)
+    val works = Seq(collectionWork, seriesWork, sectionWork)
 
     it("when listing works") {
       withApi {
@@ -246,11 +245,11 @@ class WorksFiltersTest extends ApiWorksTestBase {
 
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?type=Collection,Standard",
+            s"/$apiPrefix/works?type=Collection,Series",
             unordered = true) {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(standardWork, collectionWork)
+              works = Seq(collectionWork, seriesWork)
             )
           }
       }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/WorkType.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/WorkType.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.models.work.internal
 
 import io.circe.{Decoder, Encoder}
+import io.circe.syntax._
 import io.circe.generic.extras.semiauto.{
   deriveEnumerationDecoder,
   deriveEnumerationEncoder
@@ -18,4 +19,6 @@ object WorkType {
     deriveEnumerationEncoder[WorkType]
   implicit val workTypeDecoder: Decoder[WorkType] =
     deriveEnumerationDecoder[WorkType]
+
+  def getName(workType: WorkType): String = workType.asJson.asString.get
 }


### PR DESCRIPTION
This follows up from https://github.com/wellcomecollection/catalogue/pull/876, adding a `type` filter which enables us to distinguish between / filter for standard works, collections, series, and sections. The `type` name corresponds to the `type` aka `ontologyType` aka `data.workType` on works, and is not related to the `format` which was previously known as `workType`.