### PR TITLE
Add integration trigger to build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,3 +86,8 @@ steps:
               "--environment-id", "staging",
               "--description", $BUILDKITE_BUILD_URL,
               "--confirmation-wait-for", 3600]
+  - wait
+  - label: "Integration pipeline"
+    trigger: "integration"
+    async: true
+


### PR DESCRIPTION
Adds a step to asynchronously [trigger](https://buildkite.com/docs/pipelines/trigger-step) an [integration test pipeline](https://buildkite.com/wellcomecollection/integration) ([github](https://github.com/wellcomecollection/integration)).

It is async as we don't want to fail this, at least not yet.

The integration pipeline will be triggered to test dependencies across projects. And example would be:
* On the experience build, we have a `browser-test` step running a docker container `browser-test`. This is run on every change
* The API changes, and triggers `integration`
* The integration build contains the same `browser-test` step with the same docker container

This means we can compose this new pipeline from steps in other pipelines without having to rerun whole pipelines. It will also allow us to report that it is the integration that is broken.
