### PR TITLE
Add a script for downloading full-res images from a work

### DIFF
--- a/scripts/_downloads.py
+++ b/scripts/_downloads.py
@@ -12,21 +12,17 @@ def download_digital_location(location, out_dir, name_prefix):
 
     # e.g. https://iiif.wellcomecollection.org/image/L1234.jpg/info.json
     if location["url"].endswith("/info.json"):
-        filename = os.path.basename(
-            location["url"][:-len("/info.json")]
-        )
+        filename = os.path.basename(location["url"][: -len("/info.json")])
         out_path = os.path.join(out_dir, name_prefix + filename)
 
         urlretrieve(
-            location["url"].replace("/info.json", "/full/full/0/default.jpg"),
-            out_path
+            location["url"].replace("/info.json", "/full/full/0/default.jpg"), out_path
         )
 
     # e.g. https://wellcomelibrary.org/iiif/b28405717/manifest
-    elif (
-        location["url"].startswith("https://wellcomelibrary.org/iiif/") and
-        location["url"].endswith("/manifest")
-    ):
+    elif location["url"].startswith("https://wellcomelibrary.org/iiif/") and location[
+        "url"
+    ].endswith("/manifest"):
         manifest = httpx.get(location["url"]).json()
 
         # TODO: What if it's a multiple manifestation?
@@ -36,7 +32,7 @@ def download_digital_location(location, out_dir, name_prefix):
                     filename = os.path.basename(image["@id"])
                     urlretrieve(
                         image["resource"]["@id"].replace("!1024,1024", "full"),
-                        os.path.join(out_dir, filename)
+                        os.path.join(out_dir, filename),
                     )
 
     else:

--- a/scripts/_downloads.py
+++ b/scripts/_downloads.py
@@ -1,0 +1,22 @@
+import os
+from urllib.request import urlretrieve
+
+
+def download_digital_location(location, out_dir, name_prefix):
+    """
+    Download a DigitalLocation to the specified directory and prefix.
+    """
+    assert location["type"] == "DigitalLocation"
+
+    if location["url"].endswith("/info.json"):
+        filename = os.path.basename(
+            location["url"][:-len("/info.json")]
+        )
+        out_path = os.path.join(out_dir, name_prefix + filename)
+
+        urlretrieve(
+            location["url"].replace("/info.json", "/full/full/0/default.jpg"),
+            out_path
+        )
+    else:
+        raise RuntimeError(f"Unrecognised URL: {location['url']}")

--- a/scripts/_downloads.py
+++ b/scripts/_downloads.py
@@ -1,6 +1,8 @@
 import os
 from urllib.request import urlretrieve
 
+import httpx
+
 
 def download_digital_location(location, out_dir, name_prefix):
     """
@@ -8,6 +10,7 @@ def download_digital_location(location, out_dir, name_prefix):
     """
     assert location["type"] == "DigitalLocation"
 
+    # e.g. https://iiif.wellcomecollection.org/image/L1234.jpg/info.json
     if location["url"].endswith("/info.json"):
         filename = os.path.basename(
             location["url"][:-len("/info.json")]
@@ -18,5 +21,23 @@ def download_digital_location(location, out_dir, name_prefix):
             location["url"].replace("/info.json", "/full/full/0/default.jpg"),
             out_path
         )
+
+    # e.g. https://wellcomelibrary.org/iiif/b28405717/manifest
+    elif (
+        location["url"].startswith("https://wellcomelibrary.org/iiif/") and
+        location["url"].endswith("/manifest")
+    ):
+        manifest = httpx.get(location["url"]).json()
+
+        # TODO: What if it's a multiple manifestation?
+        for sequence in manifest["sequences"]:
+            for canvas in sequence["canvases"]:
+                for image in canvas["images"]:
+                    filename = os.path.basename(image["@id"])
+                    urlretrieve(
+                        image["resource"]["@id"].replace("!1024,1024", "full"),
+                        os.path.join(out_dir, filename)
+                    )
+
     else:
         raise RuntimeError(f"Unrecognised URL: {location['url']}")

--- a/scripts/_git_helpers.py
+++ b/scripts/_git_helpers.py
@@ -1,0 +1,22 @@
+import functools
+import os
+import subprocess
+
+
+@functools.lru_cache()
+def repo_root():
+    return subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"]).strip().decode("utf8")
+
+
+def ignore_directory(dirname):
+    """
+    Tell Git to ignore a directory.
+    """
+    full_path = os.path.abspath(dirname)
+
+    # See https://alexwlchan.net/2015/06/git-info-exclude/
+    exclude_path = os.path.join(repo_root(), ".git", "info", "exclude")
+
+    with open(exclude_path, "a") as outfile:
+        outfile.write(os.path.relpath(full_path, repo_root()) + "\n")

