### PR TITLE
Pick off some more use of LegacyWorksGenerators in the catalogue API

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -122,8 +122,10 @@ class WorksQueryTest
 
     it("searches the items.otherIdentifiers") {
       withLocalWorksIndex { index =>
-        val item1 = createIdentifiedItemWith(otherIdentifiers = List(createSourceIdentifier))
-        val item2 = createIdentifiedItemWith(otherIdentifiers = List(createSourceIdentifier))
+        val item1 = createIdentifiedItemWith(
+          otherIdentifiers = List(createSourceIdentifier))
+        val item2 = createIdentifiedItemWith(
+          otherIdentifiers = List(createSourceIdentifier))
 
         val work1 = identifiedWork().items(List(item1))
         val work2 = identifiedWork().items(List(item2))
@@ -239,13 +241,15 @@ class WorksQueryTest
         val work2 = identifiedWork()
 
         // We've put spaces in this as some Miro IDs are sentences
-        val work3 = createIdentifiedWorkWith(canonicalId = "Oxford English Dictionary")
+        val work3 =
+          createIdentifiedWorkWith(canonicalId = "Oxford English Dictionary")
 
         insertIntoElasticsearch(index, work1, work2, work3)
 
         assertResultsMatchForAllowedQueryTypes(
           index,
-          query = s"${work1.state.canonicalId} ${work2.state.canonicalId} Oxford",
+          query =
+            s"${work1.state.canonicalId} ${work2.state.canonicalId} Oxford",
           matches = List(work1, work2)
         )
       }
@@ -299,7 +303,8 @@ class WorksQueryTest
     it("Searches lettering") {
       withLocalWorksIndex { index =>
         val matchingWork = identifiedWork()
-          .lettering("Old Mughal minaret near Shahjahanabad (Delhi), Ghulam Ali Khan, early XIX century")
+          .lettering(
+            "Old Mughal minaret near Shahjahanabad (Delhi), Ghulam Ali Khan, early XIX century")
         val notMatchingWork = identifiedWork()
           .lettering("Not matching")
 
@@ -352,7 +357,9 @@ class WorksQueryTest
       }
     }
 
-  private def searchResults(index: Index, searchOptions: SearchOptions): List[Work[Identified]] = {
+  private def searchResults(
+    index: Index,
+    searchOptions: SearchOptions): List[Work[Identified]] = {
     val searchResponseFuture =
       searchService.executeSearch(searchOptions, WorksRequestBuilder, index)
     whenReady(searchResponseFuture) { response =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -27,6 +27,7 @@ import uk.ac.wellcome.platform.api.services.{
   WorksRequestBuilder
 }
 import WorkState.Identified
+import org.scalatest.Assertion
 
 class WorksQueryTest
     extends AnyFunSpec
@@ -45,9 +46,7 @@ class WorksQueryTest
 
     it("searches the canonicalId") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123"
-        )
+        val work = identifiedWork(canonicalId = "abc123")
 
         val query = "abc123"
 
@@ -59,14 +58,8 @@ class WorksQueryTest
 
     it("searches the sourceIdentifiers") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          sourceIdentifier = createSourceIdentifierWith()
-        )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          sourceIdentifier = createSourceIdentifierWith()
-        )
+        val work = identifiedWork()
+        val workNotMatching = identifiedWork()
         val query = work.sourceIdentifier.value
 
         insertIntoElasticsearch(index, work, workNotMatching)
@@ -77,14 +70,12 @@ class WorksQueryTest
 
     it("searches the otherIdentifiers") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          otherIdentifiers = List(createSourceIdentifierWith())
-        )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          otherIdentifiers = List(createSourceIdentifierWith())
-        )
+        val work = identifiedWork()
+          .otherIdentifiers(List(createSourceIdentifier))
+
+        val workNotMatching = identifiedWork()
+          .otherIdentifiers(List(createSourceIdentifier))
+
         val query = work.data.otherIdentifiers.head.value
 
         insertIntoElasticsearch(index, work, workNotMatching)
@@ -95,208 +86,177 @@ class WorksQueryTest
 
     it("searches the items.canonicalId as keyword") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          items = List(createIdentifiedItemWith(canonicalId = "def"))
-        )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          items = List(createIdentifiedItemWith(canonicalId = "def456"))
-        )
-        val query = "def"
+        val item1 = createIdentifiedItem
+        val item2 = createIdentifiedItem
 
-        insertIntoElasticsearch(index, work, workNotMatching)
+        val work1 = identifiedWork().items(List(item1))
+        val work2 = identifiedWork().items(List(item2))
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
+        insertIntoElasticsearch(index, work1, work2)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = item1.id.canonicalId,
+          matches = List(work1)
+        )
       }
     }
 
     it("searches the items.sourceIdentifiers") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          items = List(
-            createIdentifiedItemWith(sourceIdentifier =
-              createSourceIdentifierWith(value = "sourceIdentifier123")))
+        val item1 = createIdentifiedItem
+        val item2 = createIdentifiedItem
+
+        val work1 = identifiedWork().items(List(item1))
+        val work2 = identifiedWork().items(List(item2))
+
+        insertIntoElasticsearch(index, work1, work2)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = item1.id.sourceIdentifier.value,
+          matches = List(work1)
         )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          items = List(
-            createIdentifiedItemWith(sourceIdentifier =
-              createSourceIdentifierWith(value = "sourceIdentifier456")))
-        )
-
-        val query = "sourceIdentifier123"
-
-        insertIntoElasticsearch(index, work, workNotMatching)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
       }
     }
 
     it("searches the items.otherIdentifiers") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          items = List(
-            createIdentifiedItemWith(otherIdentifiers =
-              List(createSourceIdentifierWith(value = "sourceIdentifier123"))))
-        )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "def456",
-          items = List(
-            createIdentifiedItemWith(otherIdentifiers =
-              List(createSourceIdentifierWith(value = "sourceIdentifier456"))))
-        )
-        val query = "sourceIdentifier123"
+        val item1 = createIdentifiedItemWith(otherIdentifiers = List(createSourceIdentifier))
+        val item2 = createIdentifiedItemWith(otherIdentifiers = List(createSourceIdentifier))
 
-        insertIntoElasticsearch(index, work, workNotMatching)
+        val work1 = identifiedWork().items(List(item1))
+        val work2 = identifiedWork().items(List(item2))
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
+        insertIntoElasticsearch(index, work1, work2)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = item1.id.otherIdentifiers.head.value,
+          matches = List(work1)
+        )
       }
     }
 
     it("searches the images.canonicalId as keyword") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          images = List(
-            createUnmergedImage.toIdentifiedWith(id = "def")
-          ))
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          images = List(
-            createUnmergedImage.toIdentifiedWith(id = "def456")
-          )
+        val image1 = createUnmergedImage.toIdentified
+        val image2 = createUnmergedImage.toIdentified
+
+        val work1 = identifiedWork().images(List(image1))
+        val work2 = identifiedWork().images(List(image2))
+
+        insertIntoElasticsearch(index, work1, work2)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = image1.id.canonicalId,
+          matches = List(work1)
         )
-        val query = "def"
-
-        insertIntoElasticsearch(index, work, workNotMatching)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
       }
     }
 
     it("searches the images.sourceIdentifiers") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123",
-          images = List(
-            createUnmergedImageWith(identifierValue = "sourceIdentifier123").toIdentified
-          )
+        val image1 = createUnmergedImage.toIdentified
+        val image2 = createUnmergedImage.toIdentified
+
+        val work1 = identifiedWork().images(List(image1))
+        val work2 = identifiedWork().images(List(image2))
+
+        insertIntoElasticsearch(index, work1, work2)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = image1.id.sourceIdentifier.value,
+          matches = List(work1)
         )
