### PR TITLE
Many merged sources

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -28,7 +28,7 @@ class RelatedWorkServiceTest
   def work(path: String, level: CollectionLevel): Work.Visible[Identified] =
     identifiedWork(
       sourceIdentifier = createSourceIdentifierWith(value = path),
-      nMergedSources = 0)
+      nSources = 1)
       .title(path)
       .collectionPath(CollectionPath(path = path, level = Some(level)))
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/RelatedWorkServiceTest.scala
@@ -28,7 +28,7 @@ class RelatedWorkServiceTest
   def work(path: String, level: CollectionLevel): Work.Visible[Identified] =
     identifiedWork(
       sourceIdentifier = createSourceIdentifierWith(value = path),
-      nSources = 1)
+      numberOfSources = 1)
       .title(path)
       .collectionPath(CollectionPath(path = path, level = Some(level)))
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -26,7 +26,7 @@ case object ImagesIndexConfig extends IndexConfig {
     sourceWork("canonicalWork"),
     sourceWork("redirectedWork"),
     keywordField("type"),
-    intField("nMergedSources")
+    intField("nSources")
   )
 
   override val mapping: MappingDefinition = properties(

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -26,7 +26,7 @@ case object ImagesIndexConfig extends IndexConfig {
     sourceWork("canonicalWork"),
     sourceWork("redirectedWork"),
     keywordField("type"),
-    intField("nSources")
+    intField("numberOfSources")
   )
 
   override val mapping: MappingDefinition = properties(

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -205,7 +205,7 @@ object MergedWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(
     sourceIdentifier,
-    intField("nMergedSources"),
+    intField("nSources"),
   )
 }
 
@@ -213,7 +213,7 @@ object DenormalisedWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(
     sourceIdentifier,
-    intField("nMergedSources"),
+    intField("nSources"),
     relations
   )
 }
@@ -223,7 +223,7 @@ object IdentifiedWorkIndexConfig extends WorksIndexConfig {
   val state = objectField("state").fields(
     canonicalId,
     sourceIdentifier,
-    intField("nMergedSources"),
+    intField("nSources"),
     relations
   )
 }

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -205,7 +205,7 @@ object MergedWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(
     sourceIdentifier,
-    intField("nSources"),
+    intField("numberOfSources"),
   )
 }
 
@@ -213,7 +213,7 @@ object DenormalisedWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(
     sourceIdentifier,
-    intField("nSources"),
+    intField("numberOfSources"),
     relations
   )
 }
