### PR TITLE
Don't attempt to merge empty sets of works

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -12,8 +12,8 @@ import WorkFsm._
  * the works/images getters must be provided with a modifiedTime to use for all
  * the output entities.
  */
-class MergerOutcome(resultWorks: Seq[Work[Source]],
-                    imagesWithSources: Seq[ImageWithSource]) {
+case class MergerOutcome(resultWorks: Seq[Work[Source]],
+                         imagesWithSources: Seq[ImageWithSource]) {
 
   // numberOfSources is hardcoded here so as not to break builds
   // TODO: remove numberOfSources

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -82,7 +82,7 @@ trait Merger extends MergerLogging {
           val redirects = redirectedSources.map(redirectSourceToTarget(target))
           logResult(result, redirects.toList, remaining.toList)
 
-          new MergerOutcome(
+          MergerOutcome(
             resultWorks = redirects.toList ++ remaining :+ result.mergedTarget,
             imagesWithSources = result.imagesWithSources
           )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -66,7 +66,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
           redirect = IdState.Identifiable(works.head.sourceIdentifier)
         )
       }
-      new MergerOutcome(
+      MergerOutcome(
         resultWorks = outputWorks,
         imagesWithSources = Nil
       )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -330,8 +330,7 @@ class MergerWorkerServiceTest
     }
   }
 
-  it(
-    "processes the message when out of date works, emitting nothing at the output") {
+  it("doesn't send anything if the works are outdated") {
     withMergerWorkerServiceFixtures {
       case (vhs, QueuePair(queue, dlq), senders, metrics, index) =>
         val work0 = sourceWork().withVersion(0)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -330,6 +330,34 @@ class MergerWorkerServiceTest
     }
   }
 
+  it(
+    "processes the message when out of date works, emitting nothing at the output") {
+    withMergerWorkerServiceFixtures {
+      case (vhs, QueuePair(queue, dlq), senders, metrics, index) =>
+        val work0 = sourceWork().withVersion(0)
+        val work1 = sourceWork(sourceIdentifier = work0.sourceIdentifier)
+          .withVersion(1)
+        val matcherResult = matcherResultWith(Set(Set(work0)))
+        givenStoredInVhs(vhs, work1)
+
+        sendNotificationToSQS(
+          queue = queue,
+          message = matcherResult
+        )
+
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+
+          getWorksSent(senders) shouldBe empty
+          index shouldBe Map()
+
+          metrics.incrementedCounts.length shouldBe 1
+          metrics.incrementedCounts.last should endWith("_success")
+        }
+    }
+  }
+
   case class Senders(works: MemoryMessageSender, images: MemoryMessageSender)
 
   def withMergerWorkerServiceFixtures[R](


### PR DESCRIPTION
We are getting the following error on the `merger`:

```
Cannot index an empty list of documents
```

This is because we still try to apply the merge for out of date documents, and with `big_messaging` previously we would just not send the message. We should catch this earlier rather than allow pipeline storage to store an empty list.