### PR TITLE
Add ISSN and digcode identifiers

### DIFF
--- a/common/internal_model/src/main/resources/identifier-schemes.csv
+++ b/common/internal_model/src/main/resources/identifier-schemes.csv
@@ -16,3 +16,4 @@ isbn,International Standard Book Number
 issn,ISSN
 mets,METS
 mets-image, METS image
+wellcome-digcode,Wellcome digcode

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -26,18 +26,21 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
 
   type Output = List[SourceIdentifier]
 
-  def apply(bibId: SierraBibNumber, bibData: SierraBibData): List[SourceIdentifier] = {
+  def apply(bibId: SierraBibNumber,
+            bibData: SierraBibData): List[SourceIdentifier] = {
     val sierraIdentifier = SourceIdentifier(
       identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",
       value = bibId.withoutCheckDigit
     )
 
-    List(sierraIdentifier) ++ getIsbnIdentifiers(bibData) ++ getIssnIdentifiers(bibData) ++ getDigcodes(bibData)
+    List(sierraIdentifier) ++ getIsbnIdentifiers(bibData) ++ getIssnIdentifiers(
+      bibData) ++ getDigcodes(bibData)
   }
 
   // Find ISBN (International Serial Book Number) identifiers from MARC 020 ǂa.
-  private def getIsbnIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+  private def getIsbnIdentifiers(
+    bibData: SierraBibData): List[SourceIdentifier] =
     bibData
       .subfieldsWithTag("020" -> "a")
       .contents
@@ -51,7 +54,8 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
       }
 
   // Find ISSN (International Standard Serial Number) identifiers from MARC 022 ǂa.
-  private def getIssnIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+  private def getIssnIdentifiers(
+    bibData: SierraBibData): List[SourceIdentifier] =
     bibData
       .subfieldsWithTag("022" -> "a")
       .contents
@@ -95,8 +99,7 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
           case digcodeRegex(d) => d
         }
 
