### PR TITLE
Upgrade sbt to 1.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,6 +284,7 @@ tags
 .metals
 # bloop scala build server
 .bloop
+.bsp
 
 # End of https://www.gitignore.io/api/osx,vim,java,linux,scala,python,textmate,intellij
 drain_ecs_container_instance/src/boto3/

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val matcher = setupProject(
 lazy val merger = setupProject(
   project,
   "pipeline/merger",
-  localDependencies = Seq(internal_model, big_messaging_typesafe, pipeline_storage),
+  localDependencies =
+    Seq(internal_model, big_messaging_typesafe, pipeline_storage),
   externalDependencies = CatalogueDependencies.mergerDependencies
 )
 

--- a/docker_run.py
+++ b/docker_run.py
@@ -137,6 +137,22 @@ if __name__ == "__main__":
         cmd += ["--volume", "%s/.sbt:/root/.sbt" % os.environ["HOME"]]
         cmd += ["--volume", "%s/.ivy2:/root/.ivy2" % os.environ["HOME"]]
 
+        # Coursier cache location is platform-dependent
+        # https://get-coursier.io/docs/cache.html#default-location
+        linux_coursier_cache = ".cache/coursier/v1"
+        if sys.platform == "darwin":
+            cmd += [
+                "--volume",
+                "%s/Library/Caches/Coursier/v1:/root/%s"
+                % (os.environ["HOME"], linux_coursier_cache),
+            ]
+        else:
+            cmd += [
+                "--volume",
+                "%s/%s:/root/%s"
+                % (os.environ["HOME"], linux_coursier_cache, linux_coursier_cache),
+            ]
+
         if not namespace.share_aws_creds:
             cmd += _aws_credentials_args()
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -20,6 +20,7 @@ object Common {
       "-Ypartial-unification",
       "-Xcheckinit"
     ),
+    updateOptions := updateOptions.value.withCachedResolution(true),
     parallelExecution in Test := false
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.0
+sbt.version=1.4.1
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.8
+sbt.version=1.4.0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ libraryDependencies ++= Seq(
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
-addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.18.0")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
It looks like _maybe_ some of the unnecessary recompiles could have been caused by this issue https://github.com/sbt/sbt/issues/4168 so this PR upgrades SBT to 1.4.1, which resolves that issue. This also requires using Coursier for dependency resolution rather than Ivy

It also enables [cached resolution](https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html) which has improved build times for me locally, at least.