### PR TITLE
Use intermediate pipeline storage in merger and ID minter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,8 @@ steps:
     label: "ID minter works"
   - command: .buildkite/scripts/run_job.py id_minter_images
     label: "ID minter images"
+  - command: .buildkite/scripts/run_job.py relation_embedder
+    label: "relation embedder"
   - command: .buildkite/scripts/run_job.py matcher
     label: "matcher"
   - command: .buildkite/scripts/run_job.py merger

--- a/.sbt_metadata/id_minter.json
+++ b/.sbt_metadata/id_minter.json
@@ -3,6 +3,7 @@
   "folder" : "pipeline/id_minter",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe"
+    "big_messaging_typesafe",
+    "pipeline_storage"
   ]
 }

--- a/.sbt_metadata/id_minter.json
+++ b/.sbt_metadata/id_minter.json
@@ -3,7 +3,6 @@
   "folder" : "pipeline/id_minter",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe",
-    "pipeline_storage"
+    "big_messaging_typesafe"
   ]
 }

--- a/.sbt_metadata/id_minter_works.json
+++ b/.sbt_metadata/id_minter_works.json
@@ -2,6 +2,7 @@
   "id" : "id_minter_works",
   "folder" : "pipeline/id_minter/id_minter_works",
   "dependencyIds" : [
-    "id_minter_common"
+    "id_minter_common",
+    "pipeline_storage"
   ]
 }

--- a/.sbt_metadata/merger.json
+++ b/.sbt_metadata/merger.json
@@ -3,6 +3,7 @@
   "folder" : "pipeline/merger",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe"
