### PR TITLE
Minor tweaks to the snapshot reporter

### DIFF
--- a/snapshots/snapshot_reporter/requirements.in
+++ b/snapshots/snapshot_reporter/requirements.in
@@ -2,3 +2,4 @@ elasticsearch>=7.0.0,<8.0.0
 httpx
 humanize
 python-dateutil
+pytz

--- a/snapshots/snapshot_reporter/requirements.txt
+++ b/snapshots/snapshot_reporter/requirements.txt
@@ -12,6 +12,7 @@ httpx==0.16.0             # via -r requirements.in
 humanize==3.0.1           # via -r requirements.in
 idna==2.10                # via rfc3986
 python-dateutil==2.8.1    # via -r requirements.in
+pytz==2020.1              # via -r requirements.in
 rfc3986[idna2008]==1.4.0  # via httpx
 six==1.15.0               # via python-dateutil
 sniffio==1.1.0            # via httpcore, httpx

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -95,10 +95,10 @@ def prepare_slack_payload(snapshots):
         )
 
     if snapshots:
-        snapshot = snapshots[0]
+        latest_snapshot = snapshots[0]
 
         heading = ":white_check_mark: Catalogue Snapshot"
-        message = _snapshot_message(snapshot)
+        message = _snapshot_message(latest_snapshot)
     else:
         kibana_logs_link = "https://logging.wellcomecollection.org/goto/ddc4dfc7308261cf17f956515ca1ce35"
         heading = ":interrobang: Catalogue Snapshot not found"

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -94,27 +94,22 @@ def prepare_slack_payload(snapshots):
             ]
         )
 
-    def _create_header_block(text):
-        return [{"type": "header", "text": {"type": "plain_text", "text": text}}]
-
-    def _create_section_block(text):
-        return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
-
     if snapshots:
         snapshot = snapshots[0]
 
-        header_block = _create_header_block(":white_check_mark: Catalogue Snapshot")
-        section_block = _create_section_block(_snapshot_message(snapshot))
+        heading = ":white_check_mark: Catalogue Snapshot"
+        message = _snapshot_message(snapshot)
     else:
         kibana_logs_link = "https://logging.wellcomecollection.org/goto/ddc4dfc7308261cf17f956515ca1ce35"
-        header_block = _create_header_block(
-            ":interrobang: Catalogue Snapshot not found"
-        )
-        section_block = _create_section_block(
-            f"No snapshot found within the last day. See logs: {kibana_logs_link}"
-        )
+        heading = ":interrobang: Catalogue Snapshot not found"
+        message = f"No snapshot found within the last day. See logs: {kibana_logs_link}"
 
-    return {"blocks": header_block + section_block}
+    return {
+        "blocks": [
+            {"type": "header", "text": {"type": "plain_text", "text": heading}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": message}},
+        ]
+    }
 
 
 def post_to_slack(slack_secret_id, payload):

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -162,8 +162,7 @@ def main(*args):
     api_document_count = get_catalogue_api_document_count(endpoint="works")
 
     slack_payload = prepare_slack_payload(
-        snapshots=snapshots,
-        api_document_count=api_document_count
+        snapshots=snapshots, api_document_count=api_document_count
     )
 
     post_to_slack(slack_secret_id, slack_payload)

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -66,11 +66,11 @@ def format_date(d):
     d = d.astimezone(pytz.timezone("Europe/London"))
 
     if d.date() == datetime.datetime.now().date():
-        return d.strftime("today at %I:%M %p %Z")
+        return d.strftime("today at %-I:%M %p %Z")
     elif d.date() == (datetime.datetime.now() - datetime.timedelta(days=1)).date():
-        return d.strftime("yesterday at %I:%M %p %Z")
+        return d.strftime("yesterday at %-I:%M %p %Z")
     else:
-        return d.strftime("on %A, %B %-d at %I:%M %p %Z")
+        return d.strftime("on %A, %B %-d at %-I:%M %p %Z")
 
 
 def prepare_slack_payload(snapshots):

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -94,6 +94,10 @@ def prepare_slack_payload(snapshots, api_document_count):
 
         time_took = finished_at - started_at
 
+        # In general, a snapshot should have the same number of works as the
+        # catalogue API.  There might be some drift, if new works appear in the
+        # pipeline between the snapshot being taken and the reporter running,
+        # but not much.  The threshold 25 is chosen somewhat arbitrarily.
         if api_document_count == snapshot_document_count:
             api_comparison = "same as the catalogue API"
         elif abs(api_document_count - snapshot_document_count) < 25:

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -104,8 +104,9 @@ def prepare_slack_payload(snapshots, api_document_count):
         return "\n".join(
             [
                 f"The latest snapshot is of index *{index_name}*, taken *{format_date(requested_at)}*.",
-                f"It is {humanize.naturalsize(s3_size)}, took {humanize.naturaldelta(time_took)} "
-                f"and contains {humanize.intcomma(snapshot_document_count)} documents ({api_comparison}).",
+                f"• It is {humanize.naturalsize(s3_size)}",
+                f"• It took {humanize.naturaldelta(time_took)} to create",
+                f"• It contains {humanize.intcomma(snapshot_document_count)} documents ({api_comparison})",
             ]
         )
 

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -88,7 +88,7 @@ def prepare_slack_payload(snapshots):
 
         return "\n".join(
             [
-                f"The latest snapshot is of index {index_name}, taken {format_date(requested_at)}.",
+                f"The latest snapshot is of index *{index_name}*, taken *{format_date(requested_at)}*.",
                 f"It is {humanize.naturalsize(s3_size)}, took {humanize.naturaldelta(time_took)} "
                 f"and contains {humanize.intcomma(document_count)} documents.",
             ]


### PR DESCRIPTION
A couple of ideas I had over breakfast.

Before:

![Screenshot 2020-10-10 at 07 42 55](https://user-images.githubusercontent.com/301220/95648073-8079bc80-0acc-11eb-917b-d818ffd221da.png)

After:

![Screenshot 2020-10-10 at 07 42 50](https://user-images.githubusercontent.com/301220/95648079-840d4380-0acc-11eb-86a6-a302c5ea23e5.png)

Changes:

* Rather than printing the full date, it uses “today at” or “yesterday at”, because who knows what date it is any more?
* Info is printed as a list, not a sentence
* It queries the catalogue API to find out how many works it has. If the snapshot has a significantly different number of works, it warns us.

This change is already deployed.