### PR TITLE
internal_model: Be explicit about the ontologyType of a SourceIdentifier

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.work.internal
 /** An identifier received from one of the original sources */
 case class SourceIdentifier(
   identifierType: IdentifierType,
-  ontologyType: String = "SourceIdentifier",
+  ontologyType: String,
   value: String
 ) {
   override def toString = s"${identifierType.id}/$value"

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -82,5 +82,6 @@ trait IdentifiersGenerators extends RandomGenerators {
     SourceIdentifier(
       value = randomAlphanumeric(length = 6),
       identifierType = IdentifierType("calm-record-id"),
+      ontologyType = "Work"
     )
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -20,7 +20,8 @@ class OtherIdentifiersRuleTest
   val nothingWork: Work.Visible[WorkState.Source] = sourceWork(
     sourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType("fake", "fake"),
-      value = "fake"
+      value = "fake",
+      ontologyType = "Work"
     )
   )
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -160,11 +160,13 @@ object CalmTransformer
       case (key, idType) =>
         record
           .getList(key)
-          .map(id => SourceIdentifier(
-            identifierType = idType,
-            value = id,
-            ontologyType = "SourceIdentifier"
-          ))
+          .map(
+            id =>
+              SourceIdentifier(
+                identifierType = idType,
+                value = id,
+                ontologyType = "SourceIdentifier"
+            ))
     }
 
   def mergeCandidates(record: CalmRecord): List[MergeCandidate] =

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -148,6 +148,11 @@ object CalmTransformer
     SourceIdentifier(
       value = record.id,
       identifierType = CalmIdentifierTypes.recordId,
+      // Although this is a Work, we have previously created Calm-identified
+      // works with ontologyType "SourceIdentifier".  We need to keep using
+      // this ontologyType, or those works will be assigned new identifiers
+      // by the ID minter.
+      ontologyType = "SourceIdentifier"
     )
 
   def otherIdentifiers(record: CalmRecord): List[SourceIdentifier] =
@@ -155,7 +160,11 @@ object CalmTransformer
       case (key, idType) =>
         record
           .getList(key)
-          .map(id => SourceIdentifier(identifierType = idType, value = id))
+          .map(id => SourceIdentifier(
+            identifierType = idType,
+            value = id,
+            ontologyType = "SourceIdentifier"
+          ))
     }
 
   def mergeCandidates(record: CalmRecord): List[MergeCandidate] =

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -27,7 +27,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
         state = Source(
           SourceIdentifier(
             value = id,
-            identifierType = CalmIdentifierTypes.recordId
+            identifierType = CalmIdentifierTypes.recordId,
+            ontologyType = "SourceIdentifier"
           ),
           record.retrievedAt
         ),
@@ -44,10 +45,12 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
           otherIdentifiers = List(
             SourceIdentifier(
               value = "a/b/c",
-              identifierType = CalmIdentifierTypes.refNo),
+              identifierType = CalmIdentifierTypes.refNo,
+              ontologyType = "SourceIdentifier"),
             SourceIdentifier(
               value = "a.b.c",
-              identifierType = CalmIdentifierTypes.altRefNo),
+              identifierType = CalmIdentifierTypes.altRefNo,
+              ontologyType = "SourceIdentifier"),
           ),
           items = List(
             Item(
@@ -80,13 +83,16 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       List(
         SourceIdentifier(
           value = "a/b/c",
-          identifierType = CalmIdentifierTypes.refNo),
+          identifierType = CalmIdentifierTypes.refNo,
+          ontologyType = "SourceIdentifier"),
         SourceIdentifier(
           value = "a.b.c",
-          identifierType = CalmIdentifierTypes.altRefNo),
+          identifierType = CalmIdentifierTypes.altRefNo,
+          ontologyType = "SourceIdentifier"),
         SourceIdentifier(
           value = "b456",
-          identifierType = IdentifierType("sierra-system-number")),
+          identifierType = IdentifierType("sierra-system-number"),
+          ontologyType = "SourceIdentifier"),
       )
   }
 
@@ -487,7 +493,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
         state = Source(
           SourceIdentifier(
             value = id,
-            identifierType = CalmIdentifierTypes.recordId
+            identifierType = CalmIdentifierTypes.recordId,
+            ontologyType = "SourceIdentifier"
           ),
           record.retrievedAt
         ),
@@ -504,7 +511,8 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
           otherIdentifiers = List(
             SourceIdentifier(
               value = "AMSG/X/Y",
-              identifierType = CalmIdentifierTypes.refNo),
+              identifierType = CalmIdentifierTypes.refNo,
+              ontologyType = "SourceIdentifier"),
           ),
           items = List(
             Item(


### PR DESCRIPTION
Spotted while writing https://github.com/wellcomecollection/catalogue/pull/1005

The ontologyType of a SourceIdentifier is meaningful – it's used to distinguish identifiers in the ID minter. e.g. `sierra/1234567` will be minted two different canonical IDs if it's a Work or an Item.

Forcing callers to be explicit about what ontologyType they want will ensure we get meaningful identifiers – as this shows, we have an issue where the Calm transformer *hasn't* set this field previously, so the identifiers will have the wrong ontologyType. e.g. if a Calm-transformed record links to a Sierra bib, the canonical ID won't match the ID on the Sierra work.

Fixing that is beyond the scope of this patch, but at least prevents it getting any worse.