+    "big_messaging_typesafe",
+    "pipeline_storage"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val id_minter_common = setupProject(
 lazy val id_minter_works = setupProject(
   project,
   "pipeline/id_minter/id_minter_works",
-  localDependencies = Seq(id_minter_common),
+  localDependencies = Seq(id_minter_common, pipeline_storage),
   externalDependencies = Seq()
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val matcher = setupProject(
 lazy val merger = setupProject(
   project,
   "pipeline/merger",
-  localDependencies = Seq(internal_model, big_messaging_typesafe)
+  localDependencies = Seq(internal_model, big_messaging_typesafe, pipeline_storage),
+  externalDependencies = CatalogueDependencies.mergerDependencies
 )
 
 lazy val relation_embedder = setupProject(

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -248,7 +248,7 @@ trait ElasticsearchFixtures
           indexInto(index.name)
             .version(work.version)
             .versionType(ExternalGte)
-            .id(work.state.id)
+            .id(work.id)
             .doc(jsonDoc)
         }
       )

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -125,7 +125,7 @@ sealed trait WorkState {
   type TransitionArgs
 
   val sourceIdentifier: SourceIdentifier
-  val nMergedSources: Int
+  val numberOfSources: Int
 
   def id: String = sourceIdentifier.toString
 }
@@ -139,7 +139,7 @@ object WorkState {
     type WorkDataState = DataState.Unidentified
     type TransitionArgs = Unit
 
-    val nMergedSources = 1
+    val numberOfSources = 1
   }
 
   case class Merged(

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -123,6 +123,7 @@ sealed trait WorkState {
   type TransitionArgs
 
   val sourceIdentifier: SourceIdentifier
+  val nMergedSources: Int
 
   def id: String = sourceIdentifier.toString
 }
@@ -135,6 +136,8 @@ object WorkState {
 
     type WorkDataState = DataState.Unidentified
     type TransitionArgs = Unit
+
+    val nMergedSources = 1
   }
 
   case class Merged(

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -13,6 +13,8 @@ sealed trait Work[State <: WorkState] {
 
   def sourceIdentifier: SourceIdentifier = state.sourceIdentifier
 
+  def id: String = state.id
+
   def identifiers: List[SourceIdentifier] =
     sourceIdentifier :: data.otherIdentifiers
 

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -102,7 +102,7 @@ object Indexable extends Logging {
   implicit def workIndexable[State <: WorkState]: Indexable[Work[State]] =
     new Indexable[Work[State]] {
 
-      def id(work: Work[State]): String = work.state.id
+      def id(work: Work[State]): String = work.id
 
       def version(work: Work[State]) =
         work match {

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -4,7 +4,6 @@ import scala.concurrent.Future
 import grizzled.slf4j.Logging
 
 import uk.ac.wellcome.models.work.internal._
-import WorkState.Identified
 
 abstract class Indexer[T: Indexable] {
 

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -99,18 +99,17 @@ object Indexable extends Logging {
       }
     }
 
-  implicit val workIndexable: Indexable[Work[Identified]] =
-    new Indexable[Work[Identified]] {
+  implicit def workIndexable[State <: WorkState]: Indexable[Work[State]] =
+    new Indexable[Work[State]] {
 
-      def id(work: Work[Identified]) =
-        work.state.canonicalId
+      def id(work: Work[State]): String = work.state.id
 
-      def version(work: Work[Identified]) =
+      def version(work: Work[State]) =
         work match {
           case Work.Visible(_, _, state)
               if state.numberOfSources >= versionMultiplier =>
             throw new RuntimeException(
-              s"Work ${work.state.sourceIdentifier.toString} has ${work.state.numberOfSources} >= $versionMultiplier sources; versioning/ingest may be inconsistent")
+              s"Work ${work.sourceIdentifier.toString} has ${work.state.numberOfSources} >= $versionMultiplier sources; versioning/ingest may be inconsistent")
           case Work.Visible(version, _, state) =>
             (version * versionMultiplier) + (state.numberOfSources - 1) // The number of additional sources
           case Work.Redirected(version, _, _) =>

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.pipeline_storage
+
+import scala.concurrent.Future
+import scala.collection.mutable.Map
+
+class MemoryIndexer[T: Indexable](val index: Map[String, T] = Map.empty)
+    extends Indexer[T] {
+
+  def index(documents: Seq[T]): Future[Either[Seq[T], Seq[T]]] = {
+    documents.map(doc => index.put(indexable.id(doc), doc))
+    Future.successful(Right(documents))
+  }
+}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -6,6 +6,9 @@ import scala.collection.mutable.Map
 class MemoryIndexer[T: Indexable](val index: Map[String, T] = Map.empty)
     extends Indexer[T] {
 
+  def init(): Future[Unit] =
+    Future.successful(())
+
   def index(documents: Seq[T]): Future[Either[Seq[T], Seq[T]]] = {
     documents.map(doc => index.put(indexable.id(doc), doc))
     Future.successful(Right(documents))

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -3,7 +3,8 @@ package uk.ac.wellcome.pipeline_storage
 import scala.concurrent.Future
 import scala.util.Try
 
-class MemoryRetriever[T](index: Map[String, T] = Map.empty) extends Retriever[T] {
+class MemoryRetriever[T](index: Map[String, T] = Map.empty)
+    extends Retriever[T] {
 
   def apply(id: String): Future[T] =
     Future.fromTry(Try(index(id)))

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.pipeline_storage
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class MemoryRetriever[T](index: Map[String, T] = Map.empty) extends Retriever[T] {
+
+  def apply(id: String): Future[T] =
+    Future.fromTry(Try(index(id)))
+}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -7,8 +7,7 @@ trait Retriever[T] {
   /** Retrieves document with the given ID from the store
     *
     * @param id The id of the document
-    * @param expectedVersion Optionally includes an expected version to check
-    * @return The document
+    * @return A future containing the document
     */
   def apply(id: String): Future[T]
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -204,7 +204,10 @@ class WorkIndexableTest
     testWith: TestWith[(Index, ElasticIndexer[Work[Identified]]), R]) = {
     withLocalWorksIndex { index =>
       val indexer =
-        new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)
+        new ElasticIndexer[Work[Identified]](
+          elasticClient,
+          index,
+          IdentifiedWorkIndexConfig)
       testWith((index, indexer))
     }
   }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -204,7 +204,7 @@ class WorkIndexableTest
     testWith: TestWith[(Index, ElasticIndexer[Work[Identified]]), R]) = {
     withLocalWorksIndex { index =>
       val indexer =
-        new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig)
+        new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)
       testWith((index, indexer))
     }
   }

--- a/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/generators/TableNameGenerators.scala
+++ b/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/generators/TableNameGenerators.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.id_minter.generators
+
+import scala.util.Random
+
+trait TableNameGenerators {
+  // Something in our MySQL Docker image gets upset by some database names,
+  // and throws an error of the form:
+  //
+  //    You have an error in your SQL syntax; check the manual that
+  //    corresponds to your MySQL server version for the right syntax to use
+  //
+  // This error can be reproduced by running "CREATE DATABASE <name>" inside
+  // the Docker image.  It's not clear what features of the name cause this
+  // error to occur, but so far we've only seen it in database names that
+  // include numbers.  We're guessing some arrangement of numbers causes the
+  // issue; for now we just use letters to try to work around this issue.
+  //
+  // The Oracle docs are not enlightening in this regard:
+  // https://docs.oracle.com/database/121/SQLRF/sql_elements008.htm#SQLRF00223
+
+  // This is based on the implementation of alphanumeric in Scala.util.Random.
+  private def alphabetic: Stream[Char] = {
+    def nextAlpha: Char = {
+      val chars = "abcdefghijklmnopqrstuvwxyz"
+      chars charAt Random.nextInt(chars.length)
+    }
+
+    Stream continually nextAlpha
+  }
+
+  def createDatabaseName: String =
+    s"db_${alphabetic take 10 mkString}"
+
+  def createTableName: String =
+    s"tbl_${alphabetic take 10 mkString}"
+}

--- a/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
@@ -1,8 +1,9 @@
 package uk.ac.wellcome.platform.id_minter.steps
 
+import org.mockito.Matchers.{any, anyListOf}
 import org.mockito.Mockito.when
-import org.mockito.ArgumentMatchers.any
 import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Inspectors, OptionValues}
 import scalikejdbc._
@@ -14,10 +15,12 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
 import scala.util.{Failure, Success}
+import scala.collection.JavaConverters._
 
 class IdentifierGeneratorTest
     extends AnyFunSpec
     with fixtures.IdentifiersDatabase
+    with Matchers
     with Inspectors
     with OptionValues
     with MockitoSugar
@@ -122,7 +125,7 @@ class IdentifierGeneratorTest
     val sourceIdentifiers = (1 to 5).map(_ => createSourceIdentifier).toList
 
     val triedLookup = identifiersDao.lookupIds(
-      any[List[SourceIdentifier]]
+      anyListOf(classOf[SourceIdentifier]).asScala.toList
     )(any[DBSession])
     when(triedLookup)
       .thenReturn(
@@ -131,7 +134,7 @@ class IdentifierGeneratorTest
     val saveException = new Exception("Don't do that please!")
     when(
       identifiersDao.saveIdentifiers(
-        any[List[Identifier]])(any[DBSession]))
+        anyListOf(classOf[Identifier]).asScala.toList)(any[DBSession]))
       .thenThrow(IdentifiersDao.InsertError(Nil, saveException, Nil))
 
     withIdentifierGenerator(Some(identifiersDao)) {

--- a/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.id_minter.steps
 
-import org.mockito.Mockito._
+import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar

--- a/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/id_minter_common/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.platform.id_minter.steps
 
-import org.mockito.Matchers.{any, anyListOf}
-import org.mockito.Mockito.when
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.any
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Inspectors, OptionValues}
 import scalikejdbc._
@@ -15,12 +14,10 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.internal.SourceIdentifier
 
 import scala.util.{Failure, Success}
-import scala.collection.JavaConverters._
 
 class IdentifierGeneratorTest
     extends AnyFunSpec
     with fixtures.IdentifiersDatabase
-    with Matchers
     with Inspectors
     with OptionValues
     with MockitoSugar
@@ -125,7 +122,7 @@ class IdentifierGeneratorTest
     val sourceIdentifiers = (1 to 5).map(_ => createSourceIdentifier).toList
 
     val triedLookup = identifiersDao.lookupIds(
-      anyListOf(classOf[SourceIdentifier]).asScala.toList
+      any[List[SourceIdentifier]]
     )(any[DBSession])
     when(triedLookup)
       .thenReturn(
@@ -134,7 +131,7 @@ class IdentifierGeneratorTest
     val saveException = new Exception("Don't do that please!")
     when(
       identifiersDao.saveIdentifiers(
-        anyListOf(classOf[Identifier]).asScala.toList)(any[DBSession]))
+        any[List[Identifier]])(any[DBSession]))
       .thenThrow(IdentifiersDao.InsertError(Nil, saveException, Nil))
 
     withIdentifierGenerator(Some(identifiersDao)) {

--- a/pipeline/id_minter/id_minter_images/src/test/scala/uk/ac/wellcome/platform/id_minter_images/services/IdMinterWorkerServiceTest.scala
+++ b/pipeline/id_minter/id_minter_images/src/test/scala/uk/ac/wellcome/platform/id_minter_images/services/IdMinterWorkerServiceTest.scala
@@ -1,25 +1,26 @@
 package uk.ac.wellcome.platform.id_minter_images.services
 
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc._
-
 import uk.ac.wellcome.platform.id_minter.database.{
   FieldDescription,
   IdentifiersDao
 }
+import uk.ac.wellcome.platform.id_minter.models.IdentifiersTable
 import uk.ac.wellcome.platform.id_minter_images.fixtures.WorkerServiceFixture
 
 class IdMinterWorkerServiceTest
     extends AnyFunSpec
     with Matchers
-    with MockitoSugar
     with WorkerServiceFixture {
 
   it("creates the Identifiers table in MySQL upon startup") {
     withIdentifiersDatabase { identifiersTableConfig =>
-      val identifiersDao = mock[IdentifiersDao]
+      val identifiersDao = new IdentifiersDao(
+        identifiers = new IdentifiersTable(identifiersTableConfig)
+      )
+
       withWorkerService(
         identifiersDao = identifiersDao,
         identifiersTableConfig = identifiersTableConfig) { _ =>

--- a/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/Main.scala
+++ b/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/Main.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.id_minter_works
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import com.sksamuel.elastic4s.Index
 
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.platform.id_minter.config.builders.{
@@ -13,10 +14,13 @@ import uk.ac.wellcome.platform.id_minter.database.IdentifiersDao
 import uk.ac.wellcome.platform.id_minter.models.IdentifiersTable
 import uk.ac.wellcome.platform.id_minter_works.services.IdMinterWorkerService
 import uk.ac.wellcome.platform.id_minter.steps.IdentifierGenerator
+import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
+import uk.ac.wellcome.pipeline_storage.ElasticRetriever
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -36,10 +40,13 @@ object Main extends WellcomeTypesafeApp {
       )
     )
 
+    val elasticClient = ElasticBuilder.buildElasticClient(config)
+    val index = Index(config.requireString("es.index"))
+
     new IdMinterWorkerService(
       identifierGenerator = identifierGenerator,
       sender = BigMessagingBuilder.buildBigMessageSender(config),
-      jsonRetriever = ???,
+      jsonRetriever = new ElasticRetriever(elasticClient, index),
       messageStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       rdsClientConfig = RDSBuilder.buildRDSClientConfig(config),
       identifiersTableConfig = identifiersTableConfig

--- a/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
+++ b/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
@@ -1,9 +1,13 @@
 package uk.ac.wellcome.platform.id_minter_works.services
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 import akka.Done
 import grizzled.slf4j.Logging
 import io.circe.Json
-import uk.ac.wellcome.bigmessaging.message.BigMessageStream
+
+import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.id_minter.config.models.{
   IdentifiersTableConfig,
@@ -15,19 +19,18 @@ import uk.ac.wellcome.platform.id_minter.steps.{
   SourceIdentifierEmbedder
 }
 import uk.ac.wellcome.typesafe.Runnable
-
-import scala.concurrent.Future
+import uk.ac.wellcome.pipeline_storage.Retriever
+import uk.ac.wellcome.json.JsonUtil._
 
 class IdMinterWorkerService[Destination](
   identifierGenerator: IdentifierGenerator,
   sender: MessageSender[Destination],
-  messageStream: BigMessageStream[Json],
+  messageStream: SQSStream[NotificationMessage],
+  jsonRetriever: Retriever[Json],
   rdsClientConfig: RDSClientConfig,
   identifiersTableConfig: IdentifiersTableConfig
-) extends Runnable
+)(implicit ec: ExecutionContext) extends Runnable
     with Logging {
-
-  private val className = this.getClass.getSimpleName
 
   def run(): Future[Done] = {
     val tableProvisioner = new TableProvisioner(
@@ -39,10 +42,14 @@ class IdMinterWorkerService[Destination](
       tableName = identifiersTableConfig.tableName
     )
 
-    messageStream.foreach(className, processMessage)
+    messageStream.foreach(this.getClass.getSimpleName, processMessage)
   }
 
-  def processMessage(json: Json): Future[Unit] = Future fromTry {
+  def processMessage(message: NotificationMessage): Future[Unit] =
+    jsonRetriever(message.body)
+      .flatMap(json => Future.fromTry(processJson(json)))
+
+  def processJson(json: Json): Try[Unit] =
     for {
       sourceIdentifiers <- SourceIdentifierEmbedder.scan(json)
       mintedIdentifiers <- identifierGenerator.retrieveOrGenerateCanonicalIds(
@@ -50,5 +57,4 @@ class IdMinterWorkerService[Destination](
       updatedJson <- SourceIdentifierEmbedder.update(json, mintedIdentifiers)
       _ <- sender.sendT(updatedJson)
     } yield ()
-  }
 }

--- a/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
+++ b/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
@@ -29,7 +29,8 @@ class IdMinterWorkerService[Destination](
   jsonRetriever: Retriever[Json],
   rdsClientConfig: RDSClientConfig,
   identifiersTableConfig: IdentifiersTableConfig
-)(implicit ec: ExecutionContext) extends Runnable
+)(implicit ec: ExecutionContext)
+    extends Runnable
     with Logging {
 
   def run(): Future[Done] = {

--- a/pipeline/id_minter/id_minter_works/src/test/scala/uk/ac/wellcome/platform/id_minter_works/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/id_minter_works/src/test/scala/uk/ac/wellcome/platform/id_minter_works/IdMinterFeatureTest.scala
@@ -28,30 +28,31 @@ class IdMinterFeatureTest
       withIdentifiersDatabase { identifiersTableConfig =>
         val work: Work[Denormalised] = denormalisedWork()
         val index = createIndex(List(work))
-        withWorkerService(messageSender, queue, identifiersTableConfig, index) { _ =>
-          eventuallyTableExists(identifiersTableConfig)
+        withWorkerService(messageSender, queue, identifiersTableConfig, index) {
+          _ =>
+            eventuallyTableExists(identifiersTableConfig)
 
-          val messageCount = 5
+            val messageCount = 5
 
-          (1 to messageCount).foreach { _ =>
-            sendNotificationToSQS(queue = queue, body = work.id)
-          }
-
-          eventually {
-            val works = messageSender.getMessages[Work[Identified]]
-            works.length shouldBe >=(messageCount)
-
-            works.map(_.state.canonicalId).distinct should have size 1
-            works.foreach { receivedWork =>
-              receivedWork
-                .asInstanceOf[Work.Visible[Identified]]
-                .sourceIdentifier shouldBe work.sourceIdentifier
-              receivedWork
-                .asInstanceOf[Work.Visible[Identified]]
-                .data
-                .title shouldBe work.data.title
+            (1 to messageCount).foreach { _ =>
+              sendNotificationToSQS(queue = queue, body = work.id)
             }
-          }
+
+            eventually {
+              val works = messageSender.getMessages[Work[Identified]]
+              works.length shouldBe >=(messageCount)
+
+              works.map(_.state.canonicalId).distinct should have size 1
+              works.foreach { receivedWork =>
+                receivedWork
+                  .asInstanceOf[Work.Visible[Identified]]
+                  .sourceIdentifier shouldBe work.sourceIdentifier
+                receivedWork
+                  .asInstanceOf[Work.Visible[Identified]]
+                  .data
+                  .title shouldBe work.data.title
+              }
+            }
         }
       }
     }
@@ -64,21 +65,22 @@ class IdMinterFeatureTest
       withIdentifiersDatabase { identifiersTableConfig =>
         val work: Work[Denormalised] = denormalisedWork().invisible()
         val index = createIndex(List(work))
-        withWorkerService(messageSender, queue, identifiersTableConfig, index) { _ =>
-          eventuallyTableExists(identifiersTableConfig)
+        withWorkerService(messageSender, queue, identifiersTableConfig, index) {
+          _ =>
+            eventuallyTableExists(identifiersTableConfig)
 
-          sendNotificationToSQS(queue = queue, body = work.id)
+            sendNotificationToSQS(queue = queue, body = work.id)
 
-          eventually {
-            val works = messageSender.getMessages[Work[Identified]]
-            works.length shouldBe >=(1)
+            eventually {
+              val works = messageSender.getMessages[Work[Identified]]
+              works.length shouldBe >=(1)
 
-            val receivedWork = works.head
-            val invisibleWork =
-              receivedWork.asInstanceOf[Work.Invisible[Identified]]
-            invisibleWork.sourceIdentifier shouldBe work.sourceIdentifier
-            invisibleWork.state.canonicalId shouldNot be(empty)
-          }
+              val receivedWork = works.head
+              val invisibleWork =
+                receivedWork.asInstanceOf[Work.Invisible[Identified]]
+              invisibleWork.sourceIdentifier shouldBe work.sourceIdentifier
+              invisibleWork.state.canonicalId shouldNot be(empty)
+            }
         }
       }
     }
@@ -92,23 +94,23 @@ class IdMinterFeatureTest
         val work: Work[Denormalised] = denormalisedWork()
           .redirected(redirect = IdState.Identifiable(createSourceIdentifier))
         val index = createIndex(List(work))
-        withWorkerService(messageSender, queue, identifiersTableConfig, index) { _ =>
-          eventuallyTableExists(identifiersTableConfig)
+        withWorkerService(messageSender, queue, identifiersTableConfig, index) {
+          _ =>
+            eventuallyTableExists(identifiersTableConfig)
 
+            sendNotificationToSQS(queue = queue, body = work.id)
 
-          sendNotificationToSQS(queue = queue, body = work.id)
+            eventually {
+              val works = messageSender.getMessages[Work[Identified]]
+              works.length shouldBe >=(1)
 
-          eventually {
-            val works = messageSender.getMessages[Work[Identified]]
-            works.length shouldBe >=(1)
-
-            val receivedWork = works.head
-            val redirectedWork =
-              receivedWork.asInstanceOf[Work.Redirected[Identified]]
-            redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier
-            redirectedWork.state.canonicalId shouldNot be(empty)
-            redirectedWork.redirect.canonicalId shouldNot be(empty)
-          }
+              val receivedWork = works.head
+              val redirectedWork =
+                receivedWork.asInstanceOf[Work.Redirected[Identified]]
+              redirectedWork.sourceIdentifier shouldBe work.sourceIdentifier
+              redirectedWork.state.canonicalId shouldNot be(empty)
+              redirectedWork.redirect.canonicalId shouldNot be(empty)
+            }
         }
       }
     }
@@ -121,16 +123,17 @@ class IdMinterFeatureTest
       withIdentifiersDatabase { identifiersTableConfig =>
         val work: Work[Denormalised] = denormalisedWork()
         val index = createIndex(List(work))
-        withWorkerService(messageSender, queue, identifiersTableConfig, index) { _ =>
-          sendInvalidJSONto(queue)
+        withWorkerService(messageSender, queue, identifiersTableConfig, index) {
+          _ =>
+            sendInvalidJSONto(queue)
 
-          sendNotificationToSQS(queue = queue, body = work.id)
+            sendNotificationToSQS(queue = queue, body = work.id)
 
-          eventually {
-            messageSender.messages should not be empty
+            eventually {
+              messageSender.messages should not be empty
 
-            assertMessageIsNotDeleted(queue)
-          }
+              assertMessageIsNotDeleted(queue)
+            }
         }
       }
     }

--- a/pipeline/id_minter/id_minter_works/src/test/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerServiceTest.scala
+++ b/pipeline/id_minter/id_minter_works/src/test/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerServiceTest.scala
@@ -1,25 +1,26 @@
 package uk.ac.wellcome.platform.id_minter_works.services
 
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc._
-
 import uk.ac.wellcome.platform.id_minter.database.{
   FieldDescription,
   IdentifiersDao
 }
+import uk.ac.wellcome.platform.id_minter.models.IdentifiersTable
 import uk.ac.wellcome.platform.id_minter_works.fixtures.WorkerServiceFixture
 
 class IdMinterWorkerServiceTest
     extends AnyFunSpec
     with Matchers
-    with MockitoSugar
     with WorkerServiceFixture {
 
   it("creates the Identifiers table in MySQL upon startup") {
     withIdentifiersDatabase { identifiersTableConfig =>
-      val identifiersDao = mock[IdentifiersDao]
+      val identifiersDao = new IdentifiersDao(
+        identifiers = new IdentifiersTable(identifiersTableConfig)
+      )
+
       withWorkerService(
         identifiersDao = identifiersDao,
         identifiersTableConfig = identifiersTableConfig) { _ =>

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -32,7 +32,7 @@ object Main extends WellcomeTypesafeApp {
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
       documentIndexer =
-        new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig),
+        new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig),
       messageStream =
         BigMessagingBuilder.buildMessageStream[Work[Identified]](config)
     )

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -31,8 +31,10 @@ object Main extends WellcomeTypesafeApp {
     val index = Index(indexName)
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
-      documentIndexer =
-        new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig),
+      documentIndexer = new ElasticIndexer[Work[Identified]](
+        elasticClient,
+        index,
+        IdentifiedWorkIndexConfig),
       messageStream =
         BigMessagingBuilder.buildMessageStream[Work[Identified]](config)
     )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -3,8 +3,12 @@ package uk.ac.wellcome.platform.merger
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import com.sksamuel.elastic4s.Index
 
 import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
+import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
+import uk.ac.wellcome.elasticsearch.MergedWorkIndexConfig
+import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.models.Implicits._
@@ -12,7 +16,8 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.services._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
-import WorkState.Source
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import WorkState.{Merged, Source}
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -36,12 +41,17 @@ object Main extends WellcomeTypesafeApp {
         .buildBigMessageSender(
           config.getConfig("image-sender").withFallback(config)
         )
+    val elasticClient = ElasticBuilder.buildElasticClient(config)
+    val index = Index(config.requireString("es.index"))
 
     new MergerWorkerService(
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       playbackService = playbackService,
       mergerManager = mergerManager,
-      workIndexer = ???,
+      workIndexer = new ElasticIndexer[Work[Merged]](
+        elasticClient,
+        index,
+        MergedWorkIndexConfig),
       workSender = workSender,
       imageSender = imageSender
     )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -41,6 +41,7 @@ object Main extends WellcomeTypesafeApp {
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       playbackService = playbackService,
       mergerManager = mergerManager,
+      workIndexer = ???,
       workSender = workSender,
       imageSender = imageSender
     )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -46,7 +46,7 @@ class MergerWorkerService[WorkDestination, ImageDestination](
         case Right(works) => Future.successful(works)
       }
       (worksFuture, imagesFuture) = (
-        sendMessages(workSender, works.map(_.state.id)),
+        sendMessages(workSender, works.map(_.id)),
         sendMessages(imageSender, mergerOutcome.images)
       )
       _ <- worksFuture

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -42,7 +42,7 @@ class MergerIntegrationTest
             eventually {
               assertQueueEmpty(queue)
               assertQueueEmpty(dlq)
-              workSender.getMessages[String] should contain only work.state.id
+              workSender.getMessages[String] should contain only work.id
               index shouldBe Map(work.id -> work.transition[Merged](1))
             }
           }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.platform.merger
 
+import scala.collection.mutable.Map
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
+
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
@@ -28,7 +30,8 @@ class MergerIntegrationTest
     withVHS { vhs =>
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
-          withWorkerService(vhs, queue, workSender) { _ =>
+          val index = Map.empty[String, Work[Merged]]
+          withWorkerService(vhs, queue, workSender, index = index) { _ =>
             val work = sourceWork()
 
             givenStoredInVhs(vhs, work)
@@ -39,9 +42,8 @@ class MergerIntegrationTest
             eventually {
               assertQueueEmpty(queue)
               assertQueueEmpty(dlq)
-
-              workSender.getMessages[Work[Merged]] should contain only
-                work.transition[Merged](1)
+              workSender.getMessages[String] should contain only work.state.id
+              index shouldBe Map(work.id -> work.transition[Merged](1))
             }
           }
       }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -340,7 +340,11 @@ class MergerWorkerServiceTest
   case class Senders(works: MemoryMessageSender, images: MemoryMessageSender)
 
   def withMergerWorkerServiceFixtures[R](
-    testWith: TestWith[(VHS, QueuePair, Senders, MemoryMetrics[StandardUnit], Map[String, Work[Merged]]),
+    testWith: TestWith[(VHS,
+                        QueuePair,
+                        Senders,
+                        MemoryMetrics[StandardUnit],
+                        Map[String, Work[Merged]]),
                        R]): R =
     withVHS { vhs =>
       withLocalSqsQueuePair() {
@@ -351,10 +355,16 @@ class MergerWorkerServiceTest
           val metrics = new MemoryMetrics[StandardUnit]
           val index = Map.empty[String, Work[Merged]]
 
-          withWorkerService(vhs, queue, workSender, imageSender, metrics, index) { _ =>
-            testWith(
-              (vhs, queuePair, Senders(workSender, imageSender), metrics, index)
-            )
+          withWorkerService(vhs, queue, workSender, imageSender, metrics, index) {
+            _ =>
+              testWith(
+                (
+                  vhs,
+                  queuePair,
+                  Senders(workSender, imageSender),
+                  metrics,
+                  index)
+              )
           }
       }
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -1,9 +1,11 @@
 package uk.ac.wellcome.platform.merger.services
 
+import scala.collection.mutable.Map
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
@@ -31,7 +33,7 @@ class MergerWorkerServiceTest
   it(
     "reads matcher result messages, retrieves the works from vhs and sends them to sns") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, metrics) =>
+      case (vhs, QueuePair(queue, dlq), senders, metrics, index) =>
         val work1 = sourceWork()
         val work2 = sourceWork()
         val work3 = sourceWork()
@@ -50,11 +52,16 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          senders.works
-            .getMessages[Work[Merged]] should contain only (
-            work1.transition[Merged](1),
-            work2.transition[Merged](1),
-            work3.transition[Merged](1)
+          senders.works.getMessages[String] should contain only (
+            work1.id,
+            work2.id,
+            work3.id
+          )
+
+          index shouldBe Map(
+            work1.id -> work1.transition[Merged](1),
+            work2.id -> work2.transition[Merged](1),
+            work3.id -> work3.transition[Merged](1)
           )
 
           metrics.incrementedCounts.length should be >= 1
@@ -65,7 +72,7 @@ class MergerWorkerServiceTest
 
   it("sends InvisibleWorks unmerged") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, metrics) =>
+      case (vhs, QueuePair(queue, dlq), senders, metrics, index) =>
         val work = sourceWork().invisible()
 
         val matcherResult = matcherResultWith(Set(Set(work)))
@@ -81,8 +88,11 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          senders.works.getMessages[Work[Merged]] should contain only
-            work.transition[Merged](1)
+          senders.works.getMessages[String] should contain only (
+            work.id,
+          )
+
+          index shouldBe Map(work.id -> work.transition[Merged](1))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")
@@ -92,7 +102,7 @@ class MergerWorkerServiceTest
 
   it("fails if the work is not in vhs") {
     withMergerWorkerServiceFixtures {
-      case (_, QueuePair(queue, dlq), senders, metrics) =>
+      case (_, QueuePair(queue, dlq), senders, metrics, index) =>
         val work = sourceWork()
 
         val matcherResult = matcherResultWith(Set(Set(work)))
@@ -116,7 +126,7 @@ class MergerWorkerServiceTest
 
   it("discards works with newer versions in vhs, sends along the others") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, _) =>
+      case (vhs, QueuePair(queue, dlq), senders, _, index) =>
         val work = sourceWork()
         val olderWork = sourceWork()
         val newerWork =
@@ -135,16 +145,17 @@ class MergerWorkerServiceTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
-          val worksSent = senders.works.getMessages[Work[Merged]]
-          worksSent should contain only
-            work.transition[Merged](1)
+          senders.works.getMessages[String] should contain only (
+            work.id,
+          )
+          index shouldBe Map(work.id -> work.transition[Merged](1))
         }
     }
   }
 
   it("discards works with version 0 and sends along the others") {
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, metrics) =>
+      case (vhs, QueuePair(queue, dlq), senders, metrics, index) =>
         val versionZeroWork =
           sourceWork()
             .withVersion(0)
@@ -166,9 +177,10 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          val worksSent = senders.works.getMessages[Work[Merged]]
-          worksSent should contain only
-            work.transition[Merged](1)
+          senders.works.getMessages[String] should contain only (
+            work.id,
+          )
+          index shouldBe Map(work.id -> work.transition[Merged](1))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")
@@ -182,7 +194,7 @@ class MergerWorkerServiceTest
     val works = List(physicalWork, digitisedWork)
 
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, _) =>
+      case (vhs, QueuePair(queue, dlq), senders, _, index) =>
         givenStoredInVhs(vhs, works: _*)
 
         val matcherResult = MatcherResult(
@@ -197,14 +209,14 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          val worksSent = senders.works.getMessages[Work[Merged]].distinct
-          worksSent should have size 2
+          senders.works.getMessages[String] should have size 2
+          index should have size 2
 
-          val redirectedWorks = worksSent.collect {
-            case work: Work.Redirected[Merged] => work
+          val redirectedWorks = index.collect {
+            case (_, work: Work.Redirected[Merged]) => work
           }
-          val mergedWorks = worksSent.collect {
-            case work: Work.Visible[Merged] => work
+          val mergedWorks = index.collect {
+            case (_, work: Work.Visible[Merged]) => work
           }
 
           redirectedWorks should have size 1
@@ -226,7 +238,7 @@ class MergerWorkerServiceTest
       List(physicalWork, digitisedWork, miroWork)
 
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, _) =>
+      case (vhs, QueuePair(queue, dlq), senders, _, index) =>
         givenStoredInVhs(vhs, works: _*)
 
         val matcherResult = MatcherResult(
@@ -241,8 +253,8 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          val worksSent = senders.works.getMessages[Work[Merged]].distinct
-          worksSent should have size 3
+          senders.works.getMessages[String].distinct should have size 3
+          index should have size 3
 
           val imagesSent =
             senders.images
@@ -250,11 +262,11 @@ class MergerWorkerServiceTest
               .distinct
           imagesSent should have size 1
 
-          val redirectedWorks = worksSent.collect {
-            case work: Work.Redirected[Merged] => work
+          val redirectedWorks = index.collect {
+            case (_, work: Work.Redirected[Merged]) => work
           }
-          val mergedWorks = worksSent.collect {
-            case work: Work.Visible[Merged] => work
+          val mergedWorks = index.collect {
+            case (_, work: Work.Visible[Merged]) => work
           }
 
           redirectedWorks should have size 2
@@ -281,7 +293,7 @@ class MergerWorkerServiceTest
     val works = workPair1 ++ workPair2
 
     withMergerWorkerServiceFixtures {
-      case (vhs, QueuePair(queue, dlq), senders, _) =>
+      case (vhs, QueuePair(queue, dlq), senders, _, index) =>
         givenStoredInVhs(vhs, works: _*)
 
         val matcherResult = MatcherResult(
@@ -296,14 +308,13 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          val worksSent = senders.works.getMessages[Work[Merged]]
-          worksSent should have size 4
+          senders.works.getMessages[String] should have size 4
 
-          val redirectedWorks = worksSent.collect {
-            case work: Work.Redirected[Merged] => work
+          val redirectedWorks = index.collect {
+            case (_, work: Work.Redirected[Merged]) => work
           }
-          val mergedWorks = worksSent.collect {
-            case work: Work.Visible[Merged] => work
+          val mergedWorks = index.collect {
+            case (_, work: Work.Visible[Merged]) => work
           }
 
           redirectedWorks should have size 2
@@ -314,7 +325,7 @@ class MergerWorkerServiceTest
 
   it("fails if the message sent is not a matcher result") {
     withMergerWorkerServiceFixtures {
-      case (_, QueuePair(queue, dlq), _, metrics) =>
+      case (_, QueuePair(queue, dlq), _, metrics, index) =>
         sendInvalidJSONto(queue)
 
         eventually {
@@ -329,7 +340,7 @@ class MergerWorkerServiceTest
   case class Senders(works: MemoryMessageSender, images: MemoryMessageSender)
 
   def withMergerWorkerServiceFixtures[R](
-    testWith: TestWith[(VHS, QueuePair, Senders, MemoryMetrics[StandardUnit]),
+    testWith: TestWith[(VHS, QueuePair, Senders, MemoryMetrics[StandardUnit], Map[String, Work[Merged]]),
                        R]): R =
     withVHS { vhs =>
       withLocalSqsQueuePair() {
@@ -338,10 +349,11 @@ class MergerWorkerServiceTest
           val imageSender = new MemoryMessageSender()
 
           val metrics = new MemoryMetrics[StandardUnit]
+          val index = Map.empty[String, Work[Merged]]
 
-          withWorkerService(vhs, queue, workSender, imageSender, metrics) { _ =>
+          withWorkerService(vhs, queue, workSender, imageSender, metrics, index) { _ =>
             testWith(
-              (vhs, queuePair, Senders(workSender, imageSender), metrics)
+              (vhs, queuePair, Senders(workSender, imageSender), metrics, index)
             )
           }
       }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -26,6 +26,7 @@ class RelationEmbedderWorkerService[MsgDestination](
   flushInterval: FiniteDuration = 3 seconds
 )(implicit ec: ExecutionContext, materializer: Materializer)
     extends Runnable {
+
   def run(): Future[Done] =
     sqsStream.foreach(this.getClass.getSimpleName, processMessage)
 
@@ -52,9 +53,8 @@ class RelationEmbedderWorkerService[MsgDestination](
       .run()
       .flatMap {
         case Nil => Future.successful(())
-        case failedWorks =>
-          Future.failed(
-            new Exception(s"Failed indexing works: $failedWorks")
-          )
+        case failedWorks => Future.failed(
+          new Exception(s"Failed indexing works: $failedWorks")
+        )
       }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -53,8 +53,9 @@ class RelationEmbedderWorkerService[MsgDestination](
       .run()
       .flatMap {
         case Nil => Future.successful(())
-        case failedWorks => Future.failed(
-          new Exception(s"Failed indexing works: $failedWorks")
-        )
+        case failedWorks =>
+          Future.failed(
+            new Exception(s"Failed indexing works: $failedWorks")
+          )
       }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -52,8 +52,9 @@ class RelationEmbedderWorkerService[MsgDestination](
       .run()
       .flatMap {
         case Nil => Future.successful(())
-        case failedWorks => Future.failed(
-          new Exception(s"Failed indexing works: $failedWorks")
-        )
+        case failedWorks =>
+          Future.failed(
+            new Exception(s"Failed indexing works: $failedWorks")
+          )
       }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -235,8 +235,7 @@ object CatalogueDependencies {
       WellcomeDependencies.typesafeLibrary
 
   val idminterDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
-      ExternalDependencies.mySqlDependencies ++
+    ExternalDependencies.mySqlDependencies ++
       ExternalDependencies.circeOpticsDependencies
 
   val matcherDependencies: Seq[ModuleID] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -243,6 +243,8 @@ object CatalogueDependencies {
     ExternalDependencies.mockitoDependencies ++
       ExternalDependencies.scalaGraphDependencies
 
+  val mergerDependencies: Seq[ModuleID] = Nil
+
   val relationEmbedderDependencies: Seq[ModuleID] =
     WellcomeDependencies.storageTypesafeLibrary ++
       WellcomeDependencies.messagingTypesafeLibrary


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4828

## Description

This updates the communication between the `merger` and `id_minter` to use an elasticsearch index (in line with the intermediate storage RFC) instead of `big_messaging`.

Do not merge this yet: we need to set up the new infra before we can push this to `master`.