### PR TITLE
Serialise correct 'type' for relations

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/RelatedWorkRequestBuilder.scala
@@ -27,6 +27,7 @@ case class RelatedWorkRequestBuilder(index: Index,
     "data.collectionPath.path",
     "data.collectionPath.level.type",
     "data.collectionPath.label",
+    "data.workType",
   )
 
   lazy val request: MultiSearchRequest =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -609,12 +609,12 @@ class WorksIncludesTest
                   "id": "${workA.state.canonicalId}",
                   "title": "0/a",
                   "alternativeTitles": [],
-                  "type": "Work",
+                  "type": "Section",
                   "partOf": [{
                     "id": "${work0.state.canonicalId}",
                     "title": "0",
                     "alternativeTitles": [],
-                    "type": "Work",
+                    "type": "Collection",
                     "partOf": []
                   }
                 ]

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsRequestBuilder.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsRequestBuilder.scala
@@ -25,6 +25,7 @@ case class RelationsRequestBuilder(index: Index,
     "data.collectionPath.path",
     "data.collectionPath.level.type",
     "data.collectionPath.label",
+    "data.workType",
   )
 
   // To reduce response size and improve Elasticsearch performance we only


### PR DESCRIPTION
Spotted by @GarethOrmerod. This is currently always "Work". We should be using the `workType` field to discern this.