@@ -223,7 +223,7 @@ object IdentifiedWorkIndexConfig extends WorksIndexConfig {
   val state = objectField("state").fields(
     canonicalId,
     sourceIdentifier,
-    intField("nSources"),
+    intField("numberOfSources"),
     relations
   )
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -12,12 +12,13 @@ case class UnmergedImage[State <: DataState](
 ) extends BaseImage[State] {
   def mergeWith(canonicalWork: SourceWork[State],
                 redirectedWork: Option[SourceWork[State]],
-                nSources: Int): MergedImage[State] =
+                numberOfSources: Int): MergedImage[State] =
     MergedImage[State](
       id = id,
       version = version,
       location = location,
-      source = SourceWorks[State](canonicalWork, redirectedWork, nSources)
+      source =
+        SourceWorks[State](canonicalWork, redirectedWork, numberOfSources)
     )
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -12,12 +12,12 @@ case class UnmergedImage[State <: DataState](
 ) extends BaseImage[State] {
   def mergeWith(canonicalWork: SourceWork[State],
                 redirectedWork: Option[SourceWork[State]],
-                nMergedSources: Int): MergedImage[State] =
+                nSources: Int): MergedImage[State] =
     MergedImage[State](
       id = id,
       version = version,
       location = location,
-      source = SourceWorks[State](canonicalWork, redirectedWork, nMergedSources)
+      source = SourceWorks[State](canonicalWork, redirectedWork, nSources)
     )
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -8,7 +8,7 @@ sealed trait ImageSource[State <: DataState] {
 case class SourceWorks[State <: DataState](
   canonicalWork: SourceWork[State],
   redirectedWork: Option[SourceWork[State]],
-  nMergedSources: Int = 0
+  nSources: Int = 0
 ) extends ImageSource[State] {
   override val id = canonicalWork.id
   override val version =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -8,7 +8,7 @@ sealed trait ImageSource[State <: DataState] {
 case class SourceWorks[State <: DataState](
   canonicalWork: SourceWork[State],
   redirectedWork: Option[SourceWork[State]],
-  nSources: Int = 1
+  numberOfSources: Int = 1
 ) extends ImageSource[State] {
   override val id = canonicalWork.id
   override val version =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/ImageSource.scala
@@ -8,7 +8,7 @@ sealed trait ImageSource[State <: DataState] {
 case class SourceWorks[State <: DataState](
   canonicalWork: SourceWork[State],
   redirectedWork: Option[SourceWork[State]],
-  nSources: Int = 0
+  nSources: Int = 1
 ) extends ImageSource[State] {
   override val id = canonicalWork.id
   override val version =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -139,7 +139,7 @@ object WorkState {
 
   case class Merged(
     sourceIdentifier: SourceIdentifier,
-    nSources: Int
+    numberOfSources: Int
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -148,7 +148,7 @@ object WorkState {
 
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
-    nSources: Int = 1,
+    numberOfSources: Int = 1,
     relations: Relations[DataState.Unidentified] = Relations.none
   ) extends WorkState {
 
@@ -159,7 +159,7 @@ object WorkState {
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: String,
-    nSources: Int = 1,
+    numberOfSources: Int = 1,
     relations: Relations[DataState.Identified] = Relations.none
   ) extends WorkState {
 
@@ -190,8 +190,8 @@ object WorkFsm {
   }
 
   implicit val sourceToMerged = new Transition[Source, Merged] {
-    def state(state: Source, nSources: Int): Merged =
-      Merged(state.sourceIdentifier, nSources)
+    def state(state: Source, numberOfSources: Int): Merged =
+      Merged(state.sourceIdentifier, numberOfSources)
 
     def data(data: WorkData[DataState.Unidentified]) = data
 
@@ -201,7 +201,7 @@ object WorkFsm {
   implicit val mergedToDenormalised = new Transition[Merged, Denormalised] {
     def state(state: Merged,
               relations: Relations[DataState.Unidentified]): Denormalised =
-      Denormalised(state.sourceIdentifier, state.nSources, relations)
+      Denormalised(state.sourceIdentifier, state.numberOfSources, relations)
 
     def data(data: WorkData[DataState.Unidentified]) = data
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -139,7 +139,7 @@ object WorkState {
 
   case class Merged(
     sourceIdentifier: SourceIdentifier,
-    nMergedSources: Int
+    nSources: Int
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -148,7 +148,7 @@ object WorkState {
 
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
-    nMergedSources: Int = 0,
+    nSources: Int = 1,
     relations: Relations[DataState.Unidentified] = Relations.none
   ) extends WorkState {
 
@@ -159,7 +159,7 @@ object WorkState {
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: String,
-    nMergedSources: Int = 0,
+    nSources: Int = 1,
     relations: Relations[DataState.Identified] = Relations.none
   ) extends WorkState {
 
@@ -190,8 +190,8 @@ object WorkFsm {
   }
 
   implicit val sourceToMerged = new Transition[Source, Merged] {
-    def state(state: Source, nMergedSources: Int): Merged =
-      Merged(state.sourceIdentifier, nMergedSources)
+    def state(state: Source, nSources: Int): Merged =
+      Merged(state.sourceIdentifier, nSources)
 
     def data(data: WorkData[DataState.Unidentified]) = data
 
@@ -201,7 +201,7 @@ object WorkFsm {
   implicit val mergedToDenormalised = new Transition[Merged, Denormalised] {
     def state(state: Merged,
               relations: Relations[DataState.Unidentified]): Denormalised =
-      Denormalised(state.sourceIdentifier, state.nMergedSources, relations)
+      Denormalised(state.sourceIdentifier, state.nSources, relations)
 
     def data(data: WorkData[DataState.Unidentified]) = data
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -23,21 +23,21 @@ trait WorkGenerators extends IdentifiersGenerators {
 
   def mergedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    nSources: Int = 1
+    numberOfSources: Int = 1
   ): Work.Visible[Merged] =
     Work.Visible[Merged](
-      state = Merged(sourceIdentifier, nSources),
+      state = Merged(sourceIdentifier, numberOfSources),
       data = initData,
       version = createVersion
     )
 
   def denormalisedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    nSources: Int = 1,
+    numberOfSources: Int = 1,
     relations: Relations[DataState.Unidentified] = Relations.none
   ): Work.Visible[Denormalised] =
     Work.Visible[Denormalised](
-      state = Denormalised(sourceIdentifier, nSources, relations),
+      state = Denormalised(sourceIdentifier, numberOfSources, relations),
       data = initData,
       version = createVersion
     )
@@ -45,14 +45,14 @@ trait WorkGenerators extends IdentifiersGenerators {
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: String = createCanonicalId,
-    nSources: Int = chooseFrom(1, 2, 3, 4),
+    numberOfSources: Int = chooseFrom(1, 2, 3, 4),
     relations: Relations[DataState.Identified] = Relations.none
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
       state = Identified(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        nSources = nSources,
+        numberOfSources = numberOfSources,
         relations = relations
       ),
       data = initData,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -23,21 +23,21 @@ trait WorkGenerators extends IdentifiersGenerators {
 
   def mergedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    nMergedSources: Int = 0
+    nSources: Int = 1
   ): Work.Visible[Merged] =
     Work.Visible[Merged](
-      state = Merged(sourceIdentifier, nMergedSources),
+      state = Merged(sourceIdentifier, nSources),
       data = initData,
       version = createVersion
     )
 
   def denormalisedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    nMergedSources: Int = 0,
+    nSources: Int = 1,
     relations: Relations[DataState.Unidentified] = Relations.none
   ): Work.Visible[Denormalised] =
     Work.Visible[Denormalised](
-      state = Denormalised(sourceIdentifier, nMergedSources, relations),
+      state = Denormalised(sourceIdentifier, nSources, relations),
       data = initData,
       version = createVersion
     )
@@ -45,14 +45,14 @@ trait WorkGenerators extends IdentifiersGenerators {
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: String = createCanonicalId,
-    nMergedSources: Int = chooseFrom(0, 1, 2, 3),
+    nSources: Int = chooseFrom(1, 2, 3, 4),
     relations: Relations[DataState.Identified] = Relations.none
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
       state = Identified(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        nMergedSources = nMergedSources,
+        nSources = nSources,
         relations = relations
       ),
       data = initData,

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -85,7 +85,7 @@ object Indexable extends Logging {
             case SourceWorks(_, _, nMergedSources)
                 if nMergedSources >= versionMultiplier =>
               throw new RuntimeException(
-                s"Image ${image.id.canonicalId} has $nMergedSources >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
+                s"Image ${image.id.sourceIdentifier.toString} has $nMergedSources >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
             case SourceWorks(_, Some(redirected), nMergedSources) =>
               nMergedSources + 1
             case SourceWorks(_, None, nMergedSources) => nMergedSources
@@ -103,7 +103,7 @@ object Indexable extends Logging {
           case Work.Visible(_, _, state)
               if state.nMergedSources >= versionMultiplier =>
             throw new RuntimeException(
-              s"Work ${work.state.canonicalId} has ${work.state.nMergedSources} >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
+              s"Work ${work.state.sourceIdentifier.toString} has ${work.state.nMergedSources} >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
           case Work.Visible(version, _, state) =>
             (version * versionMultiplier) + state.nMergedSources
           case Work.Redirected(version, _, _) =>

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -30,7 +30,7 @@ trait Indexable[T] {
   * When the merger makes the decision to merge some works, it modifies
   * the content of the affected works. Despite the content of these works
   * being modified, their version remains the same. However, the merger
-  * attaches the number of merged sources (`nMergedSources`) to the target
+  * attaches the number of sources (`nSources`) to the target
   * work and may choose to redirect some of the source works.
   *
   * When we ingest those works, we need to make sure that the merger
@@ -82,13 +82,12 @@ object Indexable extends Logging {
       def version(image: AugmentedImage) =
         versionMultiplier * (image.version + image.source.version) +
           (image.source match {
-            case SourceWorks(_, _, nMergedSources)
-                if nMergedSources >= versionMultiplier =>
+            case SourceWorks(_, _, nSources) if nSources > versionMultiplier =>
               throw new RuntimeException(
-                s"Image ${image.id.sourceIdentifier.toString} has $nMergedSources >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
-            case SourceWorks(_, Some(redirected), nMergedSources) =>
-              nMergedSources + 1
-            case SourceWorks(_, None, nMergedSources) => nMergedSources
+                s"Image ${image.id.sourceIdentifier.toString} has $nSources > $versionMultiplier sources; versioning/ingest may be inconsistent")
+            case SourceWorks(_, Some(redirected), nSources) => nSources
+            case SourceWorks(_, None, nSources) =>
+              nSources - 1 // The number of additional sources
           })
     }
 
@@ -101,11 +100,11 @@ object Indexable extends Logging {
       def version(work: Work[Identified]) =
         work match {
           case Work.Visible(_, _, state)
-              if state.nMergedSources >= versionMultiplier =>
+              if state.nSources > versionMultiplier =>
             throw new RuntimeException(
-              s"Work ${work.state.sourceIdentifier.toString} has ${work.state.nMergedSources} >= $versionMultiplier merged sources; versioning/ingest may be inconsistent")
+              s"Work ${work.state.sourceIdentifier.toString} has ${work.state.nSources} > $versionMultiplier sources; versioning/ingest may be inconsistent")
           case Work.Visible(version, _, state) =>
-            (version * versionMultiplier) + state.nMergedSources
+            (version * versionMultiplier) + (state.nSources - 1) // The number of additional sources
           case Work.Redirected(version, _, _) =>
             (version * versionMultiplier) + 1
           case Work.Invisible(version, _, _, _) => version * versionMultiplier

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -72,6 +72,8 @@ trait Indexable[T] {
   */
 object Indexable extends Logging {
 
+  // The largest number of merged sources is about 650, so this
+  // allows sufficient room for that at the moment.
   final val versionMultiplier = 1000
 
   implicit val imageIndexable: Indexable[AugmentedImage] =

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
@@ -148,7 +148,7 @@ class ImageIndexableTest
         source = SourceWorks(
           canonicalWork = identifiedWork().toSourceWork,
           redirectedWork = None,
-          nSources = Indexable.versionMultiplier
+          numberOfSources = Indexable.versionMultiplier
         )
       )
 

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
@@ -143,12 +143,12 @@ class ImageIndexableTest
       }
     }
 
-    it("throws an error if an image has > versionMultiplier merged sources") {
+    it("throws an error if an image has >= versionMultiplier merged sources") {
       val erroneousImage = createAugmentedImage().copy(
         source = SourceWorks(
           canonicalWork = identifiedWork().toSourceWork,
           redirectedWork = None,
-          nSources = Indexable.versionMultiplier + 1
+          nSources = Indexable.versionMultiplier
         )
       )
 

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
@@ -143,12 +143,12 @@ class ImageIndexableTest
       }
     }
 
-    it("throws an error if an image has >= 10 merged sources") {
+    it("throws an error if an image has > versionMultiplier merged sources") {
       val erroneousImage = createAugmentedImage().copy(
         source = SourceWorks(
           canonicalWork = identifiedWork().toSourceWork,
           redirectedWork = None,
-          nMergedSources = 10
+          nSources = Indexable.versionMultiplier + 1
         )
       )
 

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -25,13 +25,12 @@ class WorkIndexableTest
     with WorkGenerators {
 
   describe("updating merged / redirected works") {
-    it(
-      "doesn't override a merged Work with the same version but no merged sources") {
-      val mergedWork = identifiedWork(nMergedSources = 1).withVersion(3)
+    it("doesn't override a merged Work with the same version but only 1 source") {
+      val mergedWork = identifiedWork(nSources = 2).withVersion(3)
 
       val unmergedWork = identifiedWork(
         sourceIdentifier = mergedWork.sourceIdentifier,
-        nMergedSources = 0
+        nSources = 1
       ).withVersion(mergedWork.version)
 
       withWorksIndexAndIndexer {
@@ -51,10 +50,10 @@ class WorkIndexableTest
     }
 
     it("doesn't overwrite a Work with lower version and multiple sources") {
-      val unmergedNewWork = identifiedWork(nMergedSources = 0).withVersion(4)
+      val unmergedNewWork = identifiedWork(nSources = 1).withVersion(4)
       val mergedOldWork = identifiedWork(
         sourceIdentifier = unmergedNewWork.sourceIdentifier,
-        nMergedSources = 1
+        nSources = 2
       ).withVersion(unmergedNewWork.version - 1)
 
       withWorksIndexAndIndexer {
@@ -103,7 +102,7 @@ class WorkIndexableTest
 
     it(
       "doesn't override a redirected Work with an identified work with the same version") {
-      val redirectedWork = identifiedWork(nMergedSources = 0)
+      val redirectedWork = identifiedWork(nSources = 1)
         .redirected(
           IdState.Identified(
             canonicalId = createCanonicalId,
@@ -113,7 +112,7 @@ class WorkIndexableTest
       val identifiedOldWork =
         identifiedWork(
           canonicalId = redirectedWork.state.canonicalId,
-          nMergedSources = 0)
+          nSources = 1)
           .withVersion(redirectedWork.version)
 
       withWorksIndexAndIndexer {
@@ -132,11 +131,11 @@ class WorkIndexableTest
     }
 
     it("overrides a merged work with one that has been merged again") {
-      val mergedWork1 = identifiedWork(nMergedSources = 1)
+      val mergedWork1 = identifiedWork(nSources = 2)
       val mergedWork2 =
-        mergedWork1.copy(state = mergedWork1.state.copy(nMergedSources = 2))
+        mergedWork1.copy(state = mergedWork1.state.copy(nSources = 3))
       val mergedWork3 =
-        mergedWork1.copy(state = mergedWork1.state.copy(nMergedSources = 3))
+        mergedWork1.copy(state = mergedWork1.state.copy(nSources = 4))
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -178,8 +177,9 @@ class WorkIndexableTest
       }
     }
 
-    it("throws an error if a work has >= 10 merged sources") {
-      val erroneousWork = identifiedWork(nMergedSources = 10)
+    it("throws an error if a work has > versionMultiplier sources") {
+      val erroneousWork =
+        identifiedWork(nSources = Indexable.versionMultiplier + 1)
 
       withWorksIndexAndIndexer {
         case (_, indexer) =>

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -131,23 +131,23 @@ class WorkIndexableTest
     }
 
     it("overrides a merged work with one that has been merged again") {
-      val mergedWork1 = identifiedWork(nSources = 2)
-      val mergedWork2 =
-        mergedWork1.copy(state = mergedWork1.state.copy(nSources = 3))
+      val mergedWork2 = identifiedWork(nSources = 2)
       val mergedWork3 =
-        mergedWork1.copy(state = mergedWork1.state.copy(nSources = 4))
+        mergedWork2.copy(state = mergedWork2.state.copy(nSources = 3))
+      val mergedWork4 =
+        mergedWork2.copy(state = mergedWork2.state.copy(nSources = 4))
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
           val insertFuture = ingestInOrder(indexer)(
-            mergedWork1,
-            mergedWork3,
-            mergedWork2
+            mergedWork2,
+            mergedWork4,
+            mergedWork3
           )
           whenReady(insertFuture) { result =>
             assertIngestedWorkIs(
               result = result,
-              ingestedWork = mergedWork3,
+              ingestedWork = mergedWork4,
               index = index
             )
           }
@@ -177,9 +177,9 @@ class WorkIndexableTest
       }
     }
 
-    it("throws an error if a work has > versionMultiplier sources") {
+    it("throws an error if a work has >= versionMultiplier sources") {
       val erroneousWork =
-        identifiedWork(nSources = Indexable.versionMultiplier + 1)
+        identifiedWork(nSources = Indexable.versionMultiplier)
 
       withWorksIndexAndIndexer {
         case (_, indexer) =>

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -26,11 +26,11 @@ class WorkIndexableTest
 
   describe("updating merged / redirected works") {
     it("doesn't override a merged Work with the same version but only 1 source") {
-      val mergedWork = identifiedWork(nSources = 2).withVersion(3)
+      val mergedWork = identifiedWork(numberOfSources = 2).withVersion(3)
 
       val unmergedWork = identifiedWork(
         sourceIdentifier = mergedWork.sourceIdentifier,
-        nSources = 1
+        numberOfSources = 1
       ).withVersion(mergedWork.version)
 
       withWorksIndexAndIndexer {
@@ -50,10 +50,10 @@ class WorkIndexableTest
     }
 
     it("doesn't overwrite a Work with lower version and multiple sources") {
-      val unmergedNewWork = identifiedWork(nSources = 1).withVersion(4)
+      val unmergedNewWork = identifiedWork(numberOfSources = 1).withVersion(4)
       val mergedOldWork = identifiedWork(
         sourceIdentifier = unmergedNewWork.sourceIdentifier,
-        nSources = 2
+        numberOfSources = 2
       ).withVersion(unmergedNewWork.version - 1)
 
       withWorksIndexAndIndexer {
@@ -102,7 +102,7 @@ class WorkIndexableTest
 
     it(
       "doesn't override a redirected Work with an identified work with the same version") {
-      val redirectedWork = identifiedWork(nSources = 1)
+      val redirectedWork = identifiedWork(numberOfSources = 1)
         .redirected(
           IdState.Identified(
             canonicalId = createCanonicalId,
@@ -112,7 +112,7 @@ class WorkIndexableTest
       val identifiedOldWork =
         identifiedWork(
           canonicalId = redirectedWork.state.canonicalId,
-          nSources = 1)
+          numberOfSources = 1)
           .withVersion(redirectedWork.version)
 
       withWorksIndexAndIndexer {
@@ -131,11 +131,11 @@ class WorkIndexableTest
     }
 
     it("overrides a merged work with one that has been merged again") {
-      val mergedWork2 = identifiedWork(nSources = 2)
+      val mergedWork2 = identifiedWork(numberOfSources = 2)
       val mergedWork3 =
-        mergedWork2.copy(state = mergedWork2.state.copy(nSources = 3))
+        mergedWork2.copy(state = mergedWork2.state.copy(numberOfSources = 3))
       val mergedWork4 =
-        mergedWork2.copy(state = mergedWork2.state.copy(nSources = 4))
+        mergedWork2.copy(state = mergedWork2.state.copy(numberOfSources = 4))
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -179,7 +179,7 @@ class WorkIndexableTest
 
     it("throws an error if a work has >= versionMultiplier sources") {
       val erroneousWork =
-        identifiedWork(nSources = Indexable.versionMultiplier)
+        identifiedWork(numberOfSources = Indexable.versionMultiplier)
 
       withWorksIndexAndIndexer {
         case (_, indexer) =>

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -15,7 +15,7 @@ object MergerOutcome {
 
   def passThrough(works: Seq[Work[Source]]): MergerOutcome =
     MergerOutcome(
-      works = works.map(_.transition[Merged](0)),
+      works = works.map(_.transition[Merged](1)),
       images = Nil
     )
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -79,10 +79,10 @@ trait Merger extends MergerLogging {
           }
 
           val remaining = (sources.toSet -- redirectedSources)
-            .map(_.transition[Merged](0))
+            .map(_.transition[Merged](1))
           val redirects = redirectedSources
             .map(redirectSourceToTarget(target))
-            .map(_.transition[Merged](0))
+            .map(_.transition[Merged](1))
           logResult(result, redirects.toList, remaining.toList)
 
           MergerOutcome(
@@ -141,12 +141,12 @@ object PlatformMerger extends Merger {
     if (sources.isEmpty)
       State.pure(
         MergeResult(
-          mergedTarget = target.transition[Merged](0),
+          mergedTarget = target.transition[Merged](1),
           images = standaloneImages(target).map {
             _ mergeWith (
               canonicalWork = target.toSourceWork,
               redirectedWork = None,
-              nMergedSources = 0
+              nSources = 1
             )
           }
         )
@@ -165,17 +165,17 @@ object PlatformMerger extends Merger {
             images = unmergedImages
           )
         }
-        nSources <- State.inspect[MergeState, Int](_.size)
+        nMergedSources <- State.inspect[MergeState, Int](_.size)
       } yield
         MergeResult(
-          mergedTarget = work.transition[Merged](nSources),
+          mergedTarget = work.transition[Merged](nMergedSources + 1),
           images = unmergedImages.map { image =>
             image mergeWith (
               canonicalWork = work.toSourceWork,
               redirectedWork = sources
                 .find { _.data.images.contains(image) }
                 .map(_.toSourceWork),
-              nMergedSources = nSources
+              nSources = nMergedSources + 1
             )
           }
         )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -52,7 +52,7 @@ trait Merger extends MergerLogging {
 
   implicit class MergeResultAccumulation[T](val result: FieldMergeResult[T]) {
     def redirectSources: State[MergeState, T] = shouldRedirect(true)
-    def retainSources: State[MergeState, T] = shouldRedirect(false)
+    def retainumberOfSources: State[MergeState, T] = shouldRedirect(false)
 
     // If the state already contains a source, then don't change the existing `redirect` value
     // Otherwise, add the source with the current value.
@@ -146,7 +146,7 @@ object PlatformMerger extends Merger {
             _ mergeWith (
               canonicalWork = target.toSourceWork,
               redirectedWork = None,
-              nSources = 1
+              numberOfSources = 1
             )
           }
         )
@@ -156,7 +156,7 @@ object PlatformMerger extends Merger {
         items <- ItemsRule(target, sources).redirectSources
         thumbnail <- ThumbnailRule(target, sources).redirectSources
         otherIdentifiers <- OtherIdentifiersRule(target, sources).redirectSources
-        unmergedImages <- ImagesRule(target, sources).retainSources
+        unmergedImages <- ImagesRule(target, sources).retainumberOfSources
         work = target.mapData { data =>
           data.copy[DataState.Unidentified](
             items = items,
@@ -175,7 +175,7 @@ object PlatformMerger extends Merger {
               redirectedWork = sources
                 .find { _.data.images.contains(image) }
                 .map(_.toSourceWork),
-              nSources = nMergedSources + 1
+              numberOfSources = nMergedSources + 1
             )
           }
         )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerIntegrationTest.scala
@@ -41,7 +41,7 @@ class MergerIntegrationTest
               assertQueueEmpty(dlq)
 
               workSender.getMessages[Work[Merged]] should contain only
-                work.transition[Merged](0)
+                work.transition[Merged](1)
             }
           }
       }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -16,7 +16,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
 
     val result = mergerManager.applyMerge(maybeWorks = List(Some(work)))
 
-    result.works shouldBe List(work.transition[Merged](0))
+    result.works shouldBe List(work.transition[Merged](1))
   }
 
   it("performs a merge with multiple works") {
@@ -27,7 +27,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
 
     val result = mergerManager.applyMerge(maybeWorks = works)
 
-    result.works.head shouldBe work.transition[Merged](0)
+    result.works.head shouldBe work.transition[Merged](1)
 
     result.works.tail.zip(otherWorks).map {
       case (baseWork: Work[Merged], unmergedWork: Work.Visible[Source]) =>
@@ -48,7 +48,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
     val result = mergerManager.applyMerge(maybeWorks = maybeWorks.toList)
 
     result.works should contain theSameElementsAs
-      expectedWorks.map(_.transition[Merged](0))
+      expectedWorks.map(_.transition[Merged](1))
   }
 
   val mergerRules = new Merger {
@@ -65,7 +65,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
         )
       }
       MergerOutcome(
-        works = outputWorks.map(_.transition[Merged](0)),
+        works = outputWorks.map(_.transition[Merged](1)),
         images = Nil
       )
     }
@@ -81,7 +81,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
         _ =>
           (
             sources zip Stream.continually(true) toMap,
-            MergeResult(target.transition[Merged](0), Nil))
+            MergeResult(target.transition[Merged](1), Nil))
       )
   }
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -74,7 +74,7 @@ class MergerTest
                 otherIdentifiers = otherIdentifiers
               )
             }
-            .transition[Merged](1),
+            .transition[Merged](2),
           images = Nil
         )
   }
@@ -85,7 +85,7 @@ class MergerTest
     mergedWorks.works should contain(
       inputWorks.head
         .asInstanceOf[Work.Visible[Source]]
-        .transition[Merged](1)
+        .transition[Merged](2)
         .mapData { data =>
           data.copy[DataState.Unidentified](
             items = mergedTargetItems,
@@ -105,7 +105,7 @@ class MergerTest
 
   it("returns all non-redirected and non-target works untouched") {
     mergedWorks.works should contain(
-      inputWorks.tail.head.transition[Merged](0)
+      inputWorks.tail.head.transition[Merged](1)
     )
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -54,9 +54,9 @@ class MergerWorkerServiceTest
 
           senders.works
             .getMessages[Work[Merged]] should contain only (
-            work1.transition[Merged](0),
-            work2.transition[Merged](0),
-            work3.transition[Merged](0)
+            work1.transition[Merged](1),
+            work2.transition[Merged](1),
+            work3.transition[Merged](1)
           )
 
           metrics.incrementedCounts.length should be >= 1
@@ -84,7 +84,7 @@ class MergerWorkerServiceTest
           assertQueueEmpty(dlq)
 
           senders.works.getMessages[Work[Merged]] should contain only
-            work.transition[Merged](0)
+            work.transition[Merged](1)
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")
@@ -139,7 +139,7 @@ class MergerWorkerServiceTest
           assertQueueEmpty(dlq)
           val worksSent = senders.works.getMessages[Work[Merged]]
           worksSent should contain only
-            work.transition[Merged](0)
+            work.transition[Merged](1)
         }
     }
   }
@@ -170,7 +170,7 @@ class MergerWorkerServiceTest
 
           val worksSent = senders.works.getMessages[Work[Merged]]
           worksSent should contain only
-            work.transition[Merged](0)
+            work.transition[Merged](1)
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -152,8 +152,9 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = miroWork.sourceIdentifier,
+          numberOfSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -161,7 +162,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nSources = 2
+      numberOfSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -192,8 +193,9 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = miroWork.sourceIdentifier,
+          numberOfSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(zeroItemSierraWork.sourceIdentifier)
       )
@@ -201,7 +203,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nSources = 2
+      numberOfSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -241,8 +243,9 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = miroWork.sourceIdentifier,
+          numberOfSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraDigitalWork.sourceIdentifier)
       )
@@ -250,7 +253,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nSources = 2
+      numberOfSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -306,8 +309,9 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          numberOfSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -344,8 +348,9 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          numberOfSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPictureWork.sourceIdentifier)
       )
@@ -353,7 +358,7 @@ class PlatformMergerTest
     val expectedImage = metsWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(metsWork.toSourceWork),
-      nSources = 2
+      numberOfSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -396,23 +401,25 @@ class PlatformMergerTest
       Work.Redirected[Merged](
         state = Merged(
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          nSources = 1),
+          numberOfSources = 1),
         version = sierraDigitisedWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
 
     val expectedMiroRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = miroWork.sourceIdentifier,
+          numberOfSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          numberOfSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -420,7 +427,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nSources = 4
+      numberOfSources = 4
     )
 
     result.works should contain theSameElementsAs List(
@@ -455,8 +462,9 @@ class PlatformMergerTest
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          numberOfSources = 1),
         version = metsWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -493,7 +501,7 @@ class PlatformMergerTest
       Work.Redirected[Merged](
         state = Merged(
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          nSources = 1),
+          numberOfSources = 1),
         version = sierraDigitisedWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -501,8 +509,9 @@ class PlatformMergerTest
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state =
-          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
+        state = Merged(
+          sourceIdentifier = metsWork.sourceIdentifier,
+          numberOfSources = 1),
         version = metsWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -525,7 +534,7 @@ class PlatformMergerTest
     result.images.head shouldBe miroWork.data.images.head.mergeWith(
       canonicalWork = miroWork.toSourceWork,
       redirectedWork = None,
-      nSources = 1
+      numberOfSources = 1
     )
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -136,7 +136,7 @@ class PlatformMergerTest
     val miroItem = miroWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -152,9 +152,8 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = miroWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -162,7 +161,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nMergedSources = 1
+      nSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -181,7 +180,7 @@ class PlatformMergerTest
     result.works.size shouldBe 2
 
     val expectedMergedWork = zeroItemSierraWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           otherIdentifiers = data.otherIdentifiers ++ miroWork.identifiers,
@@ -193,9 +192,8 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = miroWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(zeroItemSierraWork.sourceIdentifier)
       )
@@ -203,7 +201,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nMergedSources = 1
+      nSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -227,7 +225,7 @@ class PlatformMergerTest
     val miroItem = miroWork.data.items.head
 
     val expectedMergedWork = sierraDigitalWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -243,9 +241,8 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = miroWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraDigitalWork.sourceIdentifier)
       )
@@ -253,7 +250,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nMergedSources = 1
+      nSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -272,7 +269,7 @@ class PlatformMergerTest
     result.works.size shouldBe 2
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           images = miroWork.data.images,
@@ -280,7 +277,7 @@ class PlatformMergerTest
       }
 
     result.works should contain theSameElementsAs Seq(
-      miroWork.transition[Merged](0),
+      miroWork.transition[Merged](1),
       expectedMergedWork)
   }
 
@@ -295,7 +292,7 @@ class PlatformMergerTest
     val digitalItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           items = List(
@@ -309,9 +306,8 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = metsWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -333,7 +329,7 @@ class PlatformMergerTest
     val digitalItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPictureWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           items = List(
@@ -348,9 +344,8 @@ class PlatformMergerTest
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = metsWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPictureWork.sourceIdentifier)
       )
@@ -358,7 +353,7 @@ class PlatformMergerTest
     val expectedImage = metsWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(metsWork.toSourceWork),
-      nMergedSources = 1
+      nSources = 2
     )
 
     result.works should contain theSameElementsAs List(
@@ -381,7 +376,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](3)
+      .transition[Merged](4)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
@@ -401,25 +396,23 @@ class PlatformMergerTest
       Work.Redirected[Merged](
         state = Merged(
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          nMergedSources = 0),
+          nSources = 1),
         version = sierraDigitisedWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
 
     val expectedMiroRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = miroWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = miroWork.sourceIdentifier, nSources = 1),
         version = miroWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = metsWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
         version = metsWork.version,
         redirect = IdState.Identifiable(sierraPhysicalWork.sourceIdentifier)
       )
@@ -427,7 +420,7 @@ class PlatformMergerTest
     val expectedImage = miroWork.data.images.head mergeWith (
       canonicalWork = expectedMergedWork.toSourceWork,
       redirectedWork = Some(miroWork.toSourceWork),
-      nMergedSources = 3
+      nSources = 4
     )
 
     result.works should contain theSameElementsAs List(
@@ -452,7 +445,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](1)
+      .transition[Merged](2)
       .mapData { data =>
         data.copy(
           thumbnail = metsWork.data.thumbnail,
@@ -462,9 +455,8 @@ class PlatformMergerTest
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = metsWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
         version = metsWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -488,7 +480,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](2)
+      .transition[Merged](3)
       .mapData { data =>
         data.copy(
           otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitisedWork.identifiers,
@@ -501,7 +493,7 @@ class PlatformMergerTest
       Work.Redirected[Merged](
         state = Merged(
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          nMergedSources = 0),
+          nSources = 1),
         version = sierraDigitisedWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -509,9 +501,8 @@ class PlatformMergerTest
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
-        state = Merged(
-          sourceIdentifier = metsWork.sourceIdentifier,
-          nMergedSources = 0),
+        state =
+          Merged(sourceIdentifier = metsWork.sourceIdentifier, nSources = 1),
         version = metsWork.version,
         redirect =
           IdState.Identifiable(multipleItemsSierraWork.sourceIdentifier)
@@ -529,12 +520,12 @@ class PlatformMergerTest
     val result = merger.merge(List(miroWork))
 
     result.works should have length 1
-    result.works.head shouldBe miroWork.transition[Merged](0)
+    result.works.head shouldBe miroWork.transition[Merged](1)
     result.images should have length 1
     result.images.head shouldBe miroWork.data.images.head.mergeWith(
       canonicalWork = miroWork.toSourceWork,
       redirectedWork = None,
-      nMergedSources = 0
+      nSources = 1
     )
   }
 }


### PR DESCRIPTION
There are 2 things in here:

- It turns out that there can be a _lot_ more than 10 sources - It looks like the maximum we can currently have is about 650, so I've bumped the multiplier to accommodate this.

- After discussing with @warrd, I changed `nMergedSources` to `numberOfSources` (which behaves much like `nMergedSources + 1` as, although it's slightly more confusing when used in the indexing logic, it makes more sense from a modelling perspective and may be more useful in future.