### PR TITLE
Fix paired filters and aggregations behaviour

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -91,6 +91,28 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
         .subaggs should have length 0
     }
 
+    it("applies paired filters to non-paired aggregations") {
+      val formatFilter = FormatFilter(Seq("bananas"))
+      val sut = new FiltersAndAggregationsBuilder(
+        List(AggregationRequest.Format, AggregationRequest.Language),
+        List(formatFilter),
+        requestToAggregation,
+        filterToQuery
+      )
+
+      sut.filteredAggregations should have length 2
+      val formatAgg =
+        sut.filteredAggregations.head.asInstanceOf[MockAggregation]
+      val languageAgg =
+        sut.filteredAggregations(1).asInstanceOf[MockAggregation]
+      formatAgg.subaggs.size shouldBe 0
+      languageAgg.subaggs.head
+        .asInstanceOf[FilterAggregation]
+        .query
+        .asInstanceOf[BoolQuery]
+        .filters should contain only MockQuery(formatFilter)
+    }
+
     it("applies all other aggregation-dependent filters to the paired filter") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languageFilter = LanguageFilter(Seq("en"))

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.models.Implicits._
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
 
-  it("filters aggregations with filters that are not paired to the aggregation") {
+  it(
+    "filters an aggregation with a filter that is not paired to the aggregation") {
     withApi {
       case (ElasticConfig(worksIndex, _), routes) =>
         val works = List(
@@ -58,6 +59,116 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                         "id" : "cats",
                         "label" : "Meow",
                         "type" : "Language"
+                      },
+                      "type" : "AggregationBucket"
+                    }
+                  ]
+                }
+              },
+              "results": [${works
+                            .filter(_.data.format.get == Books)
+                            .sortBy { _.state.canonicalId }
+                            .map(workResponse)
+                            .mkString(",")}]
+            }
+          """.stripMargin
+        }
+    }
+  }
+
+  it(
+    "filters an aggregation with a filter that is paired to another aggregation") {
+    withApi {
+      case (ElasticConfig(worksIndex, _), routes) =>
+        val works = List(
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Meow", Some("cats"))),
+          (Pictures, Language("Quack", Some("ducks"))),
+          (Audio, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Books, Language("Bark", Some("dogs"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Books, Language("Meow", Some("cats"))),
+          (Journals, Language("Quack", Some("ducks"))),
+          (Audio, Language("Croak", Some("frogs")))
+        ).map {
+          case (format, language) =>
+            identifiedWork()
+              .format(format)
+              .language(language)
+        }
+
+        insertIntoElasticsearch(worksIndex, works: _*)
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/works?workType=a&aggregations=language,workType") {
+          Status.OK -> s"""
+            {
+              ${resultList(
+                            apiPrefix,
+                            totalResults =
+                              works.count(_.data.format.get == Books))},
+              "aggregations": {
+                "type" : "Aggregations",
+                "language": {
+                  "type" : "Aggregation",
+                  "buckets": [
+                    {
+                      "count" : 3,
+                      "data" : {
+                        "id" : "dogs",
+                        "label" : "Bark",
+                        "type" : "Language"
+                      },
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 1,
+                      "data" : {
+                        "id" : "cats",
+                        "label" : "Meow",
+                        "type" : "Language"
+                      },
+                      "type" : "AggregationBucket"
+                    }
+                  ]
+                },
+                "workType" : {
+                  "type": "Aggregation",
+                  "buckets" : [
+                    {
+                      "count" : 4,
+                      "data" : {
+                        "id" : "a",
+                        "label" : "Books",
+                        "type" : "Format"
+                      },
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 3,
+                      "data" : {
+                        "id" : "d",
+                        "label" : "Journals",
+                        "type" : "Format"
+                      },
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 2,
+                      "data" : {
+                        "id" : "i",
+                        "label" : "Audio",
+                        "type" : "Format"
+                      },
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 1,
+                      "data" : {
+                        "id" : "k",
+                        "label" : "Pictures",
+                        "type" : "Format"
                       },
                       "type" : "AggregationBucket"
                     }


### PR DESCRIPTION
It turns out that this behaviour has always been broken: [this](https://github.com/wellcomecollection/catalogue/compare/fix-paired-filters-aggregations?expand=1#diff-0096661338e42f3cce180fd6202bfdf75f27fda20a443e2c963d4a282cf7a0a2L45) combined with [this](https://github.com/wellcomecollection/catalogue/compare/fix-paired-filters-aggregations?expand=1#diff-0096661338e42f3cce180fd6202bfdf75f27fda20a443e2c963d4a282cf7a0a2L52) has always meant that the subaggregation did nothing.

In practice this meant that (eg) if you had 2 aggregations - say `workType` and `language` - and a filter that paired with one of them - say a `workType` filter - then the unpaired aggregation (`language`) would _not_ have the filter applied. Fixing this introduced an inconsistency where empty buckets for `language` were displayed when a paired filter/aggregation was present but were not displayed otherwise, so there's a fix for that here too.

