### PR TITLE
Single variable for index config

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -10,9 +10,11 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
+  val indexDate = "20201023"
+
   def apply(): ElasticConfig =
     ElasticConfig(
-      worksIndex = Index("works-20201023"),
-      imagesIndex = Index("images-20201023")
+      worksIndex = Index(s"works-$indexDate"),
+      imagesIndex = Index(s"images-$indexDate")
     )
 }


### PR DESCRIPTION
Thought that, since we use this to match index consumers to pipelines, it should be configured in the same way as pipelines - ie via a single variable for the date https://github.com/wellcomecollection/catalogue/blob/938ddb72dd54d573ab7e8bb30fe7b7ad1db96540/pipeline/terraform/main.tf#L4