-    digcodeValues
-      .distinct
+    digcodeValues.distinct
       .map { value =>
         SourceIdentifier(
           identifierType = IdentifierType("wellcome-digcode"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -34,6 +34,7 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
       bibData
         .subfieldsWithTag("020" -> "a")
         .contents
+        .distinct
         .map { value =>
           SourceIdentifier(
             identifierType = IdentifierType("isbn"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -78,9 +78,25 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
       bibData
         .subfieldsWithTag("759" -> "a")
         .contents
+        .distinct
 
-    marcValues
-      .distinct
+    // Capture any string starting with `dig` followed by a non-zero number
+    // of alphabet characters.  The digcode is only useful if it identifies
+    // a digitisation project, hence requiring a non-empty suffix.
+    //
+    // We match any number of characters after the alphabetic string, so the
+    // pattern match below captures (but discards) extra data.
+    //
+    // e.g. `digmoh(Channel)` becomes `digmoh`
+    val digcodeRegex = "^(dig[a-z]+).*$".r
+
+    val digcodeValues =
+      marcValues
+        .collect {
+          case digcodeRegex(d) => d
+        }
+
+    digcodeValues
       .map { value =>
         SourceIdentifier(
           identifierType = IdentifierType("wellcome-digcode"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -78,7 +78,6 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
       bibData
         .subfieldsWithTag("759" -> "a")
         .contents
-        .distinct
 
     // Capture any string starting with `dig` followed by a non-zero number
     // of alphabet characters.  The digcode is only useful if it identifies
@@ -97,6 +96,7 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
         }
 
     digcodeValues
+      .distinct
       .map { value =>
         SourceIdentifier(
           identifierType = IdentifierType("wellcome-digcode"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -17,6 +17,9 @@ import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 //    -   "isbn" from MARC tag 020 subfield $a.  This is repeatable.
 //        https://www.loc.gov/marc/bibliographic/bd020.html
 //
+//    -   "issn" from MARC tag 022 ǂa.  This is repeatable.
+//        https://www.loc.gov/marc/bibliographic/bd022.html
+//
 //    Adding other identifiers is out-of-scope for now.
 //
 object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
@@ -43,6 +46,19 @@ object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
           )
         }
 
-    List(sierraIdentifier) ++ isbnIdentifiers
+    val issnIdentifiers: List[SourceIdentifier] =
+      bibData
+        .subfieldsWithTag("022" -> "a")
+        .contents
+        .distinct
+        .map { value =>
+          SourceIdentifier(
+            identifierType = IdentifierType("issn"),
+            ontologyType = "Work",
+            value = value
+          )
+        }
+
+    List(sierraIdentifier) ++ isbnIdentifiers ++ issnIdentifiers
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -9,56 +9,55 @@ import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 
 // Populate wwork:identifiers.
 //
-//    We populate with three identifier schemes:
+//    We populate with the following identifiers:
 //
-//    -   "sierra-system-number" for the full record type (incl. prefix and
-//        check digit)
 //    -   "sierra-identifier" for the 7-digit internal ID
+//
 //    -   "isbn" from MARC tag 020 subfield $a.  This is repeatable.
 //        https://www.loc.gov/marc/bibliographic/bd020.html
 //
 //    -   "issn" from MARC tag 022 ǂa.  This is repeatable.
 //        https://www.loc.gov/marc/bibliographic/bd022.html
 //
-//    Adding other identifiers is out-of-scope for now.
-//
 object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {
 
   type Output = List[SourceIdentifier]
 
-  def apply(bibId: SierraBibNumber, bibData: SierraBibData) = {
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData): List[SourceIdentifier] = {
     val sierraIdentifier = SourceIdentifier(
       identifierType = IdentifierType("sierra-identifier"),
       ontologyType = "Work",
       value = bibId.withoutCheckDigit
     )
 
-    val isbnIdentifiers: List[SourceIdentifier] =
-      bibData
-        .subfieldsWithTag("020" -> "a")
-        .contents
-        .distinct
-        .map { value =>
-          SourceIdentifier(
-            identifierType = IdentifierType("isbn"),
-            ontologyType = "Work",
-            value = value
-          )
-        }
-
-    val issnIdentifiers: List[SourceIdentifier] =
-      bibData
-        .subfieldsWithTag("022" -> "a")
-        .contents
-        .distinct
-        .map { value =>
-          SourceIdentifier(
-            identifierType = IdentifierType("issn"),
-            ontologyType = "Work",
-            value = value
-          )
-        }
-
-    List(sierraIdentifier) ++ isbnIdentifiers ++ issnIdentifiers
+    List(sierraIdentifier) ++ getIsbnIdentifiers(bibData) ++ getIssnIdentifiers(bibData)
   }
+
+  // Find ISBN (International Serial Book Number) identifiers from MARC 020 ǂa.
+  private def getIsbnIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+    bibData
+      .subfieldsWithTag("020" -> "a")
+      .contents
+      .distinct
+      .map { value =>
+        SourceIdentifier(
+          identifierType = IdentifierType("isbn"),
+          ontologyType = "Work",
+          value = value
+        )
+      }
+
+  // Find ISSN (International Standard Serial Number) identifiers from MARC 022 ǂa.
+  private def getIssnIdentifiers(bibData: SierraBibData): List[SourceIdentifier] =
+    bibData
+      .subfieldsWithTag("022" -> "a")
+      .contents
+      .distinct
+      .map { value =>
+        SourceIdentifier(
+          identifierType = IdentifierType("issn"),
+          ontologyType = "Work",
+          value = value
+        )
+      }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 //    -   "issn" from MARC tag 022 ǂa.  This is repeatable.
 //        https://www.loc.gov/marc/bibliographic/bd022.html
 //
-//    -   "digcode" from MARC tag 759 ǂa.  This is repeatable.
+//    -   "wellcome-digcode" from MARC tag 759 ǂa.  This is repeatable.
 //        Note: MARC 759 is not assigned by the Library of Congress.
 //
 object SierraIdentifiers extends SierraDataTransformer with SierraQueryOps {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 
 class SierraIdentifiersTest
     extends AnyFunSpec
@@ -78,7 +81,9 @@ class SierraIdentifiersTest
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
 
-      val isbnIdentifiers = otherIdentifiers.filter { _.identifierType.id == "isbn" }
+      val isbnIdentifiers = otherIdentifiers.filter {
+        _.identifierType.id == "isbn"
+      }
       isbnIdentifiers should have size 1
     }
   }
@@ -134,7 +139,9 @@ class SierraIdentifiersTest
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
 
-      val issnIdentifiers = otherIdentifiers.filter { _.identifierType.id == "issn" }
+      val issnIdentifiers = otherIdentifiers.filter {
+        _.identifierType.id == "issn"
+      }
       issnIdentifiers should have size 1
     }
   }
@@ -191,7 +198,9 @@ class SierraIdentifiersTest
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
 
-      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      val digcodeIdentifiers = otherIdentifiers.filter {
+        _.identifierType.id == "wellcome-digcode"
+      }
       digcodeIdentifiers should have size 1
     }
 
@@ -202,7 +211,6 @@ class SierraIdentifiersTest
           // of any extra information makes it useless for identifying a
           // digitisation project!
           createVarFieldWith(marcTag = "759", subfieldA = "dig"),
-
           // digcodes have to start with the special string `dig`
           createVarFieldWith(marcTag = "759", subfieldA = "notadigcode")
         )
@@ -210,7 +218,9 @@ class SierraIdentifiersTest
 
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
 
-      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      val digcodeIdentifiers = otherIdentifiers.filter {
+        _.identifierType.id == "wellcome-digcode"
+      }
       digcodeIdentifiers shouldBe empty
     }
 
@@ -243,7 +253,9 @@ class SierraIdentifiersTest
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
 
-      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      val digcodeIdentifiers = otherIdentifiers.filter {
+        _.identifierType.id == "wellcome-digcode"
+      }
       digcodeIdentifiers should have size 1
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -276,6 +276,9 @@ class SierraIdentifiersTest
           createVarFieldWith(
             marcTag = "759",
             subfields = List(
+              // Although this starts with the special string `dig`, the lack
+              // of any extra information makes it useless for identifying a
+              // digitisation project!
               MarcSubfield(tag = "a", content = "dig")
             )
           ),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -270,6 +270,30 @@ class SierraIdentifiersTest
       digcodeIdentifiers should have size 1
     }
 
+    it("skips values in MARC 759 which aren't digcodes") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "dig")
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "notadigcode")
+            )
+          )
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+
+      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      digcodeIdentifiers shouldBe empty
+    }
+
     it("only captures the continuous alphabetic string starting `dig`") {
       // This example is based on b29500783
       val marcDigcode = "digmoh(Channel)"

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -317,5 +317,29 @@ class SierraIdentifiersTest
           value = parsedDigcode
         ))
     }
