### PR TITLE
Add a pre-exit hook for BuildKite

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -11,4 +11,4 @@ echo "These are the containers which are still running:"
 docker ps
 
 echo "I'm going to stop these containers now."
-docker stop $(docker ps -q)
+docker stop $(docker ps -q) || true

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This is a pre-exit hook that runs before the job finishes.
+#
+# See https://buildkite.com/docs/agent/v3/hooks
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+echo "Hello, I am the pre-exit hook!"
+echo "These are the containers which are still running:"
+docker ps
+echo "I am going away now 👋"
+exit 0

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # This is a pre-exit hook that runs before the job finishes.
-#
 # See https://buildkite.com/docs/agent/v3/hooks
-
-set -o errexit
-set -o nounset
-set -o verbose
+#
+# We don't want containers to hang around between test runs: if containers don't
+# shut down properly, they might prevent the next test from starting.
 
 echo "Hello, I am the pre-exit hook!"
+
 echo "These are the containers which are still running:"
 docker ps
-echo "I am going away now 👋"
-exit 0
+
+echo "I'm going to stop these containers now."
+docker stop $(docker ps -q)


### PR DESCRIPTION
My idea:

* We run one agent per instance, and each agent can be running a single job – which means one set of containers
* We currently can’t reuse instances in case containers are left running at the end of a test, because the next test will fail to start properly
* What if we stopped all the running containers at the end of a job, regardless of status?

A pre-exit hook is pretty much [exactly what this is for](https://buildkite.com/docs/agent/v3/hooks):

> Runs before the job finishes. Useful for performing cleanup tasks.

This PR is a quick experiment to see if hooks work like I expect, and if BuildKite is leaving any containers lying around that we wouldn't want to stop.