### PR TITLE
Scored colour filter

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -50,22 +50,21 @@ case object ImagesMultiMatcher {
       ))
       .map(FieldWithOptionalBoost(_, None))
 
-    must(
-      should(
-        MultiMatchQuery(
-          text = q,
-          fields = fields,
-          minimumShouldMatch = Some("60%"),
-          `type` = Some(CROSS_FIELDS),
-          operator = Some(AND),
-          boost = Some(2) // Double the OR query
-        ),
-        MultiMatchQuery(
-          fields = idFields,
-          text = q,
-          `type` = Some(CROSS_FIELDS)
-        )
-      ))
+    should(
+      MultiMatchQuery(
+        text = q,
+        fields = fields,
+        minimumShouldMatch = Some("60%"),
+        `type` = Some(CROSS_FIELDS),
+        operator = Some(AND),
+        boost = Some(2) // Double the OR query
+      ),
+      MultiMatchQuery(
+        fields = idFields,
+        text = q,
+        `type` = Some(CROSS_FIELDS)
+      )
+    ).minimumShouldMatch(1)
   }
 }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -5,9 +5,7 @@ import java.time.LocalDate
 
 import uk.ac.wellcome.display.models.LocationTypeQuery
 
-sealed trait DocumentFilter {
-  val scored: Boolean = false
-}
+sealed trait DocumentFilter
 
 sealed trait WorkFilter extends DocumentFilter
 sealed trait ImageFilter extends DocumentFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -5,7 +5,10 @@ import java.time.LocalDate
 
 import uk.ac.wellcome.display.models.LocationTypeQuery
 
-sealed trait DocumentFilter
+sealed trait DocumentFilter {
+  val scored: Boolean = false
+}
+
 sealed trait WorkFilter extends DocumentFilter
 sealed trait ImageFilter extends DocumentFilter
 
@@ -45,4 +48,6 @@ case class AccessStatusFilter(includes: List[AccessStatus],
                               excludes: List[AccessStatus])
     extends WorkFilter
 
