### PR TITLE
Allow calm_adapter to make other Calm queries beyond Modified field 

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -74,7 +74,8 @@ class CalmAdapterWorkerService[Destination](
     Flow[(Context, CalmQuery)]
       .mapAsync(concurrentWindows) {
         case (ctx, query) =>
-          info(s"Ingesting all Calm records for query: ${query.queryExpression}")
+          info(
+            s"Ingesting all Calm records for query: ${query.queryExpression}")
           calmRetriever(query)
             .map(calmStore.putRecord)
             .via(publishKey)
@@ -107,7 +108,9 @@ class CalmAdapterWorkerService[Destination](
                             query: CalmQuery): Result[Unit] = {
     val errs = results.collect { case Left(err) => err }.toList
     if (errs.nonEmpty)
-      Left(new Exception(s"Errors processing query: ${query.queryExpression}: $errs"))
+      Left(
+        new Exception(
+          s"Errors processing query: ${query.queryExpression}: $errs"))
     else
       Right(())
   }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.calm_adapter
 
-import java.time.LocalDate
-
 import akka.Done
 import akka.stream.Materializer
 import akka.stream.scaladsl._
@@ -17,8 +15,6 @@ import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
-
-case class CalmWindow(date: LocalDate)
 
 /** Processes SQS messages consisting of a daily window, and publishes any CALM
   * records to the transformer that have been modified within this window.
@@ -66,7 +62,7 @@ class CalmAdapterWorkerService[Destination](
     Flow[(SQSMessage, NotificationMessage)]
       .map {
         case (msg, NotificationMessage(body)) =>
-          (Context(msg), fromJson[CalmWindow](body).toEither)
+          (Context(msg), fromJson[CalmQuery](body).toEither)
       }
       .via(catchErrors)
 
@@ -75,16 +71,16 @@ class CalmAdapterWorkerService[Destination](
     * one delete action per message received.
     */
   def processWindow =
-    Flow[(Context, CalmWindow)]
+    Flow[(Context, CalmQuery)]
       .mapAsync(concurrentWindows) {
-        case (ctx, CalmWindow(date)) =>
-          info(s"Ingesting all Calm records modified on $date")
-          calmRetriever(CalmQuery.ModifiedDate(date))
+        case (ctx, query) =>
+          info(s"Ingesting all Calm records for query: ${query.queryExpression}")
+          calmRetriever(query)
             .map(calmStore.putRecord)
             .via(publishKey)
             .via(updatePublished)
             .runWith(Sink.seq)
-            .map(checkResultsForErrors(_, date))
+            .map(checkResultsForErrors(_, query))
             .map((ctx, _))
       }
       .via(catchErrors)
@@ -108,10 +104,10 @@ class CalmAdapterWorkerService[Destination](
       }
 
   def checkResultsForErrors(results: Seq[Result[_]],
-                            date: LocalDate): Result[Unit] = {
+                            query: CalmQuery): Result[Unit] = {
     val errs = results.collect { case Left(err) => err }.toList
     if (errs.nonEmpty)
-      Left(new Exception(s"Errors processing window $date: $errs"))
+      Left(new Exception(s"Errors processing query: ${query.queryExpression}: $errs"))
     else
       Right(())
   }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmQuery.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmQuery.scala
@@ -9,7 +9,9 @@ sealed trait CalmQuery {
   def logicalOperator = "OR"
   def relationalOperator = "="
   def queryExpression =
-    keys.map(key => s"($key${relationalOperator}$value)").mkString(logicalOperator)
+    keys
+      .map(key => s"($key${relationalOperator}$value)")
+      .mkString(logicalOperator)
 }
 
 object CalmQuery {

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmQuery.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmQuery.scala
@@ -4,15 +4,38 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 sealed trait CalmQuery {
-  def key: String
+  def keys: List[String]
   def value: String
-  def queryExpression = s"$key=$value"
+  def logicalOperator = "OR"
+  def relationalOperator = "="
+  def queryExpression =
+    keys.map(key => s"($key${relationalOperator}$value)").mkString(logicalOperator)
 }
 
 object CalmQuery {
 
   case class ModifiedDate(date: LocalDate) extends CalmQuery {
-    def key = "Modified"
-    def value = date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+    def keys = List("Modified")
+    def value = formatDate(date)
   }
+
+  case class CreatedOrModifiedDate(date: LocalDate) extends CalmQuery {
+    def keys = List("Created", "Modified")
+    def value = formatDate(date)
+  }
+
+  case object EmptyCreatedAndModifiedDate extends CalmQuery {
+    def keys = List("Created", "Modified")
+    override def logicalOperator = "AND"
+    override def relationalOperator = "!="
+    def value = "*"
+  }
+
+  case class RefNo(refNo: String) extends CalmQuery {
+    def keys = List("RefNo")
+    def value = refNo
+  }
+
+  def formatDate(date: LocalDate): String =
+    date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
 }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -52,7 +52,7 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, store, messageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
         eventually {
           store.entries shouldBe Map(
             Version("A", 0) -> recordA,
@@ -83,7 +83,7 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, store, messageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
         Thread.sleep(1500)
         store.entries shouldBe Map.empty
         assertQueueEmpty(queue)
@@ -119,7 +119,7 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, messageSender = brokenMessageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS(queue, CalmWindow(queryDate))
+        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, size = 1)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -52,7 +52,9 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, store, messageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
+        sendNotificationToSQS[CalmQuery](
+          queue,
+          CalmQuery.ModifiedDate(queryDate))
         eventually {
           store.entries shouldBe Map(
             Version("A", 0) -> recordA,
@@ -83,7 +85,9 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, store, messageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
+        sendNotificationToSQS[CalmQuery](
+          queue,
+          CalmQuery.ModifiedDate(queryDate))
         Thread.sleep(1500)
         store.entries shouldBe Map.empty
         assertQueueEmpty(queue)
@@ -119,7 +123,9 @@ class CalmAdapterWorkerServiceTest
 
     withCalmAdapterWorkerService(retriever, messageSender = brokenMessageSender) {
       case (_, QueuePair(queue, dlq)) =>
-        sendNotificationToSQS[CalmQuery](queue, CalmQuery.ModifiedDate(queryDate))
+        sendNotificationToSQS[CalmQuery](
+          queue,
+          CalmQuery.ModifiedDate(queryDate))
         Thread.sleep(2000)
         assertQueueEmpty(queue)
         assertQueueHasSize(dlq, size = 1)

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlRequestTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlRequestTest.scala
@@ -28,7 +28,8 @@ class CalmXmlRequestTest extends AnyFunSpec with Matchers {
     )
   }
 
-  it("generates a CALM search request for a particular created or modified date") {
+  it(
+    "generates a CALM search request for a particular created or modified date") {
     val query = CalmQuery.CreatedOrModifiedDate(LocalDate.of(2008, 10, 2))
     compareXML(
       CalmSearchRequest(query).xml,

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlRequestTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmXmlRequestTest.scala
@@ -21,7 +21,64 @@ class CalmXmlRequestTest extends AnyFunSpec with Matchers {
           <Search xmlns="http://ds.co.uk/cs/webservices/">
             <dbname>Catalog</dbname>
             <elementSet>DC</elementSet>
-            <expr>Modified=02/10/2008</expr>
+            <expr>(Modified=02/10/2008)</expr>
+          </Search>
+        </soap12:Body>
+      </soap12:Envelope>
+    )
+  }
+
+  it("generates a CALM search request for a particular created or modified date") {
+    val query = CalmQuery.CreatedOrModifiedDate(LocalDate.of(2008, 10, 2))
+    compareXML(
+      CalmSearchRequest(query).xml,
+      <soap12:Envelope
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+        <soap12:Body>
+          <Search xmlns="http://ds.co.uk/cs/webservices/">
+            <dbname>Catalog</dbname>
+            <elementSet>DC</elementSet>
+            <expr>(Created=02/10/2008)OR(Modified=02/10/2008)</expr>
+          </Search>
+        </soap12:Body>
+      </soap12:Envelope>
+    )
+  }
+
+  it("generates a CALM search request for records without created / modified") {
+    val query = CalmQuery.EmptyCreatedAndModifiedDate
+    compareXML(
+      CalmSearchRequest(query).xml,
+      <soap12:Envelope
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+        <soap12:Body>
+          <Search xmlns="http://ds.co.uk/cs/webservices/">
+            <dbname>Catalog</dbname>
+            <elementSet>DC</elementSet>
+            <expr>(Created!=*)AND(Modified!=*)</expr>
+          </Search>
+        </soap12:Body>
+      </soap12:Envelope>
+    )
+  }
+
+  it("generates a CALM search request for a particular ref no") {
+    val query = CalmQuery.RefNo("ArchiveNum*")
+    compareXML(
+      CalmSearchRequest(query).xml,
+      <soap12:Envelope
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+        <soap12:Body>
+          <Search xmlns="http://ds.co.uk/cs/webservices/">
+            <dbname>Catalog</dbname>
+            <elementSet>DC</elementSet>
+            <expr>(RefNo=ArchiveNum*)</expr>
           </Search>
         </soap12:Body>
       </soap12:Envelope>


### PR DESCRIPTION
There is currently an issue with the Calm adopter in that it just queries the `Modified` field. This can sometimes be blank, so we should also query the `Created` field. Here we also include functionality to query the `RefNo`, and data when there is neither a `Created` or `Modified` field (currently 450 records).

A further PR will update the Calm window generator lambda / cli with the functionality to provide these other messages to the adapter.