### PR TITLE
Fix ID minter dependencies

### DIFF
--- a/.sbt_metadata/id_minter.json
+++ b/.sbt_metadata/id_minter.json
@@ -1,8 +1,0 @@
-{
-  "id" : "id_minter",
-  "folder" : "pipeline/id_minter",
-  "dependencyIds" : [
-    "internal_model",
-    "big_messaging_typesafe"
-  ]
-}

--- a/project/Metadata.scala
+++ b/project/Metadata.scala
@@ -1,10 +1,17 @@
 import java.io.File
 
 import sbt.{IO, Project}
+import scala.reflect.io.Directory
 import io.circe.generic.auto._
 import io.circe.syntax._
 
 object Metadata {
+  // Clear out the .sbt_metadata directory before every invocation of sbt,
+  // so if we change the project structure old metadata entries will
+  // be deleted.
+  val directory = new Directory(new File(".sbt_metadata"))
+  directory.deleteRecursively()
+
   def write(
     project: Project,
     folder: String,


### PR DESCRIPTION
I noticed that https://buildkite.com/wellcomecollection/catalogue/builds/940#0e7a0428-4ab4-423f-aa36-237cd018c0da didn't build/test the image minter despite the changes _only_ being in that project.

I'm pretty sure the issue is this leftover project JSON file, which was still picked up by the build logic and - because the original ID minter project folder is the parent of the 3 minter projects now - was overriding the actual project lookup and giving a false negative dependency.