### PR TITLE
Add Relations model

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -175,12 +175,26 @@ case object WorksIndexConfig extends IndexConfig {
       keywordField("workType")
     )
 
+  def relation(name: String) = objectField(name).fields(
+    data(textField("path")),
+    id(),
+    intField("depth")
+  )
+
+  val relations = objectField("relations").fields(
+    relation("ancestors"),
+    relation("children"),
+    relation("siblingsPreceding"),
+    relation("siblingsSucceeding"),
+  )
+
   val fields: Seq[FieldDefinition with Product with Serializable] =
     Seq(
       objectField("state").fields(
         canonicalId,
         sourceIdentifier,
         booleanField("hasMultipleSources"),
+        relations
       ),
       version,
       objectField("redirect")

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -176,7 +176,9 @@ case object WorksIndexConfig extends IndexConfig {
     )
 
   def relation(name: String) = objectField(name).fields(
-    data(textField("path")),
+    // Locally override the strict mapping mode. No data fields are indexed for
+    // now, in the future specific fields can be added as required.
+    objectField("data").dynamic("false"),
     id(),
     intField("depth")
   )

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Relations.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Relations.scala
@@ -1,36 +1,38 @@
 package uk.ac.wellcome.models.work.internal
 
-/** Holds relations for a particular work. An Option[List[_]] is used to
-  * represent cases both where the work has no relations and where the
-  * relations are not currently known.
+/** Holds relations for a particular work.
   *
-  * @param parts Children of the work
-  * @param partOf Parents of the work
-  * @param precededBy Siblings preceding the work
-  * @param succeededBy Siblings following the work
+  * @param ancestors Ancestors from root downwards
+  * @param children Children of the work
+  * @param siblingsPreceding Siblings preceding the work
+  * @param siblingsSucceeding Siblings following the work
   */
-case class Relations[State <: WorkState](
-  parts: Option[List[Work[State]]],
-  partOf: Option[List[Work[State]]],
-  precededBy: Option[List[Work[State]]],
-  succeededBy: Option[List[Work[State]]],
+case class Relations[State <: DataState](
+  ancestors: List[Relation[State]],
+  children: List[Relation[State]],
+  siblingsPreceding: List[Relation[State]],
+  siblingsSucceeding: List[Relation[State]],
 )
 
 object Relations {
 
-  def unknown[State <: WorkState]: Relations[State] =
+  def none[State <: DataState]: Relations[State] =
     Relations(
-      parts = None,
-      partOf = None,
-      precededBy = None,
-      succeededBy = None
-    )
-
-  def nil[State <: WorkState]: Relations[State] =
-    Relations(
-      parts = Some(Nil),
-      partOf = Some(Nil),
-      precededBy = Some(Nil),
-      succeededBy = Some(Nil)
+      ancestors = Nil,
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
     )
 }
+
+/** A relation contains a particular related work
+  *
+  * @param data The work data
+  * @param id The ID
+  * @param depth The depth of the relation in the tree
+  */
+case class Relation[State <: DataState](
+  data: WorkData[State],
+  id: State#Id,
+  depth: Int,
+)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Relations.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Relations.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.models.work.internal
+
+/** Holds relations for a particular work. An Option[List[_]] is used to
+  * represent cases both where the work has no relations and where the
+  * relations are not currently known.
+  *
+  * @param parts Children of the work
+  * @param partOf Parents of the work
+  * @param precededBy Siblings preceding the work
+  * @param succeededBy Siblings following the work
+  */
+case class Relations[State <: WorkState](
+  parts: Option[List[Work[State]]],
+  partOf: Option[List[Work[State]]],
+  precededBy: Option[List[Work[State]]],
+  succeededBy: Option[List[Work[State]]],
+)
+
+object Relations {
+
+  def unknown[State <: WorkState]: Relations[State] =
+    Relations(
+      parts = None,
+      partOf = None,
+      precededBy = None,
+      succeededBy = None
+    )
+
+  def nil[State <: WorkState]: Relations[State] =
+    Relations(
+      parts = Some(Nil),
+      partOf = Some(Nil),
+      precededBy = Some(Nil),
+      succeededBy = Some(Nil)
+    )
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -180,7 +180,8 @@ object WorkFsm {
 
     def state(state: InState, args: OutState#TransitionArgs): OutState
 
-    def data(data: WorkData[InState#WorkDataState]): WorkData[OutState#WorkDataState]
+    def data(
+      data: WorkData[InState#WorkDataState]): WorkData[OutState#WorkDataState]
 
     def redirect(redirect: InState#WorkDataState#Id): OutState#WorkDataState#Id
   }
@@ -195,7 +196,8 @@ object WorkFsm {
   }
 
   implicit val mergedToDenormalised = new Transition[Merged, Denormalised] {
-    def state(state: Merged, relations: Relations[DataState.Unidentified]): Denormalised =
+    def state(state: Merged,
+              relations: Relations[DataState.Unidentified]): Denormalised =
       Denormalised(state.sourceIdentifier, state.hasMultipleSources, relations)
 
     def data(data: WorkData[DataState.Unidentified]) = data

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -147,17 +147,19 @@ object WorkState {
 
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
-    hasMultipleSources: Boolean = false
+    hasMultipleSources: Boolean = false,
+    relations: Relations[Denormalised] = Relations.unknown
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
-    type TransitionArgs = Unit
+    type TransitionArgs = Relations[Denormalised]
   }
 
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: String,
-    hasMultipleSources: Boolean = false
+    hasMultipleSources: Boolean = false,
+    relations: Relations[Identified] = Relations.unknown
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -195,6 +197,20 @@ object WorkFsm {
 
     def redirect(redirect: IdState.Identifiable,
                  hasMultipleSources: Boolean): IdState.Identifiable =
+      redirect
+  }
+
+  implicit val mergedToDenormalised = new Transition[Merged, Denormalised] {
+    def state(state: Merged, relations: Relations[Denormalised]): Denormalised =
+      Denormalised(state.sourceIdentifier, state.hasMultipleSources, relations)
+
+    def data(
+      data: WorkData[DataState.Unidentified],
+      relations: Relations[Denormalised]): WorkData[DataState.Unidentified] =
+      data
+
+    def redirect(redirect: IdState.Identifiable,
+                 relations: Relations[Denormalised]): IdState.Identifiable =
       redirect
   }
 }


### PR DESCRIPTION
Adds a new `Relations` model for storing related works on a particular work.

Note this is similar to the existing [`RelatedWorks`](https://github.com/wellcomecollection/catalogue/blob/master/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/RelatedWorks.scala) model, although now things are a bit more general and also simpler as the related works are not restricted to being in the `Identified` state, and we can use `Option[List[Work[State]]]` directly than requiring a seperated `RelatedWork` type.