### PR TITLE
Try to make the relation embedder more efficient

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -39,4 +39,8 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
           }
       }
   }
+
+  override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] =
+    Future.sequence(ids.map { lookupSingleId })
+      .map { documents => ids.zip(documents).toMap }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -21,7 +21,6 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
     with Logging {
 
   final def lookupSingleId(id: String): Future[T] = {
-    debug(s"Index $index: looking up ID $id")
     client
       .execute {
         get(index, id)
@@ -41,8 +40,6 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
   }
 
   override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] = {
-    debug(s"Index $index: looking up multiple IDs $ids")
-
     client
       .execute {
         multiget(ids.map { get(index, _) })
@@ -62,10 +59,6 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
 
           assert(
             successes.size + failures.size + missing.size == responses.size)
-
-          debug(s"Missing:   $missing")
-          debug(s"Successes: $successes")
-          debug(s"Failures:  $failures")
 
           if (missing.nonEmpty) {
             Future.failed(RetrieverNotFoundException.ids(missing.keys.toSeq))

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -20,7 +20,7 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
     extends Retriever[T]
     with Logging {
 
-  final def apply(id: String): Future[T] = {
+  final def lookupSingleId(id: String): Future[T] = {
     debug(s"Looking up ID $id in index $index")
     client
       .execute {

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -1,13 +1,17 @@
 package uk.ac.wellcome.pipeline_storage
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class MemoryRetriever[T](index: Map[String, T] = Map.empty)
+class MemoryRetriever[T](index: Map[String, T] = Map.empty)(implicit ec: ExecutionContext)
     extends Retriever[T] {
 
-  def lookupSingleId(id: String): Future[T] =
+  override def lookupSingleId(id: String): Future[T] =
     index.get(id) match {
       case Some(t) => Future.successful(t)
       case None    => Future.failed(new RetrieverNotFoundException(id))
     }
+
+  override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] =
+    Future.sequence(ids.map { lookupSingleId })
+      .map { documents => ids.zip(documents).toMap }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 class MemoryRetriever[T](index: Map[String, T] = Map.empty)
     extends Retriever[T] {
 
-  def apply(id: String): Future[T] =
+  def lookupSingleId(id: String): Future[T] =
     index.get(id) match {
       case Some(t) => Future.successful(t)
       case None    => Future.failed(new RetrieverNotFoundException(id))

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -12,10 +12,12 @@ class MemoryRetriever[T](index: Map[String, T] = Map.empty)
     }
 
   override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] = {
-    val results = ids.map { id => id -> index.get(id) }
+    val results = ids.map { id =>
+      id -> index.get(id)
+    }
 
     val successes = results.collect { case (id, Some(t)) => id -> t }
-    val failures = results.collect { case (id, None) => id }
+    val failures = results.collect { case (id, None)     => id }
 
     if (failures.isEmpty) {
       Future.successful(successes.toMap)

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -1,17 +1,26 @@
 package uk.ac.wellcome.pipeline_storage
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class MemoryRetriever[T](index: Map[String, T] = Map.empty)(implicit ec: ExecutionContext)
+class MemoryRetriever[T](index: Map[String, T] = Map.empty)
     extends Retriever[T] {
 
   override def lookupSingleId(id: String): Future[T] =
     index.get(id) match {
       case Some(t) => Future.successful(t)
-      case None    => Future.failed(new RetrieverNotFoundException(id))
+      case None    => Future.failed(RetrieverNotFoundException.id(id))
     }
 
-  override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] =
-    Future.sequence(ids.map { lookupSingleId })
-      .map { documents => ids.zip(documents).toMap }
+  override def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]] = {
+    val results = ids.map { id => id -> index.get(id) }
+
+    val successes = results.collect { case (id, Some(t)) => id -> t }
+    val failures = results.collect { case (id, None) => id }
+
+    if (failures.isEmpty) {
+      Future.successful(successes.toMap)
+    } else {
+      Future.failed(RetrieverNotFoundException.ids(failures))
+    }
+  }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -9,5 +9,5 @@ trait Retriever[T] {
     * @param id The id of the document
     * @return A future containing the document
     */
-  def apply(id: String): Future[T]
+  def lookupSingleId(id: String): Future[T]
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.pipeline_storage
 import scala.concurrent.Future
 
 trait Retriever[T] {
+
   /** Retrieves document with the given ID from the store
     *
     * @param id The id of the document

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -3,11 +3,17 @@ package uk.ac.wellcome.pipeline_storage
 import scala.concurrent.Future
 
 trait Retriever[T] {
-
   /** Retrieves document with the given ID from the store
     *
     * @param id The id of the document
     * @return A future containing the document
     */
   def lookupSingleId(id: String): Future[T]
+
+  /** Retrieves multiple documents with the given ID from the store
+    *
+    * @param ids The ids to look up
+    * @return A future containing a Map(id -> document)
+    */
+  def lookupMultipleIds(ids: Seq[String]): Future[Map[String, T]]
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverException.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverException.scala
@@ -2,12 +2,14 @@ package uk.ac.wellcome.pipeline_storage
 
 class RetrieverException(message: String) extends RuntimeException(message)
 
-class RetrieverNotFoundException(message: String) extends RetrieverException(message)
+class RetrieverNotFoundException(message: String)
+    extends RetrieverException(message)
 
 object RetrieverNotFoundException {
   def id(id: String): RetrieverNotFoundException =
     new RetrieverNotFoundException(s"Nothing found with ID $id!")
 
   def ids(ids: Seq[String]): RetrieverNotFoundException =
-    new RetrieverNotFoundException(s"Nothing found with ID(s) ${ids.mkString(", ")}!")
+    new RetrieverNotFoundException(
+      s"Nothing found with ID(s) ${ids.mkString(", ")}!")
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverException.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverException.scala
@@ -2,5 +2,12 @@ package uk.ac.wellcome.pipeline_storage
 
 class RetrieverException(message: String) extends RuntimeException(message)
 
-class RetrieverNotFoundException(id: String)
-    extends RetrieverException(s"Nothing found with ID $id!")
+class RetrieverNotFoundException(message: String) extends RetrieverException(message)
+
+object RetrieverNotFoundException {
+  def id(id: String): RetrieverNotFoundException =
+    new RetrieverNotFoundException(s"Nothing found with ID $id!")
+
+  def ids(ids: Seq[String]): RetrieverNotFoundException =
+    new RetrieverNotFoundException(s"Nothing found with ID(s) ${ids.mkString(", ")}!")
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -72,7 +72,7 @@ trait RetrieverTestCases[Context, T]
 
       whenReady(future.failed) { exc =>
         exc shouldBe a[RetrieverNotFoundException]
-        exc.getMessage shouldBe s"Nothing found with ID $missingId!"
+        exc.getMessage shouldBe s"Nothing found with ID(s) $missingId!"
       }
     }
   }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -47,8 +47,12 @@ trait RetrieverTestCases[Context, T]
   }
 
   it("retrieves multiple documents") {
-    val documents = (1 to 3).map { _ => createT }
-    val otherDocuments = (1 to 3).map { _ => createT }
+    val documents = (1 to 3).map { _ =>
+      createT
+    }
+    val otherDocuments = (1 to 3).map { _ =>
+      createT
+    }
 
     val idsToLookup = documents.map { id.canonicalId }
 
@@ -56,13 +60,17 @@ trait RetrieverTestCases[Context, T]
       val future = withRetriever { _.lookupMultipleIds(idsToLookup) }
 
       whenReady(future) { result =>
-        result shouldBe documents.map { doc => id.canonicalId(doc) -> doc }.toMap
+        result shouldBe documents.map { doc =>
+          id.canonicalId(doc) -> doc
+        }.toMap
       }
     }
   }
 
   it("throws if it can't find all the requested documents") {
-    val documents = (1 to 3).map { _ => createT }
+    val documents = (1 to 3).map { _ =>
+      createT
+    }
     val missingId = id.canonicalId(createT)
 
     val idsToLookup = documents.map { id.canonicalId } :+ missingId

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -45,4 +45,35 @@ trait RetrieverTestCases[Context, T]
       }
     }
   }
+
+  it("retrieves multiple documents") {
+    val documents = (1 to 3).map { _ => createT }
+    val otherDocuments = (1 to 3).map { _ => createT }
+
+    val idsToLookup = documents.map { id.canonicalId }
+
+    withContext(documents ++ otherDocuments) { implicit context =>
+      val future = withRetriever { _.lookupMultipleIds(idsToLookup) }
+
+      whenReady(future) { result =>
+        result shouldBe documents.map { doc => id.canonicalId(doc) -> doc }.toMap
+      }
+    }
+  }
+
+  it("throws if it can't find all the requested documents") {
+    val documents = (1 to 3).map { _ => createT }
+    val missingId = id.canonicalId(createT)
+
+    val idsToLookup = documents.map { id.canonicalId } :+ missingId
+
+    withContext(documents) { implicit context =>
+      val future = withRetriever { _.lookupMultipleIds(idsToLookup) }
+
+      whenReady(future.failed) { exc =>
+        exc shouldBe a[RetrieverNotFoundException]
+        exc.getMessage shouldBe s"Nothing found with ID $missingId!"
+      }
+    }
+  }
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -23,7 +23,7 @@ trait RetrieverTestCases[Context, T]
     val t = createT
 
     withContext(documents = Seq(t)) { implicit context =>
-      val future = withRetriever { _.apply(id.canonicalId(t)) }
+      val future = withRetriever { _.lookupSingleId(id.canonicalId(t)) }
 
       whenReady(future) {
         _ shouldBe t
@@ -37,7 +37,7 @@ trait RetrieverTestCases[Context, T]
     val someOtherDocument = createT
 
     withContext(documents = Seq(someOtherDocument)) { implicit context =>
-      val future = withRetriever { _.apply(missingId) }
+      val future = withRetriever { _.lookupSingleId(missingId) }
 
       whenReady(future.failed) { exc =>
         exc shouldBe a[RetrieverNotFoundException]

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetrieverTest.scala
@@ -66,7 +66,9 @@ class ElasticRetrieverTest
     )
 
     withContext(documents = Seq(documentWithSlash)) { implicit context =>
-      val future = withRetriever { _.lookupSingleId(documentWithSlash.canonicalId) }
+      val future = withRetriever {
+        _.lookupSingleId(documentWithSlash.canonicalId)
+      }
 
       whenReady(future) {
         _ shouldBe documentWithSlash
@@ -100,7 +102,8 @@ class ElasticRetrieverTest
           }
         }
 
-        val retriever = new ElasticRetriever[Country](elasticClient, index = index)
+        val retriever =
+          new ElasticRetriever[Country](elasticClient, index = index)
 
         whenReady(retriever.lookupSingleId(person.id).failed) {
           _ shouldBe a[DecodingFailure]
@@ -125,11 +128,14 @@ class ElasticRetrieverTest
           }
         }
 
-        val retriever = new ElasticRetriever[Country](elasticClient, index = index)
+        val retriever =
+          new ElasticRetriever[Country](elasticClient, index = index)
 
-        whenReady(retriever.lookupMultipleIds(Seq(person.id, country.id)).failed) { err =>
-          err shouldBe a[RuntimeException]
-          err.getMessage should startWith("Unable to decode some responses:")
+        whenReady(
+          retriever.lookupMultipleIds(Seq(person.id, country.id)).failed) {
+          err =>
+            err shouldBe a[RuntimeException]
+            err.getMessage should startWith("Unable to decode some responses:")
         }
       }
     }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetrieverTest.scala
@@ -63,7 +63,7 @@ class ElasticRetrieverTest
     )
 
     withContext(documents = Seq(documentWithSlash)) { implicit context =>
-      val future = withRetriever { _.apply(documentWithSlash.canonicalId) }
+      val future = withRetriever { _.lookupSingleId(documentWithSlash.canonicalId) }
 
       whenReady(future) {
         _ shouldBe documentWithSlash

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
@@ -10,6 +10,8 @@ import uk.ac.wellcome.pipeline_storage.{
   RetrieverTestCases
 }
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class MemoryRetrieverTest extends RetrieverTestCases[Map[String, UUID], UUID] {
   override def withContext[R](documents: Seq[UUID])(
     testWith: TestWith[Map[String, UUID], R]): R =

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
@@ -10,8 +10,6 @@ import uk.ac.wellcome.pipeline_storage.{
   RetrieverTestCases
 }
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class MemoryRetrieverTest extends RetrieverTestCases[Map[String, UUID], UUID] {
   override def withContext[R](documents: Seq[UUID])(
     testWith: TestWith[Map[String, UUID], R]): R =

--- a/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
+++ b/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
@@ -47,7 +47,7 @@ class IdMinterWorkerService[Destination](
   }
 
   def processMessage(message: NotificationMessage): Future[Unit] =
-    jsonRetriever(message.body)
+    jsonRetriever.lookupSingleId(message.body)
       .flatMap(json => Future.fromTry(processJson(json)))
 
   def processJson(json: Json): Try[Unit] =

--- a/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
+++ b/pipeline/id_minter/id_minter_works/src/main/scala/uk/ac/wellcome/platform/id_minter_works/services/IdMinterWorkerService.scala
@@ -47,7 +47,8 @@ class IdMinterWorkerService[Destination](
   }
 
   def processMessage(message: NotificationMessage): Future[Unit] =
-    jsonRetriever.lookupSingleId(message.body)
+    jsonRetriever
+      .lookupSingleId(message.body)
       .flatMap(json => Future.fromTry(processJson(json)))
 
   def processJson(json: Json): Try[Unit] =

--- a/pipeline/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/src/main/resources/application.conf
@@ -3,6 +3,7 @@ aws.sqs.queue.url=${?queue_url}
 aws.sqs.queue.parallelism=${?queue_parallelism}
 aws.sns.topic.arn=${?topic_arn}
 es.merged_index=${?es_merged_index}
+es.works.multiget=${?multiget_works}
 es.denormalised_index=${?es_denormalised_index}
 es.host=${?es_host}
 es.port=${?es_port}

--- a/pipeline/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 aws.metrics.namespace=${?metrics_namespace}
 aws.sqs.queue.url=${?queue_url}
+aws.sqs.queue.parallelism=${?queue_parallelism}
 aws.sns.topic.arn=${?topic_arn}
 es.merged_index=${?es_merged_index}
 es.denormalised_index=${?es_denormalised_index}

--- a/pipeline/relation_embedder/src/main/resources/logback.xml
+++ b/pipeline/relation_embedder/src/main/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+  <logger name="software.amazon.awssdk" level="WARN"/>
+</configuration>

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
@@ -37,7 +37,8 @@ object Main extends WellcomeTypesafeApp {
         esClient,
         denormalisedIndex,
         DenormalisedWorkIndexConfig),
-      relationsService = new PathQueryRelationsService(esClient, mergedIndex)
+      relationsService = new PathQueryRelationsService(esClient, mergedIndex),
+      multiGetWorks = config.getIntOption("es.works.multiget").getOrElse(250)
     )
   }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
@@ -38,7 +38,7 @@ object Main extends WellcomeTypesafeApp {
         denormalisedIndex,
         DenormalisedWorkIndexConfig),
       relationsService = new PathQueryRelationsService(esClient, mergedIndex),
-      multiGetWorks = config.getIntOption("es.works.multiget").getOrElse(250)
+      multiGetWorks = config.requireInt("es.works.multiget")
     )
   }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -35,7 +35,7 @@ class RelationEmbedderWorkerService[MsgDestination](
 
   def processMessage(message: NotificationMessage): Future[Unit] =
     Source
-      .future(workRetriever(message.body))
+      .future(workRetriever.lookupSingleId(message.body))
       .mapAsync(1) { work =>
         relationsService
           .getOtherAffectedWorks(work)
@@ -43,7 +43,7 @@ class RelationEmbedderWorkerService[MsgDestination](
       }
       .mapConcat(identity)
       .mapAsync(2) { sourceIdentifier =>
-        workRetriever(sourceIdentifier.toString)
+        workRetriever.lookupSingleId(sourceIdentifier.toString)
       }
       .mapAsync(2) { work =>
         relationsService.getRelations(work).map(work.transition[Denormalised])

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -23,7 +23,8 @@ class RelationEmbedderWorkerService[MsgDestination](
   workIndexer: Indexer[Work[Denormalised]],
   relationsService: RelationsService,
   batchSize: Int = 20,
-  flushInterval: FiniteDuration = 3 seconds
+  flushInterval: FiniteDuration = 3 seconds,
+  multiGetWorks: Int
 )(implicit ec: ExecutionContext, materializer: Materializer)
     extends Runnable {
 
@@ -45,7 +46,7 @@ class RelationEmbedderWorkerService[MsgDestination](
 
     val affectedWorks =
       affectedWorkIds
-        .grouped(250)
+        .grouped(multiGetWorks)
         .mapAsync(1) { identifiers =>
           workRetriever
             .lookupMultipleIds(identifiers.map { _.toString })

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -45,7 +45,7 @@ class RelationEmbedderWorkerService[MsgDestination](
 
     val affectedWorks =
       affectedWorkIds
-        .grouped(25)
+        .grouped(250)
         .mapAsync(1) { identifiers =>
           workRetriever
             .lookupMultipleIds(identifiers.map { _.toString })

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -3,10 +3,9 @@ package uk.ac.wellcome.relation_embedder
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.stream.scaladsl._
 import akka.stream.Materializer
-
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -33,29 +32,42 @@ class RelationEmbedderWorkerService[MsgDestination](
       sqsStream.foreach(this.getClass.getSimpleName, processMessage)
     }
 
-  def processMessage(message: NotificationMessage): Future[Unit] =
-    Source
-      .future(workRetriever.lookupSingleId(message.body))
-      .mapAsync(1) { work =>
-        relationsService
-          .getOtherAffectedWorks(work)
-          .map(work.sourceIdentifier :: _)
-      }
-      .mapConcat(identity)
-      .mapAsync(2) { sourceIdentifier =>
-        workRetriever.lookupSingleId(sourceIdentifier.toString)
-      }
-      .mapAsync(2) { work =>
-        relationsService.getRelations(work).map(work.transition[Denormalised])
-      }
+  def processMessage(message: NotificationMessage): Future[Unit] = {
+    val affectedWorkIds: Source[SourceIdentifier, NotUsed] =
+      Source
+        .future(workRetriever.lookupSingleId(message.body))
+        .mapAsync(1) { work =>
+          relationsService
+            .getOtherAffectedWorks(work)
+            .map(work.sourceIdentifier :: _)
+        }
+        .mapConcat(identity)
+
+    val affectedWorks =
+      affectedWorkIds
+        .grouped(25)
+        .mapAsync(1) { identifiers =>
+          workRetriever
+            .lookupMultipleIds(identifiers.map { _.toString })
+            .map { _.values.toList }
+        }
+        .mapConcat(identity)
+
+    val denormalisedWorks =
+      affectedWorks
+        .mapAsync(2) { work =>
+          relationsService.getRelations(work).map(work.transition[Denormalised])
+        }
+
+    denormalisedWorks
       .groupedWithin(batchSize, flushInterval)
-      .mapAsync(2) { work =>
-        workIndexer.index(work).flatMap {
+      .mapAsync(2) { works =>
+        workIndexer.index(works).flatMap {
           case Left(failedWorks) =>
             Future.failed(
               new Exception(s"Failed indexing works: $failedWorks")
             )
-          case Right(works) => Future.successful(works.toList)
+          case Right(_) => Future.successful(works.toList)
         }
       }
       .mapConcat(identity)
@@ -67,4 +79,5 @@ class RelationEmbedderWorkerService[MsgDestination](
       }
       .runWith(Sink.ignore)
       .map(_ => ())
+  }
 }

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerService.scala
@@ -24,7 +24,7 @@ class RelationEmbedderWorkerService[MsgDestination](
   relationsService: RelationsService,
   batchSize: Int = 20,
   flushInterval: FiniteDuration = 3 seconds,
-  multiGetWorks: Int
+  multiGetWorks: Int = 100
 )(implicit ec: ExecutionContext, materializer: Materializer)
     extends Runnable {
 

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
@@ -57,6 +57,7 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
                 }
               works match {
                 case Right(works) =>
+                  debug(s"work ${work.id} has ${works.size} affected works")
                   Future.successful(works.map(_.state.sourceIdentifier))
                 case Left(err) => Future.failed(err)
               }
@@ -89,7 +90,7 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
                   Right(
                     ArchiveRelationsBuilder(path, children, siblings, ancestors)
                   )
-                case works =>
+                case _ =>
                   Left(
                     new Exception(
                       "Expected multisearch response containing 3 items")

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.relation_embedder
 
 import scala.concurrent.{ExecutionContext, Future}
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index, Response}
-import com.sksamuel.elastic4s.requests.searches.{MultiSearchRequest, MultiSearchResponse, SearchRequest, SearchResponse}
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  MultiSearchResponse,
+  SearchRequest,
+  SearchResponse
+}
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.circe._
@@ -34,7 +39,8 @@ trait RelationsService {
 
 class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
   implicit ec: ExecutionContext)
-    extends RelationsService with Logging {
+    extends RelationsService
+    with Logging {
 
   def getOtherAffectedWorks(
     work: Work[Merged]): Future[List[SourceIdentifier]] =
@@ -42,7 +48,8 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
       case work: Work.Visible[Merged] =>
         work.data.collectionPath match {
           case None =>
-            info(s"work ${work.id} does not belong to an archive, skipping getOtherAffectedWorks.")
+            info(
+              s"work ${work.id} does not belong to an archive, skipping getOtherAffectedWorks.")
             Future.successful(Nil)
           case Some(CollectionPath(path, _, _)) =>
             executeSearchRequest(
@@ -72,7 +79,8 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
       case work: Work.Visible[Merged] =>
         work.data.collectionPath match {
           case None =>
-            info(s"work ${work.id} does not belong to an archive, skipping getRelations.")
+            info(
+              s"work ${work.id} does not belong to an archive, skipping getRelations.")
             Future.successful(Relations.none)
           case Some(CollectionPath(path, _, _)) =>
             executeMultiSearchRequest(

--- a/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsService.scala
@@ -42,7 +42,7 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
       case work: Work.Visible[Merged] =>
         work.data.collectionPath match {
           case None =>
-            debug(s"work ${work.id} does not belong to an archive, skipping getOtherAffectedWorks.")
+            info(s"work ${work.id} does not belong to an archive, skipping getOtherAffectedWorks.")
             Future.successful(Nil)
           case Some(CollectionPath(path, _, _)) =>
             executeSearchRequest(
@@ -57,7 +57,7 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
                 }
               works match {
                 case Right(works) =>
-                  debug(s"work ${work.id} has ${works.size} affected works")
+                  info(s"work ${work.id} has ${works.size} affected works")
                   Future.successful(works.map(_.state.sourceIdentifier))
                 case Left(err) => Future.failed(err)
               }
@@ -72,7 +72,7 @@ class PathQueryRelationsService(elasticClient: ElasticClient, index: Index)(
       case work: Work.Visible[Merged] =>
         work.data.collectionPath match {
           case None =>
-            debug(s"work ${work.id} does not belong to an archive, skipping getRelations.")
+            info(s"work ${work.id} does not belong to an archive, skipping getRelations.")
             Future.successful(Relations.none)
           case Some(CollectionPath(path, _, _)) =>
             executeMultiSearchRequest(

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -30,6 +30,7 @@ module "relation_embedder" {
     es_denormalised_index = local.es_works_denormalised_index
 
     multiget_works = 250
+    queue_parallelism = 5
   }
 
   secret_env_vars = {

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -28,6 +28,8 @@ module "relation_embedder" {
 
     es_merged_index       = local.es_works_merged_index
     es_denormalised_index = local.es_works_denormalised_index
+
+    multiget_works = 250
   }
 
   secret_env_vars = {

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -29,7 +29,7 @@ module "relation_embedder" {
     es_merged_index       = local.es_works_merged_index
     es_denormalised_index = local.es_works_denormalised_index
 
-    multiget_works = 250
+    multiget_works    = 250
     queue_parallelism = 5
   }
 


### PR DESCRIPTION
This was my first thought when looking at the relation_embedder code, and somewhat speculative.

Why do we retrieve works one at a time? Would it be more efficient to fetch them in batches? We've already seen an improvement from indexing in bulk, so let's do it for retrieval too.

My naive approach would be to load all the works into memory in one go, but I don't think that works – thinking about it some more, I'm guessing some relation graphs are way too big to load into memory? No doubt @warrd can shed more light on this.