### PR TITLE
Merger pipelne storage index should map identifiedType in id state

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 
-object ImagesIndexConfig extends IndexConfig with IndexConfigFields {
+object ImagesIndexConfig extends IndexConfig with WorksIndexConfigFields {
 
   override val analysis: Analysis = WorksAnalysis()
 
@@ -17,11 +17,12 @@ object ImagesIndexConfig extends IndexConfig with IndexConfigFields {
 
   private def sourceWork(canonicalWork: String): ObjectField =
     objectField(canonicalWork).fields(
-      id("id"),
-      IdentifiedWorkIndexConfig.data(textField("path")),
+      id(),
+      data(textField("path"), id()),
       keywordField("type"),
       version
     )
+
   val source = objectField("source").fields(
     sourceWork("canonicalWork"),
     sourceWork("redirectedWork"),

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/IndexConfig.scala
@@ -61,7 +61,15 @@ trait IndexConfigFields {
       keywordField("type"),
       canonicalId,
       objectField("sourceIdentifier").fields(sourceIdentifierFields),
-      objectField("otherIdentifiers").fields(sourceIdentifierFields)
+      objectField("otherIdentifiers").fields(sourceIdentifierFields),
+    )
+
+  def identifiable(fieldName: String = "id") =
+    objectField(fieldName).fields(
+      keywordField("type"),
+      keywordField("identifiedType"),
+      objectField("sourceIdentifier").fields(sourceIdentifierFields),
+      objectField("otherIdentifiers").fields(sourceIdentifierFields),
     )
 
   def location(fieldName: String = "locations") =

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -13,30 +13,35 @@ trait WorksIndexConfigFields extends IndexConfigFields {
   import WorksAnalysis._
 
   // Fields
-  def sourceIdentifier = objectField("sourceIdentifier")
-    .fields(sourceIdentifierFields)
+  def sourceIdentifier =
+    objectField("sourceIdentifier")
+      .fields(sourceIdentifierFields)
 
-  def otherIdentifiers = objectField("otherIdentifiers")
-    .fields(sourceIdentifierFields)
+  def otherIdentifiers =
+    objectField("otherIdentifiers")
+      .fields(sourceIdentifierFields)
 
-  def format = objectField("format")
-    .fields(
-      label,
-      keywordField("id")
-    )
+  def format =
+    objectField("format")
+      .fields(
+        label,
+        keywordField("id")
+      )
 
-  def title = asciifoldingTextFieldWithKeyword("title")
-    .fields(
-      keywordField("keyword"),
-      textField("english").analyzer(englishAnalyzer.name),
-      textField("shingles").analyzer(shingleAsciifoldingAnalyzer.name)
-    )
+  def title =
+    asciifoldingTextFieldWithKeyword("title")
+      .fields(
+        keywordField("keyword"),
+        textField("english").analyzer(englishAnalyzer.name),
+        textField("shingles").analyzer(shingleAsciifoldingAnalyzer.name)
+      )
 
-  def notes = objectField("notes")
-    .fields(
-      keywordField("type"),
-      englishTextField("content")
-    )
+  def notes =
+    objectField("notes")
+      .fields(
+        keywordField("type"),
+        englishTextField("content")
+      )
 
   def period(idState: ObjectField) = Seq(
     label,
@@ -68,7 +73,8 @@ trait WorksIndexConfigFields extends IndexConfigFields {
     keywordField("numeration")
   )
 
-  def rootConcept(idState: ObjectField) = concept(idState) ++ agent(idState) ++ period(idState)
+  def rootConcept(idState: ObjectField) =
+    concept(idState) ++ agent(idState) ++ period(idState)
 
   def subject(idState: ObjectField): Seq[FieldDefinition] = Seq(
     idState,
@@ -79,10 +85,11 @@ trait WorksIndexConfigFields extends IndexConfigFields {
   def subjects(idState: ObjectField): ObjectField =
     objectField("subjects").fields(subject(idState))
 
-  def genre(fieldName: String, idState: ObjectField) = objectField(fieldName).fields(
-    label,
-    objectField("concepts").fields(rootConcept(idState))
-  )
+  def genre(fieldName: String, idState: ObjectField) =
+    objectField(fieldName).fields(
+      label,
+      objectField("concepts").fields(rootConcept(idState))
+    )
 
   def labelledTextField(fieldName: String) = objectField(fieldName).fields(
     label
@@ -90,11 +97,12 @@ trait WorksIndexConfigFields extends IndexConfigFields {
 
   def period(fieldName: String) = labelledTextField(fieldName)
 
-  def items(fieldName: String, idState: ObjectField) = objectField(fieldName).fields(
-    idState,
-    location(),
-    title
-  )
+  def items(fieldName: String, idState: ObjectField) =
+    objectField(fieldName).fields(
+      idState,
+      location(),
+      title
+    )
 
   def language =
     objectField("language").fields(
@@ -128,10 +136,11 @@ trait WorksIndexConfigFields extends IndexConfigFields {
     version
   )
 
-  def analyzedPath: TextField = textField("path")
-    .copyTo("data.collectionPath.depth")
-    .analyzer(pathAnalyzer.name)
-    .fields(keywordField("keyword"))
+  def analyzedPath: TextField =
+    textField("path")
+      .copyTo("data.collectionPath.depth")
+      .analyzer(pathAnalyzer.name)
+      .fields(keywordField("keyword"))
 
   def data(pathField: TextField, idState: ObjectField): ObjectField =
     objectField("data").fields(

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -15,6 +15,8 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
 
   def state: ObjectField
 
+  val idState: ObjectField
+
   // Fields
   val sourceIdentifier = objectField("sourceIdentifier")
     .fields(sourceIdentifierFields)
@@ -43,7 +45,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
 
   val period = Seq(
     label,
-    id(),
+    idState,
     objectField("range").fields(
       label,
       dateField("from"),
@@ -54,18 +56,18 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
 
   val place = Seq(
     label,
-    id()
+    idState
   )
 
   val concept = Seq(
     label,
-    id(),
+    idState,
     keywordField("type")
   )
 
   val agent = Seq(
     label,
-    id(),
+    idState,
     keywordField("type"),
     keywordField("prefix"),
     keywordField("numeration")
@@ -74,7 +76,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
   val rootConcept = concept ++ agent ++ period
 
   val subject: Seq[FieldDefinition] = Seq(
-    id(),
+    idState,
     label,
     objectField("concepts").fields(rootConcept)
   )
@@ -93,7 +95,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
   def period(fieldName: String) = labelledTextField(fieldName)
 
   def items(fieldName: String) = objectField(fieldName).fields(
-    id(),
+    idState,
     location(),
     title
   )
@@ -104,7 +106,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
   )
 
   val contributors = objectField("contributors").fields(
-    id(),
+    idState,
     objectField("agent").fields(agent),
     objectField("roles").fields(label),
   )
@@ -123,7 +125,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
   )
 
   val images = objectField("images").fields(
-    id(),
+    idState,
     location("location"),
     version
   )
@@ -168,7 +170,7 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
     // Locally override the strict mapping mode. No data fields are indexed for
     // now, in the future specific fields can be added as required.
     objectField("data").dynamic("false"),
-    id(),
+    idState,
     intField("depth")
   )
 
@@ -199,6 +201,8 @@ sealed trait WorksIndexConfig extends IndexConfig with IndexConfigFields {
 object SourceWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(sourceIdentifier)
+
+  val idState = identifiable()
 }
 
 object MergedWorkIndexConfig extends WorksIndexConfig {
@@ -207,6 +211,8 @@ object MergedWorkIndexConfig extends WorksIndexConfig {
     sourceIdentifier,
     intField("numberOfSources"),
   )
+
+  val idState = identifiable()
 }
 
 object DenormalisedWorkIndexConfig extends WorksIndexConfig {
@@ -216,6 +222,8 @@ object DenormalisedWorkIndexConfig extends WorksIndexConfig {
     intField("numberOfSources"),
     relations
   )
+
+  val idState = identifiable()
 }
 
 object IdentifiedWorkIndexConfig extends WorksIndexConfig {
@@ -226,4 +234,6 @@ object IdentifiedWorkIndexConfig extends WorksIndexConfig {
     intField("numberOfSources"),
     relations
   )
+
+  val idState = id()
 }

--- a/pipeline/create_pipeline_storage_es_credentials.py
+++ b/pipeline/create_pipeline_storage_es_credentials.py
@@ -92,10 +92,7 @@ def create_roles(es, *, work_type):
     """
     Create read and write roles for a given work type.
     """
-    for role_suffix, privileges in [
-        ("read", ["read"]),
-        ("write", ["write", "create_index"]),
-    ]:
+    for role_suffix, privileges in [("read", ["read"]), ("write", ["all"])]:
         role_name = f"{work_type}_{role_suffix}"
         index_pattern = INDEX_PATTERN.format(work_type=work_type)
 


### PR DESCRIPTION
We are getting the following error for some works currently:

```
Some(BulkError(strict_dynamic_mapping_exception,mapping set to strict, dynamic introduction of [identifiedType] within [data.items.id] is not allowed,null,0,null,None))
```