### PR TITLE
Fix mapping for redirect field

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -197,16 +197,15 @@ sealed trait WorksIndexConfig extends IndexConfig with WorksIndexConfigFields {
 
   def state: ObjectField
 
-  def idState: ObjectField
+  val idState: String => ObjectField
 
   def fields: Seq[FieldDefinition with Product with Serializable] =
     Seq(
       state,
       version,
-      objectField("redirect")
-        .fields(sourceIdentifier, canonicalId, otherIdentifiers),
+      idState("redirect"),
       keywordField("type"),
-      data(analyzedPath, idState),
+      data(analyzedPath, idState("id")),
       objectField("invisibilityReasons").fields(
         keywordField("type"),
         keywordField("info")
@@ -220,7 +219,7 @@ object SourceWorkIndexConfig extends WorksIndexConfig {
 
   val state = objectField("state").fields(sourceIdentifier)
 
-  val idState = identifiable()
+  val idState = identifiable
 }
 
 object MergedWorkIndexConfig extends WorksIndexConfig {
@@ -230,28 +229,28 @@ object MergedWorkIndexConfig extends WorksIndexConfig {
     intField("numberOfSources"),
   )
 
-  val idState = identifiable()
+  val idState = identifiable
 }
 
 object DenormalisedWorkIndexConfig extends WorksIndexConfig {
 
-  val idState = identifiable()
+  val idState = identifiable
 
   val state = objectField("state").fields(
     sourceIdentifier,
     intField("numberOfSources"),
-    relations(idState)
+    relations(idState("id"))
   )
 }
 
 object IdentifiedWorkIndexConfig extends WorksIndexConfig {
 
-  val idState = id()
+  val idState = id
 
   val state = objectField("state").fields(
     canonicalId,
     sourceIdentifier,
     intField("numberOfSources"),
-    relations(idState)
+    relations(idState("id"))
   )
 }


### PR DESCRIPTION
The redirect fields mapping differs depending on the state: for non-identified states there is the field `identifiedType`, and for the `Identified` state there is the field `canonicalId`.