--- a/scripts/_git_helpers.py
+++ b/scripts/_git_helpers.py
@@ -5,8 +5,11 @@ import subprocess
 
 @functools.lru_cache()
 def repo_root():
-    return subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"]).strip().decode("utf8")
+    return (
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+        .strip()
+        .decode("utf8")
+    )
 
 
 def ignore_directory(dirname):

--- a/scripts/download_images_on_work.py
+++ b/scripts/download_images_on_work.py
@@ -41,7 +41,7 @@ def get_work_id(url):
 def get_digital_locations(work_id):
     resp = httpx.get(
         f"https://api.wellcomecollection.org/catalogue/v2/works/{work_id}",
-        params={"include": "images,items"}
+        params={"include": "images,items"},
     )
     work = resp.json()
 
@@ -81,7 +81,5 @@ if __name__ == "__main__":
 
     for i, location in enumerate(get_digital_locations(work_id), start=1):
         download_digital_location(
-            location=location,
-            out_dir=work_id,
-            name_prefix=f"{i}-"
+            location=location, out_dir=work_id, name_prefix=f"{i}-"
         )

--- a/scripts/download_images_on_work.py
+++ b/scripts/download_images_on_work.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""
+This script will download all the images from a work, and saves them to
+a local directory.
+
+Example usage:
+
+    $ python3 download_images_on_work.py "https://wellcomecollection.org/works/fecwftff"
+
+"""
+
+import os
+import sys
+
+import httpx
+import hyperlink
+
+from _downloads import download_digital_location
+from _git_helpers import ignore_directory
+
+
+def get_work_id(url):
+    """
+    Given a URL of the form https://wellcomecollection.org/works/acv8r4bv,
+    extract the work ID (in this case ``acv8r4bv``).
+    """
+    parsed_url = hyperlink.URL.from_text(url)
+
+    if parsed_url.host != "wellcomecollection.org":
+        raise RuntimeError(f"Not a wellcomecollection.org URL: {url}")
+
+    try:
+        works, work_id = parsed_url.path
+        assert works == "works"
+    except (AssertionError, ValueError):  # wrong number of path parts, or not /works
+        raise RuntimeError(f"Is this a /works URL? {url}")
+
+    return work_id
+
+
+def get_image_ids(work_id):
+    """
+    Get a list of all the image IDs associated with a work.
+    """
+    resp = httpx.get(
+        f"https://api.wellcomecollection.org/catalogue/v2/works/{work_id}",
+        params={"include": "images"}
+    )
+    work = resp.json()
+
+    return [img["id"] for img in work["images"]]
+
+
+def get_digital_locations(image_ids):
+    for img_id in image_ids:
+        resp = httpx.get(
+            f"https://api.wellcomecollection.org/catalogue/v2/images/{img_id}"
+        )
+
+        image = resp.json()
+
+        for loc in image["locations"]:
+            if loc["type"] == "DigitalLocation":
+                yield loc
+
+
+if __name__ == "__main__":
+    try:
+        works_url = sys.argv[1]
+    except IndexError:
+        sys.exit(f"Usage: {__file__} <WORKS_URL>")
+
+    try:
+        work_id = get_work_id(works_url)
+    except RuntimeError as err:
+        sys.exit(str(err))
+
+    os.makedirs(work_id, exist_ok=True)
+
+    ignore_directory(work_id)
+
+    image_ids = get_image_ids(work_id=work_id)
+
+    with open(work_id + "/README.txt", "w") as outfile:
+        outfile.write(f"Images from {works_url}\n")
+
+    for i, location in enumerate(get_digital_locations(image_ids), start=1):
+        download_digital_location(
+            location=location,
+            out_dir=work_id,
+            name_prefix=f"{i}-"
+        )


### PR DESCRIPTION
Sometimes Holly gets a request for all the high-resolution images on a work, and she forwards those to me. I write a one-off script to download all the relevant files, bundle them up into a ZIP and put them in a public S3 bucket.

This is less than ideal:

* I shouldn't be the only person who can do this. What if I'm on leave?
* I shouldn't be writing code to do this every time. What's the point of a standardised API if I do that?
* I shouldn't be the only person who does this. How else will other people learn about user requests?

This patch tries to solve the API part of this problem. It adds a script that downloads all the images in a work to a local folder. What you do with them after that is your problem.