+
+    it("deduplicates based on the actual digcode") {
+      val digcode = "digmoh"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = s"$digcode(Channel)")
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+
+      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      digcodeIdentifiers should have size 1
+    }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -269,4 +269,29 @@ class SierraIdentifiersTest
       val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
       digcodeIdentifiers should have size 1
     }
+
+    it("only captures the continuous alphabetic string starting `dig`") {
+      // This example is based on b29500783
+      val marcDigcode = "digmoh(Channel)"
+      val parsedDigcode = "digmoh"
+
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = marcDigcode)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("wellcome-digcode"),
+          ontologyType = "Work",
+          value = parsedDigcode
+        ))
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -82,5 +82,29 @@ class SierraIdentifiersTest
           value = isbn13
         ))
     }
+
+    it("deduplicates identifiers") {
+      val isbn = "1785783033"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "020",
+            subfields = List(
+              MarcSubfield(tag = "a", content = isbn)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "020",
+            subfields = List(
+              MarcSubfield(tag = "a", content = isbn)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+
+      val isbnIdentifiers = otherIdentifiers.filter { _.identifierType.id == "isbn" }
+      isbnIdentifiers should have size 1
+    }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -107,4 +107,85 @@ class SierraIdentifiersTest
       isbnIdentifiers should have size 1
     }
   }
