### PR TITLE
tweak contributors query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -32,12 +32,14 @@ case object WorksMultiMatcher {
           ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
         ),
         prefixQuery("data.title.keyword", q).boost(1000),
+        nestedQuery("data.contributors.agent").query(
+          matchQuery("data.contributors.agent.label" -> q)
+        ).scoreMode(ScoreMode.Max).boost(1000),
         MultiMatchQuery(
           q,
           `type` = Some(BEST_FIELDS),
           operator = Some(AND),
           fields = Seq(
-            ("data.contributors.agent.label", Some(1000)),
             ("data.title", Some(100)),
             ("data.title.english", Some(100)),
             ("data.title.shingles", Some(100)),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -32,9 +32,12 @@ case object WorksMultiMatcher {
           ).map(f => FieldWithOptionalBoost(f._1, f._2.map(_.toDouble)))
         ),
         prefixQuery("data.title.keyword", q).boost(1000),
-        nestedQuery("data.contributors.agent").query(
-          matchQuery("data.contributors.agent.label" -> q)
-        ).scoreMode(ScoreMode.Max).boost(1000),
+        nestedQuery("data.contributors.agent")
+          .query(
+            matchQuery("data.contributors.agent.label" -> q)
+          )
+          .scoreMode(ScoreMode.Max)
+          .boost(1000),
         MultiMatchQuery(
           q,
           `type` = Some(BEST_FIELDS),


### PR DESCRIPTION
looks like the solution to the contributors issue is to use a nested query on the contributors and changing its default `score_mode` to `max` https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html

syntax is probably all wrong here - might need some help sorting out the actual scala.

resolves #736 