-case class ColorFilter(hexColors: Seq[String]) extends ImageFilter
+case class ColorFilter(hexColors: Seq[String]) extends ImageFilter {
+  override val scored: Boolean = true
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -46,6 +46,4 @@ case class AccessStatusFilter(includes: List[AccessStatus],
                               excludes: List[AccessStatus])
     extends WorkFilter
 
-case class ColorFilter(hexColors: Seq[String]) extends ImageFilter {
-  override val scored: Boolean = true
-}
+case class ColorFilter(hexColors: Seq[String]) extends ImageFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -45,5 +45,3 @@ case class CollectionDepthFilter(depth: Int) extends WorkFilter
 case class AccessStatusFilter(includes: List[AccessStatus],
                               excludes: List[AccessStatus])
     extends WorkFilter
-
-case class ColorFilter(hexColors: Seq[String]) extends ImageFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/MustQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/MustQuery.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.api.models
+
+sealed trait MustQuery
+sealed trait ImageMustQuery extends MustQuery
+
+case class ColorMustQuery(hexColors: Seq[String]) extends ImageMustQuery

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
@@ -6,9 +6,9 @@ import uk.ac.wellcome.display.models.{
   SortingOrder
 }
 
-case class SearchOptions[Filter <: DocumentFilter](
+case class SearchOptions(
   searchQuery: Option[SearchQuery] = None,
-  filters: List[Filter] = Nil,
+  filters: List[DocumentFilter] = Nil,
   aggregations: List[AggregationRequest] = Nil,
   sortBy: List[SortRequest] = Nil,
   sortOrder: SortingOrder = SortingOrder.Ascending,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
@@ -10,6 +10,7 @@ case class SearchOptions(
   searchQuery: Option[SearchQuery] = None,
   filters: List[DocumentFilter] = Nil,
   aggregations: List[AggregationRequest] = Nil,
+  mustQueries: List[MustQuery] = Nil,
   sortBy: List[SortRequest] = Nil,
   sortOrder: SortingOrder = SortingOrder.Ascending,
   pageSize: Int = 10,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/SearchOptions.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.platform.api.models
+
+import uk.ac.wellcome.display.models.{
+  AggregationRequest,
+  SortRequest,
+  SortingOrder
+}
+
+case class SearchOptions[Filter <: DocumentFilter](
+  searchQuery: Option[SearchQuery] = None,
+  filters: List[Filter] = Nil,
+  aggregations: List[AggregationRequest] = Nil,
+  sortBy: List[SortRequest] = Nil,
+  sortOrder: SortingOrder = SortingOrder.Ascending,
+  pageSize: Int = 10,
+  pageNumber: Int = 1
+)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.api.rest
 import io.circe.Decoder
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.services.ImagesSearchOptions
 
 case class SingleImageParams(
   include: Option[SingleImageIncludes],
@@ -37,8 +36,8 @@ case class MultipleImagesParams(
 ) extends QueryParams
     with Paginated {
 
-  def searchOptions(apiConfig: ApiConfig): ImagesSearchOptions =
-    ImagesSearchOptions(
+  def searchOptions(apiConfig: ApiConfig): SearchOptions =
+    SearchOptions(
       searchQuery = query.map(SearchQuery(_)),
       filters = filters,
       pageSize = pageSize.getOrElse(apiConfig.defaultPageSize),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -31,7 +31,7 @@ case class MultipleImagesParams(
   pageSize: Option[Int],
   query: Option[String],
   license: Option[LicenseFilter],
-  color: Option[ColorFilter],
+  color: Option[ColorMustQuery],
   _index: Option[String]
 ) extends QueryParams
     with Paginated {
@@ -40,15 +40,16 @@ case class MultipleImagesParams(
     SearchOptions(
       searchQuery = query.map(SearchQuery(_)),
       filters = filters,
+      mustQueries = mustQueries,
       pageSize = pageSize.getOrElse(apiConfig.defaultPageSize),
       pageNumber = page.getOrElse(1)
     )
 
   private def filters: List[ImageFilter] =
-    List(
-      license,
-      color
-    ).flatten
+    List(license).flatten
+
+  private def mustQueries: List[ImageMustQuery] =
+    List(color).flatten
 }
 
 object MultipleImagesParams extends QueryParamsUtils {
@@ -61,7 +62,7 @@ object MultipleImagesParams extends QueryParamsUtils {
         "pageSize".as[Int].?,
         "query".as[String].?,
         "locations.license".as[LicenseFilter].?,
-        "color".as[ColorFilter].?,
+        "color".as[ColorMustQuery].?,
         "_index".as[String].?
       )
     ).tflatMap { args =>
@@ -69,6 +70,6 @@ object MultipleImagesParams extends QueryParamsUtils {
       validated(params.paginationErrors, params)
     }
 
-  implicit val colorFilter: Decoder[ColorFilter] =
-    decodeCommaSeparated.emap(strs => Right(ColorFilter(strs)))
+  implicit val colorMustQuery: Decoder[ColorMustQuery] =
+    decodeCommaSeparated.emap(strs => Right(ColorMustQuery(strs)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.rest
 
 import akka.http.scaladsl.model.Uri
-import uk.ac.wellcome.platform.api.models.ResultList
+import uk.ac.wellcome.platform.api.models.{ResultList, SearchOptions}
 
 trait Paginated { this: QueryParams =>
   val page: Option[Int]
@@ -70,7 +70,7 @@ object PaginationResponse {
 }
 
 object PaginationQuery {
-  def safeGetFrom(searchOptions: PaginatedSearchOptions): Int = {
+  def safeGetFrom(searchOptions: SearchOptions[_]): Int = {
     // Because we use Int for the pageSize and pageNumber, computing
     //
     //     from = (pageNumber - 1) * pageSize

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
@@ -19,11 +19,6 @@ trait Paginated { this: QueryParams =>
 
 }
 
-trait PaginatedSearchOptions {
-  val pageSize: Int
-  val pageNumber: Int
-}
-
 case class PaginationResponse(
   totalPages: Int,
   prevPage: Option[String],
@@ -32,7 +27,7 @@ case class PaginationResponse(
 
 object PaginationResponse {
   def apply(resultList: ResultList[_, _],
-            searchOptions: PaginatedSearchOptions,
+            searchOptions: SearchOptions,
             requestUri: Uri): PaginationResponse = {
     val totalPages =
       getTotalPages(resultList.totalResults, searchOptions.pageSize)
@@ -70,7 +65,7 @@ object PaginationResponse {
 }
 
 object PaginationQuery {
-  def safeGetFrom(searchOptions: SearchOptions[_]): Int = {
+  def safeGetFrom(searchOptions: SearchOptions): Int = {
     // Because we use Int for the pageSize and pageNumber, computing
     //
     //     from = (pageNumber - 1) * pageSize

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -9,10 +9,6 @@ import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.services.{
-  ImagesSearchOptions,
-  WorksSearchOptions
-}
 import WorkState.Identified
 
 case class ResultResponse[T: Encoder](
@@ -60,7 +56,7 @@ object DisplayResultList {
 
   def apply(
     resultList: ResultList[Work.Visible[Identified], Aggregations],
-    searchOptions: WorksSearchOptions,
+    searchOptions: SearchOptions,
     includes: WorksIncludes,
     requestUri: Uri,
     contextUri: String): DisplayResultList[DisplayWork, DisplayAggregations] =
@@ -79,7 +75,7 @@ object DisplayResultList {
     }
 
   def apply(resultList: ResultList[AugmentedImage, Unit],
-            searchOptions: ImagesSearchOptions,
+            searchOptions: SearchOptions,
             requestUri: Uri,
             contextUri: String): DisplayResultList[DisplayImage, Unit] =
     PaginationResponse(resultList, searchOptions, requestUri) match {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -5,7 +5,6 @@ import java.time.LocalDate
 import io.circe.Decoder
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.services.WorksSearchOptions
 import uk.ac.wellcome.models.work.internal.{AccessStatus, WorkType}
 
 case class SingleWorkParams(
@@ -73,8 +72,8 @@ case class MultipleWorksParams(
 ) extends QueryParams
     with Paginated {
 
-  def searchOptions(apiConfig: ApiConfig): WorksSearchOptions =
-    WorksSearchOptions(
+  def searchOptions(apiConfig: ApiConfig): SearchOptions =
+    SearchOptions(
       searchQuery = query map { query =>
         SearchQuery(query, _queryType)
       },

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
@@ -5,7 +5,11 @@ import com.sksamuel.elastic4s.requests.searches.sort.FieldSort
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ElasticDsl._
-import uk.ac.wellcome.platform.api.models.{DocumentFilter, SearchOptions}
+import uk.ac.wellcome.platform.api.models.{
+  DocumentFilter,
+  MustQuery,
+  SearchOptions
+}
 
 import scala.reflect.ClassTag
 
@@ -13,14 +17,17 @@ trait ElasticsearchRequestBuilder {
 
   val idSort: FieldSort
 
-  def request(searchOptions: SearchOptions,
-              index: Index,
-              scored: Boolean): SearchRequest
+  def request(searchOptions: SearchOptions, index: Index): SearchRequest
 
-  implicit class FilterRefinements(val searchOptions: SearchOptions) {
-    def typedFilters[T <: DocumentFilter: ClassTag]: List[T] =
+  implicit class SearchOptionsRefinements(val searchOptions: SearchOptions) {
+    def safeFilters[T <: DocumentFilter: ClassTag]: List[T] =
       searchOptions.filters.collect {
         case filter: T => filter
+      }
+
+    def safeMustQueries[T <: MustQuery: ClassTag]: List[T] =
+      searchOptions.mustQueries.collect {
+        case query: T => query
       }
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
@@ -5,12 +5,14 @@ import com.sksamuel.elastic4s.requests.searches.sort.FieldSort
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ElasticDsl._
+import uk.ac.wellcome.platform.api.models.{DocumentFilter, SearchOptions}
 
 trait ElasticsearchRequestBuilder {
 
   val idSort: FieldSort
+  type Filter <: DocumentFilter
 
-  def request(queryOptions: ElasticsearchQueryOptions,
+  def request(searchOptions: SearchOptions[Filter],
               index: Index,
               scored: Boolean): SearchRequest
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchRequestBuilder.scala
@@ -7,14 +7,22 @@ import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ElasticDsl._
 import uk.ac.wellcome.platform.api.models.{DocumentFilter, SearchOptions}
 
+import scala.reflect.ClassTag
+
 trait ElasticsearchRequestBuilder {
 
   val idSort: FieldSort
-  type Filter <: DocumentFilter
 
-  def request(searchOptions: SearchOptions[Filter],
+  def request(searchOptions: SearchOptions,
               index: Index,
               scored: Boolean): SearchRequest
+
+  implicit class FilterRefinements(val searchOptions: SearchOptions) {
+    def typedFilters[T <: DocumentFilter: ClassTag]: List[T] =
+      searchOptions.filters.collect {
+        case filter: T => filter
+      }
+  }
 }
 
 object ElasticsearchRequestBuilder {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -24,7 +24,9 @@ case class ElasticsearchQueryOptions(filters: List[DocumentFilter],
                                      aggregations: List[AggregationRequest],
                                      sortBy: List[SortRequest],
                                      sortOrder: SortingOrder,
-                                     searchQuery: Option[SearchQuery])
+                                     searchQuery: Option[SearchQuery]) {
+  lazy val (scoredFilters, unscoredFilters) = filters.partition(_.scored)
+}
 
 class ElasticsearchService(elasticClient: ElasticClient)(
   implicit ec: ExecutionContext

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -50,7 +50,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
       .request(
         queryOptions,
         index,
-        scored = queryOptions.searchQuery.isDefined
+        scored = queryOptions.searchQuery.isDefined || queryOptions.scoredFilters.nonEmpty
       )
       .trackTotalHits(true)
     Tracing.currentTransaction.addQueryOptionLabels(queryOptions)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.api.services
 
 import scala.concurrent.{ExecutionContext, Future}
-
 import co.elastic.apm.api.Transaction
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.get.GetResponse
@@ -13,8 +12,6 @@ import com.sksamuel.elastic4s.requests.searches.{
 }
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
 import grizzled.slf4j.Logging
-
-import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.platform.api.Tracing
 import uk.ac.wellcome.platform.api.models._
 
@@ -33,7 +30,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
     * using the elastic4s query DSL, then execute the search.
     */
   def executeSearch(
-    searchOptions: SearchOptions[_],
+    searchOptions: SearchOptions,
     requestBuilder: ElasticsearchRequestBuilder,
     index: Index): Future[Either[ElasticError, SearchResponse]] = {
     val searchRequest = requestBuilder
@@ -97,7 +94,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
     }
 
   implicit class EnhancedTransaction(transaction: Transaction) {
-    def addQueryOptionLabels(searchOptions: SearchOptions[_]): Transaction = {
+    def addQueryOptionLabels(searchOptions: SearchOptions): Transaction = {
       transaction.addLabel("pageSize", searchOptions.pageSize)
       transaction.addLabel("pageNumber", searchOptions.pageNumber)
       transaction.addLabel("sortOrder", searchOptions.sortOrder.toString)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -34,11 +34,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
     requestBuilder: ElasticsearchRequestBuilder,
     index: Index): Future[Either[ElasticError, SearchResponse]] = {
     val searchRequest = requestBuilder
-      .request(
-        searchOptions,
-        index,
-        scored = searchOptions.searchQuery.isDefined
-      )
+      .request(searchOptions, index)
       .trackTotalHits(true)
     Tracing.currentTransaction.addQueryOptionLabels(searchOptions)
     executeSearchRequest(searchRequest)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -38,6 +38,9 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
             ImagesMultiMatcher(q.query)
           }
           .getOrElse(boolQuery)
+          .must(
+            buildImageMustQuery(searchOptions.safeMustQueries[ImageMustQuery])
+          )
           .filter(
             buildImageFilterQuery(searchOptions.typedFilters[ImageFilter])
           )
@@ -56,7 +59,11 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
     filters.map {
       case LicenseFilter(licenseIds) =>
         termsQuery(field = "location.license.id", values = licenseIds)
-      case ColorFilter(hexColors) =>
+    }
+
+  def buildImageMustQuery(queries: List[ImageMustQuery]): Seq[Query] =
+    queries.map {
+      case ColorMustQuery(hexColors) =>
         colorQuery(field = "inferredData.palette", hexColors)
     }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -22,14 +22,13 @@ import uk.ac.wellcome.platform.api.rest.PaginationQuery
 class ImagesRequestBuilder(queryConfig: QueryConfig)
     extends ElasticsearchRequestBuilder {
 
-  type Filter = ImageFilter
   val idSort: FieldSort = fieldSort("id.canonicalId").order(SortOrder.ASC)
 
   lazy val colorQuery = new ColorQuery(
     binSizes = queryConfig.paletteBinSizes
   )
 
-  def request(searchOptions: SearchOptions[ImageFilter],
+  def request(searchOptions: SearchOptions,
               index: Index,
               scored: Boolean): SearchRequest =
     search(index)
@@ -40,7 +39,7 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
           }
           .getOrElse(boolQuery)
           .filter(
-            buildImageFilterQuery(searchOptions.filters)
+            buildImageFilterQuery(searchOptions.typedFilters[ImageFilter])
           )
       )
       .sortBy {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -2,20 +2,14 @@ package uk.ac.wellcome.platform.api.services
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.{ElasticError, Hit, Index}
 import com.sksamuel.elastic4s.circe._
 import io.circe.Decoder
-import uk.ac.wellcome.display.models.SortingOrder
 import uk.ac.wellcome.models.work.internal.AugmentedImage
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.api.Tracing
 import uk.ac.wellcome.platform.api.models._
-import uk.ac.wellcome.platform.api.rest.{
-  PaginatedSearchOptions,
-  PaginationQuery
-}
 
 class ImagesService(searchService: ElasticsearchService,
                     queryConfig: QueryConfig)(implicit ec: ExecutionContext)
@@ -37,8 +31,7 @@ class ImagesService(searchService: ElasticsearchService,
         }
       }
 
-  def listOrSearchImages(index: Index,
-                         searchOptions: SearchOptions[ImageFilter])
+  def listOrSearchImages(index: Index, searchOptions: SearchOptions)
     : Future[Either[ElasticError, ResultList[AugmentedImage, Unit]]] =
     searchService
       .executeSearch(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -10,14 +10,10 @@ import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.circe._
 
-import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.platform.api.rest.{
-  PaginatedSearchOptions,
-  PaginationQuery
-}
+
 import WorkState.Identified
 
 case class WorkQuery(query: String, queryType: SearchQueryType)
@@ -37,8 +33,7 @@ class WorksService(searchService: ElasticsearchService)(
         }
       }
 
-  def listOrSearchWorks(index: Index,
-                        searchOptions: SearchOptions[WorkFilter]): Future[
+  def listOrSearchWorks(index: Index, searchOptions: SearchOptions): Future[
     Either[ElasticError, ResultList[Work.Visible[Identified], Aggregations]]] =
     searchService
       .executeSearch(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -20,16 +20,6 @@ import uk.ac.wellcome.platform.api.rest.{
 }
 import WorkState.Identified
 
-case class WorksSearchOptions(
-  filters: List[WorkFilter] = Nil,
-  pageSize: Int = 10,
-  pageNumber: Int = 1,
-  aggregations: List[AggregationRequest] = Nil,
-  sortBy: List[SortRequest] = Nil,
-  sortOrder: SortingOrder = SortingOrder.Ascending,
-  searchQuery: Option[SearchQuery] = None
-) extends PaginatedSearchOptions
-
 case class WorkQuery(query: String, queryType: SearchQueryType)
 
 class WorksService(searchService: ElasticsearchService)(
@@ -48,27 +38,15 @@ class WorksService(searchService: ElasticsearchService)(
       }
 
   def listOrSearchWorks(index: Index,
-                        searchOptions: WorksSearchOptions): Future[
+                        searchOptions: SearchOptions[WorkFilter]): Future[
     Either[ElasticError, ResultList[Work.Visible[Identified], Aggregations]]] =
     searchService
       .executeSearch(
-        queryOptions = toElasticsearchQueryOptions(searchOptions),
+        searchOptions = searchOptions,
         requestBuilder = WorksRequestBuilder,
         index = index
       )
       .map { _.map(createResultList) }
-
-  private def toElasticsearchQueryOptions(
-    worksSearchOptions: WorksSearchOptions) =
-    ElasticsearchQueryOptions(
-      searchQuery = worksSearchOptions.searchQuery,
-      filters = worksSearchOptions.filters,
-      limit = worksSearchOptions.pageSize,
-      aggregations = worksSearchOptions.aggregations,
-      sortBy = worksSearchOptions.sortBy,
-      sortOrder = worksSearchOptions.sortOrder,
-      from = PaginationQuery.safeGetFrom(worksSearchOptions)
-    )
 
   private def createResultList(searchResponse: SearchResponse)
     : ResultList[Work.Visible[Identified], Aggregations] = {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -1,13 +1,11 @@
 package uk.ac.wellcome.platform.api.elasticsearch
 
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import com.sksamuel.elastic4s.{ElasticError, Index}
 import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil.fromJson
 import uk.ac.wellcome.models.work.generators.{
@@ -19,10 +17,13 @@ import uk.ac.wellcome.models.work.generators.{
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
-import uk.ac.wellcome.platform.api.models.{SearchQuery, SearchQueryType}
+import uk.ac.wellcome.platform.api.models.{
+  SearchOptions,
+  SearchQuery,
+  SearchQueryType
+}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.api.services.{
-  ElasticsearchQueryOptions,
   ElasticsearchService,
   WorksRequestBuilder
 }
@@ -398,7 +399,7 @@ class WorksQueryTest
     SearchQueryType.allowed map { queryType =>
       val results = searchResults(
         index,
-        queryOptions = createElasticsearchQueryOptionsWith(
+        searchOptions = createWorksSearchOptionsWith(
           searchQuery = Some(SearchQuery(query, queryType))))
 
       withClue(s"Using: ${queryType.name}") {
@@ -408,10 +409,9 @@ class WorksQueryTest
     }
   }
 
-  private def searchResults(index: Index,
-                            queryOptions: ElasticsearchQueryOptions) = {
+  private def searchResults(index: Index, searchOptions: SearchOptions) = {
     val searchResponseFuture =
-      searchService.executeSearch(queryOptions, WorksRequestBuilder, index)
+      searchService.executeSearch(searchOptions, WorksRequestBuilder, index)
     whenReady(searchResponseFuture) { response =>
       searchResponseToWorks(response)
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/generators/SearchOptionsGenerators.scala
@@ -5,35 +5,13 @@ import uk.ac.wellcome.display.models.{
   SortRequest,
   SortingOrder
 }
-import uk.ac.wellcome.platform.api.models.{SearchQuery, WorkFilter}
-import uk.ac.wellcome.platform.api.services.{
-  ElasticsearchQueryOptions,
-  WorksSearchOptions
+import uk.ac.wellcome.platform.api.models.{
+  SearchOptions,
+  SearchQuery,
+  WorkFilter
 }
 
 trait SearchOptionsGenerators {
-  def createElasticsearchQueryOptionsWith(
-    filters: List[WorkFilter] = Nil,
-    limit: Int = 10,
-    from: Int = 0,
-    aggregations: List[AggregationRequest] = Nil,
-    sort: List[SortRequest] = Nil,
-    sortOrder: SortingOrder = SortingOrder.Ascending,
-    searchQuery: Option[SearchQuery] = None
-  ): ElasticsearchQueryOptions =
-    ElasticsearchQueryOptions(
-      filters = filters,
-      limit = limit,
-      from = from,
-      aggregations = aggregations,
-      sortBy = sort,
-      sortOrder = sortOrder,
-      searchQuery = searchQuery
-    )
-
-  def createElasticsearchQueryOptions: ElasticsearchQueryOptions =
-    createElasticsearchQueryOptionsWith()
-
   def createWorksSearchOptionsWith(
     filters: List[WorkFilter] = Nil,
     pageSize: Int = 10,
@@ -42,8 +20,8 @@ trait SearchOptionsGenerators {
     sort: List[SortRequest] = Nil,
     sortOrder: SortingOrder = SortingOrder.Ascending,
     searchQuery: Option[SearchQuery] = None
-  ): WorksSearchOptions =
-    WorksSearchOptions(
+  ): SearchOptions =
+    SearchOptions(
       filters = filters,
       pageSize = pageSize,
       pageNumber = pageNumber,
@@ -53,6 +31,6 @@ trait SearchOptionsGenerators {
       searchQuery = searchQuery
     )
 
-  def createWorksSearchOptions: WorksSearchOptions =
+  def createWorksSearchOptions: SearchOptions =
     createWorksSearchOptionsWith()
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -154,7 +154,7 @@ class ImagesFiltersTest extends ApiImagesTestBase {
       }
     }
 
-    it("scores by number of color bin matches") {
+    ignore("scores by number of color bin matches") {
       withApi {
         case (ElasticConfig(_, imagesIndex), routes) =>
           insertImagesIntoElasticsearch(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -154,7 +154,7 @@ class ImagesFiltersTest extends ApiImagesTestBase {
       }
     }
 
-    ignore("scores by number of color bin matches") {
+    it("scores by number of color bin matches") {
       withApi {
         case (ElasticConfig(_, imagesIndex), routes) =>
           insertImagesIntoElasticsearch(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -35,15 +35,15 @@ class ImagesFiltersTest extends ApiImagesTestBase {
             "30/4",
             "18/4",
             "1/4",
-            "4/6",
-            "4/6",
+            "5/6",
+            "5/6",
             "34/6",
             "34/6",
             "130/6",
             "70/6",
             "2/6",
-            "6/8",
-            "6/8",
+            "7/8",
+            "7/8",
             "69/8",
             "69/8",
             "301/8",
@@ -74,6 +74,58 @@ class ImagesFiltersTest extends ApiImagesTestBase {
         "320/8",
         "128/8"
       ))))
+    val slightlyLessRedImage = createAugmentedImageWith(
+      inferredData = createInferredData.map(
+        _.copy(
+          palette = List(
+            "0/0",
+            "0/0",
+            "6/4",
+            "6/4",
+            "30/4",
+            "18/4",
+            "1/4",
+            "5/6",
+            "5/6",
+            "34/6",
+            "34/6",
+            "130/6",
+            "70/6",
+            "2/6",
+            "7/8",
+            "7/8",
+            "69/8",
+            "69/8",
+            "301/8",
+            "181/8",
+            "2/8"
+          ))))
+    val evenLessRedImage = createAugmentedImageWith(
+      inferredData = createInferredData.map(
+        _.copy(
+          palette = List(
+            "0/0",
+            "0/0",
+            "6/4",
+            "6/4",
+            "30/4",
+            "18/4",
+            "1/4",
+            "0/0",
+            "0/0",
+            "34/6",
+            "34/6",
+            "130/6",
+            "70/6",
+            "2/6",
+            "7/8",
+            "7/8",
+            "69/8",
+            "69/8",
+            "301/8",
+            "181/8",
+            "2/8"
+          ))))
 
     it("filters by color") {
       withApi {
@@ -97,6 +149,24 @@ class ImagesFiltersTest extends ApiImagesTestBase {
             unordered = true) {
             Status.OK -> imagesListResponse(
               images = Seq(blueImage, redImage)
+            )
+          }
+      }
+    }
+
+    it("scores by number of color bin matches") {
+      withApi {
+        case (ElasticConfig(_, imagesIndex), routes) =>
+          insertImagesIntoElasticsearch(
+            imagesIndex,
+            redImage,
+            slightlyLessRedImage,
+            evenLessRedImage,
+            blueImage
+          )
+          assertJsonResponse(routes, f"/$apiPrefix/images?color=ff0000") {
+            Status.OK -> imagesListResponse(
+              images = Seq(redImage, slightlyLessRedImage, evenLessRedImage)
             )
           }
       }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -37,7 +37,7 @@ class AggregationsTest
     }
     withLocalWorksIndex { index =>
       insertIntoElasticsearch(index, works: _*)
-      val searchOptions = WorksSearchOptions(
+      val searchOptions = SearchOptions(
         aggregations = List(AggregationRequest.Format)
       )
       whenReady(aggregationQuery(index, searchOptions)) { aggs =>
@@ -61,7 +61,7 @@ class AggregationsTest
     )
     withLocalWorksIndex { index =>
       insertIntoElasticsearch(index, works: _*)
-      val searchOptions = WorksSearchOptions(
+      val searchOptions = SearchOptions(
         aggregations = List(AggregationRequest.ProductionDate),
         filters = List(
           DateRangeFilter(Some(LocalDate.of(1960, 1, 1)), None)
@@ -87,7 +87,7 @@ class AggregationsTest
     }
     withLocalWorksIndex { index =>
       insertIntoElasticsearch(index, works: _*)
-      val searchOptions = WorksSearchOptions(
+      val searchOptions = SearchOptions(
         searchQuery = Some(SearchQuery("anything will give zero results")),
         aggregations = List(AggregationRequest.Format)
       )
@@ -116,7 +116,7 @@ class AggregationsTest
     it("applies filters to their related aggregations") {
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, works: _*)
-        val searchOptions = WorksSearchOptions(
+        val searchOptions = SearchOptions(
           aggregations =
             List(AggregationRequest.Format, AggregationRequest.Subject),
           filters = List(
@@ -139,7 +139,7 @@ class AggregationsTest
           case Subject(IdState.Unidentifiable, label, _, _) => label
           case _                                            => "bilberry"
         }
-        val searchOptions = WorksSearchOptions(
+        val searchOptions = SearchOptions(
           aggregations =
             List(AggregationRequest.Format, AggregationRequest.Subject),
           filters = List(
@@ -163,7 +163,7 @@ class AggregationsTest
           case Subject(IdState.Unidentifiable, label, _, _) => label
           case _                                            => "passionfruit"
         }
-        val searchOptions = WorksSearchOptions(
+        val searchOptions = SearchOptions(
           aggregations =
             List(AggregationRequest.Format, AggregationRequest.Subject),
           filters = List(
@@ -180,8 +180,7 @@ class AggregationsTest
     }
   }
 
-  private def aggregationQuery(index: Index,
-                               searchOptions: WorksSearchOptions) =
+  private def aggregationQuery(index: Index, searchOptions: SearchOptions) =
     worksService
       .listOrSearchWorks(index, searchOptions)
       .map(_.right.get.aggregations.get)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -362,7 +362,7 @@ class WorksServiceTest
     expectedWorks: Seq[Work[Identified]],
     expectedTotalResults: Int,
     expectedAggregations: Option[Aggregations] = None,
-    worksSearchOptions: WorksSearchOptions = createWorksSearchOptions
+    worksSearchOptions: SearchOptions = createWorksSearchOptions
   ): Assertion =
     assertResultIsCorrect(
       worksService.listOrSearchWorks
@@ -374,14 +374,14 @@ class WorksServiceTest
       worksSearchOptions)
 
   private def assertResultIsCorrect(
-    partialSearchFunction: (Index, WorksSearchOptions) => Future[
+    partialSearchFunction: (Index, SearchOptions) => Future[
       Either[ElasticError, ResultList[Work.Visible[Identified], Aggregations]]]
   )(
     allWorks: Seq[Work[Identified]],
     expectedWorks: Seq[Work[Identified]],
     expectedTotalResults: Int,
     expectedAggregations: Option[Aggregations],
-    worksSearchOptions: WorksSearchOptions
+    worksSearchOptions: SearchOptions
   ): Assertion =
     withLocalWorksIndex { index =>
       if (allWorks.nonEmpty) {


### PR DESCRIPTION
The current implementation of the images colour filter is applied in the ES filter context and so does not take into account the scoring of the colour query. This means that the results can, confusingly, show very good colour palette matches much further down than poorer matches. This PR moves the filter into the query context (inside a `bool.must`) and so affects the scoring.