+
+  describe("finds ISSN identifiers from MARC 022 ǂa") {
+    it("a single identifier") {
+      val issn = "0305-3342"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "022",
+            subfields = List(
+              MarcSubfield(tag = "a", content = issn)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("issn"),
+          ontologyType = "Work",
+          value = issn
+        ))
+    }
+
+    it("multiple identifiers") {
+      val issn1 = "0305-3342"
+      val issn2 = "0019-2422"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "022",
+            subfields = List(
+              MarcSubfield(tag = "a", content = issn1)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "022",
+            subfields = List(
+              MarcSubfield(tag = "a", content = issn2)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("issn"),
+          ontologyType = "Work",
+          value = issn1
+        ))
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("issn"),
+          ontologyType = "Work",
+          value = issn2
+        ))
+    }
+
+    it("deduplicates identifiers") {
+      val issn = "0305-3342"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "022",
+            subfields = List(
+              MarcSubfield(tag = "a", content = issn)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "022",
+            subfields = List(
+              MarcSubfield(tag = "a", content = issn)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+
+      val issnIdentifiers = otherIdentifiers.filter { _.identifierType.id == "issn" }
+      issnIdentifiers should have size 1
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
 
 class SierraIdentifiersTest
     extends AnyFunSpec
@@ -32,12 +32,7 @@ class SierraIdentifiersTest
       val isbn = "1785783033"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "020",
-            subfields = List(
-              MarcSubfield(tag = "a", content = isbn)
-            )
-          )
+          createVarFieldWith(marcTag = "020", subfieldA = isbn)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -54,18 +49,8 @@ class SierraIdentifiersTest
       val isbn13 = "978-1473647640"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "020",
-            subfields = List(
-              MarcSubfield(tag = "a", content = isbn10)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "020",
-            subfields = List(
-              MarcSubfield(tag = "a", content = isbn13)
-            )
-          )
+          createVarFieldWith(marcTag = "020", subfieldA = isbn10),
+          createVarFieldWith(marcTag = "020", subfieldA = isbn13)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -87,18 +72,8 @@ class SierraIdentifiersTest
       val isbn = "1785783033"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "020",
-            subfields = List(
-              MarcSubfield(tag = "a", content = isbn)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "020",
-            subfields = List(
-              MarcSubfield(tag = "a", content = isbn)
-            )
-          )
+          createVarFieldWith(marcTag = "020", subfieldA = isbn),
+          createVarFieldWith(marcTag = "020", subfieldA = isbn)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -113,12 +88,7 @@ class SierraIdentifiersTest
       val issn = "0305-3342"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "022",
-            subfields = List(
-              MarcSubfield(tag = "a", content = issn)
-            )
-          )
+          createVarFieldWith(marcTag = "022", subfieldA = issn)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -135,18 +105,8 @@ class SierraIdentifiersTest
       val issn2 = "0019-2422"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "022",
-            subfields = List(
-              MarcSubfield(tag = "a", content = issn1)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "022",
-            subfields = List(
-              MarcSubfield(tag = "a", content = issn2)
-            )
-          )
+          createVarFieldWith(marcTag = "022", subfieldA = issn1),
+          createVarFieldWith(marcTag = "022", subfieldA = issn2)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -168,18 +128,8 @@ class SierraIdentifiersTest
       val issn = "0305-3342"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "022",
-            subfields = List(
-              MarcSubfield(tag = "a", content = issn)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "022",
-            subfields = List(
-              MarcSubfield(tag = "a", content = issn)
-            )
-          )
+          createVarFieldWith(marcTag = "022", subfieldA = issn),
+          createVarFieldWith(marcTag = "022", subfieldA = issn)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -194,12 +144,7 @@ class SierraIdentifiersTest
       val digcode = "digrcs"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode)
