### PR TITLE
Start to strip out the use of LegacyWorkGenerators

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.generators.{
   ContributorGenerators,
   GenreGenerators,
   ImageGenerators,
-  LegacyWorkGenerators,
+  WorkGenerators,
   SubjectGenerators
 }
 import uk.ac.wellcome.models.work.internal._
@@ -37,7 +37,7 @@ class WorksQueryTest
     with SearchOptionsGenerators
     with SubjectGenerators
     with GenreGenerators
-    with LegacyWorkGenerators
+    with WorkGenerators
     with ImageGenerators
     with ContributorGenerators {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -12,8 +12,8 @@ import uk.ac.wellcome.models.work.generators.{
   ContributorGenerators,
   GenreGenerators,
   ImageGenerators,
-  WorkGenerators,
-  SubjectGenerators
+  SubjectGenerators,
+  WorkGenerators
 }
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.generators.SearchOptionsGenerators

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -369,9 +369,7 @@ class ElasticsearchServiceTest
 
   private def populateElasticsearch(
     index: Index): List[Work.Visible[Identified]] = {
-    val works = (1 to 10).map { _ =>
-      identifiedWork()
-    }
+    val works = identifiedWorks(count = 10)
 
     insertIntoElasticsearch(index, works: _*)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -163,7 +163,9 @@ class ElasticsearchServiceTest
         // Since every work has the same title, we expect them to be returned in
         // ID order when we search for "A".
         val works = (1 to 5)
-          .map { _ => identifiedWork().title(title) }
+          .map { _ =>
+            identifiedWork().title(title)
+          }
           .sortBy(_.state.canonicalId)
 
         insertIntoElasticsearch(index, works: _*)
@@ -367,7 +369,9 @@ class ElasticsearchServiceTest
 
   private def populateElasticsearch(
     index: Index): List[Work.Visible[Identified]] = {
-    val works = (1 to 10).map { _ => identifiedWork() }
+    val works = (1 to 10).map { _ =>
+      identifiedWork()
+    }
 
     insertIntoElasticsearch(index, works: _*)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -10,12 +10,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.{
-  ContributorGenerators,
-  GenreGenerators,
-  LegacyWorkGenerators,
-  SubjectGenerators
-}
+import uk.ac.wellcome.models.work.generators._
 import uk.ac.wellcome.models.work.internal.Format.{
   Books,
   CDRoms,
@@ -37,9 +32,10 @@ class ElasticsearchServiceTest
     with ElasticsearchFixtures
     with ScalaFutures
     with SearchOptionsGenerators
+    with ItemsGenerators
     with SubjectGenerators
     with GenreGenerators
-    with LegacyWorkGenerators
+    with WorkGenerators
     with ContributorGenerators {
 
   val searchService = new ElasticsearchService(elasticClient)
@@ -50,7 +46,7 @@ class ElasticsearchServiceTest
   describe("findResultById") {
     it("finds a result by ID") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWork
+        val work = identifiedWork()
 
         insertIntoElasticsearch(index, work)
 
@@ -167,9 +163,7 @@ class ElasticsearchServiceTest
         // Since every work has the same title, we expect them to be returned in
         // ID order when we search for "A".
         val works = (1 to 5)
-          .map { _ =>
-            createIdentifiedWorkWith(title = Some(title))
-          }
+          .map { _ => identifiedWork().title(title) }
           .sortBy(_.state.canonicalId)
 
         insertIntoElasticsearch(index, works: _*)
@@ -191,9 +185,9 @@ class ElasticsearchServiceTest
 
     it("sorts by canonicalId when scored = false") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(canonicalId = "000Z")
-        val work2 = createIdentifiedWorkWith(canonicalId = "000Y")
-        val work3 = createIdentifiedWorkWith(canonicalId = "000X")
+        val work1 = identifiedWork(canonicalId = "000Z")
+        val work2 = identifiedWork(canonicalId = "000Y")
+        val work3 = identifiedWork(canonicalId = "000X")
 
         insertIntoElasticsearch(index, work1, work2, work3)
 
@@ -207,13 +201,9 @@ class ElasticsearchServiceTest
 
     it("sorts by score then canonicalId when scored = true") {
       withLocalWorksIndex { index =>
-        val work1 =
-          createIdentifiedWorkWith(canonicalId = "000Z", title = Some("match"))
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "000Y",
-          title = Some("match stick"))
-        val work3 =
-          createIdentifiedWorkWith(canonicalId = "000X", title = Some("match"))
+        val work1 = identifiedWork(canonicalId = "000Z").title("match")
+        val work2 = identifiedWork(canonicalId = "000Y").title("match stick")
+        val work3 = identifiedWork(canonicalId = "000X").title("match")
 
         insertIntoElasticsearch(index, work1, work2, work3)
 
@@ -229,15 +219,9 @@ class ElasticsearchServiceTest
 
     it("filters list results by format") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          format = Some(ManuscriptsAsian)
-        )
-        val work2 = createIdentifiedWorkWith(
-          format = Some(ManuscriptsAsian)
-        )
-        val workWithWrongFormat = createIdentifiedWorkWith(
-          format = Some(CDRoms)
-        )
+        val work1 = identifiedWork().format(ManuscriptsAsian)
+        val work2 = identifiedWork().format(ManuscriptsAsian)
+        val workWithWrongFormat = identifiedWork().format(CDRoms)
 
         insertIntoElasticsearch(index, work1, work2, workWithWrongFormat)
 
@@ -255,18 +239,10 @@ class ElasticsearchServiceTest
 
     it("filters list results with multiple formats") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          format = Some(ManuscriptsAsian)
-        )
-        val work2 = createIdentifiedWorkWith(
-          format = Some(ManuscriptsAsian)
-        )
-        val work3 = createIdentifiedWorkWith(
-          format = Some(Books)
-        )
-        val workWithWrongFormat = createIdentifiedWorkWith(
-          format = Some(CDRoms)
-        )
+        val work1 = identifiedWork().format(ManuscriptsAsian)
+        val work2 = identifiedWork().format(ManuscriptsAsian)
+        val work3 = identifiedWork().format(Books)
+        val workWithWrongFormat = identifiedWork().format(CDRoms)
 
         insertIntoElasticsearch(index, work1, work2, work3, workWithWrongFormat)
 
@@ -284,20 +260,22 @@ class ElasticsearchServiceTest
 
     it("filters results by item locationType") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          title = Some("Tumbling tangerines"),
-          items = List(
-            createItemWithLocationType(LocationType("iiif-image")),
-            createItemWithLocationType(LocationType("acqi"))
+        val work = identifiedWork()
+          .title("Tumbling tangerines")
+          .items(
+            List(
+              createItemWithLocationType(LocationType("iiif-image")),
+              createItemWithLocationType(LocationType("acqi"))
+            )
           )
-        )
 
-        val notMatchingWork = createIdentifiedWorkWith(
-          title = Some("Tumbling tangerines"),
-          items = List(
-            createItemWithLocationType(LocationType("acqi"))
+        val notMatchingWork = identifiedWork()
+          .title("Tumbling tangerines")
+          .items(
+            List(
+              createItemWithLocationType(LocationType("acqi"))
+            )
           )
-        )
 
         insertIntoElasticsearch(index, work, notMatchingWork)
 
@@ -314,27 +292,33 @@ class ElasticsearchServiceTest
 
     it("filters results by multiple item locationTypes") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          title = Some("Tumbling tangerines"),
-          items = List(
-            createItemWithLocationType(LocationType("iiif-image")),
-            createItemWithLocationType(LocationType("acqi"))
-          )
-        )
+        val work =
+          identifiedWork()
+            .title("Tumbling tangerines")
+            .items(
+              List(
+                createItemWithLocationType(LocationType("iiif-image")),
+                createItemWithLocationType(LocationType("acqi"))
+              )
+            )
 
-        val notMatchingWork = createIdentifiedWorkWith(
-          title = Some("Tumbling tangerines"),
-          items = List(
-            createItemWithLocationType(LocationType("acqi"))
-          )
-        )
+        val notMatchingWork =
+          identifiedWork()
+            .title("Tumbling tangerines")
+            .items(
+              List(
+                createItemWithLocationType(LocationType("acqi"))
+              )
+            )
 
-        val work2 = createIdentifiedWorkWith(
-          title = Some("Tumbling tangerines"),
-          items = List(
-            createItemWithLocationType(LocationType("digit"))
-          )
-        )
+        val work2 =
+          identifiedWork()
+            .title("Tumbling tangerines")
+            .items(
+              List(
+                createItemWithLocationType(LocationType("digit"))
+              )
+            )
 
         insertIntoElasticsearch(index, work, notMatchingWork, work2)
 
@@ -383,7 +367,7 @@ class ElasticsearchServiceTest
 
   private def populateElasticsearch(
     index: Index): List[Work.Visible[Identified]] = {
-    val works = createIdentifiedWorks(count = 10)
+    val works = (1 to 10).map { _ => identifiedWork() }
 
     insertIntoElasticsearch(index, works: _*)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -27,7 +27,9 @@ class RelatedWorkServiceTest
   val service = new RelatedWorkService(new ElasticsearchService(elasticClient))
 
   def work(path: String, level: CollectionLevel): Work.Visible[Identified] =
-    identifiedWork(sourceIdentifier = createSourceIdentifierWith(value = path), hasMultipleSources = false)
+    identifiedWork(
+      sourceIdentifier = createSourceIdentifierWith(value = path),
+      hasMultipleSources = false)
       .title(path)
       .collectionPath(CollectionPath(path = path, level = Some(level)))
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -27,7 +27,7 @@ class RelatedWorkServiceTest
   val service = new RelatedWorkService(new ElasticsearchService(elasticClient))
 
   def work(path: String, level: CollectionLevel): Work.Visible[Identified] =
-    identifiedWork(sourceIdentifier = createSourceIdentifierWith(value = path))
+    identifiedWork(sourceIdentifier = createSourceIdentifierWith(value = path), hasMultipleSources = false)
       .title(path)
       .collectionPath(CollectionPath(path = path, level = Some(level)))
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.{
   IdentifiersGenerators,
   ItemsGenerators,
-  LegacyWorkGenerators
+  WorkGenerators
 }
 import WorkState.Identified
 
@@ -22,18 +22,14 @@ class RelatedWorkServiceTest
     with ElasticsearchFixtures
     with IdentifiersGenerators
     with ItemsGenerators
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   val service = new RelatedWorkService(new ElasticsearchService(elasticClient))
 
-  def work(path: String, level: CollectionLevel) =
-    createIdentifiedWorkWith(
-      collectionPath = Some(
-        CollectionPath(path = path, level = Some(level))
-      ),
-      title = Some(path),
-      sourceIdentifier = createSourceIdentifierWith(value = path)
-    )
+  def work(path: String, level: CollectionLevel): Work.Visible[Identified] =
+    identifiedWork(sourceIdentifier = createSourceIdentifierWith(value = path))
+      .title(path)
+      .collectionPath(CollectionPath(path = path, level = Some(level)))
 
   def storeWorks(index: Index, works: List[Work[Identified]] = works) =
     insertIntoElasticsearch(index, works: _*)
@@ -188,7 +184,7 @@ class RelatedWorkServiceTest
 
   it("Returns no related works when work is not part of a collection") {
     withLocalWorksIndex { index =>
-      val workX = createIdentifiedWork
+      val workX = identifiedWork()
       storeWorks(index, List(workA, work1, workX))
       whenReady(service.retrieveRelatedWorks(index, workX)) { result =>
         result shouldBe Right(RelatedWorks.nil)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -48,7 +48,9 @@ class WorksServiceTest
 
   describe("listOrSearchWorks") {
     it("gets records in Elasticsearch") {
-      val works = (1 to 2).map { _ => identifiedWork() }
+      val works = (1 to 2).map { _ =>
+        identifiedWork()
+      }
 
       assertListOrSearchResultIsCorrect(
         allWorks = works,
@@ -67,7 +69,9 @@ class WorksServiceTest
 
     it("returns an empty result set when asked for a page that does not exist") {
       assertListOrSearchResultIsCorrect(
-        allWorks = (1 to 3).map { _ => identifiedWork() },
+        allWorks = (1 to 3).map { _ =>
+          identifiedWork()
+        },
         expectedWorks = Seq(),
         expectedTotalResults = 3,
         worksSearchOptions = createWorksSearchOptionsWith(pageNumber = 4)
@@ -75,8 +79,12 @@ class WorksServiceTest
     }
 
     it("does not list invisible works") {
-      val visibleWorks = (1 to 3).map { _ => identifiedWork() }
-      val invisibleWorks = (1 to 3).map { _ => identifiedWork().invisible() }
+      val visibleWorks = (1 to 3).map { _ =>
+        identifiedWork()
+      }
+      val invisibleWorks = (1 to 3).map { _ =>
+        identifiedWork().invisible()
+      }
 
       assertListOrSearchResultIsCorrect(
         allWorks = visibleWorks ++ invisibleWorks,
@@ -167,7 +175,8 @@ class WorksServiceTest
   describe("simple query string syntax") {
     it("uses only PHRASE simple query syntax") {
       val work = identifiedWork()
-        .title("+a -title | with (all the simple) query~4 syntax operators in it*")
+        .title(
+          "+a -title | with (all the simple) query~4 syntax operators in it*")
 
       assertListOrSearchResultIsCorrect(
         allWorks = List(work),
@@ -229,7 +238,8 @@ class WorksServiceTest
   describe("filter works by date") {
     def createDatedWork(dateLabel: String): Work.Visible[Identified] =
       identifiedWork()
-        .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+        .production(
+          List(createProductionEventWith(dateLabel = Some(dateLabel))))
 
     val work1709 = createDatedWork("1709")
     val work1950 = createDatedWork("1950")

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -48,9 +48,7 @@ class WorksServiceTest
 
   describe("listOrSearchWorks") {
     it("gets records in Elasticsearch") {
-      val works = (1 to 2).map { _ =>
-        identifiedWork()
-      }
+      val works = identifiedWorks(count = 2)
 
       assertListOrSearchResultIsCorrect(
         allWorks = works,
@@ -69,9 +67,7 @@ class WorksServiceTest
 
     it("returns an empty result set when asked for a page that does not exist") {
       assertListOrSearchResultIsCorrect(
-        allWorks = (1 to 3).map { _ =>
-          identifiedWork()
-        },
+        allWorks = identifiedWorks(count = 3),
         expectedWorks = Seq(),
         expectedTotalResults = 3,
         worksSearchOptions = createWorksSearchOptionsWith(pageNumber = 4)
@@ -79,12 +75,8 @@ class WorksServiceTest
     }
 
     it("does not list invisible works") {
-      val visibleWorks = (1 to 3).map { _ =>
-        identifiedWork()
-      }
-      val invisibleWorks = (1 to 3).map { _ =>
-        identifiedWork().invisible()
-      }
+      val visibleWorks = identifiedWorks(count = 3)
+      val invisibleWorks = identifiedWorks(count = 3).map { _.invisible() }
 
       assertListOrSearchResultIsCorrect(
         allWorks = visibleWorks ++ invisibleWorks,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -12,6 +12,7 @@ trait ApiWorksTestBase
     extends ApiTestBase
     with DisplaySerialisationTestBase
     with LegacyWorkGenerators
+    with WorkGenerators
     with GenreGenerators
     with SubjectGenerators {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -166,9 +166,15 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   it("supports aggregating on dates by from year") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val works = List("1st May 1970", "1970", "1976", "1970-1979")
-          .map(label => createDatedWork(dateLabel = label))
-          .sortBy(_.state.canonicalId)
+        val dates = List("1st May 1970", "1970", "1976", "1970-1979")
+
+        val works = dates
+          .map { dateLabel =>
+            identifiedWork()
+              .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+          }
+          .sortBy { _.state.canonicalId }
+
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -171,7 +171,8 @@ class WorksAggregationsTest extends ApiWorksTestBase {
         val works = dates
           .map { dateLabel =>
             identifiedWork()
-              .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+              .production(
+                List(createProductionEventWith(dateLabel = Some(dateLabel))))
           }
           .sortBy { _.state.canonicalId }
 
@@ -327,11 +328,13 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on license") {
-    def createLicensedWork(canonicalId: String, licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+    def createLicensedWork(
+      canonicalId: String,
+      licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
       val items =
-        licenses
-          .map { license => createDigitalItemWith(license = Some(license)) }
-          .toList
+        licenses.map { license =>
+          createDigitalItemWith(license = Some(license))
+        }.toList
 
       identifiedWork(canonicalId = canonicalId).items(items)
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -321,12 +321,20 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on license") {
+    def createLicensedWork(canonicalId: String, licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+      val items =
+        licenses
+          .map { license => createDigitalItemWith(license = Some(license)) }
+          .toList
+
+      identifiedWork(canonicalId = canonicalId).items(items)
+    }
 
     val works = List(
-      createLicensedWork("A", List(License.CCBY)),
-      createLicensedWork("B", List(License.CCBYNC)),
-      createLicensedWork("C", List(License.CCBY, License.CCBYNC)),
-      createLicensedWork("D", Nil)
+      createLicensedWork("A", licenses = List(License.CCBY)),
+      createLicensedWork("B", licenses = List(License.CCBYNC)),
+      createLicensedWork("C", licenses = List(License.CCBY, License.CCBYNC)),
+      createLicensedWork("D", licenses = List.empty)
     )
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -371,13 +371,21 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on locationType") {
-
     val works = List(
-      createPhysicalWork("A"),
-      createPhysicalWork("B"),
-      createDigitalWork("C"),
-      createDigitalWork("D")
+      identifiedWork(canonicalId = "A").items(
+        List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
+      ),
+      identifiedWork(canonicalId = "B").items(
+        List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
+      ),
+      identifiedWork(canonicalId = "C").items(
+        List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
+      ),
+      identifiedWork(canonicalId = "D").items(
+        List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
+      )
     )
+
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -517,11 +517,13 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by date range") {
-    val (work1, work2, work3) = (
-      createDatedWork("1709", canonicalId = "a"),
-      createDatedWork("1950", canonicalId = "b"),
-      createDatedWork("2000", canonicalId = "c")
-    )
+    def createDatedWork(canonicalId: String, dateLabel: String): Work.Visible[WorkState.Identified] =
+      identifiedWork(canonicalId = canonicalId)
+        .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+
+    val work1 = createDatedWork(canonicalId = "1", dateLabel = "1709")
+    val work2 = createDatedWork(canonicalId = "2", dateLabel = "1950")
+    val work3 = createDatedWork(canonicalId = "3", dateLabel = "2000")
 
     it("filters by date range") {
       withApi {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -517,9 +517,11 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by date range") {
-    def createDatedWork(canonicalId: String, dateLabel: String): Work.Visible[WorkState.Identified] =
+    def createDatedWork(canonicalId: String,
+                        dateLabel: String): Work.Visible[WorkState.Identified] =
       identifiedWork(canonicalId = canonicalId)
-        .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+        .production(
+          List(createProductionEventWith(dateLabel = Some(dateLabel))))
 
     val work1 = createDatedWork(canonicalId = "1", dateLabel = "1709")
     val work2 = createDatedWork(canonicalId = "2", dateLabel = "1950")
@@ -728,11 +730,13 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by license") {
-    def createLicensedWork(canonicalId: String, licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+    def createLicensedWork(
+      canonicalId: String,
+      licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
       val items =
-        licenses
-          .map { license => createDigitalItemWith(license = Some(license)) }
-          .toList
+        licenses.map { license =>
+          createDigitalItemWith(license = Some(license))
+        }.toList
 
       identifiedWork(canonicalId = canonicalId).items(items)
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -726,11 +726,20 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by license") {
-    val ccByWork = createLicensedWork("A", List(License.CCBY))
-    val ccByNcWork = createLicensedWork("B", List(License.CCBYNC))
+    def createLicensedWork(canonicalId: String, licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+      val items =
+        licenses
+          .map { license => createDigitalItemWith(license = Some(license)) }
+          .toList
+
+      identifiedWork(canonicalId = canonicalId).items(items)
+    }
+
+    val ccByWork = createLicensedWork("A", licenses = List(License.CCBY))
+    val ccByNcWork = createLicensedWork("B", licenses = List(License.CCBYNC))
     val bothLicenseWork =
-      createLicensedWork("C", List(License.CCBY, License.CCBYNC))
-    val noLicenseWork = createLicensedWork("D", Nil)
+      createLicensedWork("C", licenses = List(License.CCBY, License.CCBYNC))
+    val noLicenseWork = createLicensedWork("D", licenses = List.empty)
 
     val works = List(ccByWork, ccByNcWork, bothLicenseWork, noLicenseWork)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
@@ -1,10 +1,16 @@
 package uk.ac.wellcome.platform.api.works
 
 import uk.ac.wellcome.elasticsearch.ElasticConfig
+import uk.ac.wellcome.models.work.internal.IdState
 
 class WorksRedirectsTest extends ApiWorksTestBase {
 
-  val redirectedWork = createIdentifiedRedirectedWork
+  val redirectedWork = identifiedWork().redirected(
+    IdState.Identified(
+      canonicalId = createCanonicalId,
+      sourceIdentifier = createSourceIdentifier
+    )
+  )
   val redirectId = redirectedWork.redirect.canonicalId
 
   it("returns a TemporaryRedirect if looking up a redirected work") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
@@ -256,28 +256,18 @@ class WorksTest extends ApiWorksTestBase {
     }
   }
 
-  it("supports production date sorting") {
+  def createDatedWork(canonicalId: String, dateLabel: String): Work.Visible[WorkState.Identified] =
+    identifiedWork(canonicalId = canonicalId)
+      .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
+
+  it("supports sorting by production date") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work1 = createDatedWork(
-          canonicalId = "1",
-          dateLabel = "1900"
-        )
-        val work2 = createDatedWork(
-          canonicalId = "2",
-          dateLabel = "1976"
-        )
-        val work3 = createDatedWork(
-          canonicalId = "3",
-          dateLabel = "1904"
-        )
-        val work4 = createDatedWork(
-          canonicalId = "4",
-          dateLabel = "2020"
-        )
-        val work5 = createDatedWork(
-          canonicalId = "5",
-          dateLabel = "1098"
+        val work1 = createDatedWork(canonicalId = "1", dateLabel = "1900")
+        val work2 = createDatedWork(canonicalId = "2", dateLabel = "1976")
+        val work3 = createDatedWork(canonicalId = "3", dateLabel = "1904")
+        val work4 = createDatedWork(canonicalId = "4", dateLabel = "2020")
+        val work5 = createDatedWork(canonicalId = "5", dateLabel = "1098"
         )
         insertIntoElasticsearch(worksIndex, work1, work2, work3, work4, work5)
 
@@ -293,18 +283,9 @@ class WorksTest extends ApiWorksTestBase {
   it("supports sorting of dates in descending order") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work1 = createDatedWork(
-          canonicalId = "1",
-          dateLabel = "1900"
-        )
-        val work2 = createDatedWork(
-          canonicalId = "2",
-          dateLabel = "1976"
-        )
-        val work3 = createDatedWork(
-          canonicalId = "3",
-          dateLabel = "1904"
-        )
+        val work1 = createDatedWork(canonicalId = "1", dateLabel = "1900")
+        val work2 = createDatedWork(canonicalId = "2", dateLabel = "1976")
+        val work3 = createDatedWork(canonicalId = "3", dateLabel = "1904")
         insertIntoElasticsearch(worksIndex, work1, work2, work3)
 
         assertJsonResponse(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
@@ -256,7 +256,8 @@ class WorksTest extends ApiWorksTestBase {
     }
   }
 
-  def createDatedWork(canonicalId: String, dateLabel: String): Work.Visible[WorkState.Identified] =
+  def createDatedWork(canonicalId: String,
+                      dateLabel: String): Work.Visible[WorkState.Identified] =
     identifiedWork(canonicalId = canonicalId)
       .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
 
@@ -267,8 +268,7 @@ class WorksTest extends ApiWorksTestBase {
         val work2 = createDatedWork(canonicalId = "2", dateLabel = "1976")
         val work3 = createDatedWork(canonicalId = "3", dateLabel = "1904")
         val work4 = createDatedWork(canonicalId = "4", dateLabel = "2020")
-        val work5 = createDatedWork(canonicalId = "5", dateLabel = "1098"
-        )
+        val work5 = createDatedWork(canonicalId = "5", dateLabel = "1098")
         insertIntoElasticsearch(worksIndex, work1, work2, work3, work4, work5)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?sort=production.dates") {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -10,26 +10,6 @@ trait LegacyWorkGenerators
 
   private def createTitle: String = randomAlphanumeric(length = 100)
 
-  def createIdentifiedRedirectedWork: Work.Redirected[Identified] =
-    createIdentifiedRedirectedWorkWith()
-
-  def createIdentifiedRedirectedWorkWith(
-    canonicalId: String = createCanonicalId,
-    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    version: Int = 1,
-  ): Work.Redirected[Identified] =
-    Work.Redirected[Identified](
-      state = Identified(
-        canonicalId = canonicalId,
-        sourceIdentifier = sourceIdentifier,
-      ),
-      version = version,
-      redirect = IdState.Identified(
-        canonicalId = createCanonicalId,
-        sourceIdentifier = createSourceIdentifier
-      )
-    )
-
   def createInvisibleSourceWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     items: List[Item[IdState.Unminted]] = Nil,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -278,12 +278,4 @@ trait LegacyWorkGenerators
           createDigitalLocationWith(locationType = createImageLocationType)))),
       images = images
     )
-
-  def createIsbnWork: Work.Visible[Source] =
-    createSourceWorkWith(
-      sourceIdentifier = createIsbnSourceIdentifier,
-    )
-
-  def createIsbnWorks(count: Int): List[Work.Visible[Source]] =
-    List.fill(count)(createIsbnWork)
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -286,13 +286,4 @@ trait LegacyWorkGenerators
 
   def createIsbnWorks(count: Int): List[Work.Visible[Source]] =
     List.fill(count)(createIsbnWork)
-
-  def createDatedWork(
-    dateLabel: String,
-    canonicalId: String = createCanonicalId
-  ): Work.Visible[Identified] =
-    createIdentifiedWorkWith(
-      canonicalId = canonicalId,
-      production = List(createProductionEventWith(dateLabel = Some(dateLabel)))
-    )
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -295,13 +295,4 @@ trait LegacyWorkGenerators
       canonicalId = canonicalId,
       production = List(createProductionEventWith(dateLabel = Some(dateLabel)))
     )
-
-  def createLicensedWork(canonicalId: String,
-                         licenses: List[License]): Work.Visible[Identified] =
-    createIdentifiedWorkWith(
-      canonicalId = canonicalId,
-      items = licenses.map { license =>
-        createDigitalItemWith(license = Some(license))
-      }
-    )
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -304,20 +304,4 @@ trait LegacyWorkGenerators
         createDigitalItemWith(license = Some(license))
       }
     )
-
-  def createPhysicalWork(canonicalId: String = createCanonicalId) =
-    createIdentifiedWorkWith(
-      canonicalId,
-      items = List(
-        createIdentifiedItemWith(locations = List(createPhysicalLocation))
-      )
-    )
-
-  def createDigitalWork(canonicalId: String = createCanonicalId) =
-    createIdentifiedWorkWith(
-      canonicalId,
-      items = List(
-        createIdentifiedItemWith(locations = List(createDigitalLocation))
-      )
-    )
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -10,21 +10,6 @@ trait LegacyWorkGenerators
 
   private def createTitle: String = randomAlphanumeric(length = 100)
 
-  def createRedirectedSourceWork: Work.Redirected[Source] =
-    Work.Redirected[Source](
-      state = Source(createSourceIdentifier),
-      version = 1,
-      redirect = IdState.Identifiable(createSourceIdentifier)
-    )
-
-  def createRedirectedSourceWorkWith(
-    redirect: IdState.Identifiable): Work.Redirected[Source] =
-    Work.Redirected[Source](
-      state = Source(createSourceIdentifier),
-      version = 1,
-      redirect = redirect
-    )
-
   def createIdentifiedRedirectedWork: Work.Redirected[Identified] =
     createIdentifiedRedirectedWorkWith()
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -65,9 +65,6 @@ trait WorkGenerators extends IdentifiersGenerators {
   def denormalisedWorks(n: Int): List[Work.Visible[Denormalised]] =
     (1 to n).map(_ => denormalisedWork()).toList
 
-  def identifiedWorks(n: Int): List[Work.Visible[Identified]] =
-    (1 to n).map(_ => identifiedWork()).toList
-
   implicit class WorkOps[State <: WorkState](work: Work.Visible[State]) {
 
     def invisible(invisibilityReasons: List[InvisibilityReason] = Nil)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -3,11 +3,15 @@ package uk.ac.wellcome.models.work.generators
 import uk.ac.wellcome.models.work.internal._
 import WorkState._
 
+import scala.util.Random
+
 trait WorkGenerators extends IdentifiersGenerators {
+  private def createVersion: Int =
+    Random.nextInt(100) + 1
 
   def sourceWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    version: Int = 1
+    version: Int = createVersion
   ): Work.Visible[Source] =
     Work.Visible[Source](
       state = Source(sourceIdentifier),

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -5,12 +5,14 @@ import WorkState._
 
 trait WorkGenerators extends IdentifiersGenerators {
 
-  def sourceWork(sourceIdentifier: SourceIdentifier = createSourceIdentifier)
-    : Work.Visible[Source] =
+  def sourceWork(
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
+    version: Int = 1
+  ): Work.Visible[Source] =
     Work.Visible[Source](
       state = Source(sourceIdentifier),
       data = initData,
-      version = 1
+      version = version
     )
 
   def mergedWork(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -61,14 +61,17 @@ trait WorkGenerators extends IdentifiersGenerators {
       version = version
     )
 
-  def sourceWorks(n: Int): List[Work.Visible[Source]] =
-    (1 to n).map(_ => sourceWork()).toList
+  def sourceWorks(count: Int): List[Work.Visible[Source]] =
+    (1 to count).map(_ => sourceWork()).toList
 
-  def mergedWorks(n: Int): List[Work.Visible[Merged]] =
-    (1 to n).map(_ => mergedWork()).toList
+  def mergedWorks(count: Int): List[Work.Visible[Merged]] =
+    (1 to count).map(_ => mergedWork()).toList
 
-  def denormalisedWorks(n: Int): List[Work.Visible[Denormalised]] =
-    (1 to n).map(_ => denormalisedWork()).toList
+  def denormalisedWorks(count: Int): List[Work.Visible[Denormalised]] =
+    (1 to count).map(_ => denormalisedWork()).toList
+
+  def identifiedWorks(count: Int): List[Work.Visible[Identified]] =
+    (1 to count).map(_ => identifiedWork()).toList
 
   implicit class WorkOps[State <: WorkState](work: Work.Visible[State]) {
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -9,6 +9,9 @@ trait WorkGenerators extends IdentifiersGenerators {
   private def createVersion: Int =
     Random.nextInt(100) + 1
 
+  private def chooseFrom[T](seq: T*): T =
+    seq(Random.nextInt(seq.size))
+
   def sourceWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     version: Int = createVersion
@@ -43,17 +46,19 @@ trait WorkGenerators extends IdentifiersGenerators {
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: String = createCanonicalId,
-    hasMultipleSources: Boolean = false,
-    relations: Relations[DataState.Identified] = Relations.none
+    hasMultipleSources: Boolean = chooseFrom(true, false),
+    relations: Relations[DataState.Identified] = Relations.none,
+    version: Int = createVersion
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
       state = Identified(
-        sourceIdentifier,
-        canonicalId,
-        hasMultipleSources,
-        relations),
+        sourceIdentifier = sourceIdentifier,
+        canonicalId = canonicalId,
+        hasMultipleSources = hasMultipleSources,
+        relations = relations
+      ),
       data = initData,
-      version = 1
+      version = version
     )
 
   def sourceWorks(n: Int): List[Work.Visible[Source]] =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -90,7 +90,8 @@ trait WorkGenerators extends IdentifiersGenerators {
       )
 
     def withVersion(version: Int): Work.Visible[State] =
-      Work.Visible[State](version = version, data = work.data, state = work.state)
+      Work
+        .Visible[State](version = version, data = work.data, state = work.state)
 
     def title(title: String): Work.Visible[State] =
       work.map(_.copy(title = Some(title)))

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -13,13 +13,12 @@ trait WorkGenerators extends IdentifiersGenerators {
     seq(Random.nextInt(seq.size))
 
   def sourceWork(
-    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    version: Int = createVersion
+    sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): Work.Visible[Source] =
     Work.Visible[Source](
       state = Source(sourceIdentifier),
       data = initData,
-      version = version
+      version = createVersion
     )
 
   def mergedWork(
@@ -29,7 +28,7 @@ trait WorkGenerators extends IdentifiersGenerators {
     Work.Visible[Merged](
       state = Merged(sourceIdentifier, hasMultipleSources),
       data = initData,
-      version = 1
+      version = createVersion
     )
 
   def denormalisedWork(
@@ -40,15 +39,14 @@ trait WorkGenerators extends IdentifiersGenerators {
     Work.Visible[Denormalised](
       state = Denormalised(sourceIdentifier, hasMultipleSources, relations),
       data = initData,
-      version = 1
+      version = createVersion
     )
 
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: String = createCanonicalId,
     hasMultipleSources: Boolean = chooseFrom(true, false),
-    relations: Relations[DataState.Identified] = Relations.none,
-    version: Int = createVersion
+    relations: Relations[DataState.Identified] = Relations.none
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
       state = Identified(
@@ -58,7 +56,7 @@ trait WorkGenerators extends IdentifiersGenerators {
         relations = relations
       ),
       data = initData,
-      version = version
+      version = createVersion
     )
 
   def sourceWorks(count: Int): List[Work.Visible[Source]] =
@@ -91,8 +89,8 @@ trait WorkGenerators extends IdentifiersGenerators {
         redirect = redirect
       )
 
-    def version(version: Int): Work.Visible[State] =
-      Work.Visible[State](version, work.data, work.state)
+    def withVersion(version: Int): Work.Visible[State] =
+      Work.Visible[State](version = version, data = work.data, state = work.state)
 
     def title(title: String): Work.Visible[State] =
       work.map(_.copy(title = Some(title)))

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.platform.idminter.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.models.Implicits._
 import WorkState.{Identified, Source}
@@ -18,7 +18,7 @@ class IdMinterFeatureTest
     with IntegrationPatience
     with Eventually
     with WorkerServiceFixture
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("mints the same IDs where source identifiers match") {
     val messageSender = new MemoryMessageSender()
@@ -27,7 +27,7 @@ class IdMinterFeatureTest
       withIdentifiersDatabase { identifiersTableConfig =>
         withWorkerService(messageSender, queue, identifiersTableConfig) { _ =>
           eventuallyTableExists(identifiersTableConfig)
-          val work: Work[Source] = createSourceWork
+          val work: Work[Source] = sourceWork()
 
           val messageCount = 5
 
@@ -62,7 +62,7 @@ class IdMinterFeatureTest
       withIdentifiersDatabase { identifiersTableConfig =>
         withWorkerService(messageSender, queue, identifiersTableConfig) { _ =>
           eventuallyTableExists(identifiersTableConfig)
-          val work: Work[Source] = createInvisibleSourceWork
+          val work: Work[Source] = sourceWork().invisible()
 
           sendMessage(queue = queue, obj = work)
 
@@ -89,7 +89,8 @@ class IdMinterFeatureTest
         withWorkerService(messageSender, queue, identifiersTableConfig) { _ =>
           eventuallyTableExists(identifiersTableConfig)
 
-          val work: Work[Source] = createRedirectedSourceWork
+          val work: Work[Source] = sourceWork()
+            .redirected(redirect = IdState.Identifiable(createSourceIdentifier))
 
           sendMessage(queue = queue, obj = work)
 
@@ -117,7 +118,7 @@ class IdMinterFeatureTest
         withWorkerService(messageSender, queue, identifiersTableConfig) { _ =>
           sendInvalidJSONto(queue)
 
-          val work: Work[Source] = createSourceWork
+          val work: Work[Source] = sourceWork()
 
           sendMessage(queue = queue, obj = work)
 

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -8,8 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.elasticsearch.WorksIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.ingestor.common.fixtures.IngestorFixtures
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
@@ -24,10 +23,12 @@ class IngestorFeatureTest
     with ScalaFutures
     with IngestorFixtures
     with ElasticsearchFixtures
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("ingests a Miro work") {
-    val work = createIdentifiedWork
+    val work = identifiedWork(
+      sourceIdentifier = createMiroSourceIdentifier
+    )
 
     withLocalSqsQueue() { queue =>
       sendMessage[Work[Identified]](queue = queue, obj = work)
@@ -44,7 +45,7 @@ class IngestorFeatureTest
   }
 
   it("ingests a Sierra work") {
-    val work = createIdentifiedWorkWith(
+    val work = identifiedWork(
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -112,10 +112,9 @@ class IngestorWorkerServiceTest
       sourceIdentifier = createSierraSystemSourceIdentifier
     )
 
-    val newSierraWork = identifiedWork(
-      sourceIdentifier = oldSierraWork.sourceIdentifier,
-      version = oldSierraWork.version + 1
-    )
+    val newSierraWork =
+      identifiedWork(sourceIdentifier = oldSierraWork.sourceIdentifier)
+        .withVersion(oldSierraWork.version + 1)
 
     val works = List(newSierraWork, oldSierraWork)
 

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -40,18 +40,21 @@ class IngestorWorkerServiceTest
   }
 
   it("indexes a Sierra identified invisible Work") {
-    val work = identifiedWork(sourceIdentifier = createSierraSystemSourceIdentifier)
-      .invisible()
+    val work =
+      identifiedWork(sourceIdentifier = createSierraSystemSourceIdentifier)
+        .invisible()
 
     assertWorksIndexedCorrectly(work)
   }
 
   it("indexes a Sierra identified redirected Work") {
-    val work = identifiedWork(sourceIdentifier = createSierraSystemSourceIdentifier)
-      .redirected(IdState.Identified(
-        canonicalId = createCanonicalId,
-        sourceIdentifier = createSourceIdentifier
-      ))
+    val work =
+      identifiedWork(sourceIdentifier = createSierraSystemSourceIdentifier)
+        .redirected(
+          IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ))
 
     assertWorksIndexedCorrectly(work)
   }
@@ -103,7 +106,8 @@ class IngestorWorkerServiceTest
     assertWorksIndexedCorrectly(works: _*)
   }
 
-  it("deletes works from the queue, including older versions of already ingested works") {
+  it(
+    "deletes works from the queue, including older versions of already ingested works") {
     val oldSierraWork = identifiedWork(
       sourceIdentifier = createSierraSystemSourceIdentifier
     )

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
@@ -78,14 +78,15 @@ class WorkIndexerTest
       "doesn't override a identified Work with redirected work with lower version") {
       val identifiedNewWork = identifiedWork()
 
-      val redirectedOldWork = identifiedWork(canonicalId = identifiedNewWork.state.canonicalId)
-        .withVersion(identifiedNewWork.version - 1)
-        .redirected(
-          IdState.Identified(
-            canonicalId = createCanonicalId,
-            sourceIdentifier = createSourceIdentifier
+      val redirectedOldWork =
+        identifiedWork(canonicalId = identifiedNewWork.state.canonicalId)
+          .withVersion(identifiedNewWork.version - 1)
+          .redirected(
+            IdState.Identified(
+              canonicalId = createCanonicalId,
+              sourceIdentifier = createSourceIdentifier
+            )
           )
-        )
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
@@ -26,13 +26,12 @@ class WorkIndexerTest
   describe("updating merged / redirected works") {
     it(
       "doesn't override a merged Work with same version but hasMultipleSources = false") {
-      val mergedWork = identifiedWork(version = 3, hasMultipleSources = true)
+      val mergedWork = identifiedWork(hasMultipleSources = true).withVersion(3)
 
       val unmergedWork = identifiedWork(
         sourceIdentifier = mergedWork.sourceIdentifier,
-        version = mergedWork.version,
         hasMultipleSources = false
-      )
+      ).withVersion(mergedWork.version)
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -56,9 +55,8 @@ class WorkIndexerTest
       val unmergedNewWork = identifiedWork()
       val mergedOldWork = identifiedWork(
         sourceIdentifier = unmergedNewWork.sourceIdentifier,
-        version = unmergedNewWork.version - 1,
         hasMultipleSources = true
-      )
+      ).withVersion(unmergedNewWork.version - 1)
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -80,15 +78,14 @@ class WorkIndexerTest
       "doesn't override a identified Work with redirected work with lower version") {
       val identifiedNewWork = identifiedWork()
 
-      val redirectedOldWork = identifiedWork(
-        canonicalId = identifiedNewWork.state.canonicalId,
-        version = identifiedNewWork.version - 1
-      ).redirected(
-        IdState.Identified(
-          canonicalId = createCanonicalId,
-          sourceIdentifier = createSourceIdentifier
+      val redirectedOldWork = identifiedWork(canonicalId = identifiedNewWork.state.canonicalId)
+        .withVersion(identifiedNewWork.version - 1)
+        .redirected(
+          IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          )
         )
-      )
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -114,10 +111,9 @@ class WorkIndexerTest
             sourceIdentifier = createSourceIdentifier
           ))
 
-      val identifiedOldWork = identifiedWork(
-        canonicalId = redirectedWork.state.canonicalId,
-        version = redirectedWork.version
-      )
+      val identifiedOldWork =
+        identifiedWork(canonicalId = redirectedWork.state.canonicalId)
+          .withVersion(redirectedWork.version)
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -137,10 +133,10 @@ class WorkIndexerTest
 
     it("overrides a identified Work with invisible work with higher version") {
       val work = identifiedWork()
-      val invisibleWork = identifiedWork(
-        canonicalId = work.state.canonicalId,
-        version = work.version + 1
-      ).invisible()
+      val invisibleWork =
+        identifiedWork(canonicalId = work.state.canonicalId)
+          .withVersion(work.version + 1)
+          .invisible()
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
@@ -51,7 +51,8 @@ class WorkIndexerTest
       }
     }
 
-    it("doesn't overwrite a Work with lower version and hasMultipleSources = true") {
+    it(
+      "doesn't overwrite a Work with lower version and hasMultipleSources = true") {
       val unmergedNewWork = identifiedWork()
       val mergedOldWork = identifiedWork(
         sourceIdentifier = unmergedNewWork.sourceIdentifier,
@@ -107,10 +108,11 @@ class WorkIndexerTest
 
     it("doesn't override a redirected Work with identified work same version") {
       val redirectedWork = identifiedWork()
-        .redirected(IdState.Identified(
-          canonicalId = createCanonicalId,
-          sourceIdentifier = createSourceIdentifier
-        ))
+        .redirected(
+          IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ))
 
       val identifiedOldWork = identifiedWork(
         canonicalId = redirectedWork.state.canonicalId,

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/WorkIndexerTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 import uk.ac.wellcome.pipeline_storage.Indexable.workIndexable
@@ -21,14 +21,17 @@ class WorkIndexerTest
     with ScalaFutures
     with Matchers
     with ElasticsearchFixtures
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   describe("updating merged / redirected works") {
     it(
-      "doesn't override a merged Work with same version but merged flag = false") {
-      val mergedWork = createIdentifiedWorkWith(version = 3, merged = true)
-      val unmergedWork = mergedWork.copy(
-        state = mergedWork.state.copy(hasMultipleSources = false)
+      "doesn't override a merged Work with same version but hasMultipleSources = false") {
+      val mergedWork = identifiedWork(version = 3, hasMultipleSources = true)
+
+      val unmergedWork = identifiedWork(
+        sourceIdentifier = mergedWork.sourceIdentifier,
+        version = mergedWork.version,
+        hasMultipleSources = false
       )
 
       withWorksIndexAndIndexer {
@@ -48,13 +51,13 @@ class WorkIndexerTest
       }
     }
 
-    it("doesn't overwrite a Work with lower version and merged = true") {
-      val unmergedNewWork = createIdentifiedWorkWith(version = 4)
-      val mergedOldWork = unmergedNewWork
-        .copy(
-          version = 3,
-          state = unmergedNewWork.state.copy(hasMultipleSources = true)
-        )
+    it("doesn't overwrite a Work with lower version and hasMultipleSources = true") {
+      val unmergedNewWork = identifiedWork()
+      val mergedOldWork = identifiedWork(
+        sourceIdentifier = unmergedNewWork.sourceIdentifier,
+        version = unmergedNewWork.version - 1,
+        hasMultipleSources = true
+      )
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -74,10 +77,17 @@ class WorkIndexerTest
 
     it(
       "doesn't override a identified Work with redirected work with lower version") {
-      val identifiedNewWork = createIdentifiedWorkWith(version = 4)
-      val redirectedOldWork = createIdentifiedRedirectedWorkWith(
+      val identifiedNewWork = identifiedWork()
+
+      val redirectedOldWork = identifiedWork(
         canonicalId = identifiedNewWork.state.canonicalId,
-        version = 3)
+        version = identifiedNewWork.version - 1
+      ).redirected(
+        IdState.Identified(
+          canonicalId = createCanonicalId,
+          sourceIdentifier = createSourceIdentifier
+        )
+      )
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -96,16 +106,22 @@ class WorkIndexerTest
     }
 
     it("doesn't override a redirected Work with identified work same version") {
-      val redirectedWork = createIdentifiedRedirectedWorkWith(version = 3)
-      val identifiedWork = createIdentifiedWorkWith(
+      val redirectedWork = identifiedWork()
+        .redirected(IdState.Identified(
+          canonicalId = createCanonicalId,
+          sourceIdentifier = createSourceIdentifier
+        ))
+
+      val identifiedOldWork = identifiedWork(
         canonicalId = redirectedWork.state.canonicalId,
-        version = 3)
+        version = redirectedWork.version
+      )
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
           val identifiedWorkInsertFuture = ingestWorkPairInOrder(indexer)(
             firstWork = redirectedWork,
-            secondWork = identifiedWork,
+            secondWork = identifiedOldWork,
             index = index
           )
           whenReady(identifiedWorkInsertFuture) { result =>
@@ -118,10 +134,11 @@ class WorkIndexerTest
     }
 
     it("overrides a identified Work with invisible work with higher version") {
-      val work = createIdentifiedWorkWith(version = 3)
-      val invisibleWork = createIdentifiedInvisibleWorkWith(
+      val work = identifiedWork()
+      val invisibleWork = identifiedWork(
         canonicalId = work.state.canonicalId,
-        version = 4)
+        version = work.version + 1
+      ).invisible()
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -64,9 +64,7 @@ class MatcherFeatureTest
               val existingWorkVersion = 2
               val updatedWorkVersion = 1
 
-              val workAv1 = sourceWork(
-                version = updatedWorkVersion
-              )
+              val workAv1 = sourceWork().withVersion(updatedWorkVersion)
 
               val existingWorkAv2 = WorkNode(
                 id = workAv1.sourceIdentifier.toString,
@@ -98,7 +96,7 @@ class MatcherFeatureTest
         withWorkGraphTable { graphTable =>
           withVHS { vhs: VHS =>
             withWorkerService(vhs, queue, messageSender, graphTable) { _ =>
-              val workv2 = sourceWork(version = 2)
+              val workv2 = sourceWork().withVersion(2)
 
               val key = vhs.put(
                 Version(workv2.sourceIdentifier.toString, workv2.version))(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.{Identified, Version}
 
@@ -23,7 +23,7 @@ class MatcherFeatureTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it(
     "processes a message with a simple Work.Visible[Source] with no linked works") {
@@ -32,7 +32,7 @@ class MatcherFeatureTest
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(vhs, queue, messageSender) { _ =>
-          val work = createSourceWork
+          val work = sourceWork()
 
           val expectedResult = MatcherResult(
             Set(
@@ -64,7 +64,7 @@ class MatcherFeatureTest
               val existingWorkVersion = 2
               val updatedWorkVersion = 1
 
-              val workAv1 = createSourceWorkWith(
+              val workAv1 = sourceWork(
                 version = updatedWorkVersion
               )
 
@@ -98,7 +98,7 @@ class MatcherFeatureTest
         withWorkGraphTable { graphTable =>
           withVHS { vhs: VHS =>
             withWorkerService(vhs, queue, messageSender, graphTable) { _ =>
-              val workv2 = createSourceWorkWith(version = 2)
+              val workv2 = sourceWork(version = 2)
 
               val key = vhs.put(
                 Version(workv2.sourceIdentifier.toString, workv2.version))(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.matcher.MatcherResult
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -22,7 +22,7 @@ class WorkMatcherConcurrencyTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {
     withLockTable { lockTable =>
@@ -37,14 +37,10 @@ class WorkMatcherConcurrencyTest
               val identifierB =
                 createSierraSystemSourceIdentifierWith(value = "B")
 
-              val workA = createSourceWorkWith(
-                sourceIdentifier = identifierA,
-                mergeCandidates = List(MergeCandidate(identifierB))
-              )
+              val workA = sourceWork(sourceIdentifier = identifierA)
+                .mergeCandidates(List(MergeCandidate(identifierB)))
 
-              val workB = createSourceWorkWith(
-                sourceIdentifier = identifierB
-              )
+              val workB = sourceWork(sourceIdentifier = identifierB)
 
               val eventualResultA = workMatcher.matchWork(workA)
               val eventualResultB = workMatcher.matchWork(workB)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -52,8 +52,8 @@ class WorkMatcherTest
 
             whenReady(workMatcher.matchWork(work)) { matcherResult =>
               matcherResult shouldBe
-                MatcherResult(
-                  Set(MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
+                MatcherResult(Set(
+                  MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
 
               val savedLinkedWork =
                 get[WorkNode](dynamoClient, graphTable.name)('id -> sourceId)
@@ -80,8 +80,8 @@ class WorkMatcherTest
 
             whenReady(workMatcher.matchWork(invisibleWork)) { matcherResult =>
               matcherResult shouldBe
-                MatcherResult(
-                  Set(MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
+                MatcherResult(Set(
+                  MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
               get[WorkNode](dynamoClient, graphTable.name)('id -> sourceId)
                 .map(_.right.get) shouldBe Some(
                 WorkNode(sourceId, version, Nil, ciHash(sourceId)))

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -98,7 +98,8 @@ class WorkMatcherTest
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
           withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val work = sourceWork(sourceIdentifier = identifierA, version = 1)
+            val work = sourceWork(sourceIdentifier = identifierA)
+              .withVersion(1)
               .mergeCandidates(List(MergeCandidate(identifierB)))
 
             whenReady(workMatcher.matchWork(work)) { identifiersList =>
@@ -156,10 +157,9 @@ class WorkMatcherTest
             put(dynamoClient, graphTable.name)(existingWorkC)
 
             val work =
-              sourceWork(
-                sourceIdentifier = identifierB,
-                version = 2
-              ).mergeCandidates(List(MergeCandidate(identifierC)))
+              sourceWork(sourceIdentifier = identifierB)
+                .withVersion(2)
+                .mergeCandidates(List(MergeCandidate(identifierC)))
 
             whenReady(workMatcher.matchWork(work)) { identifiersList =>
               identifiersList shouldBe

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
@@ -32,7 +32,7 @@ class WorkMatcherTest
     with MatcherFixtures
     with ScalaFutures
     with MockitoSugar
-    with LegacyWorkGenerators
+    with SierraWorkGenerators
     with EitherValues {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
@@ -45,20 +45,22 @@ class WorkMatcherTest
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
           withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val work = createSierraSourceWork
-            val workId = work.sourceIdentifier.toString
+            val work = sourceWork()
+
+            val sourceId = work.sourceIdentifier.toString
+            val version = work.version
 
             whenReady(workMatcher.matchWork(work)) { matcherResult =>
               matcherResult shouldBe
                 MatcherResult(
-                  Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
+                  Set(MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
 
               val savedLinkedWork =
-                get[WorkNode](dynamoClient, graphTable.name)('id -> workId)
+                get[WorkNode](dynamoClient, graphTable.name)('id -> sourceId)
                   .map(_.right.value)
 
               savedLinkedWork shouldBe Some(
-                WorkNode(workId, 1, Nil, ciHash(workId)))
+                WorkNode(sourceId, version, Nil, ciHash(sourceId)))
             }
           }
         }
@@ -71,15 +73,18 @@ class WorkMatcherTest
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
           withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val invisibleWork = createInvisibleSourceWork
-            val workId = invisibleWork.sourceIdentifier.toString
+            val invisibleWork = sourceWork().invisible()
+
+            val sourceId = invisibleWork.sourceIdentifier.toString
+            val version = invisibleWork.version
+
             whenReady(workMatcher.matchWork(invisibleWork)) { matcherResult =>
               matcherResult shouldBe
                 MatcherResult(
-                  Set(MatchedIdentifiers(Set(WorkIdentifier(workId, 1)))))
-              get[WorkNode](dynamoClient, graphTable.name)('id -> workId)
+                  Set(MatchedIdentifiers(Set(WorkIdentifier(sourceId, version)))))
+              get[WorkNode](dynamoClient, graphTable.name)('id -> sourceId)
                 .map(_.right.get) shouldBe Some(
-                WorkNode(workId, 1, Nil, ciHash(workId)))
+                WorkNode(sourceId, version, Nil, ciHash(sourceId)))
             }
           }
         }
@@ -93,10 +98,9 @@ class WorkMatcherTest
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
           withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val work = createSourceWorkWith(
-              sourceIdentifier = identifierA,
-              mergeCandidates = List(MergeCandidate(identifierB))
-            )
+            val work = sourceWork(sourceIdentifier = identifierA, version = 1)
+              .mergeCandidates(List(MergeCandidate(identifierB)))
+
             whenReady(workMatcher.matchWork(work)) { identifiersList =>
               identifiersList shouldBe
                 MatcherResult(
@@ -151,10 +155,11 @@ class WorkMatcherTest
             put(dynamoClient, graphTable.name)(existingWorkB)
             put(dynamoClient, graphTable.name)(existingWorkC)
 
-            val work = createSourceWorkWith(
-              sourceIdentifier = identifierB,
-              version = 2,
-              mergeCandidates = List(MergeCandidate(identifierC)))
+            val work =
+              sourceWork(
+                sourceIdentifier = identifierB,
+                version = 2
+              ).mergeCandidates(List(MergeCandidate(identifierC)))
 
             whenReady(workMatcher.matchWork(work)) { identifiersList =>
               identifiersList shouldBe
@@ -201,7 +206,7 @@ class WorkMatcherTest
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
           withLockDao(dynamoClient, lockTable) { implicit lockDao =>
-            val work = createSierraSourceWork
+            val work = sierraSourceWork()
             val workId = work.sourceIdentifier.toString
             withWorkMatcherAndLockingService(
               workGraphStore,
@@ -241,10 +246,10 @@ class WorkMatcherTest
                     WorkNode(idB, 0, List(idC), componentId),
                     WorkNode(idC, 0, Nil, componentId),
                   )))
-              val work = createSourceWorkWith(
-                sourceIdentifier = identifierA,
-                mergeCandidates = List(MergeCandidate(identifierB))
-              )
+
+              val work = sourceWork(sourceIdentifier = identifierA)
+                .mergeCandidates(List(MergeCandidate(identifierB)))
+
               val failedLock = for {
                 _ <- Future.successful(
                   lockDao.lock(componentId, UUID.randomUUID))
@@ -270,7 +275,7 @@ class WorkMatcherTest
         when(mockWorkGraphStore.put(any[WorkGraph]))
           .thenThrow(expectedException)
 
-        whenReady(workMatcher.matchWork(createSierraSourceWork).failed) {
+        whenReady(workMatcher.matchWork(sierraSourceWork()).failed) {
           actualException =>
             actualException shouldBe MatcherException(expectedException)
         }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -302,7 +302,8 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val workAv1 = sourceWork(sourceIdentifier = identifierA).withVersion(1)
+            val workAv1 =
+              sourceWork(sourceIdentifier = identifierA).withVersion(1)
 
             sendWork(workAv1, vhs, queue)
             eventually {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.matcher.{
   MatcherResult,
   WorkIdentifier
 }
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.models.Implicits._
@@ -24,7 +24,7 @@ class MatcherWorkerServiceTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with LegacyWorkGenerators {
+    with SierraWorkGenerators {
 
   private val identifierA = createSierraSystemSourceIdentifierWith(value = "A")
   private val identifierB = createSierraSystemSourceIdentifierWith(value = "B")
@@ -32,7 +32,7 @@ class MatcherWorkerServiceTest
 
   it("creates a work without identifiers") {
     // Work Av1 created without any matched works
-    val updatedWork = createSierraSourceWork
+    val updatedWork = sierraSourceWork()
     val expectedMatchedWorks =
       MatcherResult(
         Set(
@@ -55,7 +55,7 @@ class MatcherWorkerServiceTest
 
   it(
     "sends an invisible work as a single matched result with no other matched identifiers") {
-    val invisibleWork = createInvisibleSourceWork
+    val invisibleWork = sourceWork().invisible()
     val expectedMatchedWorks =
       MatcherResult(
         Set(
@@ -80,9 +80,8 @@ class MatcherWorkerServiceTest
     "work A with one link to B and no existing works returns a single matched work") {
     // Work Av1
     val workAv1 =
-      createSourceWorkWith(
-        sourceIdentifier = identifierA,
-        mergeCandidates = List(MergeCandidate(identifierB)))
+      sourceWork(sourceIdentifier = identifierA, version = 1)
+        .mergeCandidates(List(MergeCandidate(identifierB)))
 
     // Work Av1 matched to B (before B exists hence version is None)
     // need to match to works that do not exist to support
@@ -114,8 +113,7 @@ class MatcherWorkerServiceTest
   it(
     "matches a work with one link then matches the combined work to a new work") {
     // Work Av1
-    val workAv1 =
-      createSourceWorkWith(sourceIdentifier = identifierA)
+    val workAv1 = sourceWork(sourceIdentifier = identifierA, version = 1)
 
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
@@ -127,8 +125,7 @@ class MatcherWorkerServiceTest
     )
 
     // Work Bv1
-    val workBv1 =
-      createSourceWorkWith(sourceIdentifier = identifierB)
+    val workBv1 = sourceWork(sourceIdentifier = identifierB, version = 1)
 
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
@@ -140,10 +137,10 @@ class MatcherWorkerServiceTest
     )
 
     // Work Av1 matched to B
-    val workAv2 = createSourceWorkWith(
+    val workAv2 = sourceWork(
       sourceIdentifier = identifierA,
-      version = 2,
-      mergeCandidates = List(MergeCandidate(identifierB)))
+      version = 2
+    ).mergeCandidates(List(MergeCandidate(identifierB)))
 
     val expectedMatchedWorksAv2 = MatcherResult(
       Set(
@@ -157,8 +154,7 @@ class MatcherWorkerServiceTest
     )
 
     // Work Cv1
-    val workCv1 =
-      createSourceWorkWith(sourceIdentifier = identifierC)
+    val workCv1 = sourceWork(sourceIdentifier = identifierC, version = 1)
 
     val expectedMatcherWorksCv1 =
       MatcherResult(
@@ -171,10 +167,10 @@ class MatcherWorkerServiceTest
       )
 
     // Work Bv2 matched to C
-    val workBv2 = createSourceWorkWith(
+    val workBv2 = sourceWork(
       sourceIdentifier = identifierB,
-      version = 2,
-      mergeCandidates = List(MergeCandidate(identifierC)))
+      version = 2
+    ).mergeCandidates(List(MergeCandidate(identifierC)))
 
     val expectedMatchedWorksBv2 =
       MatcherResult(
@@ -206,10 +202,8 @@ class MatcherWorkerServiceTest
 
   it("breaks matched works into individual works") {
     // Work Av1
-    val workAv1 = createSourceWorkWith(
-      sourceIdentifier = identifierA,
-      version = 1
-    )
+    val workAv1 =
+      sourceWork(sourceIdentifier = identifierA, version = 1)
 
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
@@ -221,10 +215,8 @@ class MatcherWorkerServiceTest
     )
 
     // Work Bv1
-    val workBv1 = createSourceWorkWith(
-      sourceIdentifier = identifierB,
-      version = 1
-    )
+    val workBv1 =
+      sourceWork(sourceIdentifier = identifierB, version = 1)
 
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
@@ -236,11 +228,9 @@ class MatcherWorkerServiceTest
     )
 
     // Match Work A to Work B
-    val workAv2MatchedToB = createSourceWorkWith(
-      sourceIdentifier = identifierA,
-      version = 2,
-      mergeCandidates = List(MergeCandidate(identifierB))
-    )
+    val workAv2MatchedToB =
+      sourceWork(sourceIdentifier = identifierA, version = 2)
+        .mergeCandidates(List(MergeCandidate(identifierB)))
 
     val expectedMatchedWorksAv2MatchedToB =
       MatcherResult(
@@ -255,10 +245,8 @@ class MatcherWorkerServiceTest
       )
 
     // A no longer matches B
-    val workAv3WithNoMatchingWorks = createSourceWorkWith(
-      sourceIdentifier = identifierA,
-      version = 3
-    )
+    val workAv3WithNoMatchingWorks =
+      sourceWork(sourceIdentifier = identifierA, version = 3)
 
     val expectedMatchedWorksAv3 =
       MatcherResult(
@@ -293,10 +281,7 @@ class MatcherWorkerServiceTest
   }
 
   it("does not match a lower version") {
-    val workAv2 = createSourceWorkWith(
-      sourceIdentifier = identifierA,
-      version = 2
-    )
+    val workAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
 
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
@@ -318,10 +303,7 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val workAv1 = createSourceWorkWith(
-              sourceIdentifier = identifierA,
-              version = 1
-            )
+            val workAv1 = sourceWork(sourceIdentifier = identifierA, version = 1)
 
             sendWork(workAv1, vhs, queue)
             eventually {
@@ -339,10 +321,7 @@ class MatcherWorkerServiceTest
   }
 
   it("does not match an existing version with different information") {
-    val workAv2 = createSourceWorkWith(
-      sourceIdentifier = identifierA,
-      version = 2
-    )
+    val workAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
 
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
@@ -364,10 +343,8 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val differentWorkAv2 = createSourceWorkWith(
-              sourceIdentifier = identifierA,
-              mergeCandidates = List(MergeCandidate(identifierB)),
-              version = 2)
+            val differentWorkAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
+              .mergeCandidates(List(MergeCandidate(identifierB)))
 
             sendWork(differentWorkAv2, vhs, queue)
             eventually {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -80,7 +80,8 @@ class MatcherWorkerServiceTest
     "work A with one link to B and no existing works returns a single matched work") {
     // Work Av1
     val workAv1 =
-      sourceWork(sourceIdentifier = identifierA, version = 1)
+      sourceWork(sourceIdentifier = identifierA)
+        .withVersion(1)
         .mergeCandidates(List(MergeCandidate(identifierB)))
 
     // Work Av1 matched to B (before B exists hence version is None)
@@ -113,7 +114,7 @@ class MatcherWorkerServiceTest
   it(
     "matches a work with one link then matches the combined work to a new work") {
     // Work Av1
-    val workAv1 = sourceWork(sourceIdentifier = identifierA, version = 1)
+    val workAv1 = sourceWork(sourceIdentifier = identifierA).withVersion(1)
 
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
@@ -125,7 +126,7 @@ class MatcherWorkerServiceTest
     )
 
     // Work Bv1
-    val workBv1 = sourceWork(sourceIdentifier = identifierB, version = 1)
+    val workBv1 = sourceWork(sourceIdentifier = identifierB).withVersion(1)
 
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
@@ -137,10 +138,9 @@ class MatcherWorkerServiceTest
     )
 
     // Work Av1 matched to B
-    val workAv2 = sourceWork(
-      sourceIdentifier = identifierA,
-      version = 2
-    ).mergeCandidates(List(MergeCandidate(identifierB)))
+    val workAv2 = sourceWork(sourceIdentifier = identifierA)
+      .withVersion(2)
+      .mergeCandidates(List(MergeCandidate(identifierB)))
 
     val expectedMatchedWorksAv2 = MatcherResult(
       Set(
@@ -154,7 +154,8 @@ class MatcherWorkerServiceTest
     )
 
     // Work Cv1
-    val workCv1 = sourceWork(sourceIdentifier = identifierC, version = 1)
+    val workCv1 = sourceWork(sourceIdentifier = identifierC)
+      .withVersion(1)
 
     val expectedMatcherWorksCv1 =
       MatcherResult(
@@ -167,10 +168,9 @@ class MatcherWorkerServiceTest
       )
 
     // Work Bv2 matched to C
-    val workBv2 = sourceWork(
-      sourceIdentifier = identifierB,
-      version = 2
-    ).mergeCandidates(List(MergeCandidate(identifierC)))
+    val workBv2 = sourceWork(sourceIdentifier = identifierB)
+      .withVersion(2)
+      .mergeCandidates(List(MergeCandidate(identifierC)))
 
     val expectedMatchedWorksBv2 =
       MatcherResult(
@@ -202,8 +202,7 @@ class MatcherWorkerServiceTest
 
   it("breaks matched works into individual works") {
     // Work Av1
-    val workAv1 =
-      sourceWork(sourceIdentifier = identifierA, version = 1)
+    val workAv1 = sourceWork(sourceIdentifier = identifierA).withVersion(1)
 
     val expectedMatchedWorksAv1 = MatcherResult(
       Set(
@@ -215,8 +214,7 @@ class MatcherWorkerServiceTest
     )
 
     // Work Bv1
-    val workBv1 =
-      sourceWork(sourceIdentifier = identifierB, version = 1)
+    val workBv1 = sourceWork(sourceIdentifier = identifierB).withVersion(1)
 
     val expectedMatchedWorksBv1 = MatcherResult(
       Set(
@@ -229,7 +227,8 @@ class MatcherWorkerServiceTest
 
     // Match Work A to Work B
     val workAv2MatchedToB =
-      sourceWork(sourceIdentifier = identifierA, version = 2)
+      sourceWork(sourceIdentifier = identifierA)
+        .withVersion(2)
         .mergeCandidates(List(MergeCandidate(identifierB)))
 
     val expectedMatchedWorksAv2MatchedToB =
@@ -246,7 +245,7 @@ class MatcherWorkerServiceTest
 
     // A no longer matches B
     val workAv3WithNoMatchingWorks =
-      sourceWork(sourceIdentifier = identifierA, version = 3)
+      sourceWork(sourceIdentifier = identifierA).withVersion(3)
 
     val expectedMatchedWorksAv3 =
       MatcherResult(
@@ -281,7 +280,7 @@ class MatcherWorkerServiceTest
   }
 
   it("does not match a lower version") {
-    val workAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
+    val workAv2 = sourceWork(sourceIdentifier = identifierA).withVersion(2)
 
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
@@ -303,8 +302,7 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val workAv1 =
-              sourceWork(sourceIdentifier = identifierA, version = 1)
+            val workAv1 = sourceWork(sourceIdentifier = identifierA).withVersion(1)
 
             sendWork(workAv1, vhs, queue)
             eventually {
@@ -322,7 +320,7 @@ class MatcherWorkerServiceTest
   }
 
   it("does not match an existing version with different information") {
-    val workAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
+    val workAv2 = sourceWork(sourceIdentifier = identifierA).withVersion(2)
 
     val expectedMatchedWorkAv2 = MatcherResult(
       Set(
@@ -345,7 +343,8 @@ class MatcherWorkerServiceTest
 
             // Work V1 is sent but not matched
             val differentWorkAv2 =
-              sourceWork(sourceIdentifier = identifierA, version = 2)
+              sourceWork(sourceIdentifier = identifierA)
+                .withVersion(2)
                 .mergeCandidates(List(MergeCandidate(identifierB)))
 
             sendWork(differentWorkAv2, vhs, queue)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -303,7 +303,8 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val workAv1 = sourceWork(sourceIdentifier = identifierA, version = 1)
+            val workAv1 =
+              sourceWork(sourceIdentifier = identifierA, version = 1)
 
             sendWork(workAv1, vhs, queue)
             eventually {
@@ -343,8 +344,9 @@ class MatcherWorkerServiceTest
             processAndAssertMatchedWorkIs(workAv2, expectedMatchedWorkAv2)
 
             // Work V1 is sent but not matched
-            val differentWorkAv2 = sourceWork(sourceIdentifier = identifierA, version = 2)
-              .mergeCandidates(List(MergeCandidate(identifierB)))
+            val differentWorkAv2 =
+              sourceWork(sourceIdentifier = identifierA, version = 2)
+                .mergeCandidates(List(MergeCandidate(identifierB)))
 
             sendWork(differentWorkAv2, vhs, queue)
             eventually {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkStoreTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models.VersionExpectedConflictException
@@ -15,12 +15,12 @@ class WorkStoreTest
     extends AnyFunSpec
     with Matchers
     with VHSFixture[Work[Source]]
-    with LegacyWorkGenerators
+    with WorkGenerators
     with Inside {
   it("gets a work from vhs") {
     withVHS { vhs: VHS =>
       val workStore = new WorkStore(vhs)
-      val expectedWork = createSourceWork
+      val expectedWork = sourceWork()
       val actualWork = for {
         key <- vhs.put(Version("b12345678", 1))(expectedWork)
         work <- workStore.getWork(key.id)
@@ -43,7 +43,7 @@ class WorkStoreTest
     "returns a VersionExpectedConflictException if the work exists in VHS with a higher version") {
     withVHS { vhs: VHS =>
       val workStore = new WorkStore(vhs)
-      val expectedWork = createSourceWork
+      val expectedWork = sourceWork()
       val actualWork = for {
         _ <- vhs.put(Version("b12345678", 2))(expectedWork)
         work <- workStore.getWork(Version("b12345678", 1))
@@ -59,7 +59,7 @@ class WorkStoreTest
   it("returns a left if the work is in VHS with a lower version") {
     withVHS { vhs: VHS =>
       val workStore = new WorkStore(vhs)
-      val expectedWork = createSourceWork
+      val expectedWork = sourceWork()
       val actualWork = for {
         _ <- vhs.put(Version("b12345678", 1))(expectedWork)
         work <- workStore.getWork(Version("b12345678", 2))

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -42,7 +42,7 @@ class RecorderPlaybackServiceTest
   }
 
   it("returns None if asked to fetch a Work without a version") {
-    val work = sourceWork().version(0)
+    val work = sourceWork().withVersion(0)
     val workId = WorkIdentifier(work.sourceIdentifier.toString, None)
 
     withVHS { vhs =>
@@ -54,9 +54,9 @@ class RecorderPlaybackServiceTest
   }
 
   it("returns None if the version in VHS has a higher version") {
-    val work = sourceWork().version(2)
+    val work = sourceWork().withVersion(2)
 
-    val workToStore = sourceWork(work.sourceIdentifier).version(3)
+    val workToStore = sourceWork(work.sourceIdentifier).withVersion(3)
 
     withVHS { vhs =>
       givenStoredInVhs(vhs, workToStore)
@@ -71,7 +71,7 @@ class RecorderPlaybackServiceTest
     val unchangedWorks = sourceWorks(count = 3)
     val outdatedWorks = sourceWorks(count = 2)
     val updatedWorks = outdatedWorks.map { work =>
-      work.version(work.version + 1)
+      work.withVersion(work.version + 1)
     }
 
     val lookupWorks = (unchangedWorks ++ outdatedWorks).toList

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/RecorderPlaybackServiceTest.scala
@@ -68,10 +68,10 @@ class RecorderPlaybackServiceTest
   }
 
   it("gets a mixture of works as appropriate") {
-    val unchangedWorks = (1 to 3).map(_ => sourceWork())
-    val outdatedWorks = (4 to 5).map(_ => sourceWork())
+    val unchangedWorks = sourceWorks(count = 3)
+    val outdatedWorks = sourceWorks(count = 2)
     val updatedWorks = outdatedWorks.map { work =>
-      work.copy(version = work.version + 1)
+      work.version(work.version + 1)
     }
 
     val lookupWorks = (unchangedWorks ++ outdatedWorks).toList

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.recorder
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.bigmessaging.fixtures.VHSFixture
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
@@ -19,7 +18,6 @@ class RecorderIntegrationTest
     with Eventually
     with IntegrationPatience
     with WorkerServiceFixture
-    with VHSFixture[Work[Source]]
     with LegacyWorkGenerators {
 
   it("saves received works to VHS, and puts the VHS key on the queue") {

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/RecorderIntegrationTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.Version
@@ -18,7 +18,7 @@ class RecorderIntegrationTest
     with Eventually
     with IntegrationPatience
     with WorkerServiceFixture
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("saves received works to VHS, and puts the VHS key on the queue") {
     val messageSender = new MemoryMessageSender()
@@ -27,7 +27,7 @@ class RecorderIntegrationTest
       val vhs = new MemoryVHS()
 
       withWorkerService(queue, vhs, messageSender) { _ =>
-        val work = createSourceWork
+        val work = sourceWork()
         sendMessage[Work[Source]](queue = queue, obj = work)
         eventually {
           val key = assertWorkStored(vhs, work)

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -57,10 +57,9 @@ class RecorderWorkerServiceTest
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
           val olderWork = sourceWork()
-          val newerWork = sourceWork(
-            sourceIdentifier = olderWork.sourceIdentifier,
-            version = olderWork.version + 1
-          ).title("A nice new thing")
+          val newerWork = sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
+            .withVersion(olderWork.version + 1)
+            .title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, newerWork)
           eventually { assertWorkStored(vhs, newerWork) }
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
@@ -76,10 +75,9 @@ class RecorderWorkerServiceTest
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
           val olderWork = sourceWork()
-          val newerWork = sourceWork(
-            sourceIdentifier = olderWork.sourceIdentifier,
-            version = olderWork.version + 1
-          ).title("A nice new thing")
+          val newerWork = sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
+            .withVersion(olderWork.version + 1)
+            .title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
           eventually {
             assertWorkStored(vhs, olderWork)

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.recorder.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.{StoreReadError, StoreWriteError, Version}
@@ -22,13 +22,13 @@ class RecorderWorkerServiceTest
     with IntegrationPatience
     with WorkerServiceFixture
     with JsonAssertions
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("records Work.Visible[Source]") {
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
-          val work = createSourceWork
+          val work = sourceWork()
           sendMessage[Work[Source]](queue = queue, obj = work)
           eventually {
             assertWorkStored(vhs, work)
@@ -42,7 +42,7 @@ class RecorderWorkerServiceTest
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
-          val invisibleWork = createInvisibleSourceWork
+          val invisibleWork = sourceWork().invisible()
           sendMessage[Work[Source]](queue = queue, invisibleWork)
           eventually {
             assertWorkStored(vhs, invisibleWork)
@@ -56,10 +56,11 @@ class RecorderWorkerServiceTest
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
-          val olderWork = createSourceWork
-          val newerWork = olderWork
-            .copy(version = 10)
-            .mapData(data => data.copy(title = Some("A nice new thing")))
+          val olderWork = sourceWork()
+          val newerWork = sourceWork(
+            sourceIdentifier = olderWork.sourceIdentifier,
+            version = olderWork.version + 1
+          ).title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, newerWork)
           eventually { assertWorkStored(vhs, newerWork) }
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
@@ -74,10 +75,11 @@ class RecorderWorkerServiceTest
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
-          val olderWork = createSourceWork
-          val newerWork = olderWork
-            .copy(version = 10)
-            .mapData(data => data.copy(title = Some("A nice new thing")))
+          val olderWork = sourceWork()
+          val newerWork = sourceWork(
+            sourceIdentifier = olderWork.sourceIdentifier,
+            version = olderWork.version + 1
+          ).title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
           eventually {
             assertWorkStored(vhs, olderWork)
@@ -108,7 +110,7 @@ class RecorderWorkerServiceTest
     withLocalSqsQueuePair() {
       case SQS.QueuePair(queue, dlq) =>
         withWorkerService(queue, brokenVhs, messageSender) { _ =>
-          val work = createSourceWork
+          val work = sourceWork()
           sendMessage[Work[Source]](queue = queue, obj = work)
           eventually {
             assertQueueEmpty(queue)
@@ -128,7 +130,7 @@ class RecorderWorkerServiceTest
     withLocalSqsQueue() { queue =>
       withVHS { vhs =>
         withWorkerService(queue, vhs, messageSender) { _ =>
-          val work = createSourceWork
+          val work = sourceWork()
           sendMessage[Work[Source]](queue = queue, obj = work)
           eventually {
             val id = work.sourceIdentifier.toString

--- a/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
+++ b/pipeline/recorder/src/test/scala/uk/ac/wellcome/platform/recorder/services/RecorderWorkerServiceTest.scala
@@ -57,9 +57,10 @@ class RecorderWorkerServiceTest
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
           val olderWork = sourceWork()
-          val newerWork = sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
-            .withVersion(olderWork.version + 1)
-            .title("A nice new thing")
+          val newerWork =
+            sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
+              .withVersion(olderWork.version + 1)
+              .title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, newerWork)
           eventually { assertWorkStored(vhs, newerWork) }
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
@@ -75,9 +76,10 @@ class RecorderWorkerServiceTest
       withVHS { vhs =>
         withWorkerService(queue, vhs) { _ =>
           val olderWork = sourceWork()
-          val newerWork = sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
-            .withVersion(olderWork.version + 1)
-            .title("A nice new thing")
+          val newerWork =
+            sourceWork(sourceIdentifier = olderWork.sourceIdentifier)
+              .withVersion(olderWork.version + 1)
+              .title("A nice new thing")
           sendMessage[Work[Source]](queue = queue, obj = olderWork)
           eventually {
             assertWorkStored(vhs, olderWork)

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.VersionedStore
@@ -22,11 +22,11 @@ trait TestData
 case object ValidTestData extends TestData
 case object InvalidTestData extends TestData
 
-object TestTransformer extends Transformer[TestData] with LegacyWorkGenerators {
+object TestTransformer extends Transformer[TestData] with WorkGenerators {
   def apply(data: TestData,
             version: Int): Either[Exception, Work.Visible[Source]] =
     data match {
-      case ValidTestData   => Right(createSourceWork)
+      case ValidTestData   => Right(sourceWork())
       case InvalidTestData => Left(new Exception("No No No"))
     }
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -6,7 +6,7 @@ import io.circe.Encoder
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.exceptions.MiroTransformerException
 import uk.ac.wellcome.platform.transformer.miro.fixtures.MiroVHSRecordReceiverFixture
@@ -25,14 +25,14 @@ class MiroVHSRecordReceiverTest
     with ScalaFutures
     with IntegrationPatience
     with MiroRecordGenerators
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   case class TestException(message: String) extends Exception(message)
 
   def transformToWork(miroRecord: MiroRecord,
                       metadata: MiroMetadata,
                       version: Int) =
-    Try(createSourceWorkWith(version = version))
+    Try(sourceWork(version = version))
 
   def failingTransformToWork(miroRecord: MiroRecord,
                              metadata: MiroMetadata,

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroVHSRecordReceiverTest.scala
@@ -32,7 +32,7 @@ class MiroVHSRecordReceiverTest
   def transformToWork(miroRecord: MiroRecord,
                       metadata: MiroMetadata,
                       version: Int) =
-    Try(sourceWork(version = version))
+    Try(sourceWork().withVersion(version))
 
   def failingTransformToWork(miroRecord: MiroRecord,
                              metadata: MiroMetadata,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -284,7 +284,8 @@ class SierraTransformerTest
 
     val work = transformDataToWork(id = id, data = data)
 
-    work shouldBe sourceWork(sourceIdentifier, version = 1)
+    work shouldBe sourceWork(sourceIdentifier)
+      .withVersion(1)
       .title(title)
       .otherIdentifiers(List(sierraIdentifier))
       .description("A delightful description of a dead daisy.")

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -284,7 +284,7 @@ class SierraTransformerTest
 
     val work = transformDataToWork(id = id, data = data)
 
-    work shouldBe sourceWork(sourceIdentifier)
+    work shouldBe sourceWork(sourceIdentifier, version = 1)
       .title(title)
       .otherIdentifiers(List(sierraIdentifier))
       .description("A delightful description of a dead daisy.")

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -38,9 +38,7 @@ class SnapshotGeneratorFeatureTest
   it("completes a snapshot generation") {
     withFixtures {
       case (queue, messageSender, worksIndex, _, publicBucket: Bucket) =>
-        val works = (1 to 3).map { _ =>
-          identifiedWork()
-        }
+        val works = identifiedWorks(count = 3)
 
         insertIntoElasticsearch(worksIndex, works: _*)
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -38,7 +38,9 @@ class SnapshotGeneratorFeatureTest
   it("completes a snapshot generation") {
     withFixtures {
       case (queue, messageSender, worksIndex, _, publicBucket: Bucket) =>
-        val works = (1 to 3).map { _ => identifiedWork() }
+        val works = (1 to 3).map { _ =>
+          identifiedWork()
+        }
 
         insertIntoElasticsearch(worksIndex, works: _*)
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.platform.snapshot_generator.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.platform.snapshot_generator.models.{
   CompletedSnapshotJob,
@@ -33,12 +33,12 @@ class SnapshotGeneratorFeatureTest
     with IntegrationPatience
     with DisplaySerialisationTestBase
     with WorkerServiceFixture
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("completes a snapshot generation") {
     withFixtures {
       case (queue, messageSender, worksIndex, _, publicBucket: Bucket) =>
-        val works = createIdentifiedWorks(count = 3)
+        val works = (1 to 3).map { _ => identifiedWork() }
 
         insertIntoElasticsearch(worksIndex, works: _*)
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 
 class IdentifiedWorkToVisibleDisplayWorkFlowTest
     extends AnyFunSpec
@@ -14,14 +14,14 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
     with Akka
     with ScalaFutures
     with IntegrationPatience
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("creates DisplayWorks from IdentifiedWorks") {
     withMaterializer { implicit materializer =>
       val flow = IdentifiedWorkToVisibleDisplayWork(
         toDisplayWork = DisplayWork.apply(_, WorksIncludes.includeAll()))
 
-      val works = createIdentifiedWorks(count = 3).toList
+      val works = (1 to 3).map { _ => identifiedWork() }
 
       val eventualDisplayWorks = Source(works)
         .via(flow)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -21,7 +21,9 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
       val flow = IdentifiedWorkToVisibleDisplayWork(
         toDisplayWork = DisplayWork.apply(_, WorksIncludes.includeAll()))
 
-      val works = (1 to 3).map { _ => identifiedWork() }
+      val works = (1 to 3).map { _ =>
+        identifiedWork()
+      }
 
       val eventualDisplayWorks = Source(works)
         .via(flow)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -21,9 +21,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
       val flow = IdentifiedWorkToVisibleDisplayWork(
         toDisplayWork = DisplayWork.apply(_, WorksIncludes.includeAll()))
 
-      val works = (1 to 3).map { _ =>
-        identifiedWork()
-      }
+      val works = identifiedWorks(count = 3)
 
       val eventualDisplayWorks = Source(works)
         .via(flow)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -57,12 +57,8 @@ class SnapshotServiceTest
   it("completes a snapshot generation") {
     withFixtures {
       case (snapshotService: SnapshotService, worksIndex, publicBucket) =>
-        val visibleWorks = (1 to 4).map { _ =>
-          identifiedWork()
-        }
-        val notVisibleWorks = (1 to 2).map { _ =>
-          identifiedWork().invisible()
-        }
+        val visibleWorks = identifiedWorks(count = 3)
+        val notVisibleWorks = identifiedWorks(count = 2).map { _.invisible() }
 
         val works = visibleWorks ++ notVisibleWorks
 
@@ -110,10 +106,8 @@ class SnapshotServiceTest
   it("completes a snapshot generation of an index with more than 10000 items") {
     withFixtures {
       case (snapshotService: SnapshotService, worksIndex, publicBucket) =>
-        val works = (1 to 11000).map { _ =>
-          identifiedWork()
-            .title(randomAlphanumeric(length = 1500))
-        }
+        val works = identifiedWorks(count = 11000)
+          .map { _.title(randomAlphanumeric(length = 1500)) }
 
         insertIntoElasticsearch(worksIndex, works: _*)
 
@@ -157,9 +151,7 @@ class SnapshotServiceTest
   it("returns a failed future if the S3 upload fails") {
     withFixtures {
       case (snapshotService: SnapshotService, worksIndex, _) =>
-        val works = (1 to 3).map { _ =>
-          identifiedWork()
-        }
+        val works = identifiedWorks(count = 3)
 
         insertIntoElasticsearch(worksIndex, works: _*)
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -57,8 +57,12 @@ class SnapshotServiceTest
   it("completes a snapshot generation") {
     withFixtures {
       case (snapshotService: SnapshotService, worksIndex, publicBucket) =>
-        val visibleWorks = (1 to 4).map { _ => identifiedWork() }
-        val notVisibleWorks = (1 to 2).map { _ => identifiedWork().invisible() }
+        val visibleWorks = (1 to 4).map { _ =>
+          identifiedWork()
+        }
+        val notVisibleWorks = (1 to 2).map { _ =>
+          identifiedWork().invisible()
+        }
 
         val works = visibleWorks ++ notVisibleWorks
 
@@ -153,7 +157,9 @@ class SnapshotServiceTest
   it("returns a failed future if the S3 upload fails") {
     withFixtures {
       case (snapshotService: SnapshotService, worksIndex, _) =>
-        val works = (1 to 3).map { _ => identifiedWork() }
+        val works = (1 to 3).map { _ =>
+          identifiedWork()
+        }
 
         insertIntoElasticsearch(worksIndex, works: _*)
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -25,7 +25,9 @@ class ElasticsearchSourceTest
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val works = (1 to 10).map { _ => identifiedWork() }
+        val works = (1 to 10).map { _ =>
+          identifiedWork()
+        }
         insertIntoElasticsearch(index, works: _*)
 
         withSource(index) { source =>
@@ -42,8 +44,12 @@ class ElasticsearchSourceTest
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val visibleWorks = (1 to 10).map { _ => identifiedWork() }
-        val invisibleWorks = (1 to 3).map { _ => identifiedWork().invisible() }
+        val visibleWorks = (1 to 10).map { _ =>
+          identifiedWork()
+        }
+        val invisibleWorks = (1 to 3).map { _ =>
+          identifiedWork().invisible()
+        }
 
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(index, works: _*)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.models.work.generators.LegacyWorkGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 
 class ElasticsearchSourceTest
@@ -20,12 +20,12 @@ class ElasticsearchSourceTest
     with IntegrationPatience
     with Akka
     with ElasticsearchFixtures
-    with LegacyWorkGenerators {
+    with WorkGenerators {
 
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val works = createIdentifiedWorks(count = 10)
+        val works = (1 to 10).map { _ => identifiedWork() }
         insertIntoElasticsearch(index, works: _*)
 
         withSource(index) { source =>
@@ -42,8 +42,8 @@ class ElasticsearchSourceTest
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val visibleWorks = createIdentifiedWorks(count = 10)
-        val invisibleWorks = createIdentifiedInvisibleWorks(count = 3)
+        val visibleWorks = (1 to 10).map { _ => identifiedWork() }
+        val invisibleWorks = (1 to 3).map { _ => identifiedWork().invisible() }
 
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(index, works: _*)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/source/ElasticsearchSourceTest.scala
@@ -25,9 +25,7 @@ class ElasticsearchSourceTest
   it("outputs the entire content of the index") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val works = (1 to 10).map { _ =>
-          identifiedWork()
-        }
+        val works = identifiedWorks(count = 10)
         insertIntoElasticsearch(index, works: _*)
 
         withSource(index) { source =>
@@ -44,12 +42,8 @@ class ElasticsearchSourceTest
   it("filters non visible works") {
     withActorSystem { implicit actorSystem =>
       withLocalWorksIndex { index =>
-        val visibleWorks = (1 to 10).map { _ =>
-          identifiedWork()
-        }
-        val invisibleWorks = (1 to 3).map { _ =>
-          identifiedWork().invisible()
-        }
+        val visibleWorks = identifiedWorks(count = 10)
+        val invisibleWorks = identifiedWorks(count = 3).map { _.invisible() }
 
         val works = visibleWorks ++ invisibleWorks
         insertIntoElasticsearch(index, works: _*)


### PR DESCRIPTION
A first chunk of https://github.com/wellcomecollection/platform/issues/4821

This is all the low-hanging fruit that could be replaced easily. I’m going to keep snipping away at LegacyWorkGenerators for a bit longer, but this is enough for one pull request.