### PR TITLE
add location type aggregation

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -18,6 +18,7 @@ case class Aggregations(
   language: Option[Aggregation[Language]] = None,
   subjects: Option[Aggregation[Subject[IdState.Minted]]] = None,
   license: Option[Aggregation[License]] = None,
+  locationType: Option[Aggregation[LocationTypeAggregation]] = None,
 )
 
 object Aggregations extends Logging {
@@ -35,7 +36,9 @@ object Aggregations extends Logging {
             .decodeAgg[Language]("language", Some("data.language")),
           subjects = e4sAggregations
             .decodeAgg[Subject[IdState.Minted]]("subjects"),
-          license = e4sAggregations.decodeAgg[License]("license")
+          license = e4sAggregations.decodeAgg[License]("license"),
+          locationType =
+            e4sAggregations.decodeAgg[LocationTypeAggregation]("locationType")
         ))
     } else {
       None
@@ -77,6 +80,12 @@ object Aggregations extends Logging {
   implicit val decodeSubjectFromLabel: Decoder[Subject[IdState.Minted]] =
     Decoder.decodeString.map { str =>
       Subject(label = str, concepts = Nil)
+    }
+
+  implicit val decodeLocationTypeFromLabel: Decoder[LocationTypeAggregation] =
+    Decoder.decodeString.map {
+      case "DigitalLocation"  => LocationTypeAggregation.Digital
+      case "PhysicalLocation" => LocationTypeAggregation.Physical
     }
 
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -3,11 +3,13 @@ package uk.ac.wellcome.platform.api.models
 import scala.util.{Failure, Success, Try}
 import io.circe.{Decoder, Json}
 import java.time.{Instant, LocalDateTime, ZoneOffset}
+
 import com.sksamuel.elastic4s.requests.searches.aggs.responses.{
   Aggregations => Elastic4sAggregations
 }
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.display.models.LocationTypeQuery
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.json.JsonUtil._
 
@@ -18,7 +20,7 @@ case class Aggregations(
   language: Option[Aggregation[Language]] = None,
   subjects: Option[Aggregation[Subject[IdState.Minted]]] = None,
   license: Option[Aggregation[License]] = None,
-  locationType: Option[Aggregation[LocationTypeAggregation]] = None,
+  locationType: Option[Aggregation[LocationTypeQuery]] = None,
 )
 
 object Aggregations extends Logging {
@@ -38,7 +40,7 @@ object Aggregations extends Logging {
             .decodeAgg[Subject[IdState.Minted]]("subjects"),
           license = e4sAggregations.decodeAgg[License]("license"),
           locationType =
-            e4sAggregations.decodeAgg[LocationTypeAggregation]("locationType")
+            e4sAggregations.decodeAgg[LocationTypeQuery]("locationType")
         ))
     } else {
       None
@@ -82,10 +84,10 @@ object Aggregations extends Logging {
       Subject(label = str, concepts = Nil)
     }
 
-  implicit val decodeLocationTypeFromLabel: Decoder[LocationTypeAggregation] =
+  implicit val decodeLocationTypeFromLabel: Decoder[LocationTypeQuery] =
     Decoder.decodeString.map {
-      case "DigitalLocation"  => LocationTypeAggregation.Digital
-      case "PhysicalLocation" => LocationTypeAggregation.Physical
+      case "DigitalLocation"  => LocationTypeQuery.DigitalLocation
+      case "PhysicalLocation" => LocationTypeQuery.PhysicalLocation
     }
 
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
@@ -32,6 +32,9 @@ case class DisplayAggregations(
   @Schema(
     description = "License aggregation on a set of results."
   ) license: Option[DisplayAggregation[DisplayLicense]],
+  @Schema(
+    description = "Location type aggregation on a set of results."
+  ) locationType: Option[DisplayAggregation[DisplayLocationTypeAggregation]],
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Aggregations"
 )
 
@@ -78,6 +81,9 @@ object DisplayAggregations {
         subject => DisplaySubject(subject, false)
       ),
       license = displayAggregation(aggs.license, DisplayLicense.apply),
+      locationType = displayAggregation(
+        aggs.locationType,
+        DisplayLocationTypeAggregation.apply)
     )
 
   private def displayAggregation[T, D](

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -199,6 +199,7 @@ object MultipleWorksParams extends QueryParamsUtils {
       "subjects" -> AggregationRequest.Subject,
       "language" -> AggregationRequest.Language,
       "license" -> AggregationRequest.License,
+      "locationType" -> AggregationRequest.ItemLocationType,
     )
 
   implicit val sortDecoder: Decoder[List[SortRequest]] =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -91,7 +91,7 @@ class FiltersAndAggregationsBuilder(
     case _: CollectionPathFilter     => None
     case _: CollectionDepthFilter    => None
     case _: AccessStatusFilter       => None
-    case _: ItemLocationTypeFilter   => None
+    case _: ItemLocationTypeFilter   => Some(AggregationRequest.ItemLocationType)
     case _: ItemLocationTypeIdFilter => None
   }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -87,6 +87,12 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
         .size(100)
         .field("data.items.locations.license.id")
         .minDocCount(0)
+
+    case AggregationRequest.ItemLocationType =>
+      TermsAggregation("locationType")
+        .size(100)
+        .field("data.items.locations.ontologyType")
+        .minDocCount(0)
   }
 
   private def sort(implicit queryOptions: ElasticsearchQueryOptions) =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -356,7 +356,8 @@ trait MultipleWorksSwagger {
             "genres",
             "production.dates",
             "subjects",
-            "language")),
+            "language",
+            "locationType")),
         required = false
       ),
       new Parameter(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
@@ -82,7 +82,7 @@ class SwaggerScalaModelConverter extends AbstractModelConverter(Json.mapper()) {
     else if (cls == classOf[DisplayLanguage]) "Language"
     else if (cls == classOf[DisplayLicense]) "License"
     else if (cls == classOf[DisplayLocationTypeAggregation])
-      "LocationAggregation"
+      "LocationTypeAggregation"
     else throw new IllegalArgumentException(s"Unknown class $cls")
   }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
@@ -81,6 +81,8 @@ class SwaggerScalaModelConverter extends AbstractModelConverter(Json.mapper()) {
     else if (cls == classOf[DisplaySubject]) "Subject"
     else if (cls == classOf[DisplayLanguage]) "Language"
     else if (cls == classOf[DisplayLicense]) "License"
+    else if (cls == classOf[DisplayLocationTypeAggregation])
+      "LocationAggregation"
     else throw new IllegalArgumentException(s"Unknown class $cls")
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -42,7 +42,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo",
         description =
-          "aggregations: 'foo' is not a valid value. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license']"
+          "aggregations: 'foo' is not a valid value. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
       )
     }
 
