### PR TITLE
Expose filters/aggregations/includes for languages in the API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -108,7 +108,9 @@ object Aggregations extends Logging {
 
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {
 
-    def decodeAgg[T: Decoder](name: String, documentPath: Option[String] = None): Option[Aggregation[T]] = {
+    def decodeAgg[T: Decoder](
+      name: String,
+      documentPath: Option[String] = None): Option[Aggregation[T]] = {
       aggregations
         .getAgg(name)
         .flatMap(
@@ -166,7 +168,8 @@ object AggregationMapping extends Logging {
   private val bucketSampleDoc =
     root.sample_doc.hits.hits.index(0)._source.json
 
-  def aggregationParser[T: Decoder](json: String, path: Option[String]): Try[Aggregation[T]] =
+  def aggregationParser[T: Decoder](json: String,
+                                    path: Option[String]): Try[Aggregation[T]] =
     parse(json).toTry
       .map { parsedJson =>
         for {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -10,7 +10,6 @@ import com.sksamuel.elastic4s.requests.searches.aggs.responses.{
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.display.models.LocationTypeQuery
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal._
 
 case class Aggregations(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -36,7 +36,7 @@ object Aggregations extends Logging {
             .decodeAgg[Period[IdState.Minted]]("productionDates"),
           language = e4sAggregations.decodeAgg[Language](
             "language",
-            documentPath = Some("data.language")
+            documentPath = Some("data.language.id")
           ),
           languages = e4sAggregations.decodeAgg[Language]("languages"),
           subjects = e4sAggregations

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -11,13 +11,13 @@ import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.display.models.LocationTypeQuery
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.json.JsonUtil._
 
 case class Aggregations(
   format: Option[Aggregation[Format]] = None,
   genres: Option[Aggregation[Genre[IdState.Minted]]] = None,
   productionDates: Option[Aggregation[Period[IdState.Minted]]] = None,
   language: Option[Aggregation[Language]] = None,
+  languages: Option[Aggregation[Language]] = None,
   subjects: Option[Aggregation[Subject[IdState.Minted]]] = None,
   license: Option[Aggregation[License]] = None,
   locationType: Option[Aggregation[LocationTypeQuery]] = None,
@@ -34,8 +34,8 @@ object Aggregations extends Logging {
           genres = e4sAggregations.decodeAgg[Genre[IdState.Minted]]("genres"),
           productionDates = e4sAggregations
             .decodeAgg[Period[IdState.Minted]]("productionDates"),
-          language = e4sAggregations
-            .decodeAgg[Language]("language", Some("data.language")),
+          language = e4sAggregations.decodeAgg[Language]("language"),
+          languages = e4sAggregations.decodeAgg[Language]("languages"),
           subjects = e4sAggregations
             .decodeAgg[Subject[IdState.Minted]]("subjects"),
           license = e4sAggregations.decodeAgg[License]("license"),
@@ -72,6 +72,12 @@ object Aggregations extends Logging {
         case Some(format) => Right(format)
         case None         => Left(s"couldn't find format for code '$str'")
       }
+    }
+
+  implicit val decodeLanguage: Decoder[Language] =
+    Decoder.decodeString.emap { code =>
+      Language.fromCode(code)
+        .left.map { _ => s"couldn't find language for code $code"}
     }
 
   implicit val decodeGenreFromLabel: Decoder[Genre[IdState.Minted]] =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -34,7 +34,7 @@ object Aggregations extends Logging {
           genres = e4sAggregations.decodeAgg[Genre[IdState.Minted]]("genres"),
           productionDates = e4sAggregations
             .decodeAgg[Period[IdState.Minted]]("productionDates"),
-          language = e4sAggregations.decodeAgg[Language]("language"),
+          language = e4sAggregations.decodeAgg[Language]("language", documentPath = Some("language")),
           languages = e4sAggregations.decodeAgg[Language]("languages"),
           subjects = e4sAggregations
             .decodeAgg[Subject[IdState.Minted]]("subjects"),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -36,9 +36,11 @@ object Aggregations extends Logging {
           productionDates = e4sAggregations
             .decodeAgg[Period[IdState.Minted]]("productionDates"),
           language = e4sAggregations.decodeAgg[Language](
-            "language", documentPath = Some("data.language")
+            "language",
+            documentPath = Some("data.language")
           ),
-          languages = e4sAggregations.decodeAgg[Language]("languages")(decodeLanguageList),
+          languages = e4sAggregations.decodeAgg[Language]("languages")(
+            decodeLanguageList),
           subjects = e4sAggregations
             .decodeAgg[Subject[IdState.Minted]]("subjects"),
           license = e4sAggregations.decodeAgg[License]("license"),
@@ -79,8 +81,9 @@ object Aggregations extends Logging {
 
   val decodeLanguageList: Decoder[Language] =
     Decoder.decodeString.emap { code =>
-      Language.fromCode(code)
-        .left.map { _ => s"couldn't find language for code $code"}
+      Language.fromCode(code).left.map { _ =>
+        s"couldn't find language for code $code"
+      }
     }
 
   implicit val decodeGenreFromLabel: Decoder[Genre[IdState.Minted]] =
@@ -101,9 +104,8 @@ object Aggregations extends Logging {
 
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {
 
-    def decodeAgg[T](
-      name: String,
-      documentPath: Option[String] = None)(implicit decoder: Decoder[T]): Option[Aggregation[T]] = {
+    def decodeAgg[T](name: String, documentPath: Option[String] = None)(
+      implicit decoder: Decoder[T]): Option[Aggregation[T]] = {
       aggregations
         .getAgg(name)
         .flatMap(
@@ -112,13 +114,11 @@ object Aggregations extends Logging {
               println(s"@@AWLC json = $json")
               AggregationMapping.aggregationParser[T](json, documentPath)
             }
-          )
-            .recoverWith {
-              case err =>
-                warn("Failed to parse aggregation from ES", err)
-                Failure(err)
-            }
-            .toOption
+          ).recoverWith {
+            case err =>
+              warn("Failed to parse aggregation from ES", err)
+              Failure(err)
+          }.toOption
         )
     }
   }
@@ -164,8 +164,8 @@ object AggregationMapping extends Logging {
   private val bucketSampleDoc =
     root.sample_doc.hits.hits.index(0)._source.json
 
-  def aggregationParser[T](json: String,
-                           path: Option[String])(implicit decoder: Decoder[T]): Try[Aggregation[T]] =
+  def aggregationParser[T](json: String, path: Option[String])(
+    implicit decoder: Decoder[T]): Try[Aggregation[T]] =
     parse(json).toTry
       .map { parsedJson =>
         for {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
@@ -30,6 +30,9 @@ case class DisplayAggregations(
     description = "Language aggregation on a set of results."
   ) language: Option[DisplayAggregation[DisplayLanguage]],
   @Schema(
+    description = "Language aggregation on a set of results."
+  ) languages: Option[DisplayAggregation[DisplayLanguage]],
+  @Schema(
     description = "License aggregation on a set of results."
   ) license: Option[DisplayAggregation[DisplayLicense]],
   @Schema(
@@ -76,6 +79,7 @@ object DisplayAggregations {
         aggs.genres,
         DisplayGenre(_, includesIdentifiers = false)),
       language = displayAggregation(aggs.language, DisplayLanguage.apply),
+      languages = displayAggregation(aggs.languages, DisplayLanguage.apply),
       subjects = displayAggregation[Subject[IdState.Minted], DisplaySubject](
         aggs.subjects,
         subject => DisplaySubject(subject, includesIdentifiers = false)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -26,7 +26,12 @@ case class DateRangeFilter(fromDate: Option[LocalDate],
 
 case object VisibleWorkFilter extends WorkFilter
 
+// Note: These two filters are for ?language= and ?languages=, respectively.
+// This is temporary while we work on adding support for multiple languages.
+// Eventually we will remove the ?language= filter.
+// See https://github.com/wellcomecollection/platform/issues/4864
 case class LanguageFilter(languageIds: Seq[String]) extends WorkFilter
+case class LanguagesFilter(languageIds: Seq[String]) extends WorkFilter
 
 case class GenreFilter(genreQuery: String) extends WorkFilter
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -38,6 +38,7 @@ object SingleWorkParams extends QueryParamsUtils {
       "genres" -> WorkInclude.Genres,
       "contributors" -> WorkInclude.Contributors,
       "production" -> WorkInclude.Production,
+      "languages" -> WorkInclude.Languages,
       "notes" -> WorkInclude.Notes,
       "images" -> WorkInclude.Images,
       "parts" -> WorkInclude.Parts,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -55,6 +55,7 @@ case class MultipleWorksParams(
   `production.dates.from`: Option[LocalDate],
   `production.dates.to`: Option[LocalDate],
   language: Option[LanguageFilter],
+  languages: Option[LanguagesFilter],
   `genres.label`: Option[GenreFilter],
   `subjects.label`: Option[SubjectFilter],
   license: Option[LicenseFilter],
@@ -91,6 +92,7 @@ case class MultipleWorksParams(
       workType,
       dateFilter,
       language,
+      languages,
       `genres.label`,
       `subjects.label`,
       identifiers,
@@ -126,6 +128,7 @@ object MultipleWorksParams extends QueryParamsUtils {
         "production.dates.from".as[LocalDate].?,
         "production.dates.to".as[LocalDate].?,
         "language".as[LanguageFilter].?,
+        "languages".as[LanguagesFilter].?,
         "genres.label".as[GenreFilter].?,
         "subjects.label".as[SubjectFilter].?,
         "license".as[LicenseFilter].?,
@@ -168,6 +171,8 @@ object MultipleWorksParams extends QueryParamsUtils {
 
   implicit val languageFilter: Decoder[LanguageFilter] =
     stringListFilter(LanguageFilter)
+  implicit val languagesFilter: Decoder[LanguagesFilter] =
+    stringListFilter(LanguagesFilter)
 
   implicit val genreFilter: Decoder[GenreFilter] =
     Decoder.decodeString.emap(str => Right(GenreFilter(str)))
@@ -198,6 +203,7 @@ object MultipleWorksParams extends QueryParamsUtils {
       "production.dates" -> AggregationRequest.ProductionDate,
       "subjects" -> AggregationRequest.Subject,
       "language" -> AggregationRequest.Language,
+      "languages" -> AggregationRequest.Languages,
       "license" -> AggregationRequest.License,
       "locationType" -> AggregationRequest.ItemLocationType,
     )

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -82,6 +82,7 @@ class FiltersAndAggregationsBuilder(
     case _: DateRangeFilter          => None
     case VisibleWorkFilter           => None
     case _: LanguageFilter           => Some(AggregationRequest.Language)
+    case _: LanguagesFilter          => Some(AggregationRequest.Languages)
     case _: GenreFilter              => Some(AggregationRequest.Genre)
     case _: SubjectFilter            => Some(AggregationRequest.Subject)
     case _: LicenseFilter            => Some(AggregationRequest.License)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -75,6 +75,12 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
         .minDocCount(1)
         .additionalField("data.language.label")
 
+    case AggregationRequest.Languages =>
+      TermsAggregation("languages")
+        .size(200)
+        .field("data.languages.id")
+        .minDocCount(1)
+
     case AggregationRequest.License =>
       TermsAggregation("license")
         .size(100)
@@ -142,6 +148,8 @@ object WorksRequestBuilder extends ElasticsearchRequestBuilder {
         RangeQuery("data.production.dates.range.from", lte = lte, gte = gte)
       case LanguageFilter(languageIds) =>
         termsQuery(field = "data.language.id", values = languageIds)
+      case LanguagesFilter(languageIds) =>
+        termsQuery(field = "data.languages.id", values = languageIds)
       case GenreFilter(genreQuery) =>
         simpleStringQuery(genreQuery)
           .field("data.genres.label")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -374,11 +374,18 @@ trait MultipleWorksSwagger {
             "production.dates",
             "subjects",
             "language",
+            "languages",
             "locationType")),
         required = false
       ),
       new Parameter(
         name = "language",
+        in = ParameterIn.QUERY,
+        description = "Filter the work by language.",
+        required = false
+      ),
+      new Parameter(
+        name = "languages",
         in = ParameterIn.QUERY,
         description = "Filter the work by language.",
         required = false

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -246,11 +246,9 @@ class WorksAggregationsTest
   }
 
   it("supports aggregating on languages") {
-    // The mixture of identified and non-identified languages is
-    // deliberate -- we don't aggregate over unidentified languages.
-    val english = Language("English", id = Some("en"))
-    val swedish = Language("Swedish", id = Some("sv"))
-    val turkish = Language("Turkish", id = None)
+    val english = Language(label = "English", id = "eng")
+    val swedish = Language(label = "Swedish", id = "swe")
+    val turkish = Language(label = "Turkish", id = "tur")
 
     val works = Seq(
       identifiedWork().languages(List(english)),
@@ -271,21 +269,18 @@ class WorksAggregationsTest
                   "type" : "Aggregation",
                   "buckets": [
                     {
-                      "data" : {
-                        "id": "en",
-                        "label": "English",
-                        "type": "Language"
-                      },
+                      "data" : ${language(english)},
                       "count" : 3,
                       "type" : "AggregationBucket"
                     },
                     {
-                      "data" : {
-                        "id": "sv",
-                        "label": "Swedish",
-                        "type": "Language"
-                      },
+                      "data" : ${language(swedish)},
                       "count" : 2,
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "data" : ${language(turkish)},
+                      "count" : 1,
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -9,7 +9,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo",
         description =
-          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -17,7 +17,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo,bar",
         description =
-          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -25,7 +25,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?include=foo,identifiers,bar",
         description =
-          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+          "include: 'foo', 'bar' are not valid values. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
 
@@ -33,7 +33,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works/nfdn7wac?include=foo",
         description =
-          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+          "include: 'foo' is not a valid value. Please choose one of: ['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
       )
     }
   }
@@ -44,7 +44,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo",
         description =
-          "aggregations: 'foo' is not a valid value. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
+          "aggregations: 'foo' is not a valid value. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'languages', 'license', 'locationType']"
       )
     }
 
@@ -52,7 +52,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo,bar",
         description =
-          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
+          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'languages', 'license', 'locationType']"
       )
     }
 
@@ -68,7 +68,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
       assertIsBadRequest(
         "/works?aggregations=foo,workType,bar",
         description =
-          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'license', 'locationType']"
+          "aggregations: 'foo', 'bar' are not valid values. Please choose one of: ['workType', 'genres', 'production.dates', 'subjects', 'language', 'languages', 'license', 'locationType']"
       )
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -93,28 +93,12 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 3,
-<<<<<<< HEAD
                       "data" : ${language(bashkir)},
-=======
-                      "data" : {
-                        "id" : "ba",
-                        "label" : "Bashkir",
-                        "type" : "Language"
-                      },
->>>>>>> Get aggregations and filters working for language
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-<<<<<<< HEAD
                       "data" : ${language(marathi)},
-=======
-                      "data" : {
-                        "id" : "mr",
-                        "label" : "Marathi",
-                        "type" : "Language"
-                      },
->>>>>>> Get aggregations and filters working for language
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -5,23 +5,23 @@ import uk.ac.wellcome.models.work.internal.Format._
 import uk.ac.wellcome.models.Implicits._
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
-
-  val bark = Language(label = "Bark", id = "dogs")
-  val meow = Language(label = "Meow", id = "cats")
-  val quack = Language(label = "Quack", id = "ducks")
-  val croak = Language(label = "Croak", id = "frogs")
+  
+  val bashkir = Language(label = "Bashkir", id = "bak")
+  val marathi = Language(label = "Marathi", id = "mar")
+  val quechua = Language(label = "Quechua", id = "que")
+  val chechen = Language(label = "Chechen", id = "che")
 
   val works: List[Work.Visible[WorkState.Identified]] = List(
-    (Books, bark),
-    (Journals, meow),
-    (Pictures, quack),
-    (Audio, bark),
-    (Books, bark),
-    (Books, bark),
-    (Journals, quack),
-    (Books, meow),
-    (Journals, quack),
-    (Audio, croak)
+    (Books, bashkir),
+    (Journals, marathi),
+    (Pictures, quechua),
+    (Audio, bashkir),
+    (Books, bashkir),
+    (Books, bashkir),
+    (Journals, quechua),
+    (Books, marathi),
+    (Journals, quechua),
+    (Audio, chechen)
   ).map {
     case (format, language) =>
       identifiedWork()
@@ -50,12 +50,12 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 3,
-                      "data" : ${language(bark)},
+                      "data" : ${language(bashkir)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : ${language(meow)},
+                      "data" : ${language(marathi)},
                       "type" : "AggregationBucket"
                     }
                   ]
@@ -93,12 +93,28 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 3,
-                      "data" : ${language(bark)},
+<<<<<<< HEAD
+                      "data" : ${language(bashkir)},
+=======
+                      "data" : {
+                        "id" : "ba",
+                        "label" : "Bashkir",
+                        "type" : "Language"
+                      },
+>>>>>>> Get aggregations and filters working for language
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : ${language(meow)},
+<<<<<<< HEAD
+                      "data" : ${language(marathi)},
+=======
+                      "data" : {
+                        "id" : "mr",
+                        "label" : "Marathi",
+                        "type" : "Language"
+                      },
+>>>>>>> Get aggregations and filters working for language
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.models.work.internal.Format._
 import uk.ac.wellcome.models.Implicits._
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
-  
+
   val bashkir = Language(label = "Bashkir", id = "bak")
   val marathi = Language(label = "Marathi", id = "mar")
   val quechua = Language(label = "Quechua", id = "que")

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -452,8 +452,8 @@ class WorksFiltersTest
   }
 
   describe("filtering works by language (new filter ?language=)") {
-    val english = Language("English", id = Some("en"))
-    val turkish = Language("Turkish", id = Some("tr"))
+    val english = Language(label = "English", id = "eng")
+    val turkish = Language(label = "Turkish", id = "tur")
 
     val englishWork = identifiedWork().languages(List(english))
     val turkishWork = identifiedWork().languages(List(turkish))
@@ -465,7 +465,7 @@ class WorksFiltersTest
       withWorksApi {
         case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(routes, s"/$apiPrefix/works?languages=en") {
+          assertJsonResponse(routes, s"/$apiPrefix/works?languages=eng") {
             Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork))
           }
       }
@@ -475,7 +475,7 @@ class WorksFiltersTest
       withWorksApi {
         case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(routes, s"/$apiPrefix/works?languages=en,tr") {
+          assertJsonResponse(routes, s"/$apiPrefix/works?languages=eng,tur") {
             Status.OK -> worksListResponse(
               apiPrefix,
               works = Seq(englishWork, turkishWork).sortBy {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -462,8 +462,8 @@ class WorksFiltersTest
     val works = List(englishWork, turkishWork, noLanguageWork)
 
     it("filters by language") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?languages=en") {
             Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork))
@@ -472,8 +472,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple comma separated languages") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?languages=en,tr") {
             Status.OK -> worksListResponse(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -416,7 +416,7 @@ class WorksFiltersTest
     }
   }
 
-  describe("filtering works by language") {
+  describe("filtering works by language (old filter ?language=)") {
     val englishWork =
       identifiedWork().language(Language(label = "English", id = "eng"))
     val germanWork =
@@ -443,6 +443,42 @@ class WorksFiltersTest
             Status.OK -> worksListResponse(
               apiPrefix,
               works = Seq(englishWork, germanWork).sortBy {
+                _.state.canonicalId
+              }
+            )
+          }
+      }
+    }
+  }
+
+  describe("filtering works by language (new filter ?language=)") {
+    val english = Language("English", id = Some("en"))
+    val turkish = Language("Turkish", id = Some("tr"))
+
+    val englishWork = identifiedWork().languages(List(english))
+    val turkishWork = identifiedWork().languages(List(turkish))
+    val noLanguageWork = identifiedWork()
+
+    val works = List(englishWork, turkishWork, noLanguageWork)
+
+    it("filters by language") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(routes, s"/$apiPrefix/works?languages=en") {
+            Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork))
+          }
+      }
+    }
+
+    it("filters by multiple comma separated languages") {
+      withApi {
+        case (ElasticConfig(worksIndex, _), routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(routes, s"/$apiPrefix/works?languages=en,tr") {
+            Status.OK -> worksListResponse(
+              apiPrefix,
+              works = Seq(englishWork, turkishWork).sortBy {
                 _.state.canonicalId
               }
             )

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -387,7 +387,8 @@ class WorksIncludesTest
           val turkish = Language(label = "Turkish")
           val swedish = Language(label = "Swedish")
 
-          val work1 = identifiedWork(canonicalId = "1").languages(List(english, turkish))
+          val work1 =
+            identifiedWork(canonicalId = "1").languages(List(english, turkish))
           val work2 = identifiedWork(canonicalId = "2").languages(List(swedish))
 
           insertIntoElasticsearch(worksIndex, work1, work2)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -383,9 +383,9 @@ class WorksIncludesTest
     it("includes languages on a list endpoint if we pass ?include=languages") {
       withWorksApi {
         case (worksIndex, routes) =>
-          val english = Language(label = "English")
-          val turkish = Language(label = "Turkish")
-          val swedish = Language(label = "Swedish")
+          val english = Language(label = "English", id = "eng")
+          val turkish = Language(label = "Turkish", id = "tur")
+          val swedish = Language(label = "Swedish", id = "swe")
 
           val work1 =
             identifiedWork(canonicalId = "1").languages(List(english, turkish))
@@ -422,9 +422,9 @@ class WorksIncludesTest
     it("includes languages on a work endpoint if we pass ?include=languages") {
       withWorksApi {
         case (worksIndex, routes) =>
-          val english = Language(label = "English")
-          val turkish = Language(label = "Turkish")
-          val swedish = Language(label = "Swedish")
+          val english = Language(label = "English", id = "eng")
+          val turkish = Language(label = "Turkish", id = "tur")
+          val swedish = Language(label = "Swedish", id = "swe")
 
           val work = identifiedWork().languages(List(english, turkish, swedish))
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -381,8 +381,8 @@ class WorksIncludesTest
 
   describe("languages includes") {
     it("includes languages on a list endpoint if we pass ?include=languages") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val english = Language(label = "English")
           val turkish = Language(label = "Turkish")
           val swedish = Language(label = "Swedish")
@@ -419,8 +419,8 @@ class WorksIncludesTest
     }
 
     it("includes languages on a work endpoint if we pass ?include=languages") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val english = Language(label = "English")
           val turkish = Language(label = "Turkish")
           val swedish = Language(label = "Swedish")

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/AggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/AggregationRequest.scala
@@ -13,6 +13,7 @@ object AggregationRequest {
   case object Subject extends AggregationRequest
 
   case object Language extends AggregationRequest
+  case object Languages extends AggregationRequest
 
   case object License extends AggregationRequest
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -218,13 +218,7 @@ trait DisplaySerialisationTestBase {
     production.map(productionEvent).mkString(",")
 
   def languages(ls: List[Language]): String =
-    ls.map(lang => s"""
-         |{
-         |  "label": "${lang.label}",
-         |  ${optionalString("id", lang.id)}
-         |  "type": "Language"
-         |}
-       """.stripMargin).mkString(",")
+    ls.map(language).mkString(",")
 
   def workImageInclude(image: UnmergedImage[DataState.Identified]) =
     s"""

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -217,6 +217,17 @@ trait DisplaySerialisationTestBase {
   def production(production: List[ProductionEvent[IdState.Minted]]) =
     production.map(productionEvent).mkString(",")
 
+  def languages(ls: List[Language]): String =
+    ls.map(lang =>
+      s"""
+         |{
+         |  "label": "${lang.label}",
+         |  ${optionalString("id", lang.id)}
+         |  "type": "Language"
+         |}
+       """.stripMargin
+    ).mkString(",")
+
   def workImageInclude(image: UnmergedImage[DataState.Identified]) =
     s"""
        {

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -218,15 +218,13 @@ trait DisplaySerialisationTestBase {
     production.map(productionEvent).mkString(",")
 
   def languages(ls: List[Language]): String =
-    ls.map(lang =>
-      s"""
+    ls.map(lang => s"""
          |{
          |  "label": "${lang.label}",
          |  ${optionalString("id", lang.id)}
          |  "type": "Language"
          |}
-       """.stripMargin
-    ).mkString(",")
+       """.stripMargin).mkString(",")
 
   def workImageInclude(image: UnmergedImage[DataState.Identified]) =
     s"""


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4864

I struggled to get the aggregations working. This is the JSON that comes back from a languages aggregation as currently implemented:

<details><summary>Elasticsearch response</summary>

```json
{
  "doc_count_error_upper_bound": 0,
  "sum_other_doc_count": 0,
  "buckets": [
    {
      "key": "en",
      "doc_count": 3,
      "sample_doc": {
        "hits": {
          "total": {
            "value": 3,
            "relation": "eq"
          },
          "max_score": 0.0,
          "hits": [
            {
              "_score": 0.0,
              "_type": "_doc",
              "_source": {
                "data": {
                  "languages": [
                    {
                      "label": "English",
                      "id": "en"
                    }
                  ]
                }
              },
              "_id": "ylhsqawzwo",
              "_index": "index-tn9gqnctm"
            }
          ]
        }
      }
    },
    {
      "key": "sv",
      "doc_count": 2,
      "sample_doc": {
        "hits": {
          "total": {
            "value": 2,
            "relation": "eq"
          },
          "max_score": 0.0,
          "hits": [
            {
              "_score": 0.0,
              "_type": "_doc",
              "_source": {
                "data": {
                  "languages": [
                    {
                      "label": "English",
                      "id": "en"
                    },
                    {
                      "label": "Swedish",
                      "id": "sv"
                    },
                    {
                      "label": "Turkish",
                      "id": "tr"
                    }
                  ]
                }
              },
              "_id": "tnmjufcamy",
              "_index": "index-tn9gqnctm"
            }
          ]
        }
      }
    },
    {
      "key": "tr",
      "doc_count": 1,
      "sample_doc": {
        "hits": {
          "total": {
            "value": 1,
            "relation": "eq"
          },
          "max_score": 0.0,
          "hits": [
            {
              "_score": 0.0,
              "_type": "_doc",
              "_source": {
                "data": {
                  "languages": [
                    {
                      "label": "English",
                      "id": "en"
                    },
                    {
                      "label": "Swedish",
                      "id": "sv"
                    },
                    {
                      "label": "Turkish",
                      "id": "tr"
                    }
                  ]
                }
              },
              "_id": "tnmjufcamy",
              "_index": "index-tn9gqnctm"
            }
          ]
        }
      }
    }
  ]
}
```

</details>

A language is currently implemented as `case class Language(label: String, id: Option[String])`. I can't see a way to get the ID and the label out of an Aggregation result.

If we're going to lean more heavily on the ISO/LOC language codes, does it make sense to lean more heavily on the pre-defined language codes, and use those as the canonical identifier for a language through the pipeline?