### PR TITLE
Add init() method to Indexer trait

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 
-case object ImagesIndexConfig extends IndexConfig {
+object ImagesIndexConfig extends IndexConfig with IndexConfigFields {
 
   override val analysis: Analysis = WorksAnalysis()
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -13,7 +13,11 @@ import uk.ac.wellcome.elasticsearch.WorksAnalysis._
 trait IndexConfig {
   def mapping: MappingDefinition
   def analysis: Analysis
+}
 
+/** Mixin for common fields used within an IndexConfig in our internal models.
+  */
+trait IndexConfigFields {
   // `textWithKeyword` and `keywordWithText` are slightly different in the semantics and their use case.
   // If the intended field type is keyword, but you would like to search it textually, use `keywordWithText` and
   // visa versa.

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -93,3 +93,8 @@ trait IndexConfig {
   val canonicalId = lowercaseKeyword("canonicalId")
   val version = intField("version")
 }
+
+object NoStrictMapping extends IndexConfig {
+  val analysis: Analysis = Analysis(analyzers = List())
+  val mapping: MappingDefinition = MappingDefinition.empty
+}

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.requests.mappings.{
 }
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 
-sealed trait WorksIndexConfig extends IndexConfig {
+sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
 
   import WorksAnalysis._
   val analysis = WorksAnalysis()

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -9,16 +9,12 @@ import com.sksamuel.elastic4s.circe._
 import io.circe.Encoder
 import grizzled.slf4j.Logging
 
-import uk.ac.wellcome.elasticsearch.{
-  ElasticsearchIndexCreator,
-  IndexConfig,
-}
+import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig,}
 
-class ElasticIndexer[T: Indexable](client: ElasticClient,
-                                   index: Index,
-                                   config: IndexConfig)(
-  implicit ec: ExecutionContext,
-  encoder: Encoder[T])
+class ElasticIndexer[T: Indexable](
+  client: ElasticClient,
+  index: Index,
+  config: IndexConfig)(implicit ec: ExecutionContext, encoder: Encoder[T])
     extends Indexer[T]
     with Logging {
 

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -12,12 +12,11 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.elasticsearch.{
   ElasticsearchIndexCreator,
   IndexConfig,
-  NoStrictMapping
 }
 
 class ElasticIndexer[T: Indexable](client: ElasticClient,
                                    index: Index,
-                                   config: IndexConfig = NoStrictMapping)(
+                                   config: IndexConfig)(
   implicit ec: ExecutionContext,
   encoder: Encoder[T])
     extends Indexer[T]

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -9,12 +9,15 @@ import com.sksamuel.elastic4s.circe._
 import io.circe.Encoder
 import grizzled.slf4j.Logging
 
-import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig, NoStrictMapping}
+import uk.ac.wellcome.elasticsearch.{
+  ElasticsearchIndexCreator,
+  IndexConfig,
+  NoStrictMapping
+}
 
-class ElasticIndexer[T: Indexable](
-  client: ElasticClient,
-  index: Index,
-  config: IndexConfig = NoStrictMapping)(
+class ElasticIndexer[T: Indexable](client: ElasticClient,
+                                   index: Index,
+                                   config: IndexConfig = NoStrictMapping)(
   implicit ec: ExecutionContext,
   encoder: Encoder[T])
     extends Indexer[T]

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -9,7 +9,7 @@ import com.sksamuel.elastic4s.circe._
 import io.circe.Encoder
 import grizzled.slf4j.Logging
 
-import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig,}
+import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig}
 
 class ElasticIndexer[T: Indexable](
   client: ElasticClient,

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.pipeline_storage
 
 import scala.concurrent.{ExecutionContext, Future}
-
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.bulk.{BulkResponse, BulkResponseItem}
 import com.sksamuel.elastic4s.requests.common.VersionType.ExternalGte
@@ -10,11 +9,19 @@ import com.sksamuel.elastic4s.circe._
 import io.circe.Encoder
 import grizzled.slf4j.Logging
 
-class ElasticIndexer[T: Indexable](client: ElasticClient, index: Index)(
+import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig, NoStrictMapping}
+
+class ElasticIndexer[T: Indexable](
+  client: ElasticClient,
+  index: Index,
+  config: IndexConfig = NoStrictMapping)(
   implicit ec: ExecutionContext,
   encoder: Encoder[T])
     extends Indexer[T]
     with Logging {
+
+  final def init(): Future[Unit] =
+    new ElasticsearchIndexCreator(client, index, config).create
 
   final def index(documents: Seq[T]): Future[Either[Seq[T], Seq[T]]] = {
 

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -1,13 +1,16 @@
 package uk.ac.wellcome.pipeline_storage
 
 import scala.concurrent.Future
+import grizzled.slf4j.Logging
+
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
-import grizzled.slf4j.Logging
 
 abstract class Indexer[T: Indexable] {
 
   protected val indexable: Indexable[T] = implicitly
+
+  def init(): Future[Unit]
 
   /** Indexes the given documents into the store
     *

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
@@ -155,7 +155,9 @@ class ElasticIndexerTest
       }
     }
 
-  object StrictWithNoDataIndexConfig extends IndexConfig with IndexConfigFields {
+  object StrictWithNoDataIndexConfig
+      extends IndexConfig
+      with IndexConfigFields {
     import com.sksamuel.elastic4s.ElasticDsl._
 
     val analysis = WorksAnalysis()

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import io.circe.Encoder
 
-import uk.ac.wellcome.elasticsearch.{IndexConfig, WorksAnalysis}
+import uk.ac.wellcome.elasticsearch.{IndexConfig, WorksAnalysis, NoStrictMapping}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
@@ -10,7 +10,11 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import io.circe.Encoder
 
-import uk.ac.wellcome.elasticsearch.{IndexConfig, WorksAnalysis, NoStrictMapping}
+import uk.ac.wellcome.elasticsearch.{
+  IndexConfig,
+  NoStrictMapping,
+  WorksAnalysis
+}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexerTest.scala
@@ -12,6 +12,7 @@ import io.circe.Encoder
 
 import uk.ac.wellcome.elasticsearch.{
   IndexConfig,
+  IndexConfigFields,
   NoStrictMapping,
   WorksAnalysis
 }
@@ -154,7 +155,7 @@ class ElasticIndexerTest
       }
     }
 
-  object StrictWithNoDataIndexConfig extends IndexConfig {
+  object StrictWithNoDataIndexConfig extends IndexConfig with IndexConfigFields {
     import com.sksamuel.elastic4s.ElasticDsl._
 
     val analysis = WorksAnalysis()

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ElasticRetrieverTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import io.circe.Encoder
 
-import uk.ac.wellcome.elasticsearch.IndexConfig
+import uk.ac.wellcome.elasticsearch.{IndexConfig, NoStrictMapping}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
+import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
@@ -172,7 +174,7 @@ class ImageIndexableTest
   private def withImagesIndexAndIndexer[R](
     testWith: TestWith[(Index, ElasticIndexer[AugmentedImage]), R]) =
     withLocalImagesIndex { index =>
-      val indexer = new ElasticIndexer(elasticClient, index)
+      val indexer = new ElasticIndexer(elasticClient, index, ImagesIndexConfig)
       testWith((index, indexer))
     }
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -203,7 +203,8 @@ class WorkIndexableTest
   def withWorksIndexAndIndexer[R](
     testWith: TestWith[(Index, ElasticIndexer[Work[Identified]]), R]) = {
     withLocalWorksIndex { index =>
-      val indexer = new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig)
+      val indexer =
+        new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig)
       testWith((index, indexer))
     }
   }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
+import uk.ac.wellcome.elasticsearch.IdentifiedWorkIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.generators.WorkGenerators
@@ -201,7 +203,7 @@ class WorkIndexableTest
   def withWorksIndexAndIndexer[R](
     testWith: TestWith[(Index, ElasticIndexer[Work[Identified]]), R]) = {
     withLocalWorksIndex { index =>
-      val indexer = new ElasticIndexer(elasticClient, index)
+      val indexer = new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig)
       testWith((index, indexer))
     }
   }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
@@ -1,16 +1,14 @@
 package uk.ac.wellcome.pipeline_storage.fixtures
 
-import com.sksamuel.elastic4s.analysis.Analysis
-
 import scala.concurrent.{ExecutionContext, Future}
-import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import org.scalatest.Suite
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.elasticsearch.IndexConfig
+import uk.ac.wellcome.elasticsearch.{IndexConfig, NoStrictMapping}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, Indexable}
 import uk.ac.wellcome.json.JsonUtil._
@@ -37,17 +35,13 @@ trait ElasticIndexerFixtures extends ElasticsearchFixtures with Akka {
   this: Suite =>
 
   def withElasticIndexer[T, R](idx: Index,
-                               esClient: ElasticClient = elasticClient)(
+                               esClient: ElasticClient = elasticClient,
+                               config: IndexConfig = NoStrictMapping)(
     testWith: TestWith[ElasticIndexer[T], R])(implicit
                                               ec: ExecutionContext,
                                               encoder: Encoder[T],
                                               indexable: Indexable[T]): R =
-    testWith(new ElasticIndexer[T](esClient, idx))
-
-  object NoStrictMapping extends IndexConfig {
-    val analysis: Analysis = Analysis(analyzers = List())
-    val mapping: MappingDefinition = MappingDefinition.empty
-  }
+    testWith(new ElasticIndexer[T](esClient, idx, config))
 
   implicit def canonicalId[T](
     implicit indexable: Indexable[T]): CanonicalId[T] =

--- a/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerService.scala
@@ -4,7 +4,6 @@ import akka.Done
 import software.amazon.awssdk.services.sqs.model.Message
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.bigmessaging.message.BigMessageStream
-import uk.ac.wellcome.elasticsearch.ElasticsearchIndexCreator
 import uk.ac.wellcome.pipeline_storage.Indexer
 import uk.ac.wellcome.platform.ingestor.common.models.IngestorConfig
 import uk.ac.wellcome.typesafe.Runnable
@@ -13,7 +12,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class IngestorWorkerService[T](
   ingestorConfig: IngestorConfig,
-  indexCreator: ElasticsearchIndexCreator,
   documentIndexer: Indexer[T],
   messageStream: BigMessageStream[T]
 )(implicit
@@ -28,7 +26,7 @@ class IngestorWorkerService[T](
 
   def run(): Future[Done] =
     for {
-      _ <- indexCreator.create
+      _ <- documentIndexer.init()
       result <- runStream()
     } yield result
 

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/fixtures/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/fixtures/IngestorFixtures.scala
@@ -5,7 +5,6 @@ import io.circe.Decoder
 import org.scalatest.Suite
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.elasticsearch.{ElasticsearchIndexCreator, IndexConfig}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.pipeline_storage.Indexer
@@ -24,7 +23,6 @@ trait IngestorFixtures
 
   def withWorkerService[T, R](queue: Queue,
                               index: Index,
-                              indexConfig: IndexConfig,
                               indexer: Indexer[T],
                               elasticClient: ElasticClient = elasticClient)(
     testWith: TestWith[IngestorWorkerService[T], R])(
@@ -38,8 +36,6 @@ trait IngestorFixtures
           )
 
           val workerService = new IngestorWorkerService(
-            indexCreator =
-              new ElasticsearchIndexCreator(elasticClient, index, indexConfig),
             documentIndexer = indexer,
             ingestorConfig = ingestorConfig,
             messageStream = messageStream

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
@@ -6,10 +6,7 @@ import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import org.scalatest.funspec.AnyFunSpec
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
-import uk.ac.wellcome.elasticsearch.{
-  ElasticCredentials,
-  ElasticsearchIndexCreator
-}
+import uk.ac.wellcome.elasticsearch.ElasticCredentials
 import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators

--- a/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/uk/ac/wellcome/platform/ingestor/common/services/IngestorWorkerServiceTest.scala
@@ -32,7 +32,6 @@ class IngestorWorkerServiceTest
         withWorkerService[SampleDocument, Any](
           queue,
           index,
-          NoStrictMapping,
           indexer,
           elasticClient) { _ =>
           eventuallyIndexExists(index)
@@ -51,7 +50,6 @@ class IngestorWorkerServiceTest
           withWorkerService[SampleDocument, Any](
             queue,
             index,
-            NoStrictMapping,
             indexer,
             elasticClient) { _ =>
             assertElasticsearchEventuallyHas(index = index, document)
@@ -76,7 +74,6 @@ class IngestorWorkerServiceTest
           withWorkerService[SampleDocument, Any](
             queue,
             index,
-            NoStrictMapping,
             indexer,
             elasticClient) { _ =>
             assertElasticsearchEventuallyHas(index = index, documents: _*)
@@ -96,7 +93,6 @@ class IngestorWorkerServiceTest
         withWorkerService[SampleDocument, Any](
           queue,
           index,
-          NoStrictMapping,
           indexer,
           elasticClient) { _ =>
           sendNotificationToSQS(
@@ -153,10 +149,6 @@ class IngestorWorkerServiceTest
             indexer =>
               val service = new IngestorWorkerService(
                 ingestorConfig = config,
-                indexCreator = new ElasticsearchIndexCreator(
-                  brokenClient,
-                  index,
-                  NoStrictMapping),
                 messageStream = messageStream,
                 documentIndexer = indexer
               )

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.platform.ingestor.images
 
+import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
+
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
-import uk.ac.wellcome.elasticsearch.{
-  ElasticsearchIndexCreator,
-  ImagesIndexConfig
-}
+import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.AugmentedImage
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
@@ -18,8 +17,6 @@ import uk.ac.wellcome.platform.ingestor.common.services.IngestorWorkerService
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-
-import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -33,9 +30,10 @@ object Main extends WellcomeTypesafeApp {
     val index = Index(indexName)
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
-      documentIndexer = new ElasticIndexer(elasticClient, index),
-      indexCreator =
-        new ElasticsearchIndexCreator(elasticClient, index, ImagesIndexConfig),
+      documentIndexer = new ElasticIndexer(
+        elasticClient,
+        index,
+        ImagesIndexConfig),
       messageStream =
         BigMessagingBuilder.buildMessageStream[AugmentedImage](config)
     )

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
@@ -30,10 +30,8 @@ object Main extends WellcomeTypesafeApp {
     val index = Index(indexName)
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
-      documentIndexer = new ElasticIndexer(
-        elasticClient,
-        index,
-        ImagesIndexConfig),
+      documentIndexer =
+        new ElasticIndexer(elasticClient, index, ImagesIndexConfig),
       messageStream =
         BigMessagingBuilder.buildMessageStream[AugmentedImage](config)
     )

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -30,8 +30,8 @@ class ImagesIngestorFeatureTest
       case QueuePair(queue, dlq) =>
         sendMessage[AugmentedImage](queue = queue, obj = image)
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index)
-          withWorkerService(queue, index, ImagesIndexConfig, indexer) { _ =>
+          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+          withWorkerService(queue, index, indexer) { _ =>
             assertElasticsearchEventuallyHas(index, image)
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
@@ -48,8 +48,8 @@ class ImagesIngestorFeatureTest
       case QueuePair(queue, dlq) =>
         sendMessage[Something](queue = queue, obj = wrongMessage)
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index)
-          withWorkerService(queue, index, ImagesIndexConfig, indexer) { _ =>
+          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+          withWorkerService(queue, index, indexer) { _ =>
             assertElasticsearchEmpty(index)
             eventually(Timeout(Span(5, Seconds))) {
               assertQueueEmpty(queue)

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -30,7 +30,10 @@ class ImagesIngestorFeatureTest
       case QueuePair(queue, dlq) =>
         sendMessage[AugmentedImage](queue = queue, obj = image)
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+          val indexer = new ElasticIndexer[AugmentedImage](
+            elasticClient,
+            index,
+            ImagesIndexConfig)
           withWorkerService(queue, index, indexer) { _ =>
             assertElasticsearchEventuallyHas(index, image)
             assertQueueEmpty(queue)
@@ -48,7 +51,10 @@ class ImagesIngestorFeatureTest
       case QueuePair(queue, dlq) =>
         sendMessage[Something](queue = queue, obj = wrongMessage)
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+          val indexer = new ElasticIndexer[AugmentedImage](
+            elasticClient,
+            index,
+            ImagesIndexConfig)
           withWorkerService(queue, index, indexer) { _ =>
             assertElasticsearchEmpty(index)
             eventually(Timeout(Span(5, Seconds))) {

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
@@ -25,7 +25,10 @@ class ImagesIndexerTest
   it("ingests an image") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+        new ElasticIndexer[AugmentedImage](
+          elasticClient,
+          index,
+          ImagesIndexConfig)
       val image = createAugmentedImage()
       whenReady(imagesIndexer.index(List(image))) { r =>
         r.isRight shouldBe true
@@ -38,7 +41,10 @@ class ImagesIndexerTest
   it("ingests a list of images") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+        new ElasticIndexer[AugmentedImage](
+          elasticClient,
+          index,
+          ImagesIndexConfig)
       val images = (1 to 5).map(_ => createAugmentedImage())
       whenReady(imagesIndexer.index(images)) { r =>
         r.isRight shouldBe true
@@ -51,7 +57,10 @@ class ImagesIndexerTest
   it("ingests a higher version of the same image") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+        new ElasticIndexer[AugmentedImage](
+          elasticClient,
+          index,
+          ImagesIndexConfig)
       val image = createAugmentedImage()
       val newerImage = image.copy(version = image.version + 1)
       val result = for {
@@ -69,7 +78,10 @@ class ImagesIndexerTest
   it("doesn't replace a newer version with a lower one") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
+        new ElasticIndexer[AugmentedImage](
+          elasticClient,
+          index,
+          ImagesIndexConfig)
       val image = createAugmentedImage()
       val olderImage = image.copy(version = image.version - 1)
       val result = for {

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.ingestor.images.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.models.work.internal.AugmentedImage
@@ -24,7 +25,7 @@ class ImagesIndexerTest
   it("ingests an image") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index)
+        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
       val image = createAugmentedImage()
       whenReady(imagesIndexer.index(List(image))) { r =>
         r.isRight shouldBe true
@@ -37,7 +38,7 @@ class ImagesIndexerTest
   it("ingests a list of images") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index)
+        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
       val images = (1 to 5).map(_ => createAugmentedImage())
       whenReady(imagesIndexer.index(images)) { r =>
         r.isRight shouldBe true
@@ -50,7 +51,7 @@ class ImagesIndexerTest
   it("ingests a higher version of the same image") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index)
+        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
       val image = createAugmentedImage()
       val newerImage = image.copy(version = image.version + 1)
       val result = for {
@@ -68,7 +69,7 @@ class ImagesIndexerTest
   it("doesn't replace a newer version with a lower one") {
     withLocalImagesIndex { index =>
       val imagesIndexer =
-        new ElasticIndexer[AugmentedImage](elasticClient, index)
+        new ElasticIndexer[AugmentedImage](elasticClient, index, ImagesIndexConfig)
       val image = createAugmentedImage()
       val olderImage = image.copy(version = image.version - 1)
       val result = for {

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -31,10 +31,8 @@ object Main extends WellcomeTypesafeApp {
     val index = Index(indexName)
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
-      documentIndexer = new ElasticIndexer(
-        elasticClient,
-        index,
-        IdentifiedWorkIndexConfig),
+      documentIndexer =
+        new ElasticIndexer(elasticClient, index, IdentifiedWorkIndexConfig),
       messageStream =
         BigMessagingBuilder.buildMessageStream[Work[Identified]](config)
     )

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.platform.ingestor.works
 
+import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
+
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
-import uk.ac.wellcome.elasticsearch.{
-  ElasticsearchIndexCreator,
-  IdentifiedWorkIndexConfig
-}
+import uk.ac.wellcome.elasticsearch.IdentifiedWorkIndexConfig
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
@@ -19,8 +18,6 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import WorkState.Identified
-
-import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -34,8 +31,7 @@ object Main extends WellcomeTypesafeApp {
     val index = Index(indexName)
     new IngestorWorkerService(
       ingestorConfig = IngestorConfigBuilder.buildIngestorConfig(config),
-      documentIndexer = new ElasticIndexer(elasticClient, index),
-      indexCreator = new ElasticsearchIndexCreator(
+      documentIndexer = new ElasticIndexer(
         elasticClient,
         index,
         IdentifiedWorkIndexConfig),

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -32,8 +32,7 @@ class IngestorFeatureTest
         withWorkerService(
           queue,
           index,
-          IdentifiedWorkIndexConfig,
-          new ElasticIndexer[Work[Identified]](elasticClient, index)) { _ =>
+          new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
           assertElasticsearchEventuallyHasWork(index, work)
         }
       }
@@ -51,8 +50,7 @@ class IngestorFeatureTest
         withWorkerService(
           queue,
           index,
-          IdentifiedWorkIndexConfig,
-          new ElasticIndexer[Work[Identified]](elasticClient, index)) { _ =>
+          new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
           assertElasticsearchEventuallyHasWork(index, work)
         }
       }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -32,7 +32,10 @@ class IngestorFeatureTest
         withWorkerService(
           queue,
           index,
-          new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
+          new ElasticIndexer[Work[Identified]](
+            elasticClient,
+            index,
+            IdentifiedWorkIndexConfig)) { _ =>
           assertElasticsearchEventuallyHasWork(index, work)
         }
       }
@@ -50,7 +53,10 @@ class IngestorFeatureTest
         withWorkerService(
           queue,
           index,
-          new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
+          new ElasticIndexer[Work[Identified]](
+            elasticClient,
+            index,
+            IdentifiedWorkIndexConfig)) { _ =>
           assertElasticsearchEventuallyHasWork(index, work)
         }
       }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -126,8 +126,7 @@ class IngestorWorkerServiceTest
           withWorkerService(
             queue,
             index,
-            IdentifiedWorkIndexConfig,
-            new ElasticIndexer[Work[Identified]](elasticClient, index)) { _ =>
+            new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
             works.map { work =>
               sendMessage[Work[Identified]](queue = queue, obj = work)
             }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/services/IngestorWorkerServiceTest.scala
@@ -126,7 +126,10 @@ class IngestorWorkerServiceTest
           withWorkerService(
             queue,
             index,
-            new ElasticIndexer[Work[Identified]](elasticClient, index, IdentifiedWorkIndexConfig)) { _ =>
+            new ElasticIndexer[Work[Identified]](
+              elasticClient,
+              index,
+              IdentifiedWorkIndexConfig)) { _ =>
             works.map { work =>
               sendMessage[Work[Identified]](queue = queue, obj = work)
             }


### PR DESCRIPTION
In #914 we will be using an `Indexer[Work[Merged]]` for intermediate pipeline storage in the `merger`. In order to reduce some boilerplate, here we add an `init()` method to `Indexer`: for the `ElasticIndexer` this calls of too `ElasticsearchIndexCreator` to set up the mappings given some config.