@@ -50,7 +50,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo,bar",
         description =
-          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license']"
+          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
       )
     }
 
@@ -66,7 +66,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo,workType,bar",
         description =
-          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license']"
+          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
       )
     }
   }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/AggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/AggregationRequest.scala
@@ -15,4 +15,6 @@ object AggregationRequest {
   case object Language extends AggregationRequest
 
   case object License extends AggregationRequest
+
+  case object ItemLocationType extends AggregationRequest
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.display.models
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.ac.wellcome.models.work.internal.LocationTypeAggregation
 
 @Schema(
   name = "LocationTypeAggregation",
@@ -9,12 +8,12 @@ import uk.ac.wellcome.models.work.internal.LocationTypeAggregation
 )
 case class DisplayLocationTypeAggregation(label: String, `type`: String)
 object DisplayLocationTypeAggregation {
-  def apply(locationAggregation: LocationTypeAggregation)
-    : DisplayLocationTypeAggregation =
-    locationAggregation match {
-      case LocationTypeAggregation.Digital =>
+  def apply(
+    locationTypeQuery: LocationTypeQuery): DisplayLocationTypeAggregation =
+    locationTypeQuery match {
+      case LocationTypeQuery.DigitalLocation =>
         DisplayLocationTypeAggregation("Online", "DigitalLocation")
-      case LocationTypeAggregation.Physical =>
+      case LocationTypeQuery.PhysicalLocation =>
         DisplayLocationTypeAggregation("In the library", "PhysicalLocation")
     }
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
@@ -6,10 +6,6 @@ import uk.ac.wellcome.models.work.internal.LocationTypeAggregation
 @Schema(
   name = "LocationTypeAggregation",
   description = "A location that provides access to an item",
-  discriminatorProperty = "type",
-  allOf = Array(
-    classOf[DisplayDigitalLocationDeprecated],
-    classOf[DisplayPhysicalLocationDeprecated])
 )
 case class DisplayLocationTypeAggregation(label: String, `type`: String)
 object DisplayLocationTypeAggregation {

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocationTypeAggregation.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.display.models
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.ac.wellcome.models.work.internal.LocationTypeAggregation
+
+@Schema(
+  name = "LocationTypeAggregation",
+  description = "A location that provides access to an item",
+  discriminatorProperty = "type",
+  allOf = Array(
+    classOf[DisplayDigitalLocationDeprecated],
+    classOf[DisplayPhysicalLocationDeprecated])
+)
+case class DisplayLocationTypeAggregation(label: String, `type`: String)
+object DisplayLocationTypeAggregation {
+  def apply(locationAggregation: LocationTypeAggregation)
+    : DisplayLocationTypeAggregation =
+    locationAggregation match {
+      case LocationTypeAggregation.Digital =>
+        DisplayLocationTypeAggregation("Online", "DigitalLocation")
+      case LocationTypeAggregation.Physical =>
+        DisplayLocationTypeAggregation("In the library", "PhysicalLocation")
+    }
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
@@ -29,9 +29,3 @@ case class PhysicalLocationDeprecated(
   accessConditions: List[AccessCondition] = Nil,
   ontologyType: String = "PhysicalLocation"
 ) extends LocationDeprecated
-
-sealed trait LocationTypeAggregation
-object LocationTypeAggregation {
-  case object Digital extends LocationTypeAggregation
-  case object Physical extends LocationTypeAggregation
-}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
@@ -29,3 +29,9 @@ case class PhysicalLocationDeprecated(
   accessConditions: List[AccessCondition] = Nil,
   ontologyType: String = "PhysicalLocation"
 ) extends LocationDeprecated
+
+sealed trait LocationTypeAggregation
+object LocationTypeAggregation {
+  case object Digital extends LocationTypeAggregation
+  case object Physical extends LocationTypeAggregation
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorksGenerators.scala
@@ -338,4 +338,20 @@ trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
         createDigitalItemWith(license = Some(license))
       }
     )
+
+  def createPhysicalWork(canonicalId: String = createCanonicalId) =
+    createIdentifiedWorkWith(
+      canonicalId,
+      items = List(
+        createIdentifiedItemWith(locations = List(createPhysicalLocation))
+      )
+    )
+
+  def createDigitalWork(canonicalId: String = createCanonicalId) =
+    createIdentifiedWorkWith(
+      canonicalId,
+      items = List(
+        createIdentifiedItemWith(locations = List(createDigitalLocation))
+      )
+    )
 }


### PR DESCRIPTION
I had to invent a new piece of model specifically for the aggregations. It does seem a little odd that we:
* decode into the internal model from elastic specific JSON
* convert those to display models
* encode the display models as JSON

It feels like we should be able to just encode elastic JSON => display model as that's the only place it is used. Thoughts?