### PR TITLE
use cross_fields over best_fields for works query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksQuery.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.api.elasticsearch
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.common.Operator.{AND, OR}
 import com.sksamuel.elastic4s.requests.searches.queries.BoolQuery
-import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.BEST_FIELDS
+import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.{
+  BEST_FIELDS,
+  CROSS_FIELDS
+}
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   FieldWithOptionalBoost,
   MultiMatchQuery
@@ -34,7 +37,7 @@ case object WorksMultiMatcher {
         prefixQuery("data.title.keyword", q).boost(1000),
         MultiMatchQuery(
           q,
-          `type` = Some(BEST_FIELDS),
+          `type` = Some(CROSS_FIELDS),
           operator = Some(AND),
           fields = Seq(
             ("data.contributors.agent.label", Some(1000)),


### PR DESCRIPTION
Fixes #981 

A few other ideas were discussed, as listed below:

## Use `minimum_should_match`
This _might_ fix the immediate problem, but doesn't really match what we're trying to do. That would make the query match `title` on `bulloch history of bacteriology` by essentially removing `bulloch` from the query. It wouldn't match on the `contributors` field, whereas we want it to match on both.

## Create a new combo-field
We could create a new field and `copy_to` and search on that. This feels useful, but using the `cross_fields` feels like it essentially does the same thing.

## Create a new part of the query which is `cross_fields` only on `title` and `contributors`
Again, could be useful but we went down the over-specific querying before, which we have all but removed.

I am trying to find a pre-stage way of sharing the results from the rank_eval as I have just tested them locally, but haven't quite got a solution yet bar a screen grab:

## before
<img width="474" alt="Screenshot 2020-10-23 at 16 20 15" src="https://user-images.githubusercontent.com/31692/97022126-a7fc6a80-154b-11eb-9f81-4ba4c013c3ee.png">

## after
<img width="396" alt="Screenshot 2020-10-23 at 16 20 56" src="https://user-images.githubusercontent.com/31692/97022224-c3677580-154b-11eb-8600-7e05ac383b2e.png">




