### PR TITLE
Add an ECR repository for the relation embedder

### DIFF
--- a/pipeline/terraform/ecr.tf
+++ b/pipeline/terraform/ecr.tf
@@ -65,3 +65,7 @@ resource "aws_ecr_repository" "ecr_repository_ingestor_images" {
 resource "aws_ecr_repository" "ecr_repository_elasticdump" {
   name = "uk.ac.wellcome/elasticdump"
 }
+
+resource "aws_ecr_repository" "ecr_repository_relation_embedder" {
+  name = "uk.ac.wellcome/relation_embedder"
+}


### PR DESCRIPTION
The build on master is failing because the ECR repo for the relation_embedder doesn't exist yet. I've created it in the console and imported it into the Terraform state and restarted the latest build. Fingers crossed this makes it go green!

Part of https://github.com/wellcomecollection/platform/issues/4830