### PR TITLE
Include a schema for the pageSize and page in the Swagger output

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
@@ -3,6 +3,11 @@ package uk.ac.wellcome.platform.api.rest
 import akka.http.scaladsl.model.Uri
 import uk.ac.wellcome.platform.api.models.{ResultList, SearchOptions}
 
+object PaginationLimits {
+  val minSize = 1
+  val maxSize = 100
+}
+
 trait Paginated { this: QueryParams =>
   val page: Option[Int]
   val pageSize: Option[Int]
@@ -13,8 +18,11 @@ trait Paginated { this: QueryParams =>
         .filterNot(_ >= 1)
         .map(_ => "page: must be greater than 1"),
       pageSize
-        .filterNot(size => size >= 1 && size <= 100)
-        .map(_ => "pageSize: must be between 1 and 100")
+        .filterNot { size =>
+          size >= PaginationLimits.minSize &&
+          size <= PaginationLimits.maxSize
+        }
+        .map(_ => s"pageSize: must be between ${PaginationLimits.minSize} and ${PaginationLimits.maxSize}")
     ).flatten
 
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Pagination.scala
@@ -22,7 +22,8 @@ trait Paginated { this: QueryParams =>
           size >= PaginationLimits.minSize &&
           size <= PaginationLimits.maxSize
         }
-        .map(_ => s"pageSize: must be between ${PaginationLimits.minSize} and ${PaginationLimits.maxSize}")
+        .map(_ =>
+          s"pageSize: must be between ${PaginationLimits.minSize} and ${PaginationLimits.maxSize}")
     ).flatten
 
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -227,7 +227,15 @@ trait MultipleImagesSwagger {
         name = "page",
         in = ParameterIn.QUERY,
         description = "The page to return from the result list",
-        required = false
+        required = false,
+        // Note: these annotations need to be compile-time constants, which is
+        // why they're hard-coded rather than loaded from the Pagination class.
+        // The min/max values are checked in the tests.
+        schema = new Schema(
+          minimum = "1",
+          `type` = "integer",
+          defaultValue = "1"
+        )
       ),
       new Parameter(
         name = "pageSize",
@@ -471,7 +479,15 @@ trait MultipleWorksSwagger {
         name = "page",
         in = ParameterIn.QUERY,
         description = "The page to return from the result list",
-        required = false
+        required = false,
+        // Note: these annotations need to be compile-time constants, which is
+        // why they're hard-coded rather than loaded from the Pagination class.
+        // The min/max values are checked in the tests.
+        schema = new Schema(
+          minimum = "1",
+          `type` = "integer",
+          defaultValue = "1"
+        )
       ),
       new Parameter(
         name = "pageSize",

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -232,8 +232,17 @@ trait MultipleImagesSwagger {
       new Parameter(
         name = "pageSize",
         in = ParameterIn.QUERY,
-        description = "The number of images to return per page (default: 10)",
-        required = false
+        description = "The number of images to return per page",
+        required = false,
+        // Note: these annotations need to be compile-time constants, which is
+        // why they're hard-coded rather than loaded from the Pagination class.
+        // The min/max values are checked in the tests.
+        schema = new Schema(
+          minimum = "1",
+          maximum = "100",
+          `type` = "integer",
+          defaultValue = "10"
+        )
       ),
     )
   )
@@ -467,8 +476,17 @@ trait MultipleWorksSwagger {
       new Parameter(
         name = "pageSize",
         in = ParameterIn.QUERY,
-        description = "The number of works to return per page (default: 10)",
-        required = false
+        description = "The number of works to return per page",
+        required = false,
+        // Note: these annotations need to be compile-time constants, which is
+        // why they're hard-coded rather than loaded from the Pagination class.
+        // The min/max values are checked in the tests.
+        schema = new Schema(
+          minimum = "1",
+          maximum = "100",
+          `type` = "integer",
+          defaultValue = "10"
+        )
       ),
       new Parameter(
         name = "_queryType",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -181,6 +181,30 @@ class ApiSwaggerTest extends ApiWorksTestBase with Matchers with JsonHelpers {
     }
   }
 
+  describe("includes bounds for the page parameter") {
+    it("images endpoint") {
+      checkPageParameter(imagesEndpoint)
+    }
+
+    it("works endpoint") {
+      checkPageParameter(worksEndpoint)
+    }
+
+    def checkPageParameter(endpointString: String): Unit = {
+      checkSwaggerJson { json =>
+        val endpoint = getEndpoint(json, endpointString = endpointString)
+
+        val pageSizeParam = getParameter(endpoint, name = "page").get
+
+        val schema = getKey(pageSizeParam, key = "schema").get
+
+        getNumericKey(schema, key = "minimum") shouldBe Some(1)
+        getNumericKey(schema, key = "default") shouldBe Some(1)
+        getKey(schema, key = "type").flatMap { _.asString } shouldBe Some("integer")
+      }
+    }
+  }
+
   //. We write this test for this specific parameter as it's used by the frontend
   it("should contain `_queryType parameter with valid `allowedValues`") {
     checkSwaggerJson { json =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -173,10 +173,13 @@ class ApiSwaggerTest extends ApiWorksTestBase with Matchers with JsonHelpers {
 
         val schema = getKey(pageSizeParam, key = "schema").get
 
-        getNumericKey(schema, key = "minimum") shouldBe Some(PaginationLimits.minSize)
-        getNumericKey(schema, key = "maximum") shouldBe Some(PaginationLimits.maxSize)
+        getNumericKey(schema, key = "minimum") shouldBe Some(
+          PaginationLimits.minSize)
+        getNumericKey(schema, key = "maximum") shouldBe Some(
+          PaginationLimits.maxSize)
         getNumericKey(schema, key = "default") shouldBe Some(10)
-        getKey(schema, key = "type").flatMap { _.asString } shouldBe Some("integer")
+        getKey(schema, key = "type").flatMap { _.asString } shouldBe Some(
+          "integer")
       }
     }
   }
@@ -200,7 +203,8 @@ class ApiSwaggerTest extends ApiWorksTestBase with Matchers with JsonHelpers {
 
         getNumericKey(schema, key = "minimum") shouldBe Some(1)
         getNumericKey(schema, key = "default") shouldBe Some(1)
-        getKey(schema, key = "type").flatMap { _.asString } shouldBe Some("integer")
+        getKey(schema, key = "type").flatMap { _.asString } shouldBe Some(
+          "integer")
       }
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/JsonHelpers.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/JsonHelpers.scala
@@ -5,7 +5,7 @@ import io.circe.Json
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 trait JsonHelpers extends ApiWorksTestBase {
-  protected def getParameter(endpoint: Json, name: String) =
+  protected def getParameter(endpoint: Json, name: String): Option[Json] =
     getKey(endpoint, "parameters")
       .flatMap(_.asArray)
       .flatMap(
@@ -41,6 +41,11 @@ trait JsonHelpers extends ApiWorksTestBase {
       arr => Some(arr.length),
       obj => Some(obj.keys.toList.length)
     )
+
+  protected def getNumericKey(json: Json, key: String): Option[Int] =
+    getKey(json, key = key)
+      .flatMap { _.asNumber }
+      .flatMap { _.toInt }
 
   protected def getNumPublicQueryParams[T: TypeTag]: Int =
     typeOf[T].members


### PR DESCRIPTION
You get something like:

```json
    "schema" : {
        "default" : 10,
        "format" : "int64",
        "maximum" : 100,
        "minimum" : 1,
        "type" : "integer"
    }
```

In particular I hope this will expose the maximum page size in the docs on developers.wellcomecollection.org.