-            )
-          )
+          createVarFieldWith(marcTag = "759", subfieldA = digcode)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -217,18 +162,8 @@ class SierraIdentifiersTest
       val digcode2 = "digukmhl"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode1)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode2)
-            )
-          )
+          createVarFieldWith(marcTag = "759", subfieldA = digcode1),
+          createVarFieldWith(marcTag = "759", subfieldA = digcode2)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -250,18 +185,8 @@ class SierraIdentifiersTest
       val digcode = "digrcs"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode)
-            )
-          )
+          createVarFieldWith(marcTag = "759", subfieldA = digcode),
+          createVarFieldWith(marcTag = "759", subfieldA = digcode)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -273,21 +198,13 @@ class SierraIdentifiersTest
     it("skips values in MARC 759 which aren't digcodes") {
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              // Although this starts with the special string `dig`, the lack
-              // of any extra information makes it useless for identifying a
-              // digitisation project!
-              MarcSubfield(tag = "a", content = "dig")
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = "notadigcode")
-            )
-          )
+          // Although this starts with the special string `dig`, the lack
+          // of any extra information makes it useless for identifying a
+          // digitisation project!
+          createVarFieldWith(marcTag = "759", subfieldA = "dig"),
+
+          // digcodes have to start with the special string `dig`
+          createVarFieldWith(marcTag = "759", subfieldA = "notadigcode")
         )
       )
 
@@ -304,12 +221,7 @@ class SierraIdentifiersTest
 
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = marcDigcode)
-            )
-          )
+          createVarFieldWith(marcTag = "759", subfieldA = marcDigcode)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -325,18 +237,8 @@ class SierraIdentifiersTest
       val digcode = "digmoh"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = digcode)
-            )
-          ),
-          createVarFieldWith(
-            marcTag = "759",
-            subfields = List(
-              MarcSubfield(tag = "a", content = s"$digcode(Channel)")
-            )
-          )
+          createVarFieldWith(marcTag = "759", subfieldA = digcode),
+          createVarFieldWith(marcTag = "759", subfieldA = s"$digcode(Channel)")
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -345,4 +247,12 @@ class SierraIdentifiersTest
       digcodeIdentifiers should have size 1
     }
   }
+
+  private def createVarFieldWith(marcTag: String, subfieldA: String): VarField =
+    createVarFieldWith(
+      marcTag = marcTag,
+      subfields = List(
+        MarcSubfield(tag = "a", content = subfieldA)
+      )
+    )
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -28,11 +28,14 @@ class SierraIdentifiersTest
   }
 
   describe("finds ISBN identifiers from MARC 020 ǂa") {
+    // This example is taken from b1754201
+    val isbn10 = "159463078X"
+    val isbn13 = "9781594630781"
+
     it("a single identifier") {
-      val isbn = "1785783033"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(marcTag = "020", subfieldA = isbn)
+          createVarFieldWith(marcTag = "020", subfieldA = isbn10)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
@@ -40,13 +43,11 @@ class SierraIdentifiersTest
         SourceIdentifier(
           identifierType = IdentifierType("isbn"),
           ontologyType = "Work",
-          value = isbn
+          value = isbn10
         ))
     }
 
     it("multiple identifiers") {
-      val isbn10 = "1473647649"
-      val isbn13 = "978-1473647640"
       val bibData = createSierraBibDataWith(
         varFields = List(
           createVarFieldWith(marcTag = "020", subfieldA = isbn10),
@@ -69,11 +70,10 @@ class SierraIdentifiersTest
     }
 
     it("deduplicates identifiers") {
-      val isbn = "1785783033"
       val bibData = createSierraBibDataWith(
         varFields = List(
-          createVarFieldWith(marcTag = "020", subfieldA = isbn),
-          createVarFieldWith(marcTag = "020", subfieldA = isbn)
+          createVarFieldWith(marcTag = "020", subfieldA = isbn10),
+          createVarFieldWith(marcTag = "020", subfieldA = isbn10)
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -27,58 +27,60 @@ class SierraIdentifiersTest
     SierraIdentifiers(bibId, createSierraBibData) shouldBe expectedIdentifiers
   }
 
-  it("passes through an ISBN identifier if present") {
-    val isbn = "1785783033"
-    val bibData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "020",
-          subfields = List(
-            MarcSubfield(tag = "a", content = isbn)
+  describe("finds ISBN identifiers from MARC 020 ǂa") {
+    it("a single identifier") {
+      val isbn = "1785783033"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "020",
+            subfields = List(
+              MarcSubfield(tag = "a", content = isbn)
+            )
           )
         )
       )
-    )
-    val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
-    otherIdentifiers should contain(
-      SourceIdentifier(
-        identifierType = IdentifierType("isbn"),
-        ontologyType = "Work",
-        value = isbn
-      ))
-  }
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("isbn"),
+          ontologyType = "Work",
+          value = isbn
+        ))
+    }
 
