### PR TITLE
Keep trimming the use of LegacyWorkGenerators in the catalogue API

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQueryTest.scala
@@ -241,8 +241,7 @@ class WorksQueryTest
         val work2 = identifiedWork()
 
         // We've put spaces in this as some Miro IDs are sentences
-        val work3 =
-          createIdentifiedWorkWith(canonicalId = "Oxford English Dictionary")
+        val work3 = identifiedWork(canonicalId = "Oxford English Dictionary")
 
         insertIntoElasticsearch(index, work1, work2, work3)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -96,7 +96,8 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
     withApi {
       case (ElasticConfig(_, imagesIndex), routes) =>
         val focacciaImage = createAugmentedImageWith(
-          parentWork = identifiedWork().title("A Ligurian style of bread, Focaccia")
+          parentWork =
+            identifiedWork().title("A Ligurian style of bread, Focaccia")
         )
         insertImagesIntoElasticsearch(imagesIndex, focacciaImage)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -96,8 +96,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
     withApi {
       case (ElasticConfig(_, imagesIndex), routes) =>
         val focacciaImage = createAugmentedImageWith(
-          parentWork = createIdentifiedWorkWith(
-            title = Some("A Ligurian style of bread, Focaccia"))
+          parentWork = identifiedWork().title("A Ligurian style of bread, Focaccia")
         )
         insertImagesIntoElasticsearch(imagesIndex, focacciaImage)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.api.images
 
 import uk.ac.wellcome.elasticsearch.ElasticConfig
-import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 
-class ImagesTest extends ApiImagesTestBase with ElasticsearchFixtures {
+class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
 
   it("returns a list of images") {
     withApi {
@@ -44,7 +44,7 @@ class ImagesTest extends ApiImagesTestBase with ElasticsearchFixtures {
   it("returns only linked images when a source work ID is requested") {
     withApi {
       case (ElasticConfig(_, imagesIndex), routes) =>
-        val parentWork = createIdentifiedSierraWorkWith()
+        val parentWork = sierraIdentifiedWork()
         val workImages =
           (0 to 3)
             .map(_ => createAugmentedImageWith(parentWork = parentWork))

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -118,10 +118,9 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
           imageId = IdState.Identified("c", createSourceIdentifier),
           parentWork = identifiedWork()
             .title("Schiacciata is a Tuscan focaccia"),
-          redirectedWork =
-            Some(
-              identifiedWork().title("A Tusdan bread")
-            )
+          redirectedWork = Some(
+            identifiedWork().title("A Tusdan bread")
+          )
         )
         insertImagesIntoElasticsearch(
           imagesIndex,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -71,19 +71,18 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
       case (ElasticConfig(_, imagesIndex), routes) =>
         val baguetteImage = createAugmentedImageWith(
           imageId = IdState.Identified("a", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title = Some("Baguette is a French bread style"))
+          parentWork = identifiedWork()
+            .title("Baguette is a French bread style")
         )
         val focacciaImage = createAugmentedImageWith(
           imageId = IdState.Identified("b", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title = Some("A Ligurian style of bread, Focaccia"))
+          parentWork = identifiedWork()
+            .title("A Ligurian style of bread, Focaccia")
         )
         val mantouImage = createAugmentedImageWith(
           imageId = IdState.Identified("c", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title =
-              Some("Mantou is a steamed bread associated with Northern China"))
+          parentWork = identifiedWork()
+            .title("Mantou is a steamed bread associated with Northern China")
         )
         insertImagesIntoElasticsearch(
           imagesIndex,
@@ -107,20 +106,22 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
       case (ElasticConfig(_, imagesIndex), routes) =>
         val baguetteImage = createAugmentedImageWith(
           imageId = IdState.Identified("a", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title = Some("Baguette is a French bread style"))
+          parentWork = identifiedWork()
+            .title("Baguette is a French bread style")
         )
         val focacciaImage = createAugmentedImageWith(
           imageId = IdState.Identified("b", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title = Some("A Ligurian style of bread, Focaccia"))
+          parentWork = identifiedWork()
+            .title("A Ligurian style of bread, Focaccia")
         )
         val schiacciataImage = createAugmentedImageWith(
           imageId = IdState.Identified("c", createSourceIdentifier),
-          parentWork = createIdentifiedWorkWith(
-            title = Some("Schiacciata is a Tuscan focaccia")),
+          parentWork = identifiedWork()
+            .title("Schiacciata is a Tuscan focaccia"),
           redirectedWork =
-            Some(createIdentifiedWorkWith(title = Some("A Tuscan bread")))
+            Some(
+              identifiedWork().title("A Tusdan bread")
+            )
         )
         insertImagesIntoElasticsearch(
           imagesIndex,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
@@ -4,11 +4,10 @@ import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal._
 
 class WorksTest extends ApiWorksTestBase {
-
   it("returns a list of works") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val works = createIdentifiedWorks(count = 3).sortBy {
+        val works = identifiedWorks(count = 3).sortBy {
           _.state.canonicalId
         }
 
@@ -23,7 +22,7 @@ class WorksTest extends ApiWorksTestBase {
   it("returns a single work when requested with id") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWork
+        val work = identifiedWork()
 
         insertIntoElasticsearch(worksIndex, work)
 
@@ -45,10 +44,10 @@ class WorksTest extends ApiWorksTestBase {
   it("returns optional fields when they exist") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWorkWith(
-          duration = Some(3600),
-          edition = Some("Special edition"),
-        )
+        val work = identifiedWork()
+          .duration(3600)
+          .edition("Special edition")
+
         insertIntoElasticsearch(worksIndex, work)
         assertJsonResponse(
           routes,
@@ -71,7 +70,7 @@ class WorksTest extends ApiWorksTestBase {
     "returns the requested page of results when requested with page & pageSize") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val works = createIdentifiedWorks(count = 3).sortBy {
+        val works = identifiedWorks(count = 3).sortBy {
           _.state.canonicalId
         }
 
@@ -140,12 +139,8 @@ class WorksTest extends ApiWorksTestBase {
   it("returns matching results if doing a full-text search") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val workDodo = createIdentifiedWorkWith(
-          title = Some("A drawing of a dodo")
-        )
-        val workMouse = createIdentifiedWorkWith(
-          title = Some("A mezzotint of a mouse")
-        )
+        val workDodo = identifiedWork().title("A drawing of a dodo")
+        val workMouse = identifiedWork().title("A mezzotint of a mouse")
         insertIntoElasticsearch(worksIndex, workDodo, workMouse)
 
         assertJsonResponse(routes, s"/$apiPrefix/works?query=cat") {
@@ -162,10 +157,10 @@ class WorksTest extends ApiWorksTestBase {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         withLocalWorksIndex { altIndex =>
-          val work = createIdentifiedWork
+          val work = identifiedWork()
           insertIntoElasticsearch(worksIndex, work)
 
-          val altWork = createIdentifiedWork
+          val altWork = identifiedWork()
           insertIntoElasticsearch(index = altIndex, altWork)
 
           assertJsonResponse(
@@ -201,14 +196,10 @@ class WorksTest extends ApiWorksTestBase {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         withLocalWorksIndex { altIndex =>
-          val work = createIdentifiedWorkWith(
-            title = Some("Playing with pangolins")
-          )
+          val work = identifiedWork().title("Playing with pangolins")
           insertIntoElasticsearch(worksIndex, work)
 
-          val altWork = createIdentifiedWorkWith(
-            title = Some("Playing with pangolins")
-          )
+          val altWork = identifiedWork().title("Playing with pangolins")
           insertIntoElasticsearch(index = altIndex, altWork)
 
           assertJsonResponse(routes, s"/$apiPrefix/works?query=pangolins") {
@@ -227,14 +218,14 @@ class WorksTest extends ApiWorksTestBase {
   it("shows the thumbnail field if available") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
-        val work = createIdentifiedWorkWith(
-          thumbnail = Some(
+        val work = identifiedWork()
+          .thumbnail(
             DigitalLocationDeprecated(
               locationType = LocationType("thumbnail-image"),
               url = "https://iiif.example.org/1234/default.jpg",
               license = Some(License.CCBY)
-            ))
-        )
+            )
+          )
         insertIntoElasticsearch(worksIndex, work)
 
         assertJsonResponse(routes, s"/$apiPrefix/works") {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -7,7 +7,8 @@ trait ImageGenerators
     extends IdentifiersGenerators
     with ItemsGenerators
     with LegacyWorkGenerators
-    with VectorGenerators {
+    with VectorGenerators
+    with SierraWorkGenerators {
   def createUnmergedImageWith(
     location: DigitalLocationDeprecated = createDigitalLocation,
     version: Int = 1,
@@ -59,9 +60,9 @@ trait ImageGenerators
     location: DigitalLocationDeprecated = createDigitalLocation,
     version: Int = 1,
     parentWork: Work.Visible[WorkState.Identified] =
-      createIdentifiedSierraWorkWith(),
+      sierraIdentifiedWork(),
     redirectedWork: Option[Work[WorkState.Identified]] = Some(
-      createIdentifiedSierraWorkWith())): MergedImage[DataState.Identified] =
+      sierraIdentifiedWork())): MergedImage[DataState.Identified] =
     MergedImage[DataState.Identified](
       imageId,
       version,
@@ -88,7 +89,7 @@ trait ImageGenerators
       createCanonicalId,
       createSourceIdentifierWith(IdentifierType("miro-image-number"))),
     parentWork: Work.Visible[WorkState.Identified] =
-      createIdentifiedSierraWorkWith(),
+      sierraIdentifiedWork(),
     redirectedWork: Option[Work.Visible[WorkState.Identified]] = Some(
       createIdentifiedWork),
     inferredData: Option[InferredData] = createInferredData,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -91,7 +91,7 @@ trait ImageGenerators
     parentWork: Work.Visible[WorkState.Identified] =
       sierraIdentifiedWork(),
     redirectedWork: Option[Work.Visible[WorkState.Identified]] = Some(
-      createIdentifiedWork),
+      identifiedWork()),
     inferredData: Option[InferredData] = createInferredData,
     location: DigitalLocationDeprecated = createDigitalLocation,
     version: Int = 1,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -59,8 +59,7 @@ trait ImageGenerators
       IdState.Identified(createCanonicalId, createSourceIdentifier),
     location: DigitalLocationDeprecated = createDigitalLocation,
     version: Int = 1,
-    parentWork: Work.Visible[WorkState.Identified] =
-      sierraIdentifiedWork(),
+    parentWork: Work.Visible[WorkState.Identified] = sierraIdentifiedWork(),
     redirectedWork: Option[Work[WorkState.Identified]] = Some(
       sierraIdentifiedWork())): MergedImage[DataState.Identified] =
     MergedImage[DataState.Identified](
@@ -88,8 +87,7 @@ trait ImageGenerators
     imageId: IdState.Identified = IdState.Identified(
       createCanonicalId,
       createSourceIdentifierWith(IdentifierType("miro-image-number"))),
-    parentWork: Work.Visible[WorkState.Identified] =
-      sierraIdentifiedWork(),
+    parentWork: Work.Visible[WorkState.Identified] = sierraIdentifiedWork(),
     redirectedWork: Option[Work.Visible[WorkState.Identified]] = Some(
       identifiedWork()),
     inferredData: Option[InferredData] = createInferredData,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -155,19 +155,6 @@ trait LegacyWorkGenerators
       mergeCandidates = mergeCandidates
     )
 
-  def createIdentifiedSierraWorkWith(
-    format: Option[Format] = None,
-    items: List[Item[IdState.Minted]] = Nil,
-    mergeCandidates: List[MergeCandidate] = Nil,
-  ): Work.Visible[Identified] =
-    createIdentifiedWorkWith(
-      sourceIdentifier = createSierraSystemSourceIdentifier,
-      format = format,
-      otherIdentifiers = List(createSierraSystemSourceIdentifier),
-      items = items,
-      mergeCandidates = mergeCandidates
-    )
-
   def createCalmSourceWorkWith(data: WorkData[DataState.Unidentified] =
                                  WorkData[DataState.Unidentified](
                                    items = List(createCalmItem)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -73,67 +73,6 @@ trait LegacyWorkGenerators
   def createSourceWork: Work.Visible[Source] =
     createSourceWorkWith()
 
-  def createIdentifiedWorkWith(
-    canonicalId: String = createCanonicalId,
-    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    otherIdentifiers: List[SourceIdentifier] = List(),
-    title: Option[String] = Some(createTitle),
-    alternativeTitles: List[String] = Nil,
-    format: Option[Format] = None,
-    description: Option[String] = None,
-    physicalDescription: Option[String] = None,
-    lettering: Option[String] = None,
-    createdDate: Option[Period[IdState.Minted]] = None,
-    subjects: List[Subject[IdState.Minted]] = Nil,
-    genres: List[Genre[IdState.Minted]] = Nil,
-    contributors: List[Contributor[IdState.Minted]] = Nil,
-    thumbnail: Option[LocationDeprecated] = None,
-    production: List[ProductionEvent[IdState.Minted]] = Nil,
-    notes: List[Note] = Nil,
-    edition: Option[String] = None,
-    language: Option[Language] = None,
-    duration: Option[Int] = None,
-    items: List[Item[IdState.Minted]] = Nil,
-    images: List[UnmergedImage[DataState.Identified]] = Nil,
-    version: Int = 1,
-    merged: Boolean = false,
-    collectionPath: Option[CollectionPath] = None,
-    mergeCandidates: List[MergeCandidate] = Nil,
-    workType: WorkType = WorkType.Standard,
-  ): Work.Visible[Identified] =
-    Work.Visible[Identified](
-      state = Identified(
-        canonicalId = canonicalId,
-        sourceIdentifier = sourceIdentifier,
-        hasMultipleSources = merged
-      ),
-      version = version,
-      data = WorkData[DataState.Identified](
-        otherIdentifiers = otherIdentifiers,
-        mergeCandidates = mergeCandidates,
-        title = title,
-        alternativeTitles = alternativeTitles,
-        format = format,
-        description = description,
-        physicalDescription = physicalDescription,
-        lettering = lettering,
-        createdDate = createdDate,
-        subjects = subjects,
-        genres = genres,
-        contributors = contributors,
-        thumbnail = thumbnail,
-        production = production,
-        language = language,
-        edition = edition,
-        notes = notes,
-        duration = duration,
-        items = items,
-        images = images,
-        collectionPath = collectionPath,
-        workType = workType,
-      )
-    )
-
   def createSierraSourceWorkWith(
     format: Option[Format] = None,
     items: List[Item[IdState.Unminted]] = Nil,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LegacyWorkGenerators.scala
@@ -134,14 +134,6 @@ trait LegacyWorkGenerators
       )
     )
 
-  def createIdentifiedWork: Work.Visible[Identified] =
-    createIdentifiedWorkWith()
-
-  def createIdentifiedWorks(count: Int): Seq[Work.Visible[Identified]] =
-    (1 to count).map { _ =>
-      createIdentifiedWork
-    }
-
   def createSierraSourceWorkWith(
     format: Option[Format] = None,
     items: List[Item[IdState.Unminted]] = Nil,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -164,6 +164,9 @@ trait WorkGenerators extends IdentifiersGenerators {
     def workType(workType: WorkType): Work.Visible[State] =
       work.map(_.copy(workType = workType))
 
+    def duration(newDuration: Int): Work.Visible[State] =
+      work.map(_.copy(duration = Some(newDuration)))
+
     def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
       : Work.Visible[State] =
       Work.Visible[State](work.version, f(work.data), work.state)


### PR DESCRIPTION
Lots more low-hanging fruit, mostly focusing on use of createIdentifiedWorkWith(…).

Pretty much everything left is in the merger, so I don't want to touch it until Jamie's PR gets merged.

For wellcomecollection/platform#4821