### PR TITLE
Big Bin Manifesto

### DIFF
--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -10,14 +10,16 @@ logger = get_logger(__name__)
 
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
-palette_encoder = PaletteEncoder(palette_weights=[2, 2, 1, 1, 1], bin_sizes=[4, 6, 8])
+palette_encoder = PaletteEncoder(
+    palette_weights=[2, 2, 1, 1, 1], bin_sizes=[2, 4, 6, 8])
 
 # initialise API
 logger.info("Starting API")
 app = FastAPI(title="Palette extractor", description="extracts palettes")
 logger.info("API started, awaiting requests")
 
-batch_inferrer_queue = BatchExecutionQueue(palette_encoder, batch_size=4, timeout=0.5)
+batch_inferrer_queue = BatchExecutionQueue(
+    palette_encoder, batch_size=4, timeout=0.5)
 
 
 @app.get("/palette/")

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -11,15 +11,15 @@ logger = get_logger(__name__)
 # Initialise encoder
 logger.info("Initialising PaletteEncoder model")
 palette_encoder = PaletteEncoder(
-    palette_weights=[2, 2, 1, 1, 1], bin_sizes=[2, 4, 6, 8])
+    palette_weights=[2, 2, 1, 1, 1], bin_sizes=[2, 4, 6, 8]
+)
 
 # initialise API
 logger.info("Starting API")
 app = FastAPI(title="Palette extractor", description="extracts palettes")
 logger.info("API started, awaiting requests")
 
-batch_inferrer_queue = BatchExecutionQueue(
-    palette_encoder, batch_size=4, timeout=0.5)
+batch_inferrer_queue = BatchExecutionQueue(palette_encoder, batch_size=4, timeout=0.5)
 
 
 @app.get("/palette/")


### PR DESCRIPTION
We're seeing lots of examples of our colour filters being overly restrictive, eg below, where a fairly generic green filter on a "botany" query returns 0 results. 

![Screenshot 2020-10-05 at 14 41 33](https://user-images.githubusercontent.com/11006680/95086916-f40c7a00-0718-11eb-8c2f-325f79c1ffed.png)

We know that there's [green botanical stuff in the collection](https://wellcomecollection.org/works/w5xd7b7w/items?canvas=1), so the lack of results indicates that our internal definition of green is too precise. We can broaden those definitions by adding coarser divisions to our separation of colour space. 

We currently divide RGB space into bins of 4, 6, and 8 in each dimension. This PR adds a set of 2-bins.