### PR TITLE
Refactor work generators

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -12,8 +12,8 @@ import uk.ac.wellcome.models.work.generators.{
   ContributorGenerators,
   GenreGenerators,
   ImageGenerators,
-  SubjectGenerators,
-  LegacyWorkGenerators
+  LegacyWorkGenerators,
+  SubjectGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.work.generators.{
   GenreGenerators,
   ImageGenerators,
   SubjectGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators
@@ -37,7 +37,7 @@ class WorksQueryTest
     with SearchOptionsGenerators
     with SubjectGenerators
     with GenreGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ImageGenerators
     with ContributorGenerators {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.generators.{
   GenreGenerators,
   SubjectGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 
 class AggregationsTest
@@ -24,7 +24,7 @@ class AggregationsTest
     with ElasticsearchFixtures
     with SubjectGenerators
     with GenreGenerators
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   val worksService = new WorksService(
     searchService = new ElasticsearchService(elasticClient)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -13,8 +13,8 @@ import uk.ac.wellcome.platform.api.models._
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.generators.{
   GenreGenerators,
-  SubjectGenerators,
-  LegacyWorkGenerators
+  LegacyWorkGenerators,
+  SubjectGenerators
 }
 
 class AggregationsTest

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -13,8 +13,8 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.{
   ContributorGenerators,
   GenreGenerators,
-  SubjectGenerators,
-  LegacyWorkGenerators
+  LegacyWorkGenerators,
+  SubjectGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.{
   Books,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.models.work.generators.{
   ContributorGenerators,
   GenreGenerators,
   SubjectGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.{
   Books,
@@ -39,7 +39,7 @@ class ElasticsearchServiceTest
     with SearchOptionsGenerators
     with SubjectGenerators
     with GenreGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ContributorGenerators {
 
   val searchService = new ElasticsearchService(elasticClient)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -154,10 +154,10 @@ class RelatedWorkServiceTest
 
   it("Only returns core fields on related works") {
     withLocalWorksIndex { index =>
-      val workP = work("p", CollectionLevel.Collection) withData (
+      val workP = work("p", CollectionLevel.Collection) mapData (
         _.copy[DataState.Identified](items = List(createIdentifiedItem))
       )
-      val workQ = work("p/q", CollectionLevel.Series) withData (
+      val workQ = work("p/q", CollectionLevel.Series) mapData (
         _.copy[DataState.Identified](notes = List(GeneralNote("hi")))
       )
       val workR = work("p/q/r", CollectionLevel.Item)
@@ -169,10 +169,10 @@ class RelatedWorkServiceTest
             partOf = Some(
               List(
                 RelatedWork(
-                  workQ.withData(_.copy(notes = Nil)),
+                  workQ.mapData(_.copy(notes = Nil)),
                   RelatedWorks.partOf(
                     RelatedWork(
-                      workP.withData(_.copy(items = Nil)),
+                      workP.mapData(_.copy(items = Nil)),
                       RelatedWorks(partOf = Some(Nil))
                     )
                   )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.{
   IdentifiersGenerators,
   ItemsGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import WorkState.Identified
 
@@ -22,7 +22,7 @@ class RelatedWorkServiceTest
     with ElasticsearchFixtures
     with IdentifiersGenerators
     with ItemsGenerators
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   val service = new RelatedWorkService(new ElasticsearchService(elasticClient))
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -14,8 +14,8 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.display.models.AggregationRequest
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.{
-  ProductionEventGenerators,
-  LegacyWorkGenerators
+  LegacyWorkGenerators,
+  ProductionEventGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.internal.Format.{

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.display.models.AggregationRequest
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.{
   ProductionEventGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.internal.Format.{
@@ -35,7 +35,7 @@ class WorksServiceTest
     with Matchers
     with ScalaFutures
     with SearchOptionsGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ProductionEventGenerators {
 
   val elasticsearchService = new ElasticsearchService(elasticClient)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -11,7 +11,7 @@ import WorkState.Identified
 trait ApiWorksTestBase
     extends ApiTestBase
     with DisplaySerialisationTestBase
-    with WorksGenerators
+    with LegacyWorkGenerators
     with GenreGenerators
     with SubjectGenerators {
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.{
   IdentifiersGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 
@@ -14,7 +14,7 @@ class DisplayLocationTest
     with DisplaySerialisationTestBase
     with JsonMapperTestUtil
     with IdentifiersGenerators
-    with WorksGenerators {
+    with LegacyWorkGenerators {
   it("Encodes the DisplayLocation ADT correctly") {
     val digitalResource = DisplayLocation(
       Location.DigitalResource(

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -3,18 +3,10 @@ package uk.ac.wellcome.display.models
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.generators.{
-  IdentifiersGenerators,
-  LegacyWorkGenerators
-}
 import uk.ac.wellcome.models.work.internal._
 
-class DisplayLocationTest
-    extends AnyFunSpec
-    with DisplaySerialisationTestBase
-    with JsonMapperTestUtil
-    with IdentifiersGenerators
-    with LegacyWorkGenerators {
+class DisplayLocationTest extends AnyFunSpec with JsonMapperTestUtil {
+
   it("Encodes the DisplayLocation ADT correctly") {
     val digitalResource = DisplayLocation(
       Location.DigitalResource(

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
@@ -4,7 +4,7 @@ import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators._
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
@@ -12,7 +12,8 @@ class DisplayLocationsSerialisationTestDeprecated
     extends AnyFunSpec
     with DisplaySerialisationTestBase
     with JsonMapperTestUtil
-    with LegacyWorkGenerators {
+    with WorkGenerators
+    with ItemsGenerators {
 
   it("serialises a physical location") {
     val physicalLocation = PhysicalLocationDeprecated(
@@ -20,8 +21,8 @@ class DisplayLocationsSerialisationTestDeprecated
       label = "a stack of slick slimes"
     )
 
-    val work = createIdentifiedWorkWith(
-      items = List(createIdentifiedItemWith(locations = List(physicalLocation)))
+    val work = identifiedWork().items(
+      List(createIdentifiedItemWith(locations = List(physicalLocation)))
     )
 
     val expectedJson = s"""
@@ -43,8 +44,8 @@ class DisplayLocationsSerialisationTestDeprecated
       locationType = LocationType("iiif-image"),
     )
 
-    val work = createIdentifiedWorkWith(
-      items = List(createIdentifiedItemWith(locations = List(digitalLocation)))
+    val work = identifiedWork().items(
+      List(createIdentifiedItemWith(locations = List(digitalLocation)))
     )
 
     val expectedJson = s"""
@@ -67,8 +68,8 @@ class DisplayLocationsSerialisationTestDeprecated
       license = Some(License.CC0)
     )
 
-    val work = createIdentifiedWorkWith(
-      items = List(createIdentifiedItemWith(locations = List(digitalLocation)))
+    val work = identifiedWork().items(
+      List(createIdentifiedItemWith(locations = List(digitalLocation)))
     )
 
     val expectedJson = s"""
@@ -97,8 +98,8 @@ class DisplayLocationsSerialisationTestDeprecated
       )
     )
 
-    val work = createIdentifiedWorkWith(
-      items = List(createIdentifiedItemWith(locations = List(digitalLocation)))
+    val work = identifiedWork().items(
+      List(createIdentifiedItemWith(locations = List(digitalLocation)))
     )
 
     val expectedJson = s"""

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
@@ -4,7 +4,7 @@ import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
@@ -12,7 +12,7 @@ class DisplayLocationsSerialisationTestDeprecated
     extends AnyFunSpec
     with DisplaySerialisationTestBase
     with JsonMapperTestUtil
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("serialises a physical location") {
     val physicalLocation = PhysicalLocationDeprecated(

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -4,9 +4,9 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
-  WorkGenerators,
   ProductionEventGenerators,
-  SubjectGenerators
+  SubjectGenerators,
+  WorkGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.{Books, EBooks}
 import uk.ac.wellcome.models.work.internal._
@@ -343,7 +343,7 @@ class DisplayWorkSerialisationTest
 
   it("shows the thumbnail field if available") {
     val work = identifiedWork().thumbnail(
-    DigitalLocationDeprecated(
+      DigitalLocationDeprecated(
         locationType = LocationType("thumbnail-image"),
         url = "https://iiif.example.org/1234/default.jpg",
         license = Some(License.CCBY)

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -4,9 +4,9 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
+  LegacyWorkGenerators,
   ProductionEventGenerators,
-  SubjectGenerators,
-  LegacyWorkGenerators
+  SubjectGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.{Books, EBooks}
 import uk.ac.wellcome.models.work.internal._

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.display.test.util.JsonMapperTestUtil
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
-  LegacyWorkGenerators,
+  WorkGenerators,
   ProductionEventGenerators,
   SubjectGenerators
 }
@@ -18,16 +18,15 @@ class DisplayWorkSerialisationTest
     with JsonMapperTestUtil
     with ProductionEventGenerators
     with SubjectGenerators
-    with LegacyWorkGenerators
+    with WorkGenerators
     with ImageGenerators {
 
   it("serialises a DisplayWork") {
-    val work = createIdentifiedWorkWith(
-      format = Some(Books),
-      description = Some(randomAlphanumeric(100)),
-      lettering = Some(randomAlphanumeric(100)),
-      createdDate = Some(Period("1901"))
-    )
+    val work = identifiedWork()
+      .format(Books)
+      .description(randomAlphanumeric(100))
+      .lettering(randomAlphanumeric(100))
+      .createdDate(Period("1901"))
 
     val expectedJson = s"""
       |{
@@ -46,9 +45,8 @@ class DisplayWorkSerialisationTest
   }
 
   it("renders an item if the items include is present") {
-    val work = createIdentifiedWorkWith(
-      items = createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith()
-    )
+    val work = identifiedWork()
+      .items(createIdentifiedItems(count = 1) :+ createUnidentifiableItemWith())
 
     val expectedJson = s"""
       |{
@@ -67,9 +65,7 @@ class DisplayWorkSerialisationTest
   }
 
   it("includes 'items' if the items include is present, even with no items") {
-    val work = createIdentifiedWorkWith(
-      items = List()
-    )
+    val work = identifiedWork().items(Nil)
 
     val expectedJson = s"""
       |{
@@ -95,9 +91,7 @@ class DisplayWorkSerialisationTest
       license = Some(License.CCBY)
     )
     val item = createIdentifiedItemWith(locations = List(location))
-    val workWithCopyright = createIdentifiedWorkWith(
-      items = List(item)
-    )
+    val workWithCopyright = identifiedWork().items(List(item))
 
     val expectedJson = s"""
       |{
@@ -135,10 +129,8 @@ class DisplayWorkSerialisationTest
 
   it(
     "includes subject information in DisplayWork serialisation with the subjects include") {
-    val workWithSubjects = createIdentifiedWorkWith(
-      subjects = (1 to 3).map { _ =>
-        createSubject
-      }.toList
+    val workWithSubjects = identifiedWork().subjects(
+      (1 to 3).map(_ => createSubject).toList
     )
 
     val expectedJson = s"""
@@ -162,8 +154,8 @@ class DisplayWorkSerialisationTest
 
   it(
     "includes production information in DisplayWork serialisation with the production include") {
-    val workWithProduction = createIdentifiedWorkWith(
-      production = createProductionEventList(count = 3)
+    val workWithProduction = identifiedWork().production(
+      createProductionEventList(count = 3)
     )
 
     val expectedJson = s"""
@@ -187,15 +179,16 @@ class DisplayWorkSerialisationTest
 
   it(
     "includes the contributors in DisplayWork serialisation with the contribuotrs include") {
-    val work = createIdentifiedWorkWith(
-      format = Some(EBooks),
-      description = Some(randomAlphanumeric(100)),
-      lettering = Some(randomAlphanumeric(100)),
-      createdDate = Some(Period("1901")),
-      contributors = List(
-        Contributor(agent = Agent(randomAlphanumeric(25)), roles = Nil)
+    val work = identifiedWork()
+      .format(EBooks)
+      .description(randomAlphanumeric(100))
+      .lettering(randomAlphanumeric(100))
+      .createdDate(Period("1901"))
+      .contributors(
+        List(
+          Contributor(agent = Agent(randomAlphanumeric(25)), roles = Nil)
+        )
       )
-    )
 
     val expectedJson = s"""
       |{
@@ -219,8 +212,8 @@ class DisplayWorkSerialisationTest
 
   it(
     "includes genre information in DisplayWork serialisation with the genres include") {
-    val work = createIdentifiedWorkWith(
-      genres = List(
+    val work = identifiedWork().genres(
+      List(
         Genre(
           label = "genre",
           concepts = List(Concept("woodwork"), Concept("etching"))
@@ -246,8 +239,8 @@ class DisplayWorkSerialisationTest
 
   it(
     "includes 'notes' if the notes include is present, with similar notes grouped together") {
-    val work = createIdentifiedWorkWith(
-      notes = List(GeneralNote("A"), FundingInformation("B"), GeneralNote("C"))
+    val work = identifiedWork().notes(
+      List(GeneralNote("A"), FundingInformation("B"), GeneralNote("C"))
     )
 
     val expectedJson = s"""
@@ -287,9 +280,7 @@ class DisplayWorkSerialisationTest
 
   it("includes a list of identifiers on DisplayWork") {
     val otherIdentifier = createSourceIdentifier
-    val work = createIdentifiedWorkWith(
-      otherIdentifiers = List(otherIdentifier)
-    )
+    val work = identifiedWork().otherIdentifiers(List(otherIdentifier))
 
     val expectedJson = s"""
       |{
@@ -311,9 +302,7 @@ class DisplayWorkSerialisationTest
   }
 
   it("always includes 'identifiers' with the identifiers include") {
-    val work = createIdentifiedWorkWith(
-      otherIdentifiers = List()
-    )
+    val work = identifiedWork().otherIdentifiers(Nil)
 
     val expectedJson = s"""
       |{
@@ -332,8 +321,8 @@ class DisplayWorkSerialisationTest
   }
 
   it("includes image stubs with the images include") {
-    val work = createIdentifiedWorkWith(
-      images = (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
+    val work = identifiedWork().images(
+      (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
     )
 
     val expectedJson = s"""
@@ -353,13 +342,12 @@ class DisplayWorkSerialisationTest
   }
 
   it("shows the thumbnail field if available") {
-    val work = createIdentifiedWorkWith(
-      thumbnail = Some(
-        DigitalLocationDeprecated(
-          locationType = LocationType("thumbnail-image"),
-          url = "https://iiif.example.org/1234/default.jpg",
-          license = Some(License.CCBY)
-        ))
+    val work = identifiedWork().thumbnail(
+    DigitalLocationDeprecated(
+        locationType = LocationType("thumbnail-image"),
+        url = "https://iiif.example.org/1234/default.jpg",
+        license = Some(License.CCBY)
+      )
     )
 
     val expectedJson = s"""

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
   ProductionEventGenerators,
   SubjectGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.{Books, EBooks}
 import uk.ac.wellcome.models.work.internal._
@@ -18,7 +18,7 @@ class DisplayWorkSerialisationTest
     with JsonMapperTestUtil
     with ProductionEventGenerators
     with SubjectGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ImageGenerators {
 
   it("serialises a DisplayWork") {

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -10,8 +10,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
-  WorkGenerators,
-  ProductionEventGenerators
+  ProductionEventGenerators,
+  WorkGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.Videos
 import uk.ac.wellcome.models.work.internal._
@@ -260,7 +260,9 @@ class DisplayWorkTest
             agent = Agent(
               label = "Bond",
               id = IdState
-                .Identified(createCanonicalId, contributorAgentSourceIdentifier),
+                .Identified(
+                  createCanonicalId,
+                  contributorAgentSourceIdentifier),
             ),
             roles = Nil
           ),
@@ -277,7 +279,9 @@ class DisplayWorkTest
             agent = Person(
               label = "Blue Blaise",
               id = IdState
-                .Identified(createCanonicalId, contributorPersonSourceIdentifier),
+                .Identified(
+                  createCanonicalId,
+                  contributorPersonSourceIdentifier),
             ),
             roles = Nil
           )
@@ -292,17 +296,19 @@ class DisplayWorkTest
             concepts = List(
               Concept(
                 label = "Bonding",
-                id =
-                  IdState.Identified(createCanonicalId, conceptSourceIdentifier),
+                id = IdState
+                  .Identified(createCanonicalId, conceptSourceIdentifier),
               ),
               Period(
                 label = "Before",
-                id = IdState.Identified(createCanonicalId, periodSourceIdentifier),
+                id =
+                  IdState.Identified(createCanonicalId, periodSourceIdentifier),
                 range = None,
               ),
               Place(
                 label = "Bulgaria",
-                id = IdState.Identified(createCanonicalId, placeSourceIdentifier),
+                id =
+                  IdState.Identified(createCanonicalId, placeSourceIdentifier),
               )
             )
           ),

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -10,8 +10,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
-  ProductionEventGenerators,
-  LegacyWorkGenerators
+  LegacyWorkGenerators,
+  ProductionEventGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.Videos
 import uk.ac.wellcome.models.work.internal._

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
-  LegacyWorkGenerators,
+  WorkGenerators,
   ProductionEventGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.Videos
@@ -21,7 +21,7 @@ class DisplayWorkTest
     extends AnyFunSpec
     with Matchers
     with ProductionEventGenerators
-    with LegacyWorkGenerators
+    with WorkGenerators
     with ImageGenerators
     with ScalaCheckPropertyChecks {
 
@@ -42,9 +42,7 @@ class DisplayWorkTest
     }
 
   it("parses a Work without any items") {
-    val work = createIdentifiedWorkWith(
-      items = List()
-    )
+    val work = identifiedWork().items(Nil)
 
     val displayWork = DisplayWork(
       work = work,
@@ -55,9 +53,7 @@ class DisplayWorkTest
 
   it("parses identified items on a work") {
     val items = createIdentifiedItems(count = 1)
-    val work = createIdentifiedWorkWith(
-      items = items
-    )
+    val work = identifiedWork().items(items)
 
     val displayWork = DisplayWork(
       work = work,
@@ -70,7 +66,7 @@ class DisplayWorkTest
   it("parses unidentified items on a work") {
     val item = createUnidentifiableItemWith()
     val location = item.locations.head.asInstanceOf[DigitalLocationDeprecated]
-    val work = createIdentifiedWorkWith(items = List(item))
+    val work = identifiedWork().items(List(item))
 
     val displayWork = DisplayWork(
       work = work,
@@ -95,9 +91,7 @@ class DisplayWorkTest
   }
 
   it("parses a work without any extra identifiers") {
-    val work = createIdentifiedWorkWith(
-      otherIdentifiers = List()
-    )
+    val work = identifiedWork().otherIdentifiers(Nil)
 
     val displayWork = DisplayWork(
       work = work,
@@ -110,9 +104,7 @@ class DisplayWorkTest
   it("gets the physicalDescription from a Work") {
     val physicalDescription = "A magnificent mural of magpies"
 
-    val work = createIdentifiedWorkWith(
-      physicalDescription = Some(physicalDescription)
-    )
+    val work = identifiedWork().physicalDescription(physicalDescription)
 
     val displayWork = DisplayWork(work)
     displayWork.physicalDescription shouldBe Some(physicalDescription)
@@ -126,18 +118,14 @@ class DisplayWorkTest
       label = format.label
     )
 
-    val work = createIdentifiedWorkWith(
-      format = Some(format)
-    )
+    val work = identifiedWork().format(format)
 
     val displayWork = DisplayWork(work)
     displayWork.workType shouldBe Some(expectedDisplayWork)
   }
 
   it("gets the ontologyType from a Work") {
-    val work = createIdentifiedWorkWith(
-      workType = WorkType.Section
-    )
+    val work = identifiedWork().workType(WorkType.Section)
     val displayWork = DisplayWork(work)
 
     displayWork.ontologyType shouldBe "Section"
@@ -149,9 +137,7 @@ class DisplayWorkTest
       label = "British Sign Language"
     )
 
-    val work = createIdentifiedWorkWith(
-      language = Some(language)
-    )
+    val work = identifiedWork().language(language)
 
     val displayWork = DisplayWork(work)
     val displayLanguage = displayWork.language.get
@@ -165,8 +151,8 @@ class DisplayWorkTest
       ontologyType = "Person"
     )
 
-    val work = createIdentifiedWorkWith(
-      contributors = List(
+    val work = identifiedWork().contributors(
+      List(
         Contributor(
           agent = Person(
             label = "Vlad the Vanquished",
@@ -217,9 +203,7 @@ class DisplayWorkTest
   it("extracts production events from a work with the production include") {
     val productionEvent = createProductionEvent
 
-    val work = createIdentifiedWorkWith(
-      production = List(productionEvent)
-    )
+    val work = identifiedWork().production(List(productionEvent))
 
     val displayWork =
       DisplayWork(work, includes = WorksIncludes(WorkInclude.Production))
@@ -269,71 +253,78 @@ class DisplayWorkTest
       ontologyType = "Concept"
     )
 
-    val work = createIdentifiedWorkWith(
-      contributors = List(
-        Contributor(
-          agent = Agent(
-            label = "Bond",
-            id = IdState
-              .Identified(createCanonicalId, contributorAgentSourceIdentifier),
-          ),
-          roles = Nil
-        ),
-        Contributor(
-          agent = Organisation(
-            label = "Big Business",
-            id = IdState.Identified(
-              createCanonicalId,
-              contributorOrganisationSourceIdentifier),
-          ),
-          roles = Nil
-        ),
-        Contributor(
-          agent = Person(
-            label = "Blue Blaise",
-            id = IdState
-              .Identified(createCanonicalId, contributorPersonSourceIdentifier),
-          ),
-          roles = Nil
-        )
-      ),
-      items = createIdentifiedItems(count = 1),
-      subjects = List(
-        Subject(
-          label = "Beryllium-Boron Bonding",
-          id = IdState.Identified(createCanonicalId, subjectSourceIdentifier),
-          concepts = List(
-            Concept(
-              label = "Bonding",
-              id =
-                IdState.Identified(createCanonicalId, conceptSourceIdentifier),
+    val work = identifiedWork()
+      .contributors(
+        List(
+          Contributor(
+            agent = Agent(
+              label = "Bond",
+              id = IdState
+                .Identified(createCanonicalId, contributorAgentSourceIdentifier),
             ),
-            Period(
-              label = "Before",
-              id = IdState.Identified(createCanonicalId, periodSourceIdentifier),
-              range = None,
+            roles = Nil
+          ),
+          Contributor(
+            agent = Organisation(
+              label = "Big Business",
+              id = IdState.Identified(
+                createCanonicalId,
+                contributorOrganisationSourceIdentifier),
             ),
-            Place(
-              label = "Bulgaria",
-              id = IdState.Identified(createCanonicalId, placeSourceIdentifier),
-            )
-          )
-        ),
-      ),
-      genres = List(
-        Genre(
-          label = "Black, Brown and Blue",
-          concepts = List(
-            Concept(
-              label = "Colours",
-              id =
-                IdState.Identified(createCanonicalId, conceptSourceIdentifier)
-            )
+            roles = Nil
+          ),
+          Contributor(
+            agent = Person(
+              label = "Blue Blaise",
+              id = IdState
+                .Identified(createCanonicalId, contributorPersonSourceIdentifier),
+            ),
+            roles = Nil
           )
         )
-      ),
-      images = (1 to 5).map(_ => createUnmergedImage.toIdentified).toList
-    )
+      )
+      .items(createIdentifiedItems(count = 1))
+      .subjects(
+        List(
+          Subject(
+            label = "Beryllium-Boron Bonding",
+            id = IdState.Identified(createCanonicalId, subjectSourceIdentifier),
+            concepts = List(
+              Concept(
+                label = "Bonding",
+                id =
+                  IdState.Identified(createCanonicalId, conceptSourceIdentifier),
+              ),
+              Period(
+                label = "Before",
+                id = IdState.Identified(createCanonicalId, periodSourceIdentifier),
+                range = None,
+              ),
+              Place(
+                label = "Bulgaria",
+                id = IdState.Identified(createCanonicalId, placeSourceIdentifier),
+              )
+            )
+          ),
+        )
+      )
+      .genres(
+        List(
+          Genre(
+            label = "Black, Brown and Blue",
+            concepts = List(
+              Concept(
+                label = "Colours",
+                id =
+                  IdState.Identified(createCanonicalId, conceptSourceIdentifier)
+              )
+            )
+          )
+        )
+      )
+      .images(
+        (1 to 5).map(_ => createUnmergedImage.toIdentified).toList
+      )
 
     describe("omits identifiers if WorksIncludes.identifiers is false") {
       val displayWork = DisplayWork(work, includes = WorksIncludes())
@@ -459,13 +450,13 @@ class DisplayWorkTest
   }
 
   describe("related works") {
-    val work = createIdentifiedWork
-    val workA = createIdentifiedWork
-    val workB = createIdentifiedWork
-    val workC = createIdentifiedWork
-    val workD = createIdentifiedWork
-    val workE = createIdentifiedWork
-    val workF = createIdentifiedWork
+    val work = identifiedWork()
+    val workA = identifiedWork()
+    val workB = identifiedWork()
+    val workC = identifiedWork()
+    val workD = identifiedWork()
+    val workE = identifiedWork()
+    val workF = identifiedWork()
 
     val relatedWorks = RelatedWorks(
       partOf = Some(

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -11,7 +11,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
   ProductionEventGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import uk.ac.wellcome.models.work.internal.Format.Videos
 import uk.ac.wellcome.models.work.internal._
@@ -21,7 +21,7 @@ class DisplayWorkTest
     extends AnyFunSpec
     with Matchers
     with ProductionEventGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ImageGenerators
     with ScalaCheckPropertyChecks {
 

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -16,10 +16,7 @@ import io.circe.generic.semiauto.deriveEncoder
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.{
-  ImageGenerators,
-  LegacyWorkGenerators
-}
+import uk.ac.wellcome.models.work.generators.{ImageGenerators, WorkGenerators}
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
@@ -31,7 +28,7 @@ class WorksIndexConfigTest
     with Matchers
     with JsonAssertions
     with ScalaCheckPropertyChecks
-    with LegacyWorkGenerators
+    with WorkGenerators
     with ImageGenerators {
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.
@@ -72,8 +69,8 @@ class WorksIndexConfigTest
   // So let's add a specific one
   it("puts a work with a person subject") {
     withLocalWorksIndex { index =>
-      val sampleWork = createIdentifiedWorkWith(
-        subjects = List(
+      val sampleWork = identifiedWork().subjects(
+        List(
           Subject(
             id = IdState.Unidentifiable,
             label = "Daredevil",
@@ -103,8 +100,8 @@ class WorksIndexConfigTest
       to = Some("2014"))
 
     withLocalWorksIndex { index =>
-      val sampleWork = createIdentifiedWorkWith(
-        items = List(
+      val sampleWork = identifiedWork().items(
+        List(
           createIdentifiedItemWith(locations = List(createDigitalLocationWith(
             accessConditions = List(accessCondition))))))
       whenReady(indexObject(index, sampleWork)) { _ =>
@@ -119,15 +116,13 @@ class WorksIndexConfigTest
   // which would not work as the mapping is strict and `collection`
   // only exists at the `data.collectionPath` level
   it("puts a work with a collection") {
-    val collectionPath =
-      Some(
-        CollectionPath(
-          path = "PATH/FOR/THE/COLLECTION",
-          level = Some(CollectionLevel.Item),
-          label = Some("PATH/FOR/THE/COLLECTION")))
-
+    val collectionPath = CollectionPath(
+        path = "PATH/FOR/THE/COLLECTION",
+        level = Some(CollectionLevel.Item),
+        label = Some("PATH/FOR/THE/COLLECTION")
+    )
     withLocalWorksIndex { index =>
-      val sampleWork = createIdentifiedWorkWith(collectionPath = collectionPath)
+      val sampleWork = identifiedWork().collectionPath(collectionPath)
       whenReady(indexObject(index, sampleWork)) { _ =>
         assertObjectIndexed(index, sampleWork)
       }
@@ -136,8 +131,8 @@ class WorksIndexConfigTest
 
   it("can ingest a work with an image") {
     withLocalWorksIndex { index =>
-      val sampleWork = createIdentifiedWorkWith(
-        images = List(createUnmergedImage.toIdentified)
+      val sampleWork = identifiedWork().images(
+        List(createUnmergedImage.toIdentified)
       )
       whenReady(indexObject(index, sampleWork)) { _ =>
         assertObjectIndexed(index, sampleWork)

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -117,9 +117,9 @@ class WorksIndexConfigTest
   // only exists at the `data.collectionPath` level
   it("puts a work with a collection") {
     val collectionPath = CollectionPath(
-        path = "PATH/FOR/THE/COLLECTION",
-        level = Some(CollectionLevel.Item),
-        label = Some("PATH/FOR/THE/COLLECTION")
+      path = "PATH/FOR/THE/COLLECTION",
+      level = Some(CollectionLevel.Item),
+      label = Some("PATH/FOR/THE/COLLECTION")
     )
     withLocalWorksIndex { index =>
       val sampleWork = identifiedWork().collectionPath(collectionPath)

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -16,7 +16,10 @@ import io.circe.generic.semiauto.deriveEncoder
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.{ImageGenerators, LegacyWorkGenerators}
+import uk.ac.wellcome.models.work.generators.{
+  ImageGenerators,
+  LegacyWorkGenerators
+}
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -16,7 +16,7 @@ import io.circe.generic.semiauto.deriveEncoder
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.{ImageGenerators, WorksGenerators}
+import uk.ac.wellcome.models.work.generators.{ImageGenerators, LegacyWorkGenerators}
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
@@ -28,7 +28,7 @@ class WorksIndexConfigTest
     with Matchers
     with JsonAssertions
     with ScalaCheckPropertyChecks
-    with WorksGenerators
+    with LegacyWorkGenerators
     with ImageGenerators {
 
   // On failure, scalacheck tries to shrink to the smallest input that causes a failure.

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -16,8 +16,7 @@ sealed trait Work[State <: WorkState] {
   def identifiers: List[SourceIdentifier] =
     sourceIdentifier :: data.otherIdentifiers
 
-  def mapData(
-    f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
+  def mapData(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
     : Work[State] =
     this match {
       case Work.Visible(version, data, state) =>

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -16,7 +16,7 @@ sealed trait Work[State <: WorkState] {
   def identifiers: List[SourceIdentifier] =
     sourceIdentifier :: data.otherIdentifiers
 
-  def withData(
+  def mapData(
     f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
     : Work[State] =
     this match {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -6,7 +6,7 @@ import SourceWork._
 trait ImageGenerators
     extends IdentifiersGenerators
     with ItemsGenerators
-    with WorksGenerators
+    with LegacyWorkGenerators
     with VectorGenerators {
   def createUnmergedImageWith(
     location: DigitalLocationDeprecated = createDigitalLocation,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal._
 
-trait WorksGenerators extends ItemsGenerators with ProductionEventGenerators {
+trait LegacyWorkGenerators extends ItemsGenerators with ProductionEventGenerators {
 
   import WorkState._
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -2,7 +2,9 @@ package uk.ac.wellcome.models.work.generators
 
 import uk.ac.wellcome.models.work.internal._
 
-trait LegacyWorkGenerators extends ItemsGenerators with ProductionEventGenerators {
+trait LegacyWorkGenerators
+    extends ItemsGenerators
+    with ProductionEventGenerators {
 
   import WorkState._
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SierraWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SierraWorkGenerators.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.models.work.generators
+
+import uk.ac.wellcome.models.work.internal._
+import WorkState._
+
+trait SierraWorkGenerators extends WorkGenerators with ItemsGenerators {
+
+  def sierraSourceWork(): Work.Visible[Source] =
+    sourceWork(sourceIdentifier = createSierraSystemSourceIdentifier)
+      .otherIdentifiers(
+        List(createSierraSystemSourceIdentifier)
+      )
+
+  def sierraIdentifiedWork(): Work.Visible[Identified] =
+    identifiedWork(sourceIdentifier = createSierraSystemSourceIdentifier)
+      .otherIdentifiers(
+        List(createSierraSystemSourceIdentifier)
+      )
+
+  def sierraPhysicalSourceWork(): Work.Visible[Source] =
+    sierraSourceWork().items(List(createPhysicalItem))
+
+  def sierraDigitalSourceWork(): Work.Visible[Source] =
+    sierraSourceWork().items(
+      List(
+        createUnidentifiableItemWith(locations = List(createDigitalLocation))
+      )
+    )
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -1,0 +1,141 @@
+package uk.ac.wellcome.models.work.generators
+
+import uk.ac.wellcome.models.work.internal._
+import WorkState._
+
+trait WorkGenerators extends IdentifiersGenerators {
+
+  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier)
+    : Work.Visible[Source] =
+    Work.Visible[Source](
+      state = Source(sourceIdentifier),
+      data = WorkData[DataState.Unidentified](),
+      version = 1
+    )
+
+  def mergedWork(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    hasMultipleSources: Boolean = false
+  ): Work.Visible[Merged] =
+    Work.Visible[Merged](
+      state = Merged(sourceIdentifier, hasMultipleSources),
+      data = WorkData[DataState.Unidentified](),
+      version = 1
+    )
+
+  def denormalisedWork(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    hasMultipleSources: Boolean = false,
+    relations: Relations[DataState.Unidentified] = Relations.none
+  ): Work.Visible[Denormalised] =
+    Work.Visible[Denormalised](
+      state = Denormalised(sourceIdentifier, hasMultipleSources, relations),
+      data = WorkData[DataState.Unidentified](),
+      version = 1
+    )
+
+  def identifiedWork(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    canonicalId: String = createCanonicalId,
+    hasMultipleSources: Boolean = false,
+    relations: Relations[DataState.Identified] = Relations.none
+  ): Work.Visible[Identified] =
+    Work.Visible[Identified](
+      state = Identified(
+        sourceIdentifier,
+        canonicalId,
+        hasMultipleSources,
+        relations),
+      data = WorkData[DataState.Identified](),
+      version = 1
+    )
+
+  implicit class WorkOps[State <: WorkState](work: Work[State]) {
+
+    def invisible(invisibilityReasons: List[InvisibilityReason] = Nil)
+      : Work.Invisible[State] =
+      Work.Invisible[State](
+        data = work.data,
+        state = work.state,
+        version = work.version,
+        invisibilityReasons = invisibilityReasons
+      )
+
+    def redirected(redirect: State#WorkDataState#Id): Work.Redirected[State] =
+      Work.Redirected[State](
+        state = work.state,
+        version = work.version,
+        redirect = redirect
+      )
+
+    def version(version: Int): Work[State] =
+      work match {
+        case Work.Visible(_, data, state) =>
+          Work.Visible[State](version, data, state)
+        case Work.Invisible(_, data, state, invisibilityReasons) =>
+          Work.Invisible[State](version, data, state, invisibilityReasons)
+        case Work.Redirected(_, redirect, state) =>
+          Work.Redirected[State](version, redirect, state)
+      }
+
+    def title(title: String): Work[State] =
+      work.mapData(_.copy(title = Some(title)))
+
+    def otherIdentifiers(
+      otherIdentifiers: List[SourceIdentifier]): Work[State] =
+      work.mapData(_.copy(otherIdentifiers = otherIdentifiers))
+
+    def mergeCandidates(mergeCandidates: List[MergeCandidate]): Work[State] =
+      work.mapData(_.copy(mergeCandidates = mergeCandidates))
+
+    def format(format: Format): Work[State] =
+      work.mapData(_.copy(format = Some(format)))
+
+    def description(description: String): Work[State] =
+      work.mapData(_.copy(description = Some(description)))
+
+    def physicalDescription(physicalDescription: String): Work[State] =
+      work.mapData(_.copy(physicalDescription = Some(physicalDescription)))
+
+    def subjects(
+      subjects: List[Subject[State#WorkDataState#MaybeId]]): Work[State] =
+      work.mapData(_.copy(subjects = subjects))
+
+    def genres(genres: List[Genre[State#WorkDataState#MaybeId]]): Work[State] =
+      work.mapData(_.copy(genres = genres))
+
+    def contributors(
+      contributors: List[Contributor[State#WorkDataState#MaybeId]])
+      : Work[State] =
+      work.mapData(_.copy(contributors = contributors))
+
+    def thumbnail(thumbnail: LocationDeprecated): Work[State] =
+      work.mapData(_.copy(thumbnail = Some(thumbnail)))
+
+    def production(
+      production: List[ProductionEvent[State#WorkDataState#MaybeId]])
+      : Work[State] =
+      work.mapData(_.copy(production = production))
+
+    def language(language: Language): Work[State] =
+      work.mapData(_.copy(language = Some(language)))
+
+    def edition(edition: String): Work[State] =
+      work.mapData(_.copy(edition = Some(edition)))
+
+    def notes(notes: List[Note]): Work[State] =
+      work.mapData(_.copy(notes = notes))
+
+    def items(items: List[Item[State#WorkDataState#MaybeId]]): Work[State] =
+      work.mapData(_.copy(items = items))
+
+    def collectionPath(collectionPath: CollectionPath): Work[State] =
+      work.mapData(_.copy(collectionPath = Some(collectionPath)))
+
+    def images(images: List[UnmergedImage[State#WorkDataState]]): Work[State] =
+      work.mapData(_.copy(images = images))
+
+    def workType(workType: WorkType): Work[State] =
+      work.mapData(_.copy(workType = workType))
+  }
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -50,7 +50,7 @@ trait WorkGenerators extends IdentifiersGenerators {
       version = 1
     )
 
-  implicit class WorkOps[State <: WorkState](work: Work[State]) {
+  implicit class WorkOps[State <: WorkState](work: Work.Visible[State]) {
 
     def invisible(invisibilityReasons: List[InvisibilityReason] = Nil)
       : Work.Invisible[State] =
@@ -68,74 +68,76 @@ trait WorkGenerators extends IdentifiersGenerators {
         redirect = redirect
       )
 
-    def version(version: Int): Work[State] =
-      work match {
-        case Work.Visible(_, data, state) =>
-          Work.Visible[State](version, data, state)
-        case Work.Invisible(_, data, state, invisibilityReasons) =>
-          Work.Invisible[State](version, data, state, invisibilityReasons)
-        case Work.Redirected(_, redirect, state) =>
-          Work.Redirected[State](version, redirect, state)
-      }
+    def version(version: Int): Work.Visible[State] =
+      Work.Visible[State](version, work.data, work.state)
 
-    def title(title: String): Work[State] =
-      work.mapData(_.copy(title = Some(title)))
+    def title(title: String): Work.Visible[State] =
+      work.map(_.copy(title = Some(title)))
 
     def otherIdentifiers(
-      otherIdentifiers: List[SourceIdentifier]): Work[State] =
-      work.mapData(_.copy(otherIdentifiers = otherIdentifiers))
+      otherIdentifiers: List[SourceIdentifier]): Work.Visible[State] =
+      work.map(_.copy(otherIdentifiers = otherIdentifiers))
 
-    def mergeCandidates(mergeCandidates: List[MergeCandidate]): Work[State] =
-      work.mapData(_.copy(mergeCandidates = mergeCandidates))
+    def mergeCandidates(mergeCandidates: List[MergeCandidate]): Work.Visible[State] =
+      work.map(_.copy(mergeCandidates = mergeCandidates))
 
-    def format(format: Format): Work[State] =
-      work.mapData(_.copy(format = Some(format)))
+    def format(format: Format): Work.Visible[State] =
+      work.map(_.copy(format = Some(format)))
 
-    def description(description: String): Work[State] =
-      work.mapData(_.copy(description = Some(description)))
+    def description(description: String): Work.Visible[State] =
+      work.map(_.copy(description = Some(description)))
 
-    def physicalDescription(physicalDescription: String): Work[State] =
-      work.mapData(_.copy(physicalDescription = Some(physicalDescription)))
+    def physicalDescription(physicalDescription: String): Work.Visible[State] =
+      work.map(_.copy(physicalDescription = Some(physicalDescription)))
+
+    def lettering(lettering: String): Work.Visible[State] =
+      work.map(_.copy(lettering = Some(lettering)))
+
+    def createdDate(createdDate: Period[State#WorkDataState#MaybeId]): Work.Visible[State] =
+      work.map(_.copy(createdDate = Some(createdDate)))
 
     def subjects(
-      subjects: List[Subject[State#WorkDataState#MaybeId]]): Work[State] =
-      work.mapData(_.copy(subjects = subjects))
+      subjects: List[Subject[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+      work.map(_.copy(subjects = subjects))
 
-    def genres(genres: List[Genre[State#WorkDataState#MaybeId]]): Work[State] =
-      work.mapData(_.copy(genres = genres))
+    def genres(genres: List[Genre[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+      work.map(_.copy(genres = genres))
 
     def contributors(
       contributors: List[Contributor[State#WorkDataState#MaybeId]])
-      : Work[State] =
-      work.mapData(_.copy(contributors = contributors))
+      : Work.Visible[State] =
+      work.map(_.copy(contributors = contributors))
 
-    def thumbnail(thumbnail: LocationDeprecated): Work[State] =
-      work.mapData(_.copy(thumbnail = Some(thumbnail)))
+    def thumbnail(thumbnail: LocationDeprecated): Work.Visible[State] =
+      work.map(_.copy(thumbnail = Some(thumbnail)))
 
     def production(
       production: List[ProductionEvent[State#WorkDataState#MaybeId]])
-      : Work[State] =
-      work.mapData(_.copy(production = production))
+      : Work.Visible[State] =
+      work.map(_.copy(production = production))
 
-    def language(language: Language): Work[State] =
-      work.mapData(_.copy(language = Some(language)))
+    def language(language: Language): Work.Visible[State] =
+      work.map(_.copy(language = Some(language)))
 
-    def edition(edition: String): Work[State] =
-      work.mapData(_.copy(edition = Some(edition)))
+    def edition(edition: String): Work.Visible[State] =
+      work.map(_.copy(edition = Some(edition)))
 
-    def notes(notes: List[Note]): Work[State] =
-      work.mapData(_.copy(notes = notes))
+    def notes(notes: List[Note]): Work.Visible[State] =
+      work.map(_.copy(notes = notes))
 
-    def items(items: List[Item[State#WorkDataState#MaybeId]]): Work[State] =
-      work.mapData(_.copy(items = items))
+    def items(items: List[Item[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+      work.map(_.copy(items = items))
 
-    def collectionPath(collectionPath: CollectionPath): Work[State] =
-      work.mapData(_.copy(collectionPath = Some(collectionPath)))
+    def collectionPath(collectionPath: CollectionPath): Work.Visible[State] =
+      work.map(_.copy(collectionPath = Some(collectionPath)))
 
-    def images(images: List[UnmergedImage[State#WorkDataState]]): Work[State] =
-      work.mapData(_.copy(images = images))
+    def images(images: List[UnmergedImage[State#WorkDataState]]): Work.Visible[State] =
+      work.map(_.copy(images = images))
 
-    def workType(workType: WorkType): Work[State] =
-      work.mapData(_.copy(workType = workType))
+    def workType(workType: WorkType): Work.Visible[State] =
+      work.map(_.copy(workType = workType))
+
+    def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState]): Work.Visible[State] =
+      Work.Visible[State](work.version, f(work.data), work.state)
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -50,6 +50,18 @@ trait WorkGenerators extends IdentifiersGenerators {
       version = 1
     )
 
+  def sourceWorks(n: Int): List[Work.Visible[Source]] =
+    (1 to n).map(_ => sourceWork()).toList
+
+  def mergedWorks(n: Int): List[Work.Visible[Merged]] =
+    (1 to n).map(_ => mergedWork()).toList
+
+  def denormalisedWorks(n: Int): List[Work.Visible[Denormalised]] =
+    (1 to n).map(_ => denormalisedWork()).toList
+
+  def identifiedWorks(n: Int): List[Work.Visible[Identified]] =
+    (1 to n).map(_ => identifiedWork()).toList
+
   implicit class WorkOps[State <: WorkState](work: Work.Visible[State]) {
 
     def invisible(invisibilityReasons: List[InvisibilityReason] = Nil)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -5,7 +5,8 @@ import WorkState._
 
 trait WorkGenerators extends IdentifiersGenerators {
 
-  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier) : Work.Visible[Source] =
+  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier)
+    : Work.Visible[Source] =
     Work.Visible[Source](
       state = Source(sourceIdentifier),
       data = initData,
@@ -89,7 +90,8 @@ trait WorkGenerators extends IdentifiersGenerators {
       otherIdentifiers: List[SourceIdentifier]): Work.Visible[State] =
       work.map(_.copy(otherIdentifiers = otherIdentifiers))
 
-    def mergeCandidates(mergeCandidates: List[MergeCandidate]): Work.Visible[State] =
+    def mergeCandidates(
+      mergeCandidates: List[MergeCandidate]): Work.Visible[State] =
       work.map(_.copy(mergeCandidates = mergeCandidates))
 
     def format(format: Format): Work.Visible[State] =
@@ -104,14 +106,16 @@ trait WorkGenerators extends IdentifiersGenerators {
     def lettering(lettering: String): Work.Visible[State] =
       work.map(_.copy(lettering = Some(lettering)))
 
-    def createdDate(createdDate: Period[State#WorkDataState#MaybeId]): Work.Visible[State] =
+    def createdDate(
+      createdDate: Period[State#WorkDataState#MaybeId]): Work.Visible[State] =
       work.map(_.copy(createdDate = Some(createdDate)))
 
-    def subjects(
-      subjects: List[Subject[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+    def subjects(subjects: List[Subject[State#WorkDataState#MaybeId]])
+      : Work.Visible[State] =
       work.map(_.copy(subjects = subjects))
 
-    def genres(genres: List[Genre[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+    def genres(
+      genres: List[Genre[State#WorkDataState#MaybeId]]): Work.Visible[State] =
       work.map(_.copy(genres = genres))
 
     def contributors(
@@ -136,19 +140,22 @@ trait WorkGenerators extends IdentifiersGenerators {
     def notes(notes: List[Note]): Work.Visible[State] =
       work.map(_.copy(notes = notes))
 
-    def items(items: List[Item[State#WorkDataState#MaybeId]]): Work.Visible[State] =
+    def items(
+      items: List[Item[State#WorkDataState#MaybeId]]): Work.Visible[State] =
       work.map(_.copy(items = items))
 
     def collectionPath(collectionPath: CollectionPath): Work.Visible[State] =
       work.map(_.copy(collectionPath = Some(collectionPath)))
 
-    def images(images: List[UnmergedImage[State#WorkDataState]]): Work.Visible[State] =
+    def images(
+      images: List[UnmergedImage[State#WorkDataState]]): Work.Visible[State] =
       work.map(_.copy(images = images))
 
     def workType(workType: WorkType): Work.Visible[State] =
       work.map(_.copy(workType = workType))
 
-    def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState]): Work.Visible[State] =
+    def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
+      : Work.Visible[State] =
       Work.Visible[State](work.version, f(work.data), work.state)
   }
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -5,11 +5,10 @@ import WorkState._
 
 trait WorkGenerators extends IdentifiersGenerators {
 
-  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier)
-    : Work.Visible[Source] =
+  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier) : Work.Visible[Source] =
     Work.Visible[Source](
       state = Source(sourceIdentifier),
-      data = WorkData[DataState.Unidentified](),
+      data = initData,
       version = 1
     )
 
@@ -19,7 +18,7 @@ trait WorkGenerators extends IdentifiersGenerators {
   ): Work.Visible[Merged] =
     Work.Visible[Merged](
       state = Merged(sourceIdentifier, hasMultipleSources),
-      data = WorkData[DataState.Unidentified](),
+      data = initData,
       version = 1
     )
 
@@ -30,7 +29,7 @@ trait WorkGenerators extends IdentifiersGenerators {
   ): Work.Visible[Denormalised] =
     Work.Visible[Denormalised](
       state = Denormalised(sourceIdentifier, hasMultipleSources, relations),
-      data = WorkData[DataState.Unidentified](),
+      data = initData,
       version = 1
     )
 
@@ -46,7 +45,7 @@ trait WorkGenerators extends IdentifiersGenerators {
         canonicalId,
         hasMultipleSources,
         relations),
-      data = WorkData[DataState.Identified](),
+      data = initData,
       version = 1
     )
 
@@ -152,4 +151,9 @@ trait WorkGenerators extends IdentifiersGenerators {
     def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState]): Work.Visible[State] =
       Work.Visible[State](work.version, f(work.data), work.state)
   }
+
+  private def initData[State <: DataState]: WorkData[State] =
+    WorkData(
+      title = Some(randomAlphanumeric(length = 10))
+    )
 }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.platform.idminter.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.models.Implicits._
 import WorkState.{Identified, Source}
@@ -18,7 +18,7 @@ class IdMinterFeatureTest
     with IntegrationPatience
     with Eventually
     with WorkerServiceFixture
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("mints the same IDs where source identifiers match") {
     val messageSender = new MemoryMessageSender()

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.elasticsearch.WorksIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.ingestor.common.fixtures.IngestorFixtures
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
@@ -24,7 +24,7 @@ class IngestorFeatureTest
     with ScalaFutures
     with IngestorFixtures
     with ElasticsearchFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("ingests a Miro work") {
     val work = createIdentifiedWork

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.elasticsearch.WorksIndexConfig
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.ingestor.common.fixtures.IngestorFixtures
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
@@ -22,7 +22,7 @@ class IngestorWorkerServiceTest
     with Matchers
     with ScalaFutures
     with IngestorFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("indexes a Miro identified Work") {
     val miroSourceIdentifier = createSourceIdentifier

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 import uk.ac.wellcome.pipeline_storage.Indexable.workIndexable
@@ -21,7 +21,7 @@ class WorkIndexerTest
     with ScalaFutures
     with Matchers
     with ElasticsearchFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   describe("updating merged / redirected works") {
     it(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.{Identified, Version}
 
@@ -23,7 +23,7 @@ class MatcherFeatureTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it(
     "processes a message with a simple Work.Visible[Source] with no linked works") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.matcher.MatcherResult
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -22,7 +22,7 @@ class WorkMatcherConcurrencyTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {
     withLockTable { lockTable =>

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -32,7 +32,7 @@ class WorkMatcherTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with WorksGenerators
+    with LegacyWorkGenerators
     with EitherValues {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.matcher.{
   MatcherResult,
   WorkIdentifier
 }
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.models.Implicits._
@@ -24,7 +24,7 @@ class MatcherWorkerServiceTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkStoreTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models.VersionExpectedConflictException
@@ -15,7 +15,7 @@ class WorkStoreTest
     extends AnyFunSpec
     with Matchers
     with VHSFixture[Work[Source]]
-    with WorksGenerators
+    with LegacyWorkGenerators
     with Inside {
   it("gets a work from vhs") {
     withVHS { vhs: VHS =>

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -123,7 +123,7 @@ object PlatformMerger extends Merger {
         thumbnail <- ThumbnailRule(target, sources)
         otherIdentifiers <- OtherIdentifiersRule(target, sources)
         images <- ImagesRule(target, sources)
-        work = target.withData { data =>
+        work = target.mapData { data =>
           data.copy[DataState.Unidentified](
             items = items,
             thumbnail = thumbnail,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.fixtures.{
   MatcherResultFixture,
@@ -20,7 +20,7 @@ class MergerIntegrationTest
     with IntegrationPatience
     with MatcherResultFixture
     with WorkerServiceFixture
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("reads matcher result messages off a queue and deletes them") {
     val workSender = new MemoryMessageSender()

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.fixtures.{
   MatcherResultFixture,
@@ -20,7 +20,7 @@ class MergerIntegrationTest
     with IntegrationPatience
     with MatcherResultFixture
     with WorkerServiceFixture
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("reads matcher result messages off a queue and deletes them") {
     val workSender = new MemoryMessageSender()
@@ -29,7 +29,7 @@ class MergerIntegrationTest
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withWorkerService(vhs, queue, workSender) { _ =>
-            val work = createSourceWork
+            val work = sourceWork()
 
             givenStoredInVhs(vhs, work)
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.matchers.should.Matchers
 import cats.data.NonEmptyList
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 import uk.ac.wellcome.platform.merger.rules.WorkPredicates.WorkPredicate
@@ -13,7 +13,7 @@ class FieldMergeRuleTest
     extends AnyFunSpec
     with Matchers
     with FieldMergeRule
-    with WorksGenerators {
+    with LegacyWorkGenerators {
   override protected type FieldData = Unit
 
   val targetTitleIsA = new PartialRule {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/FieldMergeRuleTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.matchers.should.Matchers
 import cats.data.NonEmptyList
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 import uk.ac.wellcome.platform.merger.rules.WorkPredicates.WorkPredicate
@@ -13,7 +13,8 @@ class FieldMergeRuleTest
     extends AnyFunSpec
     with Matchers
     with FieldMergeRule
-    with LegacyWorkGenerators {
+    with WorkGenerators {
+
   override protected type FieldData = Unit
 
   val targetTitleIsA = new PartialRule {
@@ -35,8 +36,8 @@ class FieldMergeRuleTest
       ()
   }
 
-  val workWithTitleA = createSourceWorkWith(title = Some("A"))
-  val workWithTitleB = createSourceWorkWith(title = Some("B"))
+  val workWithTitleA = sourceWork().title("A")
+  val workWithTitleB = sourceWork().title("B")
 
   describe("PartialRule") {
     it(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal.{
   AccessCondition,
   AccessStatus,
@@ -15,7 +15,7 @@ import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 class ThumbnailRuleTest
     extends AnyFunSpec
     with Matchers
-    with WorksGenerators
+    with LegacyWorkGenerators
     with Inside {
 
   val physicalSierraWork = createSierraPhysicalWork

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
 import uk.ac.wellcome.models.work.internal.{
   AccessCondition,
   AccessStatus,
@@ -15,54 +15,52 @@ import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 class ThumbnailRuleTest
     extends AnyFunSpec
     with Matchers
-    with LegacyWorkGenerators
+    with SierraWorkGenerators
     with Inside {
 
-  val physicalSierraWork = createSierraPhysicalWork
+  val physicalSierraWork = sierraPhysicalSourceWork()
 
-  val digitalSierraWork = createSierraDigitalWork
+  val digitalSierraWork = sierraDigitalSourceWork()
 
-  val metsWork = createSourceWorkWith(
-    sourceIdentifier = createMetsSourceIdentifier,
-    items = List(createDigitalItem),
-    thumbnail = Some(
+  val metsWork = sourceWork(createMetsSourceIdentifier)
+    .items(List(createDigitalItem))
+    .thumbnail(
       DigitalLocationDeprecated(
         url = "mets.com/thumbnail.jpg",
         locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBY)
       )
     )
-  )
 
   val miroWorks = (0 to 3)
     .map { i =>
       f"V$i%04d"
     }
     .map { id =>
-      createSourceWorkWith(
-        sourceIdentifier = createMiroSourceIdentifierWith(id),
-        thumbnail = Some(
+      sourceWork(createMiroSourceIdentifierWith(id))
+        .thumbnail(
           DigitalLocationDeprecated(
             url = s"https://iiif.wellcomecollection.org/$id.jpg",
             locationType = LocationType("thumbnail-image"),
             license = Some(License.CCBY)
           )
-        ),
-        items = List(
-          createUnidentifiableItemWith(
-            locations = List(
-              createDigitalLocationWith(
-                locationType = createImageLocationType
+        )
+        .items(
+          List(
+            createUnidentifiableItemWith(
+              locations = List(
+                createDigitalLocationWith(
+                  locationType = createImageLocationType
+                )
               )
             )
           )
         )
-      )
     }
 
   val restrictedDigitalWork =
-    createSierraSourceWorkWith(
-      items = List(
+    sierraSourceWork().items(
+      List(
         createUnidentifiableItemWith(
           locations = List(
             createDigitalLocationWith(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -9,10 +9,7 @@ import uk.ac.wellcome.platform.merger.models.{MergeResult, MergerOutcome}
 import WorkState.{Merged, Source}
 import WorkFsm._
 
-class MergerManagerTest
-    extends AnyFunSpec
-    with Matchers
-    with WorkGenerators {
+class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
 
   it("performs a merge with a single work") {
     val work = sourceWork()

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.platform.merger.services
 import cats.data.State
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.{MergeResult, MergerOutcome}
 import WorkState.{Merged, Source}
 import WorkFsm._
 
-class MergerManagerTest extends AnyFunSpec with Matchers with WorksGenerators {
+class MergerManagerTest extends AnyFunSpec with Matchers with LegacyWorkGenerators {
 
   it("performs a merge with a single work") {
     val work = createSourceWork

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.merger.services
 import cats.data.State
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.{MergeResult, MergerOutcome}
 import WorkState.{Merged, Source}
@@ -12,10 +12,10 @@ import WorkFsm._
 class MergerManagerTest
     extends AnyFunSpec
     with Matchers
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("performs a merge with a single work") {
-    val work = createSourceWork
+    val work = sourceWork()
 
     val result = mergerManager.applyMerge(maybeWorks = List(Some(work)))
 
@@ -23,8 +23,8 @@ class MergerManagerTest
   }
 
   it("performs a merge with multiple works") {
-    val work = createSourceWork
-    val otherWorks = createSourceWorks(3)
+    val work = sourceWork()
+    val otherWorks = sourceWorks(3)
 
     val works = (work +: otherWorks).map { Some(_) }.toList
 
@@ -44,7 +44,7 @@ class MergerManagerTest
   }
 
   it("returns the works unmerged if any of the work entries are None") {
-    val expectedWorks = createSourceWorks(3)
+    val expectedWorks = sourceWorks(3)
 
     val maybeWorks = expectedWorks.map { Some(_) } ++ List(None)
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.platform.merger.models.{MergeResult, MergerOutcome}
 import WorkState.{Merged, Source}
 import WorkFsm._
 
-class MergerManagerTest extends AnyFunSpec with Matchers with LegacyWorkGenerators {
+class MergerManagerTest
+    extends AnyFunSpec
+    with Matchers
+    with LegacyWorkGenerators {
 
   it("performs a merge with a single work") {
     val work = createSourceWork

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -58,7 +58,7 @@ class MergerTest
       } yield
         MergeResult(
           mergedTarget = target
-            .withData { data =>
+            .mapData { data =>
               data.copy[DataState.Unidentified](
                 items = items,
                 otherIdentifiers = otherIdentifiers
@@ -76,7 +76,7 @@ class MergerTest
       inputWorks.head
         .asInstanceOf[Work.Visible[Source]]
         .transition[Merged](true)
-        .withData { data =>
+        .mapData { data =>
           data.copy[DataState.Unidentified](
             items = mergedTargetItems,
             otherIdentifiers = mergedOtherIdentifiers

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -54,7 +54,7 @@ class PlatformMergerTest
     createInvisibleMetsSourceWorkWith(
       items = List(createDigitalItemWith(List(digitalLocationCCBYNC))),
       images = List(createUnmergedMetsImage)
-    ).withData { data =>
+    ).mapData { data =>
       data.copy(
         thumbnail = Some(
           DigitalLocationDeprecated(
@@ -112,7 +112,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
           thumbnail = miroWork.data.thumbnail,
@@ -153,7 +153,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = zeroItemSierraWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           otherIdentifiers = data.otherIdentifiers ++ miroWork.identifiers,
           thumbnail = miroWork.data.thumbnail,
@@ -196,7 +196,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraDigitalWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
           thumbnail = miroWork.data.thumbnail,
@@ -237,7 +237,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           images = miroWork.data.images,
         )
@@ -260,7 +260,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           items = List(
             physicalItem.copy(
@@ -296,7 +296,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPictureWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           items = List(
             physicalItem.copy(
@@ -341,7 +341,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
             ++ sierraDigitised.identifiers
@@ -403,7 +403,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           thumbnail = metsWork.data.thumbnail,
           items = sierraItems :+ metsItem,
@@ -436,7 +436,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](true)
-      .withData { data =>
+      .mapData { data =>
         data.copy(
           otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitised.identifiers,
           thumbnail = metsWork.data.thumbnail,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.matcher.WorkIdentifier
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.fixtures.LocalWorksVhs
 import WorkState.Source
@@ -16,7 +16,7 @@ class RecorderPlaybackServiceTest
     with Matchers
     with ScalaFutures
     with LocalWorksVhs
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("fetches a single Work") {
     val work = createSourceWork

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.Version
@@ -20,7 +20,7 @@ class RecorderIntegrationTest
     with IntegrationPatience
     with WorkerServiceFixture
     with VHSFixture[Work[Source]]
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("saves received works to VHS, and puts the VHS key on the queue") {
     val messageSender = new MemoryMessageSender()

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -59,7 +59,7 @@ class RecorderWorkerServiceTest
           val olderWork = createSourceWork
           val newerWork = olderWork
             .copy(version = 10)
-            .withData(data => data.copy(title = Some("A nice new thing")))
+            .mapData(data => data.copy(title = Some("A nice new thing")))
           sendMessage[Work[Source]](queue = queue, newerWork)
           eventually { assertWorkStored(vhs, newerWork) }
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
@@ -77,7 +77,7 @@ class RecorderWorkerServiceTest
           val olderWork = createSourceWork
           val newerWork = olderWork
             .copy(version = 10)
-            .withData(data => data.copy(title = Some("A nice new thing")))
+            .mapData(data => data.copy(title = Some("A nice new thing")))
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
           eventually {
             assertWorkStored(vhs, olderWork)

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
@@ -22,7 +22,7 @@ class RecorderWorkerServiceTest
     with IntegrationPatience
     with WorkerServiceFixture
     with JsonAssertions
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("records Work.Visible[Source]") {
     withLocalSqsQueue() { queue =>

--- a/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
+++ b/pipeline/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelatedWorksServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.{
   IdentifiersGenerators,
   ItemsGenerators,
-  WorksGenerators
+  LegacyWorkGenerators
 }
 import WorkState.Identified
 
@@ -22,7 +22,7 @@ class RelatedWorksServiceTest
     with ElasticsearchFixtures
     with IdentifiersGenerators
     with ItemsGenerators
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   def service(index: Index) =
     new PathQueryRelatedWorksService(elasticClient, index)

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.VersionedStore
@@ -22,7 +22,7 @@ trait TestData
 case object ValidTestData extends TestData
 case object InvalidTestData extends TestData
 
-object TestTransformer extends Transformer[TestData] with WorksGenerators {
+object TestTransformer extends Transformer[TestData] with LegacyWorkGenerators {
   def apply(data: TestData,
             version: Int): Either[Exception, Work.Visible[Source]] =
     data match {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -6,7 +6,7 @@ import io.circe.Encoder
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.exceptions.MiroTransformerException
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
@@ -25,7 +25,7 @@ class MiroVHSRecordReceiverTest
     with ScalaFutures
     with IntegrationPatience
     with MiroRecordGenerators
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   case class TestException(message: String) extends Exception(message)
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
@@ -28,7 +28,7 @@ class SierraTransformerTest
     with MarcGenerators
     with SierraGenerators
     with SierraTransformableTestBase
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("performs a transformation on a work with physical items") {
     val itemRecords = List(
@@ -284,23 +284,23 @@ class SierraTransformerTest
 
     val work = transformDataToWork(id = id, data = data)
 
-    work shouldBe createSourceWorkWith(
-      title = Some(title),
-      sourceIdentifier = sourceIdentifier,
-      otherIdentifiers = List(sierraIdentifier),
-      description = Some("A delightful description of a dead daisy."),
-      production = List(
-        ProductionEvent(
-          label = "Peaceful Poetry 1923",
-          places = List(),
-          agents = List(Agent(label = "Peaceful Poetry")),
-          dates = List(Period("1923")),
-          function = None
+    work shouldBe sourceWork(sourceIdentifier)
+      .title(title)
+      .otherIdentifiers(List(sierraIdentifier))
+      .description("A delightful description of a dead daisy.")
+      .production(
+        List(
+          ProductionEvent(
+            label = "Peaceful Poetry 1923",
+            places = List(),
+            agents = List(Agent(label = "Peaceful Poetry")),
+            dates = List(Period("1923")),
+            function = None
+          )
         )
-      ),
-      notes = List(GeneralNote("It's a note")),
-      lettering = Some(lettering)
-    )
+      )
+      .notes(List(GeneralNote("It's a note")))
+      .lettering(lettering)
   }
 
   it("makes deleted works invisible") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.SierraTransformerException
@@ -28,7 +28,7 @@ class SierraTransformerTest
     with MarcGenerators
     with SierraGenerators
     with SierraTransformableTestBase
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("performs a transformation on a work with physical items") {
     val itemRecords = List(

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.platform.snapshot_generator.models.{
   CompletedSnapshotJob,
@@ -38,7 +38,7 @@ class SnapshotGeneratorFeatureTest
     with IntegrationPatience
     with DisplaySerialisationTestBase
     with WorkerServiceFixture
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("completes a snapshot generation") {
     withFixtures {

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 
 class IdentifiedWorkToVisibleDisplayWorkFlowTest
     extends AnyFunSpec
@@ -14,7 +14,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
     with Akka
     with ScalaFutures
     with IntegrationPatience
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("creates DisplayWorks from IdentifiedWorks") {
     withMaterializer { implicit materializer =>

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.display.json.DisplayJsonUtil
 import uk.ac.wellcome.display.json.DisplayJsonUtil._
 import uk.ac.wellcome.display.models.{ApiVersions, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.elasticsearch.ElasticClientBuilder
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.{
   AkkaS3,
   SnapshotServiceFixture
@@ -40,7 +40,7 @@ class SnapshotServiceTest
     with GzipUtils
     with IntegrationPatience
     with SnapshotServiceFixture
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   def withFixtures[R](
     testWith: TestWith[(SnapshotService, Index, Bucket), R]): R =

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.generators.WorksGenerators
+import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 
 class ElasticsearchSourceTest
@@ -20,7 +20,7 @@ class ElasticsearchSourceTest
     with IntegrationPatience
     with Akka
     with ElasticsearchFixtures
-    with WorksGenerators {
+    with LegacyWorkGenerators {
 
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>


### PR DESCRIPTION
For the `relation_embedder` tests the current work generators are not suitable, as we only have generators for works in `Source` or `Identified` states.

Rather than following the current pattern and adding new methods such as `createDenormalisedWorkWith` (which have verbose implementations and are not composable), I have attempted a redesign of the current generators.

Examples:

```scala
// before
createInvisibleSourceWorkWith(version = 2, items = List(item))
// after
sourceWork(version = 2).invisible().items(List(item))

// before
createIdentifiedWorkWith(canonicalId = "123", workType = WorkType.Collection)
// after
identifiedWork(canonicalId = "123").workType(WorkType.Collection)
```