### PR TITLE
Use latest TF modules to add deployment label to services

### DIFF
--- a/api/terraform/modules/stack/service/main.tf
+++ b/api/terraform/modules/stack/service/main.tf
@@ -1,23 +1,23 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.0.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.2.0"
   namespace = var.service_name
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.2.0"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.0"
   name   = "app"
 
   image = var.container_image
@@ -32,13 +32,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.0.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.0"
   secrets   = var.secrets
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.2.0"
 
   cpu    = 1024
   memory = 2048
@@ -58,7 +58,7 @@ locals {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.2.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
@@ -77,10 +77,8 @@ module "service" {
 
   container_name = module.nginx_container.container_name
   container_port = module.nginx_container.container_port
-
-
-  tags = {
-    "deployment:service" = local.deployment_service_name
-    "deployment:env"     = var.deployment_service_env
-  }
+  
+  deployment_service = local.deployment_service_name
+  deployment_env     = var.deployment_service_env
+  deployment_label   = "initial"
 }

--- a/api/terraform/modules/stack/service/main.tf
+++ b/api/terraform/modules/stack/service/main.tf
@@ -77,7 +77,7 @@ module "service" {
 
   container_name = module.nginx_container.container_name
   container_port = module.nginx_container.container_port
-  
+
   deployment_service = local.deployment_service_name
   deployment_env     = var.deployment_service_env
   deployment_label   = "initial"

--- a/infrastructure/modules/worker/main.tf
+++ b/infrastructure/modules/worker/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.2.0"
 
   task_definition_arn            = module.task_definition.arn
   service_name                   = var.name
@@ -20,14 +20,13 @@ module "service" {
 
   propagate_tags = "SERVICE"
 
-  tags = {
-    "deployment:service" = local.deployment_service_name
-    "deployment:env"     = var.deployment_service_env
-  }
+  deployment_service = local.deployment_service_name
+  deployment_env     = var.deployment_service_env
+  deployment_label   = "initial"
 }
 
 module "autoscaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.2.0"
 
   name = var.name
 
@@ -39,7 +38,7 @@ module "autoscaling" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.2.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -54,7 +53,7 @@ module "task_definition" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.1.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.2.0"
 
   name  = var.name
   image = var.image
@@ -66,18 +65,18 @@ module "app_container" {
 }
 
 module "app_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.1.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.0"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.1.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.2.0"
   namespace = var.name
 }
 
 module "log_router_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.1.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.2.0"
   secrets   = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }


### PR DESCRIPTION
This updates the ECS service modules to add a deployment:label tag to services - this is populated by the latest version of weco-deploy with the release id so that it is possible to identify which services and tasks originated from which release.

*Note:* This terraform has been applied.