### PR TITLE
Add a "languages" field to the internal and ES model

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -89,6 +89,10 @@ case class DisplayWork(
     description = "Relates a work to its primary language."
   ) language: Option[DisplayLanguage] = None,
   @Schema(
+    `type` = "List[uk.ac.wellcome.display.models.DisplayLanguage]",
+    description = "Relates a work to its languages."
+  ) languages: Option[List[DisplayLanguage]] = None,
+  @Schema(
     `type` = "String",
     description = "Information relating to the edition of a work."
   ) edition: Option[String] = None,
@@ -169,6 +173,10 @@ case object DisplayWork {
         })
         else None,
       language = work.data.language.map { DisplayLanguage(_) },
+      languages =
+        if (includes.languages)
+          Some(work.data.languages.map { DisplayLanguage(_) })
+        else None,
       edition = work.data.edition,
       notes =
         if (includes.notes)

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -9,6 +9,7 @@ object WorkInclude {
   case object Genres extends WorkInclude
   case object Contributors extends WorkInclude
   case object Production extends WorkInclude
+  case object Languages extends WorkInclude
   case object Notes extends WorkInclude
   case object Images extends WorkInclude
   case object Parts extends WorkInclude
@@ -24,6 +25,7 @@ case class WorksIncludes(
   genres: Boolean,
   contributors: Boolean,
   production: Boolean,
+  languages: Boolean,
   notes: Boolean,
   images: Boolean,
   parts: Boolean,
@@ -43,6 +45,7 @@ case object WorksIncludes {
       genres = includes.contains(WorkInclude.Genres),
       contributors = includes.contains(WorkInclude.Contributors),
       production = includes.contains(WorkInclude.Production),
+      languages = includes.contains(WorkInclude.Languages),
       notes = includes.contains(WorkInclude.Notes),
       images = includes.contains(WorkInclude.Images),
       parts = includes.contains(WorkInclude.Parts),
@@ -59,6 +62,7 @@ case object WorksIncludes {
       genres = true,
       contributors = true,
       production = true,
+      languages = true,
       notes = true,
       images = true,
       parts = true,

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -145,6 +145,29 @@ class DisplayWorkTest
     displayLanguage.label shouldBe language.label
   }
 
+  it("gets the languages from a Work") {
+    val languages = List(
+      Language(id = Some("bsl"), label = "British Sign Language"),
+      Language(id = Some("ger"), label = "German")
+    )
+
+    val work = identifiedWork().languages(languages)
+
+    val noLanguagesInclude = WorksIncludes().copy(languages = false)
+    val languagesInclude = WorksIncludes().copy(languages = true)
+
+    DisplayWork(work, includes = noLanguagesInclude).languages shouldBe None
+
+    val displayWork = DisplayWork(work, includes = languagesInclude)
+
+    displayWork.languages shouldBe Some(
+      List(
+        DisplayLanguage(id = Some("bsl"), label = "British Sign Language"),
+        DisplayLanguage(id = Some("ger"), label = "German")
+      )
+    )
+  }
+
   it("extracts contributors from a Work with the contributors include") {
     val canonicalId = createCanonicalId
     val sourceIdentifier = createSourceIdentifierWith(

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -104,11 +104,13 @@ trait WorksIndexConfigFields extends IndexConfigFields {
       title
     )
 
+  val languageFields: Seq[FieldDefinition] = Seq(
+    label,
+    keywordField("id")
+  )
+
   def language =
-    objectField("language").fields(
-      label,
-      keywordField("id")
-    )
+    objectField("language").fields(languageFields)
 
   def contributors(idState: ObjectField) = objectField("contributors").fields(
     idState,
@@ -159,6 +161,7 @@ trait WorksIndexConfigFields extends IndexConfigFields {
       items("items", idState),
       production(idState),
       language,
+      objectField("languages").fields(languageFields),
       location("thumbnail"),
       textField("edition"),
       notes,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -90,7 +90,7 @@ case class WorkData[State <: DataState](
   thumbnail: Option[LocationDeprecated] = None,
   production: List[ProductionEvent[State#MaybeId]] = Nil,
   language: Option[Language] = None,
-  languages: List[Language] = List.empty,
+  languages: List[Language] = Nil,
   edition: Option[String] = None,
   notes: List[Note] = Nil,
   duration: Option[Int] = None,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -90,6 +90,7 @@ case class WorkData[State <: DataState](
   thumbnail: Option[LocationDeprecated] = None,
   production: List[ProductionEvent[State#MaybeId]] = Nil,
   language: Option[Language] = None,
+  languages: List[Language] = List.empty,
   edition: Option[String] = None,
   notes: List[Note] = Nil,
   duration: Option[Int] = None,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -149,6 +149,9 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
     def language(language: Language): Work.Visible[State] =
       work.map(_.copy(language = Some(language)))
 
+    def languages(languages: List[Language]): Work.Visible[State] =
+      work.map(_.copy(languages = languages))
+
     def edition(edition: String): Work.Visible[State] =
       work.map(_.copy(edition = Some(edition)))
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -77,6 +77,7 @@ class SnapshotGeneratorFeatureTest
               |  "subjects": [ ],
               |  "items": [ ],
               |  "production": [ ],
+              |  "languages": [ ],
               |  "alternativeTitles": [ ],
               |  "notes": [ ],
               |  "images": [ ],


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/4864

I’ll add the other pieces (populating the field in the transformer, reading the field in the API) in separate patches.