### PR TITLE
CI environment has same auth as local

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
 import java.io.File
+import java.util.UUID
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 
 def setupProject(
   project: Project,
@@ -242,15 +244,12 @@ lazy val snapshot_generator = setupProject(
   externalDependencies = CatalogueDependencies.snapshotGeneratorDependencies
 )
 
-/**
-  * To download form the wellcome maven repo in s3 locally, uncomment this
- **/
-//import java.util.UUID
-//import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
-//s3CredentialsProvider := { _ =>
-//  val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
-//    "arn:aws:iam::760097843905:role/platform-read_only",
-//    UUID.randomUUID().toString
-//  )
-//  builder.build()
-//}
+// AWS Credentials to read from S3
+
+s3CredentialsProvider := { _ =>
+  val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
+    "arn:aws:iam::760097843905:role/platform-read_only",
+    UUID.randomUUID().toString
+  )
+  builder.build()
+}


### PR DESCRIPTION
We should now be able to remove the comment/uncomment auth mechanism as CI will behave the same way as local.