### PR TITLE
Use a generic MessageSender in the snapshot generator

### DIFF
--- a/snapshots/snapshot_generator/docker-compose.yml
+++ b/snapshots/snapshot_generator/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -31,7 +31,7 @@ object Main extends WellcomeTypesafeApp {
     new SnapshotGeneratorWorkerService(
       snapshotService = snapshotService,
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      snsWriter = SNSBuilder.buildSNSMessageSender(
+      messageSender = SNSBuilder.buildSNSMessageSender(
         config,
         subject = s"source: ${this.getClass.getSimpleName}.processMessage",
       )

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/flow/DisplayWorkToJsonStringFlow.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/flow/DisplayWorkToJsonStringFlow.scala
@@ -8,15 +8,12 @@ import uk.ac.wellcome.display.json.DisplayJsonUtil
 import uk.ac.wellcome.display.models.Implicits._
 
 object DisplayWorkToJsonStringFlow extends Logging {
-
   def flow: Flow[DisplayWork, String, NotUsed] =
     Flow[DisplayWork]
-      .map { obj =>
-        obj match {
-          case work: DisplayWork => DisplayJsonUtil.toJson(work)
-          case _ =>
-            throw new IllegalArgumentException(
-              s"Unrecognised object: ${obj.getClass}")
-        }
+      .map {
+        case work: DisplayWork => DisplayJsonUtil.toJson(work)
+        case obj =>
+          throw new IllegalArgumentException(
+            s"Unrecognised object: ${obj.getClass}")
       }
 }

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.snapshot_generator.services
 
 import akka.Done
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSMessageSender}
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotJob
 import uk.ac.wellcome.typesafe.Runnable
@@ -12,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SnapshotGeneratorWorkerService(
   snapshotService: SnapshotService,
   sqsStream: SQSStream[NotificationMessage],
-  snsWriter: SNSMessageSender
+  messageSender: MessageSender[_]
 )(implicit ec: ExecutionContext)
     extends Runnable {
 
@@ -24,9 +25,8 @@ class SnapshotGeneratorWorkerService(
       snapshotJob <- Future.fromTry(fromJson[SnapshotJob](message.body))
       completedSnapshotJob <- snapshotService.generateSnapshot(
         snapshotJob = snapshotJob)
-      _ <- Future.fromTry(
-        snsWriter.sendT(
-          completedSnapshotJob
-        ))
+      _ <- Future.fromTry {
+        messageSender.sendT(completedSnapshotJob)
+      }
     } yield ()
 }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -94,13 +94,15 @@ class SnapshotGeneratorFeatureTest
               s"http://localhost:33333/${publicBucket.name}/$publicObjectKey"
           )
 
-          messageSender.getMessages[CompletedSnapshotJob] shouldBe Seq(expectedJob)
+          messageSender.getMessages[CompletedSnapshotJob] shouldBe Seq(
+            expectedJob)
         }
     }
   }
 
   def withFixtures[R](
-    testWith: TestWith[(Queue, MemoryMessageSender, Index, Index, Bucket), R]): R =
+    testWith: TestWith[(Queue, MemoryMessageSender, Index, Index, Bucket), R])
+    : R =
     withActorSystem { implicit actorSystem =>
       withLocalSqsQueue(visibilityTimeout = 5) { queue =>
         val messageSender = new MemoryMessageSender()

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -13,7 +13,6 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.WorkerServiceFixture
@@ -22,7 +21,6 @@ import uk.ac.wellcome.platform.snapshot_generator.models.{
   SnapshotJob
 }
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 class SnapshotGeneratorFeatureTest
@@ -30,8 +28,6 @@ class SnapshotGeneratorFeatureTest
     with Eventually
     with Matchers
     with Akka
-    with S3Fixtures
-    with SQS
     with GzipUtils
     with JsonAssertions
     with IntegrationPatience

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -102,7 +102,7 @@ class SnapshotGeneratorFeatureTest
   def withFixtures[R](
     testWith: TestWith[(Queue, MemoryMessageSender, Index, Index, Bucket), R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueue() { queue =>
+      withLocalSqsQueue(visibilityTimeout = 5) { queue =>
         val messageSender = new MemoryMessageSender()
 
         withLocalWorksIndex { worksIndex =>

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
@@ -12,12 +12,12 @@ import uk.ac.wellcome.platform.snapshot_generator.services.SnapshotGeneratorWork
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait WorkerServiceFixture
-    extends AkkaS3
-    with SnapshotServiceFixture
-    with SQS { this: Suite =>
-  def withWorkerService[R](queue: Queue, messageSender: MemoryMessageSender, worksIndex: Index)(
-    testWith: TestWith[SnapshotGeneratorWorkerService, R])(
+trait WorkerServiceFixture extends AkkaS3 with SnapshotServiceFixture with SQS {
+  this: Suite =>
+  def withWorkerService[R](
+    queue: Queue,
+    messageSender: MemoryMessageSender,
+    worksIndex: Index)(testWith: TestWith[SnapshotGeneratorWorkerService, R])(
     implicit actorSystem: ActorSystem): R =
     withS3AkkaSettings { s3AkkaClient =>
       withSnapshotService(s3AkkaClient, worksIndex) { snapshotService =>

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
@@ -3,47 +3,35 @@ package uk.ac.wellcome.platform.snapshot_generator.fixtures
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.Index
 import org.scalatest.Suite
-import uk.ac.wellcome.messaging.sns.{
-  NotificationMessage,
-  SNSConfig,
-  SNSMessageSender
-}
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.snapshot_generator.services.SnapshotGeneratorWorkerService
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.platform.snapshot_generator.services.SnapshotGeneratorWorkerService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait WorkerServiceFixture
     extends AkkaS3
     with SnapshotServiceFixture
-    with SNS
     with SQS { this: Suite =>
-  def withWorkerService[R](queue: Queue, topic: Topic, worksIndex: Index)(
+  def withWorkerService[R](queue: Queue, messageSender: MemoryMessageSender, worksIndex: Index)(
     testWith: TestWith[SnapshotGeneratorWorkerService, R])(
     implicit actorSystem: ActorSystem): R =
     withS3AkkaSettings { s3AkkaClient =>
       withSnapshotService(s3AkkaClient, worksIndex) { snapshotService =>
         withSQSStream[NotificationMessage, R](queue) { sqsStream =>
-          withSNSMessageSender(topic) { messageSender =>
-            val workerService = new SnapshotGeneratorWorkerService(
-              snapshotService = snapshotService,
-              sqsStream = sqsStream,
-              messageSender = messageSender
-            )
+          val workerService = new SnapshotGeneratorWorkerService(
+            snapshotService = snapshotService,
+            sqsStream = sqsStream,
+            messageSender = messageSender
+          )
 
-            workerService.run()
+          workerService.run()
 
-            testWith(workerService)
-          }
+          testWith(workerService)
         }
       }
     }
-
-  def withSNSMessageSender[R](topic: Topic)(
-    testWith: TestWith[SNSMessageSender, R]): R = {
-    testWith(new SNSMessageSender(snsClient, SNSConfig(topic.arn), ""))
-  }
 }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/WorkerServiceFixture.scala
@@ -31,7 +31,7 @@ trait WorkerServiceFixture
             val workerService = new SnapshotGeneratorWorkerService(
               snapshotService = snapshotService,
               sqsStream = sqsStream,
-              snsWriter = messageSender
+              messageSender = messageSender
             )
 
             workerService.run()

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -27,7 +27,6 @@ import uk.ac.wellcome.platform.snapshot_generator.models.{
   SnapshotJob
 }
 import uk.ac.wellcome.platform.snapshot_generator.test.utils.GzipUtils
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 
 class SnapshotServiceTest
@@ -36,7 +35,6 @@ class SnapshotServiceTest
     with Matchers
     with Akka
     with AkkaS3
-    with S3Fixtures
     with GzipUtils
     with IntegrationPatience
     with SnapshotServiceFixture


### PR DESCRIPTION
Small improvement spotted while reading this code.

We have a generic MessageSender class, which includes an in-memory implementation for testing. Use it in the snapshot generator and save ourselves a Docker image pull on every test.