### PR TITLE
Stop using Mockito where it's unnecessary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,8 +144,7 @@ lazy val relation_embedder = setupProject(
 lazy val recorder = setupProject(
   project,
   "pipeline/recorder",
-  localDependencies = Seq(internal_model, big_messaging_typesafe),
-  externalDependencies = CatalogueDependencies.recorderDependencies
+  localDependencies = Seq(internal_model, big_messaging_typesafe)
 )
 
 lazy val reindex_worker = setupProject(

--- a/build.sbt
+++ b/build.sbt
@@ -131,8 +131,8 @@ lazy val matcher = setupProject(
 lazy val merger = setupProject(
   project,
   "pipeline/merger",
-  localDependencies = Seq(internal_model, big_messaging_typesafe),
-  externalDependencies = CatalogueDependencies.mergerDependencies)
+  localDependencies = Seq(internal_model, big_messaging_typesafe)
+)
 
 lazy val relation_embedder = setupProject(
   project,

--- a/build.sbt
+++ b/build.sbt
@@ -68,8 +68,7 @@ lazy val big_messaging_typesafe = setupProject(
 lazy val pipeline_storage = setupProject(
   project,
   "common/pipeline_storage",
-  localDependencies = Seq(elasticsearch_typesafe),
-  externalDependencies = CatalogueDependencies.pipelineStorageDependencies
+  localDependencies = Seq(elasticsearch_typesafe)
 )
 
 lazy val api = setupProject(

--- a/build.sbt
+++ b/build.sbt
@@ -104,24 +104,21 @@ lazy val ingestor_common = setupProject(
   project,
   "pipeline/ingestor/ingestor_common",
   localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, pipeline_storage),
-  externalDependencies = CatalogueDependencies.ingestorDependencies
+    Seq(elasticsearch_typesafe, big_messaging_typesafe, pipeline_storage)
 )
 
 lazy val ingestor_works = setupProject(
   project,
   "pipeline/ingestor/ingestor_works",
   localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common),
-  externalDependencies = Seq()
+    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common)
 )
 
 lazy val ingestor_images = setupProject(
   project,
   "pipeline/ingestor/ingestor_images",
   localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common),
-  externalDependencies = Seq()
+    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common)
 )
 
 lazy val matcher = setupProject(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.merger.services
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
@@ -27,7 +26,6 @@ class MergerWorkerServiceTest
     with IntegrationPatience
     with MiroWorkGenerators
     with MatcherResultFixture
-    with MockitoSugar
     with WorkerServiceFixture {
 
   it(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -243,9 +243,6 @@ object CatalogueDependencies {
     ExternalDependencies.mockitoDependencies ++
       ExternalDependencies.scalaGraphDependencies
 
-  val mergerDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies
-
   val relationEmbedderDependencies: Seq[ModuleID] =
     WellcomeDependencies.storageTypesafeLibrary ++
       WellcomeDependencies.messagingTypesafeLibrary

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -250,9 +250,6 @@ object CatalogueDependencies {
   val miroTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.apacheCommonsDependencies
 
-  val recorderDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies
-
   val reindexWorkerDependencies: Seq[ModuleID] = Nil
 
   val sierraTransformerDependencies: Seq[ModuleID] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -253,8 +253,7 @@ object CatalogueDependencies {
   val reindexWorkerDependencies: Seq[ModuleID] = Nil
 
   val sierraTransformerDependencies: Seq[ModuleID] =
-    ExternalDependencies.apacheCommonsDependencies ++
-      ExternalDependencies.mockitoDependencies
+    ExternalDependencies.apacheCommonsDependencies
 
   val metsTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.apacheCommonsDependencies ++

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -248,8 +248,7 @@ object CatalogueDependencies {
       WellcomeDependencies.messagingTypesafeLibrary
 
   val miroTransformerDependencies: Seq[ModuleID] =
-    ExternalDependencies.apacheCommonsDependencies ++
-      ExternalDependencies.mockitoDependencies
+    ExternalDependencies.apacheCommonsDependencies
 
   val recorderDependencies: Seq[ModuleID] =
     ExternalDependencies.mockitoDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -302,8 +302,7 @@ object CatalogueDependencies {
   // Sierra adapter stack
 
   val sierraAdapterCommonDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
-      WellcomeDependencies.storageTypesafeLibrary ++
+    WellcomeDependencies.storageTypesafeLibrary ++
       WellcomeDependencies.messagingTypesafeLibrary ++
       WellcomeDependencies.jsonLibrary ++
       ExternalDependencies.javaxDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -239,9 +239,6 @@ object CatalogueDependencies {
       ExternalDependencies.mySqlDependencies ++
       ExternalDependencies.circeOpticsDependencies
 
-  val ingestorDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies
-
   val matcherDependencies: Seq[ModuleID] =
     ExternalDependencies.mockitoDependencies ++
       ExternalDependencies.scalaGraphDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -320,8 +320,7 @@ object CatalogueDependencies {
   // Snapshots stack
 
   val snapshotGeneratorDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies ++
-      WellcomeDependencies.messagingTypesafeLibrary ++
+    WellcomeDependencies.messagingTypesafeLibrary ++
       WellcomeDependencies.storageLibrary ++
       ExternalDependencies.alpakkaS3Dependencies
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -267,7 +267,6 @@ object CatalogueDependencies {
 
   val calmTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.apacheCommonsDependencies ++
-      ExternalDependencies.mockitoDependencies ++
       ExternalDependencies.jsoupDependencies
 
   // METS adapter

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -228,9 +228,6 @@ object CatalogueDependencies {
   val elasticsearchTypesafeDependencies: Seq[ModuleID] =
     WellcomeDependencies.typesafeLibrary
 
-  val pipelineStorageDependencies: Seq[ModuleID] =
-    ExternalDependencies.mockitoDependencies
-
   val apiDependencies: Seq[ModuleID] =
     ExternalDependencies.akkaHttpDependencies ++
       ExternalDependencies.apmDependencies ++

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.sierra_bib_merger
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.sierra_bib_merger.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.sierra_adapter.model.{
@@ -16,7 +15,6 @@ class SierraBibMergerFeatureTest
     extends AnyFunSpec
     with Matchers
     with Eventually
-    with MockitoSugar
     with IntegrationPatience
     with ScalaFutures
     with SierraGenerators

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -5,13 +5,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.platform.sierra_bib_merger.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.sierra_adapter.model.{
   SierraGenerators,
   SierraTransformable
 }
-import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 import uk.ac.wellcome.storage.Version
 
 class SierraBibMergerFeatureTest
@@ -21,9 +19,7 @@ class SierraBibMergerFeatureTest
     with MockitoSugar
     with IntegrationPatience
     with ScalaFutures
-    with SQS
     with SierraGenerators
-    with SierraAdapterHelpers
     with WorkerServiceFixture {
 
   it("stores a bib in the hybrid store") {

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/WorkerServiceFixture.scala
@@ -29,7 +29,8 @@ trait WorkerServiceFixture
     queue: Queue,
     metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit]())(
     testWith: TestWith[(SierraBibMergerWorkerService[String],
-                        MemoryMessageSender), R]): R =
+                        MemoryMessageSender),
+                       R]): R =
     withActorSystem { implicit actorSystem =>
       val updaterService = new SierraBibMergerUpdaterService(
         versionedHybridStore = store

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/fixtures/WorkerServiceFixture.scala
@@ -1,11 +1,14 @@
 package uk.ac.wellcome.platform.sierra_bib_merger.fixtures
 
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.monitoring.Metrics
+import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.platform.sierra_bib_merger.services.{
   SierraBibMergerUpdaterService,
   SierraBibMergerWorkerService
@@ -14,6 +17,8 @@ import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
 import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 import uk.ac.wellcome.storage.store.VersionedStore
 
+import scala.concurrent.Future
+
 trait WorkerServiceFixture
     extends Akka
     with SierraAdapterHelpers
@@ -21,15 +26,16 @@ trait WorkerServiceFixture
     with SQS {
   def withWorkerService[R](
     store: VersionedStore[String, Int, SierraTransformable],
-    queue: Queue)(testWith: TestWith[(SierraBibMergerWorkerService[String],
-                                      MemoryMessageSender),
-                                     R]): R =
+    queue: Queue,
+    metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit]())(
+    testWith: TestWith[(SierraBibMergerWorkerService[String],
+                        MemoryMessageSender), R]): R =
     withActorSystem { implicit actorSystem =>
       val updaterService = new SierraBibMergerUpdaterService(
         versionedHybridStore = store
       )
 
-      withSQSStream[NotificationMessage, R](queue) { sqsStream =>
+      withSQSStream[NotificationMessage, R](queue, metrics) { sqsStream =>
         val messageSender = new MemoryMessageSender
         val workerService = new SierraBibMergerWorkerService(
           sqsStream = sqsStream,

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -49,7 +49,7 @@ class SierraBibMergerWorkerServiceTest
   }
 
   private def withWorkerServiceFixtures[R](
-    testWith: TestWith[(Metrics[Future, StandardUnit], QueuePair), R]) = {
+    testWith: TestWith[(Metrics[Future, StandardUnit], QueuePair), R]): R = {
     val metricsSender = mock[Metrics[Future, StandardUnit]]
     withLocalSqsQueuePair() {
       case queuePair @ QueuePair(queue, _) =>

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -58,7 +58,5 @@ class SierraBibMergerWorkerServiceTest
           testWith((metricsSender, queuePair))
         }
     }
-
   }
-
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -34,7 +34,8 @@ class SierraBibMergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, 1)
 
-          metrics.incrementedCounts should contain("SierraBibMergerWorkerService_ProcessMessage_recognisedFailure")
+          metrics.incrementedCounts should contain(
+            "SierraBibMergerWorkerService_ProcessMessage_recognisedFailure")
         }
     }
   }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.monitoring.Metrics
 import uk.ac.wellcome.platform.sierra_bib_merger.fixtures.WorkerServiceFixture
@@ -15,7 +14,6 @@ import uk.ac.wellcome.sierra_adapter.model.{
   SierraGenerators,
   SierraTransformable
 }
-import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 
 import scala.concurrent.Future
 
@@ -23,8 +21,6 @@ class SierraBibMergerWorkerServiceTest
     extends AnyFunSpec
     with MockitoSugar
     with Matchers
-    with SQS
-    with SierraAdapterHelpers
     with SierraGenerators
     with WorkerServiceFixture
     with Eventually

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -50,7 +50,7 @@ class SierraBibMergerWorkerServiceTest
     withLocalSqsQueuePair() {
       case queuePair @ QueuePair(queue, _) =>
         val store = createStore[SierraTransformable]()
-        withWorkerService(store, queue) { _ =>
+        withWorkerService(store, queue, metricsSender) { _ =>
           testWith((metricsSender, queuePair))
         }
     }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.mockito.MockitoSugar
 import uk.ac.wellcome.platform.sierra_item_merger.fixtures.SierraItemMergerFixtures
 import uk.ac.wellcome.sierra_adapter.model.{
   SierraGenerators,
@@ -14,8 +13,7 @@ import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 class SierraItemMergerUpdaterServiceTest
     extends AnyFunSpec
     with SierraGenerators
-    with SierraItemMergerFixtures
-    with MockitoSugar {
+    with SierraItemMergerFixtures {
 
   it("creates a record if it receives an item with a bibId that doesn't exist") {
     val sierraTransformableStore = createStore[SierraTransformable]()

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -2,21 +2,17 @@ package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.mockito.MockitoSugar
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.platform.sierra_item_merger.fixtures.SierraItemMergerFixtures
 import uk.ac.wellcome.sierra_adapter.model.{
   SierraGenerators,
   SierraTransformable
 }
-import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 import uk.ac.wellcome.storage.{UpdateNotApplied, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
 class SierraItemMergerUpdaterServiceTest
     extends AnyFunSpec
-    with SQS
-    with SierraAdapterHelpers
     with SierraGenerators
     with SierraItemMergerFixtures
     with MockitoSugar {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures.DynamoInserterFixture
 import uk.ac.wellcome.sierra_adapter.model.{SierraGenerators, SierraItemRecord}
 import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
@@ -13,7 +12,6 @@ import uk.ac.wellcome.storage.{UpdateNotApplied, Version}
 class DynamoInserterTest
     extends AnyFunSpec
     with Matchers
-    with MockitoSugar
     with DynamoInserterFixture
     with SierraGenerators
     with SierraAdapterHelpers {

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -81,7 +81,7 @@ class SierraItemsToDynamoWorkerServiceTest
           eventually {
             assertQueueEmpty(queue)
             assertQueueHasSize(dlq, size = 1)
-            metrics.incrementedCounts should not contain("SierraItemsToDynamoWorkerService_ProcessMessage_failure")
+            metrics.incrementedCounts should not contain ("SierraItemsToDynamoWorkerService_ProcessMessage_failure")
           }
         }
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -8,7 +8,6 @@ import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
 import uk.ac.wellcome.monitoring.Metrics
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.merger.SierraItemRecordMerger
@@ -20,8 +19,6 @@ import scala.concurrent.Future
 
 class SierraItemsToDynamoWorkerServiceTest
     extends AnyFunSpec
-    with SNS
-    with SQS
     with Matchers
     with Eventually
     with IntegrationPatience


### PR DESCRIPTION
Following a conversation with @warrd about how Mockito's runtime shenanigans are frequently a source of pain, I decided to go see if I could clean up some of our uses of Mockito. Spoiler: yes.

* Use a `MemoryMetrics[…]` instance instead of a `mock[MetricsSender]`, which is exactly what the in-memory implementations are meant to be used for.
* Remove `MockitoSugar` from a bunch of test classes that weren't using it.

I've also evicted it from the ID minter in this PR: https://github.com/wellcomecollection/catalogue/pull/914