-        val workNotMatching = createIdentifiedWorkWith(
-          canonicalId = "123abc",
-          images = List(
-            createUnmergedImageWith(identifierValue = "sourceIdentifier456").toIdentified
-          )
-        )
-
-        val query = "sourceIdentifier123"
-
-        insertIntoElasticsearch(index, work, workNotMatching)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
       }
     }
 
     it("matches when searching for an ID") {
       withLocalWorksIndex { index =>
-        val work = createIdentifiedWorkWith(
-          canonicalId = "abc123"
-        )
-        val query = "abc123"
+        val work: Work.Visible[Identified] = identifiedWork()
 
         insertIntoElasticsearch(index, work)
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work))
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = work.state.canonicalId,
+          matches = List(work)
+        )
       }
     }
 
     it("doesn't match on partial IDs") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "1234567"
+        val work = identifiedWork(canonicalId = "1234567")
+
+        insertIntoElasticsearch(index, work)
+
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = "123",
+          matches = List()
         )
-        val query = "123"
-
-        insertIntoElasticsearch(index, work1)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List())
       }
     }
 
     it("matches IDs case insensitively") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "AbCDeF1234"
-        )
-        val nonMatchingWork = createIdentifiedWorkWith(
-          canonicalId = "bloopybloop"
-        )
-        val query = "abcdef1234"
+        val work1 = identifiedWork(canonicalId = "AbCDeF1234")
+        val work2 = identifiedWork(canonicalId = "bloopybloop")
 
-        insertIntoElasticsearch(index, work1, nonMatchingWork)
+        insertIntoElasticsearch(index, work1, work2)
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1))
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = work1.state.canonicalId.toLowerCase(),
+          matches = List(work1)
+        )
       }
     }
 
     it("matches multiple IDs") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "AbCDeF1234"
-        )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "rstYui786"
-        )
-        val nonMatchingWork = createIdentifiedWorkWith(
-          canonicalId = "bloopybloop"
-        )
-        val query = "abcdef1234 rstyui786"
+        val work1 = identifiedWork()
+        val work2 = identifiedWork()
+        val work3 = identifiedWork()
 
-        insertIntoElasticsearch(index, work1, work2, nonMatchingWork)
+        insertIntoElasticsearch(index, work1, work2, work3)
 
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
+        assertResultsMatchForAllowedQueryTypes(
+          index,
+          query = s"${work1.state.canonicalId} ${work2.state.canonicalId}",
+          List(work1, work2)
+        )
       }
     }
 
     it("doesn't match partially matching IDs") {
       withLocalWorksIndex { index =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "AbCDeF1234"
-        )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "rstYui786"
-        )
-        val nonMatchingWork1 = createIdentifiedWorkWith(
-          canonicalId = "bloopybloop"
-        )
+        val work1 = identifiedWork()
+        val work2 = identifiedWork()
+
         // We've put spaces in this as some Miro IDs are sentences
-        val nonMatchingWork2 = createIdentifiedWorkWith(
-          canonicalId = "Oxford english dictionary"
-        )
-        val query = "abcdef1234 rstyui786 Oxford"
+        val work3 = createIdentifiedWorkWith(canonicalId = "Oxford English Dictionary")
 
-        insertIntoElasticsearch(
+        insertIntoElasticsearch(index, work1, work2, work3)
+
+        assertResultsMatchForAllowedQueryTypes(
           index,
-          work1,
-          work2,
-          nonMatchingWork1,
-          nonMatchingWork2)
-
-        assertResultsMatchForAllowedQueryTypes(index, query, List(work1, work2))
+          query = s"${work1.state.canonicalId} ${work2.state.canonicalId} Oxford",
+          matches = List(work1, work2)
+        )
       }
     }
 
