### PR TITLE
bump weco-deploy deploy timeout to an hour

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,4 +85,4 @@ steps:
               "--from-label", "latest",
               "--environment-id", "staging",
               "--description", $BUILDKITE_BUILD_URL,
-              "--confirmation-wait-for", 1200]
+              "--confirmation-wait-for", 3600]


### PR DESCRIPTION
To help us find the sweet spot without doing too many commits / deploys.
This is part of a bigger piece of work around deployment perf budgets.