-  it("passes through multiple ISBN identifiers if present") {
-    val isbn10 = "1473647649"
-    val isbn13 = "978-1473647640"
-    val bibData = createSierraBibDataWith(
-      varFields = List(
-        createVarFieldWith(
-          marcTag = "020",
-          subfields = List(
-            MarcSubfield(tag = "a", content = isbn10)
-          )
-        ),
-        createVarFieldWith(
-          marcTag = "020",
-          subfields = List(
-            MarcSubfield(tag = "a", content = isbn13)
+    it("multiple identifiers") {
+      val isbn10 = "1473647649"
+      val isbn13 = "978-1473647640"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "020",
+            subfields = List(
+              MarcSubfield(tag = "a", content = isbn10)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "020",
+            subfields = List(
+              MarcSubfield(tag = "a", content = isbn13)
+            )
           )
         )
       )
-    )
-    val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
-    otherIdentifiers should contain(
-      SourceIdentifier(
-        identifierType = IdentifierType("isbn"),
-        ontologyType = "Work",
-        value = isbn10
-      ))
-    otherIdentifiers should contain(
-      SourceIdentifier(
-        identifierType = IdentifierType("isbn"),
-        ontologyType = "Work",
-        value = isbn13
-      ))
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("isbn"),
+          ontologyType = "Work",
+          value = isbn10
+        ))
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("isbn"),
+          ontologyType = "Work",
+          value = isbn13
+        ))
+    }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -188,4 +188,85 @@ class SierraIdentifiersTest
       issnIdentifiers should have size 1
     }
   }
+
+  describe("finds digcodes from MARC 759 ǂa") {
+    it("a single identifier") {
+      val digcode = "digrcs"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("wellcome-digcode"),
+          ontologyType = "Work",
+          value = digcode
+        ))
+    }
+
+    it("multiple identifiers") {
+      // This example is based on b22474262
+      val digcode1 = "digrcs"
+      val digcode2 = "digukmhl"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode1)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode2)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("wellcome-digcode"),
+          ontologyType = "Work",
+          value = digcode1
+        ))
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType("wellcome-digcode"),
+          ontologyType = "Work",
+          value = digcode2
+        ))
+    }
+
+    it("deduplicates identifiers") {
+      val digcode = "digrcs"
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode)
+            )
+          ),
+          createVarFieldWith(
+            marcTag = "759",
+            subfields = List(
+              MarcSubfield(tag = "a", content = digcode)
+            )
+          )
+        )
+      )
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+
+      val digcodeIdentifiers = otherIdentifiers.filter { _.identifierType.id == "wellcome-digcode" }
+      digcodeIdentifiers should have size 1
+    }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4867 and https://github.com/wellcomecollection/platform/issues/4865

This patch updates the Sierra transformer to get the ISSN from MARC 022 and the Wellcome digcode from MARC 759. I copied the comments about digcodes directly from https://github.com/wellcomecollection/platform/issues/4865.