-    it("Searches for contributors") {
+    it("searches for contributors") {
       withLocalWorksIndex { index =>
-        val matchingWork = createIdentifiedWorkWith(
-          contributors = List(createPersonContributorWith("Matching"))
-        )
-        val notMatchingWork = createIdentifiedWorkWith(
-          contributors = List(createPersonContributorWith("Notmatching"))
-        )
+        val matchingWork = identifiedWork()
+          .contributors(List(createPersonContributorWith("Matching")))
+        val notMatchingWork = identifiedWork()
+          .contributors(List(createPersonContributorWith("Notmatching")))
 
         val query = "matching"
 
@@ -308,12 +268,10 @@ class WorksQueryTest
 
     it("Searches for genres") {
       withLocalWorksIndex { index =>
-        val matchingWork = createIdentifiedWorkWith(
-          genres = List(createGenreWithMatchingConcept("Matching"))
-        )
-        val notMatchingWork = createIdentifiedWorkWith(
-          genres = List(createGenreWithMatchingConcept("Notmatching"))
-        )
+        val matchingWork = identifiedWork()
+          .genres(List(createGenreWithMatchingConcept("Matching")))
+        val notMatchingWork = identifiedWork()
+          .genres(List(createGenreWithMatchingConcept("Notmatching")))
 
         val query = "matching"
 
@@ -325,12 +283,10 @@ class WorksQueryTest
 
     it("Searches for subjects") {
       withLocalWorksIndex { index =>
-        val matchingWork = createIdentifiedWorkWith(
-          subjects = List(createSubjectWithMatchingConcept("Matching"))
-        )
-        val notMatchingWork = createIdentifiedWorkWith(
-          subjects = List(createSubjectWithMatchingConcept("Notmatching"))
-        )
+        val matchingWork = identifiedWork()
+          .subjects(List(createSubjectWithMatchingConcept("Matching")))
+        val notMatchingWork = identifiedWork()
+          .subjects(List(createSubjectWithMatchingConcept("Notmatching")))
 
         val query = "matching"
 
@@ -342,13 +298,10 @@ class WorksQueryTest
 
     it("Searches lettering") {
       withLocalWorksIndex { index =>
-        val matchingWork = createIdentifiedWorkWith(
-          lettering = Some(
-            "Old Mughal minaret near Shahjahanabad (Delhi), Ghulam Ali Khan, early XIX century")
-        )
-        val notMatchingWork = createIdentifiedWorkWith(
-          lettering = Some("Notmatching")
-        )
+        val matchingWork = identifiedWork()
+          .lettering("Old Mughal minaret near Shahjahanabad (Delhi), Ghulam Ali Khan, early XIX century")
+        val notMatchingWork = identifiedWork()
+          .lettering("Not matching")
 
         val query = "shahjahanabad"
 
@@ -360,13 +313,10 @@ class WorksQueryTest
 
     it("Searches for collection in collectionPath.path") {
       withLocalWorksIndex { index =>
-        val matchingWork = createIdentifiedWorkWith(
-          collectionPath = Some(CollectionPath("PPCPB", label = Some("PP/CRI")))
-        )
-        val notMatchingWork = createIdentifiedWorkWith(
-          collectionPath =
-            Some(CollectionPath("NUFFINK", label = Some("NUF/FINK")))
-        )
+        val matchingWork = identifiedWork()
+          .collectionPath(CollectionPath("PPCPB", label = Some("PP/CRI")))
+        val notMatchingWork = identifiedWork()
+          .collectionPath(CollectionPath("NUFFINK", label = Some("NUF/FINK")))
         val query = "PPCPB"
         insertIntoElasticsearch(index, matchingWork, notMatchingWork)
         assertResultsMatchForAllowedQueryTypes(index, query, List(matchingWork))
@@ -376,13 +326,10 @@ class WorksQueryTest
 
   it("Searches for collection in collectionPath.label") {
     withLocalWorksIndex { index =>
-      val matchingWork = createIdentifiedWorkWith(
-        collectionPath = Some(CollectionPath("PPCPB", label = Some("PP/CRI")))
-      )
-      val notMatchingWork = createIdentifiedWorkWith(
-        collectionPath =
-          Some(CollectionPath("NUFFINK", label = Some("NUF/FINK")))
-      )
+      val matchingWork = identifiedWork()
+        .collectionPath(CollectionPath("PPCPB", label = Some("PP/CRI")))
+      val notMatchingWork = identifiedWork()
+        .collectionPath(CollectionPath("NUFFINK", label = Some("NUF/FINK")))
       val query = "PP/CRI"
       insertIntoElasticsearch(index, matchingWork, notMatchingWork)
       assertResultsMatchForAllowedQueryTypes(index, query, List(matchingWork))
@@ -392,8 +339,7 @@ class WorksQueryTest
   private def assertResultsMatchForAllowedQueryTypes(
     index: Index,
     query: String,
-    matches: List[Work[Identified]]) = {
-
+    matches: List[Work[Identified]]): List[Assertion] =
     SearchQueryType.allowed map { queryType =>
       val results = searchResults(
         index,
@@ -402,12 +348,11 @@ class WorksQueryTest
 
       withClue(s"Using: ${queryType.name}") {
         results.size shouldBe matches.size
-        results should contain theSameElementsAs (matches)
+        results should contain theSameElementsAs matches
       }
     }
-  }
 
-  private def searchResults(index: Index, searchOptions: SearchOptions) = {
+  private def searchResults(index: Index, searchOptions: SearchOptions): List[Work[Identified]] = {
     val searchResponseFuture =
       searchService.executeSearch(searchOptions, WorksRequestBuilder, index)
     whenReady(searchResponseFuture) { response =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -62,7 +62,10 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                 }
               },
               "results": [
-                ${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}
+                ${works
+            .sortBy { _.state.canonicalId }
+            .map(workResponse)
+            .mkString(",")}
               ]
             }
           """
@@ -234,7 +237,10 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
+              "results": [${works
+            .sortBy { _.state.canonicalId }
+            .map(workResponse)
+            .mkString(",")}]
             }
           """
         }
@@ -289,7 +295,10 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
+              "results": [${works
+                            .sortBy { _.state.canonicalId }
+                            .map(workResponse)
+                            .mkString(",")}]
             }
           """.stripMargin
         }
@@ -297,7 +306,8 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on license") {
-    def createLicensedWork(licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+    def createLicensedWork(
+      licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
       val items =
         licenses.map { license =>
           createDigitalItemWith(license = Some(license))
@@ -351,7 +361,10 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
+              "results": [${works
+                            .sortBy { _.state.canonicalId }
+                            .map(workResponse)
+                            .mkString(",")}]
             }
           """.stripMargin
         }
@@ -405,7 +418,10 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                 },
                 "type" : "Aggregations"
               },
-              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
+              "results": [${works
+                            .sortBy { _.state.canonicalId }
+                            .map(workResponse)
+                            .mkString(",")}]
             }
           """.stripMargin
         }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -9,37 +9,23 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   it("supports fetching the format aggregation") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "1",
-          title = Some("Working with wombats"),
-          format = Some(Books)
+        val formats = List(
+          Books,
+          Books,
+          Books,
+          Pictures,
+          Pictures,
+          Journals
         )
-        val work2 = createIdentifiedWorkWith(
-          canonicalId = "2",
-          title = Some("Working with wombats"),
-          format = Some(Books)
-        )
-        val work3 = createIdentifiedWorkWith(
-          canonicalId = "3",
-          title = Some("Working with wombats"),
-          format = Some(Pictures)
-        )
-        val work4 = createIdentifiedWorkWith(
-          canonicalId = "4",
-          title = Some("Working with wombats"),
-          format = Some(Pictures)
-        )
-        val work5 = createIdentifiedWorkWith(
-          canonicalId = "5",
-          title = Some("Working with wombats"),
-          format = Some(Journals)
-        )
-        insertIntoElasticsearch(worksIndex, work1, work2, work3, work4, work5)
+
+        val works = formats.map { identifiedWork().format(_) }
+
+        insertIntoElasticsearch(worksIndex, works: _*)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=workType") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 5)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations": {
                 "type" : "Aggregations",
                 "workType": {
@@ -51,7 +37,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                         "label" : "Books",
                         "type" : "Format"
                       },
-                      "count" : 2,
+                      "count" : 3,
                       "type" : "AggregationBucket"
                     },
                     {
@@ -76,11 +62,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                 }
               },
               "results": [
-                ${workResponse(work1)},
-                ${workResponse(work2)},
-                ${workResponse(work3)},
-                ${workResponse(work4)},
-                ${workResponse(work5)}
+                ${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}
               ]
             }
           """
@@ -109,13 +91,9 @@ class WorksAggregationsTest extends ApiWorksTestBase {
           concepts = List(concept0, concept1, concept2)
         )
 
-        val work1 = createIdentifiedWorkWith(
-          canonicalId = "1",
-          title = Some("Working with wombats"),
-          genres = List(genre)
-        )
+        val work = identifiedWork().genres(List(genre))
 
-        insertIntoElasticsearch(worksIndex, work1)
+        insertIntoElasticsearch(worksIndex, work)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=genres") {
           Status.OK -> s"""
@@ -156,7 +134,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${workResponse(work1)}]
+              "results": [${workResponse(work)}]
             }
           """
         }
@@ -182,7 +160,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
           s"/$apiPrefix/works?aggregations=production.dates") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 4)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations": {
                 "type" : "Aggregations",
                 "production.dates": {
@@ -215,25 +193,21 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on language") {
-    val works = List(
-      createIdentifiedWorkWith(
-        language = Some(Language("English", Some("eng")))
-      ),
-      createIdentifiedWorkWith(
-        language = Some(Language("German", Some("ger")))
-      ),
-      createIdentifiedWorkWith(
-        language = Some(Language("German", Some("ger")))
-      ),
-      createIdentifiedWorkWith(language = None)
-    ).sortBy(_.state.canonicalId)
+    val languages = List(
+      Language("English", Some("eng")),
+      Language("German", Some("ger")),
+      Language("German", Some("ger"))
+    )
+
+    val works = languages.map { identifiedWork().language(_) }
+
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=language") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 4)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations": {
                 "type" : "Aggregations",
                 "language": {
@@ -260,7 +234,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.map(workResponse).mkString(",")}]
+              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
             }
           """
         }
@@ -268,32 +242,27 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on subject, ordered by frequency") {
-
     val paeleoNeuroBiology = createSubjectWith(label = "paeleoNeuroBiology")
     val realAnalysis = createSubjectWith(label = "realAnalysis")
 
-    val works = List(
-      createIdentifiedWorkWith(
-        subjects = List(paeleoNeuroBiology)
-      ),
-      createIdentifiedWorkWith(
-        subjects = List(realAnalysis)
-      ),
-      createIdentifiedWorkWith(
-        subjects = List(realAnalysis)
-      ),
-      createIdentifiedWorkWith(
-        subjects = List(paeleoNeuroBiology, realAnalysis)
-      ),
-      createIdentifiedWorkWith(subjects = Nil)
-    ).sortBy(_.state.canonicalId)
+    val subjectLists = List(
+      List(paeleoNeuroBiology),
+      List(realAnalysis),
+      List(realAnalysis),
+      List(paeleoNeuroBiology, realAnalysis),
+      List.empty
+    )
+
+    val works = subjectLists
+      .map { identifiedWork().subjects(_) }
+
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=subjects") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 5)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations": {
                 "type" : "Aggregations",
                 "subjects": {
@@ -320,7 +289,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.map(workResponse).mkString(",")}]
+              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
             }
           """.stripMargin
         }
@@ -328,37 +297,39 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on license") {
-    def createLicensedWork(
-      canonicalId: String,
-      licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
+    def createLicensedWork(licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
       val items =
         licenses.map { license =>
           createDigitalItemWith(license = Some(license))
         }.toList
 
-      identifiedWork(canonicalId = canonicalId).items(items)
+      identifiedWork().items(items)
     }
 
-    val works = List(
-      createLicensedWork("A", licenses = List(License.CCBY)),
-      createLicensedWork("B", licenses = List(License.CCBYNC)),
-      createLicensedWork("C", licenses = List(License.CCBY, License.CCBYNC)),
-      createLicensedWork("D", licenses = List.empty)
+    val licenseLists = List(
+      List(License.CCBY),
+      List(License.CCBY),
+      List(License.CCBYNC),
+      List(License.CCBY, License.CCBYNC),
+      List.empty
     )
+
+    val works = licenseLists.map { createLicensedWork(_) }
+
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=license") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 4)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations": {
                 "type" : "Aggregations",
                 "license": {
                   "type" : "Aggregation",
                   "buckets": [
                     {
-                      "count" : 2,
+                      "count" : 3,
                       "data" : {
                         "id" : "cc-by",
                         "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -380,7 +351,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works.map(workResponse).mkString(",")}]
+              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
             }
           """.stripMargin
         }
@@ -388,20 +359,18 @@ class WorksAggregationsTest extends ApiWorksTestBase {
   }
 
   it("supports aggregating on locationType") {
-    val works = List(
-      identifiedWork(canonicalId = "A").items(
-        List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
-      ),
-      identifiedWork(canonicalId = "B").items(
-        List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
-      ),
-      identifiedWork(canonicalId = "C").items(
-        List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
-      ),
-      identifiedWork(canonicalId = "D").items(
-        List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
-      )
+    val locations = List(
+      createPhysicalLocation,
+      createPhysicalLocation,
+      createDigitalLocation,
+      createDigitalLocation,
+      createDigitalLocation
     )
+
+    val works = locations.map { loc =>
+      identifiedWork()
+        .items(List(createIdentifiedItemWith(locations = List(loc))))
+    }
 
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
@@ -411,12 +380,12 @@ class WorksAggregationsTest extends ApiWorksTestBase {
           s"/$apiPrefix/works?aggregations=locationType") {
           Status.OK -> s"""
             {
-              ${resultList(apiPrefix, totalResults = 4)},
+              ${resultList(apiPrefix, totalResults = works.size)},
               "aggregations" : {
                 "locationType" : {
                   "buckets" : [
                     {
-                      "count" : 2,
+                      "count" : 3,
                       "data" : {
                         "label" : "Online",
                         "type" : "DigitalLocation"
@@ -436,7 +405,7 @@ class WorksAggregationsTest extends ApiWorksTestBase {
                 },
                 "type" : "Aggregations"
               },
-              "results": [${works.map(workResponse).mkString(",")}]
+              "results": [${works.sortBy { _.state.canonicalId }.map(workResponse).mkString(",")}]
             }
           """.stripMargin
         }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -20,20 +20,17 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
           (Books, Language("Meow", Some("cats"))),
           (Journals, Language("Quack", Some("ducks"))),
           (Audio, Language("Croak", Some("frogs")))
-        ).zipWithIndex.map {
-          case ((format, language), i) =>
-            createIdentifiedWorkWith(
-              title = Some("Robust rambutan"),
-              canonicalId = i.toString,
-              format = Some(format),
-              language = Some(language)
-            )
+        ).map {
+          case (format, language) =>
+            identifiedWork()
+              .format(format)
+              .language(language)
         }
 
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,
-          s"/$apiPrefix/works?query=rambutan&workType=a&aggregations=language") {
+          s"/$apiPrefix/works?workType=a&aggregations=language") {
           Status.OK -> s"""
             {
               ${resultList(
@@ -68,6 +65,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
               },
               "results": [${works
                             .filter(_.data.format.get == Books)
+                            .sortBy { _.state.canonicalId }
                             .map(workResponse)
                             .mkString(",")}]
             }
@@ -90,20 +88,17 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
           (Books, Language("Meow", Some("cats"))),
           (Journals, Language("Quack", Some("ducks"))),
           (Audio, Language("Croak", Some("frogs")))
-        ).zipWithIndex.map {
-          case ((format, language), i) =>
-            createIdentifiedWorkWith(
-              title = Some("Robust rambutan"),
-              canonicalId = i.toString,
-              format = Some(format),
-              language = Some(language)
-            )
+        ).map {
+          case (format, language) =>
+            identifiedWork()
+              .format(format)
+              .language(language)
         }
 
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,
-          s"/$apiPrefix/works?query=rambutan&workType=a&aggregations=workType") {
+          s"/$apiPrefix/works?workType=a&aggregations=workType") {
           Status.OK -> s"""
             {
               ${resultList(
@@ -156,6 +151,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
               },
               "results": [${works
                             .filter(_.data.format.get == Books)
+                            .sortBy { _.state.canonicalId }
                             .map(workResponse)
                             .mkString(",")}]
             }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -8,7 +8,6 @@ import uk.ac.wellcome.models.work.internal.Format.{
 }
 import uk.ac.wellcome.models.work.internal._
 
-
 class WorksFiltersTest extends ApiWorksTestBase {
   it("combines multiple filters") {
     val work1 = identifiedWork()
@@ -39,7 +38,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
       identifiedWork()
         .title("An example digital work")
         .items(
-          List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
+          List(
+            createIdentifiedItemWith(locations = List(createDigitalLocation)))
         )
     }
 
@@ -47,7 +47,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
       identifiedWork()
         .title("An example physical work")
         .items(
-          List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
+          List(
+            createIdentifiedItemWith(locations = List(createPhysicalLocation)))
         )
     }
 
@@ -55,7 +56,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
       identifiedWork()
         .title("An example combo work")
         .items(
-          List(createIdentifiedItemWith(locations = List(createPhysicalLocation, createDigitalLocation)))
+          List(
+            createIdentifiedItemWith(
+              locations = List(createPhysicalLocation, createDigitalLocation)))
         )
     }
 
@@ -150,20 +153,23 @@ class WorksFiltersTest extends ApiWorksTestBase {
 
     val work1 = identifiedWork()
       .title("Crumbling carrots")
-      .items(List(
-        createItemWithLocationType(LocationType("iiif-image"))
-      ))
+      .items(
+        List(
+          createItemWithLocationType(LocationType("iiif-image"))
+        ))
     val work2 = identifiedWork()
       .title("Crumbling carrots")
-      .items(List(
-        createItemWithLocationType(LocationType("digit")),
-        createItemWithLocationType(LocationType("dimgs"))
-      ))
+      .items(
+        List(
+          createItemWithLocationType(LocationType("digit")),
+          createItemWithLocationType(LocationType("dimgs"))
+        ))
     val work3 = identifiedWork()
       .title("Crumbling carrots")
-      .items(List(
-        createItemWithLocationType(LocationType("dpoaa"))
-      ))
+      .items(
+        List(
+          createItemWithLocationType(LocationType("dpoaa"))
+        ))
 
     val works = worksWithNoItem ++ Seq(work1, work2, work3)
 
@@ -244,7 +250,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id},${CDRoms.id}") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(cdRomWork, manuscriptWork).sortBy { _.state.canonicalId }
+              works = Seq(cdRomWork, manuscriptWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -260,7 +268,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?query=apple&workType=${ManuscriptsAsian.id},${CDRoms.id}") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(cdRomWork, manuscriptWork).sortBy { _.state.canonicalId }
+              works = Seq(cdRomWork, manuscriptWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -302,7 +312,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
             unordered = true) {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(collectionWork, seriesWork).sortBy { _.state.canonicalId }
+              works = Seq(collectionWork, seriesWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -319,7 +331,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
             unordered = true) {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(seriesWork, sectionWork).sortBy { _.state.canonicalId }
+              works = Seq(seriesWork, sectionWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -372,7 +386,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?production.dates.to=1960-01-01") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(work1709, work1950).sortBy { _.state.canonicalId}
+              works = Seq(work1709, work1950).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -396,7 +410,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by language") {
-    val englishWork = identifiedWork().language(Language("English", Some("eng")))
+    val englishWork =
+      identifiedWork().language(Language("English", Some("eng")))
     val germanWork = identifiedWork().language(Language("German", Some("ger")))
     val noLanguageWork = identifiedWork()
 
@@ -419,7 +434,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng,ger") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(englishWork, germanWork).sortBy { _.state.canonicalId }
+              works = Seq(englishWork, germanWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -444,7 +461,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(horrorWork, romcomHorrorWork).sortBy { _.state.canonicalId }
+              works = Seq(horrorWork, romcomHorrorWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -469,9 +488,11 @@ class WorksFiltersTest extends ApiWorksTestBase {
     val nineteenthCentury = createSubjectWith("19th Century")
     val paris = createSubjectWith("Paris")
 
-    val nineteenthCenturyWork = identifiedWork().subjects(List(nineteenthCentury))
+    val nineteenthCenturyWork =
+      identifiedWork().subjects(List(nineteenthCentury))
     val parisWork = identifiedWork().subjects(List(paris))
-    val nineteenthCenturyParisWork = identifiedWork().subjects(List(nineteenthCentury, paris))
+    val nineteenthCenturyParisWork =
+      identifiedWork().subjects(List(nineteenthCentury, paris))
     val noSubjectWork = identifiedWork()
 
     val works = List(
@@ -487,7 +508,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(parisWork, nineteenthCenturyParisWork).sortBy { _.state.canonicalId }
+              works = Seq(parisWork, nineteenthCenturyParisWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -535,7 +558,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?license=cc-by") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(ccByWork, bothLicenseWork).sortBy { _.state.canonicalId }
+              works = Seq(ccByWork, bothLicenseWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -550,7 +575,9 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?license=cc-by,cc-by-nc") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(ccByWork, ccByNcWork, bothLicenseWork).sortBy { _.state.canonicalId }
+              works = Seq(ccByWork, ccByNcWork, bothLicenseWork).sortBy {
+                _.state.canonicalId
+              }
             )
           }
       }
@@ -599,7 +626,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by an otherIdentifier") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
+          val work =
+            identifiedWork().otherIdentifiers(List(createSourceIdentifier))
           insertIntoElasticsearch(worksIndex, unknownWork, work)
           assertJsonResponse(
             routes,
@@ -615,8 +643,10 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by multiple otherIdentifiers") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work1 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
-          val work2 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
+          val work1 =
+            identifiedWork().otherIdentifiers(List(createSourceIdentifier))
+          val work2 =
+            identifiedWork().otherIdentifiers(List(createSourceIdentifier))
 
           insertIntoElasticsearch(worksIndex, unknownWork, work1, work2)
           assertJsonResponse(
@@ -634,7 +664,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           val work1 = identifiedWork()
-          val work2 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
+          val work2 =
+            identifiedWork().otherIdentifiers(List(createSourceIdentifier))
 
           insertIntoElasticsearch(worksIndex, unknownWork, work1, work2)
           assertJsonResponse(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -8,22 +8,18 @@ import uk.ac.wellcome.models.work.internal.Format.{
 }
 import uk.ac.wellcome.models.work.internal._
 
-import scala.util.Random
 
 class WorksFiltersTest extends ApiWorksTestBase {
   it("combines multiple filters") {
-    val work1 = createIdentifiedWorkWith(
-      genres = List(createGenreWith(label = "horror")),
-      subjects = List(createSubjectWith(label = "france"))
-    )
-    val work2 = createIdentifiedWorkWith(
-      genres = List(createGenreWith(label = "horror")),
-      subjects = List(createSubjectWith(label = "england"))
-    )
-    val work3 = createIdentifiedWorkWith(
-      genres = List(createGenreWith(label = "fantasy")),
-      subjects = List(createSubjectWith(label = "england"))
-    )
+    val work1 = identifiedWork()
+      .genres(List(createGenreWith(label = "horror")))
+      .subjects(List(createSubjectWith(label = "france")))
+    val work2 = identifiedWork()
+      .genres(List(createGenreWith(label = "horror")))
+      .subjects(List(createSubjectWith(label = "england")))
+    val work3 = identifiedWork()
+      .genres(List(createGenreWith(label = "fantasy")))
+      .subjects(List(createSubjectWith(label = "england")))
 
     val works = Seq(work1, work2, work3)
 
@@ -39,102 +35,46 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering by item Location type") {
-    val digitalWork1 = createIdentifiedWorkWith(
-      canonicalId = "1",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(locations = List(createDigitalLocation))
-      )
-    )
-    val digitalWork2 = createIdentifiedWorkWith(
-      canonicalId = "2",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(locations = List(createDigitalLocation))
-      )
-    )
-    val physicalWork1 = createIdentifiedWorkWith(
-      canonicalId = "3",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(locations = List(createPhysicalLocation))
-      )
-    )
-    val physicalWork2 = createIdentifiedWorkWith(
-      canonicalId = "4",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(locations = List(createPhysicalLocation))
-      )
-    )
-    val comboWork1 = createIdentifiedWorkWith(
-      canonicalId = "5",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(
-          locations = List(createPhysicalLocation, createDigitalLocation))
-      )
-    )
-    val comboWork2 = createIdentifiedWorkWith(
-      canonicalId = "6",
-      title = Some("locationtype"),
-      items = List(
-        createIdentifiedItemWith(
-          locations = List(createDigitalLocation, createPhysicalLocation))
-      )
-    )
+    val digitalWorks = (1 to 2).map { _ =>
+      identifiedWork()
+        .title("An example digital work")
+        .items(
+          List(createIdentifiedItemWith(locations = List(createDigitalLocation)))
+        )
+    }
 
-    val works = List(
-      digitalWork1,
-      digitalWork2,
-      physicalWork1,
-      physicalWork2,
-      comboWork1,
-      comboWork2)
+    val physicalWorks = (1 to 2).map { _ =>
+      identifiedWork()
+        .title("An example physical work")
+        .items(
+          List(createIdentifiedItemWith(locations = List(createPhysicalLocation)))
+        )
+    }
+
+    val comboWorks = (1 to 2).map { _ =>
+      identifiedWork()
+        .title("An example combo work")
+        .items(
+          List(createIdentifiedItemWith(locations = List(createPhysicalLocation, createDigitalLocation)))
+        )
+    }
+
+    val works = digitalWorks ++ physicalWorks ++ comboWorks
 
     it("filters by PhysicalLocation when listing") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = physicalWorks ++ comboWorks
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?items.locations.type=PhysicalLocation&include=items") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 4)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${physicalWork1.state.canonicalId}",
-                  "title": "${physicalWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(physicalWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${physicalWork2.state.canonicalId}",
-                  "title": "${physicalWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(physicalWork2.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork1.state.canonicalId}",
-                  "title": "${comboWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork2.state.canonicalId}",
-                  "title": "${comboWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?items.locations.type=PhysicalLocation") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -144,44 +84,15 @@ class WorksFiltersTest extends ApiWorksTestBase {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = physicalWorks ++ comboWorks
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?items.locations.type=PhysicalLocation&include=items&query=locationtype") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 4)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${physicalWork1.state.canonicalId}",
-                  "title": "${physicalWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(physicalWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${physicalWork2.state.canonicalId}",
-                  "title": "${physicalWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(physicalWork2.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork1.state.canonicalId}",
-                  "title": "${comboWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork2.state.canonicalId}",
-                  "title": "${comboWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?items.locations.type=PhysicalLocation&query=example") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -191,94 +102,36 @@ class WorksFiltersTest extends ApiWorksTestBase {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = digitalWorks ++ comboWorks
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?items.locations.type=DigitalLocation&include=items") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 4)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${digitalWork1.state.canonicalId}",
-                  "title": "${digitalWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(digitalWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${digitalWork2.state.canonicalId}",
-                  "title": "${digitalWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(digitalWork2.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork1.state.canonicalId}",
-                  "title": "${comboWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork2.state.canonicalId}",
-                  "title": "${comboWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?items.locations.type=DigitalLocation") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
+
     it("filters by DigitalLocation when searching") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = digitalWorks ++ comboWorks
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?items.locations.type=DigitalLocation&include=items&query=locationtype") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 4)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${digitalWork1.state.canonicalId}",
-                  "title": "${digitalWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(digitalWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${digitalWork2.state.canonicalId}",
-                  "title": "${digitalWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(digitalWork2.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork1.state.canonicalId}",
-                  "title": "${comboWork1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${comboWork2.state.canonicalId}",
-                  "title": "${comboWork2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(comboWork2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?items.locations.type=DigitalLocation&query=example") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
-
   }
 
   describe("filtering works by item LocationType") {
@@ -286,40 +139,31 @@ class WorksFiltersTest extends ApiWorksTestBase {
       locationType: LocationType): Item[IdState.Minted] =
       createIdentifiedItemWith(
         locations = List(
-          // This test really shouldn't be affected by physical/digital locations;
-          // we just pick randomly here to ensure we get a good mixture.
-          Random
-            .shuffle(
-              List(
-                createPhysicalLocationWith(locationType = locationType),
-                createDigitalLocationWith(locationType = locationType)
-              ))
-            .head
+          chooseFrom(
+            createPhysicalLocationWith(locationType = locationType),
+            createDigitalLocationWith(locationType = locationType)
+          )
         )
       )
 
-    val worksWithNoItem = createIdentifiedWorks(count = 3)
+    val worksWithNoItem = identifiedWorks(count = 3)
 
-    val work1 = createIdentifiedWorkWith(
-      canonicalId = "1",
-      title = Some("Crumbling carrots"),
-      items = List(
+    val work1 = identifiedWork()
+      .title("Crumbling carrots")
+      .items(List(
         createItemWithLocationType(LocationType("iiif-image"))
-      )
-    )
-    val work2 = createIdentifiedWorkWith(
-      canonicalId = "2",
-      title = Some("Crumbling carrots"),
-      items = List(
+      ))
+    val work2 = identifiedWork()
+      .title("Crumbling carrots")
+      .items(List(
         createItemWithLocationType(LocationType("digit")),
         createItemWithLocationType(LocationType("dimgs"))
-      )
-    )
-    val work3 = createIdentifiedWorkWith(
-      items = List(
+      ))
+    val work3 = identifiedWork()
+      .title("Crumbling carrots")
+      .items(List(
         createItemWithLocationType(LocationType("dpoaa"))
-      )
-    )
+      ))
 
     val works = worksWithNoItem ++ Seq(work1, work2, work3)
 
@@ -328,30 +172,15 @@ class WorksFiltersTest extends ApiWorksTestBase {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = Seq(work1, work2)
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?items.locations.locationType=iiif-image,digit&include=items") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 2)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${work1.state.canonicalId}",
-                  "title": "${work1.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(work1.data.items)}]
-                },
-                {
-                  "type": "Work",
-                  "id": "${work2.state.canonicalId}",
-                  "title": "${work2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(work2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?items.locations.locationType=iiif-image,digit") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -361,49 +190,32 @@ class WorksFiltersTest extends ApiWorksTestBase {
         case (ElasticConfig(worksIndex, _), routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
+          val matchingWorks = Seq(work2)
+
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/works?query=carrots&items.locations.locationType=digit&include=items") {
-            Status.OK -> s"""
-            {
-              ${resultList(apiPrefix, totalResults = 1)},
-              "results": [
-                {
-                  "type": "Work",
-                  "id": "${work2.state.canonicalId}",
-                  "title": "${work2.data.title.get}",
-                  "alternativeTitles": [],
-                  "items": [${items(work2.data.items)}]
-                }
-              ]
-            }
-          """
+            s"/$apiPrefix/works?query=carrots&items.locations.locationType=digit") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = matchingWorks.sortBy { _.state.canonicalId }
+            )
           }
       }
     }
   }
 
   describe("filtering works by Format") {
-    val noFormatWorks = (1 to 3).map { _ =>
-      createIdentifiedWorkWith(format = None)
-    }
+    val noFormatWorks = identifiedWorks(count = 3)
 
-    // We assign explicit canonical IDs to ensure stable ordering when listing
-    val bookWork = createIdentifiedWorkWith(
-      title = Some("apple apple apple"),
-      canonicalId = "book1",
-      format = Some(Books)
-    )
-    val cdRomWork = createIdentifiedWorkWith(
-      title = Some("apple apple"),
-      canonicalId = "cdrom1",
-      format = Some(CDRoms)
-    )
-    val manuscriptWork = createIdentifiedWorkWith(
-      title = Some("apple"),
-      canonicalId = "manuscript1",
-      format = Some(ManuscriptsAsian)
-    )
+    val bookWork = identifiedWork()
+      .title("apple")
+      .format(Books)
+    val cdRomWork = identifiedWork()
+      .title("apple")
+      .format(CDRoms)
+    val manuscriptWork = identifiedWork()
+      .title("apple")
+      .format(ManuscriptsAsian)
 
     val works = noFormatWorks ++ Seq(bookWork, cdRomWork, manuscriptWork)
 
@@ -432,7 +244,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?workType=${ManuscriptsAsian.id},${CDRoms.id}") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(cdRomWork, manuscriptWork))
+              works = Seq(cdRomWork, manuscriptWork).sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -447,7 +260,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?query=apple&workType=${ManuscriptsAsian.id},${CDRoms.id}") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(cdRomWork, manuscriptWork))
+              works = Seq(cdRomWork, manuscriptWork).sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -455,15 +269,11 @@ class WorksFiltersTest extends ApiWorksTestBase {
 
   describe("filtering works by type") {
     val collectionWork =
-      createIdentifiedWorkWith(
-        title = Some("rats"),
-        workType = WorkType.Collection)
-    val seriesWork = createIdentifiedWorkWith(
-      title = Some("rats rats"),
-      workType = WorkType.Series)
-    val sectionWork = createIdentifiedWorkWith(
-      title = Some("rats rats bats"),
-      workType = WorkType.Section)
+      identifiedWork().title("rats").workType(WorkType.Collection)
+    val seriesWork =
+      identifiedWork().title("rats").workType(WorkType.Series)
+    val sectionWork =
+      identifiedWork().title("rats").workType(WorkType.Section)
 
     val works = Seq(collectionWork, seriesWork, sectionWork)
 
@@ -492,7 +302,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
             unordered = true) {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(collectionWork, seriesWork)
+              works = Seq(collectionWork, seriesWork).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -509,7 +319,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
             unordered = true) {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(seriesWork, sectionWork)
+              works = Seq(seriesWork, sectionWork).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -517,24 +327,23 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by date range") {
-    def createDatedWork(canonicalId: String,
-                        dateLabel: String): Work.Visible[WorkState.Identified] =
-      identifiedWork(canonicalId = canonicalId)
+    def createDatedWork(dateLabel: String): Work.Visible[WorkState.Identified] =
+      identifiedWork()
         .production(
           List(createProductionEventWith(dateLabel = Some(dateLabel))))
 
-    val work1 = createDatedWork(canonicalId = "1", dateLabel = "1709")
-    val work2 = createDatedWork(canonicalId = "2", dateLabel = "1950")
-    val work3 = createDatedWork(canonicalId = "3", dateLabel = "2000")
+    val work1709 = createDatedWork(dateLabel = "1709")
+    val work1950 = createDatedWork(dateLabel = "1950")
+    val work2000 = createDatedWork(dateLabel = "2000")
 
     it("filters by date range") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          insertIntoElasticsearch(worksIndex, work1, work2, work3)
+          insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.from=1900-01-01&production.dates.to=1960-01-01") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(work2))
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(work1950))
           }
       }
     }
@@ -542,11 +351,14 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by from date") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          insertIntoElasticsearch(worksIndex, work1, work2, work3)
+          insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.from=1900-01-01") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(work2, work3))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(work1950, work2000).sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -554,11 +366,14 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by to date") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          insertIntoElasticsearch(worksIndex, work1, work2, work3)
+          insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.to=1960-01-01") {
-            Status.OK -> worksListResponse(apiPrefix, works = Seq(work1, work2))
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(work1709, work1950).sortBy { _.state.canonicalId}
+            )
           }
       }
     }
@@ -566,7 +381,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("errors on invalid date") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          insertIntoElasticsearch(worksIndex, work1, work2, work3)
+          insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?production.dates.from=1900-01-01&production.dates.to=INVALID") {
@@ -581,17 +396,10 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("filtering works by language") {
-    val englishWork = createIdentifiedWorkWith(
-      canonicalId = "1",
-      title = Some("Caterpiller"),
-      language = Some(Language("English", Some("eng")))
-    )
-    val germanWork = createIdentifiedWorkWith(
-      canonicalId = "2",
-      title = Some("Ubergang"),
-      language = Some(Language("German", Some("ger")))
-    )
-    val noLanguageWork = createIdentifiedWorkWith(title = Some("£@@!&$"))
+    val englishWork = identifiedWork().language(Language("English", Some("eng")))
+    val germanWork = identifiedWork().language(Language("German", Some("ger")))
+    val noLanguageWork = identifiedWork()
+
     val works = List(englishWork, germanWork, noLanguageWork)
 
     it("filters by language") {
@@ -611,7 +419,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng,ger") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(englishWork, germanWork))
+              works = Seq(englishWork, germanWork).sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -621,25 +430,10 @@ class WorksFiltersTest extends ApiWorksTestBase {
     val horror = createGenreWith("horrible stuff")
     val romcom = createGenreWith("heartwarming stuff")
 
-    val horrorWork = createIdentifiedWorkWith(
-      title = Some("horror"),
-      canonicalId = "1",
-      genres = List(horror)
-    )
-    val romcomWork = createIdentifiedWorkWith(
-      title = Some("romcom"),
-      canonicalId = "2",
-      genres = List(romcom)
-    )
-    val romcomHorrorWork = createIdentifiedWorkWith(
-      title = Some("romcom horror"),
-      canonicalId = "3",
-      genres = List(romcom, horror)
-    )
-    val noGenreWork = createIdentifiedWorkWith(
-      title = Some("no genre"),
-      canonicalId = "4"
-    )
+    val horrorWork = identifiedWork().genres(List(horror))
+    val romcomWork = identifiedWork().genres(List(romcom))
+    val romcomHorrorWork = identifiedWork().genres(List(romcom, horror))
+    val noGenreWork = identifiedWork()
 
     val works = List(horrorWork, romcomWork, romcomHorrorWork, noGenreWork)
 
@@ -650,7 +444,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(horrorWork, romcomHorrorWork))
+              works = Seq(horrorWork, romcomHorrorWork).sortBy { _.state.canonicalId }
+            )
           }
       }
     }
@@ -674,25 +469,10 @@ class WorksFiltersTest extends ApiWorksTestBase {
     val nineteenthCentury = createSubjectWith("19th Century")
     val paris = createSubjectWith("Paris")
 
-    val nineteenthCenturyWork = createIdentifiedWorkWith(
-      title = Some("19th century"),
-      canonicalId = "1",
-      subjects = List(nineteenthCentury)
-    )
-    val parisWork = createIdentifiedWorkWith(
-      title = Some("paris"),
-      canonicalId = "2",
-      subjects = List(paris)
-    )
-    val nineteenthCenturyParisWork = createIdentifiedWorkWith(
-      title = Some("19th century paris"),
-      canonicalId = "3",
-      subjects = List(nineteenthCentury, paris)
-    )
-    val noSubjectWork = createIdentifiedWorkWith(
-      title = Some("no subject"),
-      canonicalId = "4"
-    )
+    val nineteenthCenturyWork = identifiedWork().subjects(List(nineteenthCentury))
+    val parisWork = identifiedWork().subjects(List(paris))
+    val nineteenthCenturyParisWork = identifiedWork().subjects(List(nineteenthCentury, paris))
+    val noSubjectWork = identifiedWork()
 
     val works = List(
       nineteenthCenturyWork,
@@ -707,7 +487,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
             Status.OK -> worksListResponse(
               apiPrefix,
-              works = Seq(parisWork, nineteenthCenturyParisWork)
+              works = Seq(parisWork, nineteenthCenturyParisWork).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -731,21 +511,20 @@ class WorksFiltersTest extends ApiWorksTestBase {
 
   describe("filtering works by license") {
     def createLicensedWork(
-      canonicalId: String,
       licenses: Seq[License]): Work.Visible[WorkState.Identified] = {
       val items =
         licenses.map { license =>
           createDigitalItemWith(license = Some(license))
         }.toList
 
-      identifiedWork(canonicalId = canonicalId).items(items)
+      identifiedWork().items(items)
     }
 
-    val ccByWork = createLicensedWork("A", licenses = List(License.CCBY))
-    val ccByNcWork = createLicensedWork("B", licenses = List(License.CCBYNC))
+    val ccByWork = createLicensedWork(licenses = List(License.CCBY))
+    val ccByNcWork = createLicensedWork(licenses = List(License.CCBYNC))
     val bothLicenseWork =
-      createLicensedWork("C", licenses = List(License.CCBY, License.CCBYNC))
-    val noLicenseWork = createLicensedWork("D", licenses = List.empty)
+      createLicensedWork(licenses = List(License.CCBY, License.CCBYNC))
+    val noLicenseWork = createLicensedWork(licenses = List.empty)
 
     val works = List(ccByWork, ccByNcWork, bothLicenseWork, noLicenseWork)
 
@@ -756,7 +535,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
           assertJsonResponse(routes, s"/$apiPrefix/works?license=cc-by") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(ccByWork, bothLicenseWork)
+              works = Seq(ccByWork, bothLicenseWork).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -771,7 +550,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?license=cc-by,cc-by-nc") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(ccByWork, ccByNcWork, bothLicenseWork)
+              works = Seq(ccByWork, ccByNcWork, bothLicenseWork).sortBy { _.state.canonicalId }
             )
           }
       }
@@ -779,13 +558,12 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("Identifiers filter") {
-    val unknownWork = createIdentifiedWork
+    val unknownWork = identifiedWork()
 
     it("filters by a sourceIdentifier") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work =
-            createIdentifiedWorkWith(sourceIdentifier = createSourceIdentifier)
+          val work = identifiedWork()
           insertIntoElasticsearch(worksIndex, unknownWork, work)
 
           assertJsonResponse(
@@ -793,7 +571,7 @@ class WorksFiltersTest extends ApiWorksTestBase {
             s"/$apiPrefix/works?identifiers=${work.sourceIdentifier.value}") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(work).sortBy(_.state.canonicalId)
+              works = Seq(work)
             )
           }
       }
@@ -802,10 +580,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by multiple sourceIdentifiers") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work1 =
-            createIdentifiedWorkWith(sourceIdentifier = createSourceIdentifier)
-          val work2 =
-            createIdentifiedWorkWith(sourceIdentifier = createSourceIdentifier)
+          val work1 = identifiedWork()
+          val work2 = identifiedWork()
 
           insertIntoElasticsearch(worksIndex, unknownWork, work1, work2)
 
@@ -823,16 +599,14 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by an otherIdentifier") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work =
-            createIdentifiedWorkWith(
-              otherIdentifiers = List(createSourceIdentifier))
+          val work = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
           insertIntoElasticsearch(worksIndex, unknownWork, work)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works?identifiers=${work.data.otherIdentifiers.head.value}") {
             Status.OK -> worksListResponse(
               apiPrefix = apiPrefix,
-              works = Seq(work).sortBy(_.state.canonicalId)
+              works = Seq(work)
             )
           }
       }
@@ -841,13 +615,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by multiple otherIdentifiers") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work1 =
-            createIdentifiedWorkWith(
-              otherIdentifiers = List(createSourceIdentifier))
-
-          val work2 =
-            createIdentifiedWorkWith(
-              otherIdentifiers = List(createSourceIdentifier))
+          val work1 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
+          val work2 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
 
           insertIntoElasticsearch(worksIndex, unknownWork, work1, work2)
           assertJsonResponse(
@@ -864,12 +633,8 @@ class WorksFiltersTest extends ApiWorksTestBase {
     it("filters by mixed identifiers") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work1 =
-            createIdentifiedWork
-
-          val work2 =
-            createIdentifiedWorkWith(
-              otherIdentifiers = List(createSourceIdentifier))
+          val work1 = identifiedWork()
+          val work2 = identifiedWork().otherIdentifiers(List(createSourceIdentifier))
 
           insertIntoElasticsearch(worksIndex, unknownWork, work1, work2)
           assertJsonResponse(
@@ -885,23 +650,23 @@ class WorksFiltersTest extends ApiWorksTestBase {
   }
 
   describe("Access status filter") {
-
-    def work(status: AccessStatus) =
-      createIdentifiedWorkWith(
-        items = List(
-          createIdentifiedItemWith(
-            locations = List(
-              createDigitalLocationWith(
-                accessConditions = List(
-                  AccessCondition(
-                    status = Some(status)
+    def work(status: AccessStatus): Work.Visible[WorkState.Identified] =
+      identifiedWork()
+        .items(
+          List(
+            createIdentifiedItemWith(
+              locations = List(
+                createDigitalLocationWith(
+                  accessConditions = List(
+                    AccessCondition(
+                      status = Some(status)
+                    )
                   )
                 )
               )
             )
           )
         )
-      )
 
     val workA = work(AccessStatus.Restricted)
     val workB = work(AccessStatus.Restricted)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -94,10 +94,11 @@ class WorksIncludesTest
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         val work = identifiedWork()
-          .items(List(
-            createIdentifiedItemWith(title = Some("item title")),
-            createUnidentifiableItemWith()
-          ))
+          .items(
+            List(
+              createIdentifiedItemWith(title = Some("item title")),
+              createUnidentifiableItemWith()
+            ))
 
         insertIntoElasticsearch(worksIndex, work)
 
@@ -222,7 +223,8 @@ class WorksIncludesTest
       "includes a list of genres on a single work endpoint if we pass ?include=genres") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work = identifiedWork().genres(List(Genre("ornithology", List(Concept("ornithology")))))
+          val work = identifiedWork().genres(
+            List(Genre("ornithology", List(Concept("ornithology")))))
 
           insertIntoElasticsearch(worksIndex, work)
 
@@ -252,8 +254,10 @@ class WorksIncludesTest
             List(Contributor(Person("Ginger Rogers"), roles = Nil))
           val contributors2 =
             List(Contributor(Person("Fred Astair"), roles = Nil))
-          val work1 = identifiedWork(canonicalId = "1").contributors(contributors1)
-          val work2 = identifiedWork(canonicalId = "2").contributors(contributors2)
+          val work1 =
+            identifiedWork(canonicalId = "1").contributors(contributors1)
+          val work2 =
+            identifiedWork(canonicalId = "2").contributors(contributors2)
 
           insertIntoElasticsearch(worksIndex, work1, work2)
 
@@ -288,7 +292,8 @@ class WorksIncludesTest
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
           val work = identifiedWork()
-            .contributors(List(Contributor(Person("Ginger Rogers"), roles = Nil)))
+            .contributors(
+              List(Contributor(Person("Ginger Rogers"), roles = Nil)))
 
           insertIntoElasticsearch(worksIndex, work)
 
@@ -316,8 +321,10 @@ class WorksIncludesTest
         case (ElasticConfig(worksIndex, _), routes) =>
           val productionEvents1 = createProductionEventList()
           val productionEvents2 = createProductionEventList()
-          val work1 = identifiedWork(canonicalId = "1").production(productionEvents1)
-          val work2 = identifiedWork(canonicalId = "2").production(productionEvents2)
+          val work1 =
+            identifiedWork(canonicalId = "1").production(productionEvents1)
+          val work2 =
+            identifiedWork(canonicalId = "2").production(productionEvents2)
 
           insertIntoElasticsearch(worksIndex, work1, work2)
 
@@ -440,7 +447,8 @@ class WorksIncludesTest
     it("includes notes on the single work endpoint if we pass ?include=notes") {
       withApi {
         case (ElasticConfig(worksIndex, _), routes) =>
-          val work = identifiedWork().notes(List(GeneralNote("A"), GeneralNote("B")))
+          val work =
+            identifiedWork().notes(List(GeneralNote("A"), GeneralNote("B")))
           insertIntoElasticsearch(worksIndex, work)
           assertJsonResponse(
             routes,
@@ -476,9 +484,11 @@ class WorksIncludesTest
         case (ElasticConfig(worksIndex, _), routes) =>
           val works = List(
             identifiedWork()
-              .images((1 to 3).map(_ => createUnmergedImage.toIdentified).toList),
+              .images(
+                (1 to 3).map(_ => createUnmergedImage.toIdentified).toList),
             identifiedWork()
-              .images((1 to 3).map(_ => createUnmergedImage.toIdentified).toList)
+              .images(
+                (1 to 3).map(_ => createUnmergedImage.toIdentified).toList)
           ).sortBy { _.state.canonicalId }
 
           insertIntoElasticsearch(worksIndex, works: _*)
@@ -537,8 +547,10 @@ class WorksIncludesTest
   }
 
   describe("relation includes") {
-    def work(path: String, workType: WorkType): Work.Visible[WorkState.Identified] =
-      identifiedWork(sourceIdentifier = createSourceIdentifierWith(value = path))
+    def work(path: String,
+             workType: WorkType): Work.Visible[WorkState.Identified] =
+      identifiedWork(
+        sourceIdentifier = createSourceIdentifierWith(value = path))
         .collectionPath(CollectionPath(path = path))
         .title(path)
         .workType(workType)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
@@ -21,7 +21,7 @@ class WorksTestInvisible extends ApiWorksTestBase {
   it("excludes works with visible=false from list results") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val works = createIdentifiedWorks(count = 2).sortBy {
+        val works = identifiedWorks(count = 2).sortBy {
           _.state.canonicalId
         }
 
@@ -37,9 +37,7 @@ class WorksTestInvisible extends ApiWorksTestBase {
   it("excludes works with visible=false from search results") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWorkWith(
-          title = Some("This shouldn't be deleted!")
-        )
+        val work = identifiedWork().title("This shouldn't be deleted!")
         insertIntoElasticsearch(worksIndex, work, deletedWork)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?query=deleted") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
@@ -5,8 +5,7 @@ import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
 class WorksTestInvisible extends ApiWorksTestBase {
-
-  val deletedWork = createIdentifiedInvisibleWork
+  val deletedWork: Work.Invisible[Identified] = identifiedWork().invisible()
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withApi {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -27,29 +27,6 @@ trait LegacyWorkGenerators
   def createInvisibleSourceWork: Work.Invisible[Source] =
     createInvisibleSourceWorkWith()
 
-  def createIdentifiedInvisibleWorkWith(
-    canonicalId: String = createCanonicalId,
-    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    version: Int = 1
-  ): Work.Invisible[Identified] =
-    Work.Invisible(
-      state = Identified(
-        sourceIdentifier = sourceIdentifier,
-        canonicalId = canonicalId,
-      ),
-      version = version,
-      data = WorkData()
-    )
-
-  def createIdentifiedInvisibleWork: Work.Invisible[Identified] =
-    createIdentifiedInvisibleWorkWith()
-
-  def createIdentifiedInvisibleWorks(
-    count: Int): Seq[Work.Invisible[Identified]] =
-    (1 to count).map { _ =>
-      createIdentifiedInvisibleWork
-    }
-
   def createSourceWorkWith(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     version: Int = 1,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -73,11 +73,6 @@ trait LegacyWorkGenerators
   def createSourceWork: Work.Visible[Source] =
     createSourceWorkWith()
 
-  def createSourceWorks(count: Int): Seq[Work.Visible[Source]] =
-    (1 to count).map { _ =>
-      createSourceWork
-    }
-
   def createIdentifiedWorkWith(
     canonicalId: String = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -9,7 +9,7 @@ trait WorkGenerators extends IdentifiersGenerators {
   private def createVersion: Int =
     Random.nextInt(100) + 1
 
-  private def chooseFrom[T](seq: T*): T =
+  def chooseFrom[T](seq: T*): T =
     seq(Random.nextInt(seq.size))
 
   def sourceWork(


### PR DESCRIPTION
Lots more low-hanging fruit, mostly focusing on use of `createIdentifiedWorkWith(…)`.

I don’t think this conflicts with any of Jamie’s work, but if it does I’ll sort it out.

For https://github.com/orgs/wellcomecollection/projects/2