### PR TITLE
Automatically deploy api to stage from latest on merge to master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,7 @@ steps:
     label: "complete build"
   - wait
   - label: release to stage
-    #if: build.branch == "master"
+    if: build.branch == "master"
     plugins:
       - docker#v3.5.0:
           image: wellcome/weco-deploy:5.1.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,3 +64,12 @@ steps:
   - wait
   - command: .buildkite/scripts/complete_build.py
     label: "complete build"
+  - wait
+  - label: release to stage
+    #if: build.branch == "master"
+    plugins:
+      - docker#v3.5.0:
+          image: wellcome/weco-deploy:5.1.1
+          workdir: /repo
+          mount-ssh-agent: true
+          command: ["--project-id", "catalogue_api", "--confirm", "release-deploy", "--from-label", "latest", "--environment-id", "staging", "--description", $BUILDKITE_BUILD_URL]


### PR DESCRIPTION
In order to provide a consistently up-to-date stage environment and to provide a basis for testing whether a release to production can be done safely, this change keeps stage up to date with the latest build of the catalogue api.

This change will naively trigger a stage deployment from the "latest" tag whenever a merge is made to master. This does not check if the catalogue api images have actually been updated in a merge - but the deployment tool will ensure deploys only occur when the latest tag has been changed.

