### PR TITLE
Make the API tests go faster ⚡️

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Main.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.Config
 import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.platform.api.models.{ApiConfig, QueryConfig}
+import uk.ac.wellcome.platform.api.swagger.SwaggerDocs
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -46,8 +47,15 @@ object Main extends WellcomeTypesafeApp {
     val queryConfig =
       QueryConfig.fetchFromIndex(elasticClient, elasticConfig.imagesIndex)
 
-    val router =
-      new Router(elasticClient, elasticConfig, queryConfig, apiConfig)
+    val swaggerDocs = new SwaggerDocs(apiConfig)
+
+    val router = new Router(
+      elasticClient = elasticClient,
+      elasticConfig = elasticConfig,
+      queryConfig = queryConfig,
+      swaggerDocs = swaggerDocs,
+      apiConfig = apiConfig
+    )
 
     () =>
       Http()

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -20,6 +20,7 @@ import uk.ac.wellcome.platform.api.services.ElasticsearchService
 class Router(elasticClient: ElasticClient,
              elasticConfig: ElasticConfig,
              queryConfig: QueryConfig,
+             swaggerDocs: SwaggerDocs,
              implicit val apiConfig: ApiConfig)(implicit ec: ExecutionContext)
     extends CustomDirectives {
 
@@ -96,8 +97,6 @@ class Router(elasticClient: ElasticClient,
       HttpEntity(MediaTypes.`application/json`, swaggerDocs.json)
     )
   }
-
-  val swaggerDocs = new SwaggerDocs(apiConfig)
 
   def getClusterHealth: Route = {
     import com.sksamuel.elastic4s.ElasticDsl._

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -82,13 +82,13 @@ class Router(elasticClient: ElasticClient,
   lazy val elasticsearchService = new ElasticsearchService(elasticClient)
 
   lazy val worksController =
-    new WorksController(elasticsearchService, apiConfig, elasticConfig)
+    new WorksController(elasticsearchService, apiConfig, worksIndex = elasticConfig.worksIndex)
 
   lazy val imagesController =
     new ImagesController(
       elasticsearchService,
       apiConfig,
-      elasticConfig,
+      imagesIndex = elasticConfig.imagesIndex,
       queryConfig)
 
   def swagger: Route = get {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Router.scala
@@ -83,7 +83,10 @@ class Router(elasticClient: ElasticClient,
   lazy val elasticsearchService = new ElasticsearchService(elasticClient)
 
   lazy val worksController =
-    new WorksController(elasticsearchService, apiConfig, worksIndex = elasticConfig.worksIndex)
+    new WorksController(
+      elasticsearchService,
+      apiConfig,
+      worksIndex = elasticConfig.worksIndex)
 
   lazy val imagesController =
     new ImagesController(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregations.scala
@@ -74,11 +74,11 @@ object DisplayAggregations {
         displayAggregation(aggs.productionDates, DisplayPeriod.apply),
       genres = displayAggregation[Genre[IdState.Minted], DisplayGenre](
         aggs.genres,
-        DisplayGenre(_, false)),
+        DisplayGenre(_, includesIdentifiers = false)),
       language = displayAggregation(aggs.language, DisplayLanguage.apply),
       subjects = displayAggregation[Subject[IdState.Minted], DisplaySubject](
         aggs.subjects,
-        subject => DisplaySubject(subject, false)
+        subject => DisplaySubject(subject, includesIdentifiers = false)
       ),
       license = displayAggregation(aggs.license, DisplayLicense.apply),
       locationType = displayAggregation(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesController.scala
@@ -5,7 +5,6 @@ import com.sksamuel.elastic4s.Index
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.Implicits._
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.api.Tracing
 import uk.ac.wellcome.platform.api.models.{
   ApiConfig,
@@ -22,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ImagesController(elasticsearchService: ElasticsearchService,
                        implicit val apiConfig: ApiConfig,
-                       elasticConfig: ElasticConfig,
+                       imagesIndex: Index,
                        queryConfig: QueryConfig)(implicit ec: ExecutionContext)
     extends CustomDirectives
     with Tracing
@@ -34,7 +33,7 @@ class ImagesController(elasticsearchService: ElasticsearchService,
     getWithFuture {
       transactFuture("GET /images/{imageId}") {
         val index =
-          params._index.map(Index(_)).getOrElse(elasticConfig.imagesIndex)
+          params._index.map(Index(_)).getOrElse(imagesIndex)
         imagesService
           .findImageById(id)(index)
           .flatMap {
@@ -74,7 +73,7 @@ class ImagesController(elasticsearchService: ElasticsearchService,
       transactFuture("GET /images") {
         val searchOptions = params.searchOptions(apiConfig)
         val index =
-          params._index.map(Index(_)).getOrElse(elasticConfig.imagesIndex)
+          params._index.map(Index(_)).getOrElse(imagesIndex)
         imagesService
           .listOrSearchImages(index, searchOptions)
           .map {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -9,7 +9,6 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import grizzled.slf4j.Logger
 import uk.ac.wellcome.display.models._
 import uk.ac.wellcome.display.models.Implicits._
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.services.{
@@ -23,7 +22,7 @@ import WorkState.Identified
 class WorksController(
   elasticsearchService: ElasticsearchService,
   implicit val apiConfig: ApiConfig,
-  elasticConfig: ElasticConfig)(implicit ec: ExecutionContext)
+  worksIndex: Index)(implicit ec: ExecutionContext)
     extends Tracing
     with CustomDirectives
     with FailFastCirceSupport {
@@ -35,7 +34,7 @@ class WorksController(
       transactFuture("GET /works") {
         val searchOptions = params.searchOptions(apiConfig)
         val index =
-          params._index.map(Index(_)).getOrElse(elasticConfig.worksIndex)
+          params._index.map(Index(_)).getOrElse(worksIndex)
         worksService
           .listOrSearchWorks(index, searchOptions)
           .map {
@@ -60,7 +59,7 @@ class WorksController(
     getWithFuture {
       transactFuture("GET /works/{workId}") {
         val index =
-          params._index.map(Index(_)).getOrElse(elasticConfig.worksIndex)
+          params._index.map(Index(_)).getOrElse(worksIndex)
         val includes = params.include.getOrElse(WorksIncludes())
         worksService
           .findWorkById(id)(index)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -19,10 +19,9 @@ import uk.ac.wellcome.platform.api.services.{
 import uk.ac.wellcome.platform.api.Tracing
 import WorkState.Identified
 
-class WorksController(
-  elasticsearchService: ElasticsearchService,
-  implicit val apiConfig: ApiConfig,
-  worksIndex: Index)(implicit ec: ExecutionContext)
+class WorksController(elasticsearchService: ElasticsearchService,
+                      implicit val apiConfig: ApiConfig,
+                      worksIndex: Index)(implicit ec: ExecutionContext)
     extends Tracing
     with CustomDirectives
     with FailFastCirceSupport {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiContextTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiContextTest.scala
@@ -9,13 +9,12 @@ import scala.io.Source
 class ApiContextTest extends ApiWorksTestBase {
 
   it("returns a context for v2") {
-    withApi {
-      case (_, routes) =>
-        val path = s"/${getApiPrefix(ApiVersions.v2)}/context.json"
-        assertJsonResponse(routes, path)(
-          OK ->
-            Source.fromResource("context-v2.json").getLines.mkString("\n")
-        )
+    withApi { routes =>
+      val path = s"/${getApiPrefix(ApiVersions.v2)}/context.json"
+      assertJsonResponse(routes, path)(
+        OK ->
+          Source.fromResource("context-v2.json").getLines.mkString("\n")
+      )
     }
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiErrorsTest.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
 class ApiErrorsTest extends ApiWorksTestBase {
 
-  it("returns a Not Found error if you try to get an API version") {
+  it("returns a Not Found error if you try to get a non-existent API version") {
     withApi {
       case (_, routes) =>
         assertJsonResponse(routes, "/catalogue/v567/works") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiErrorsTest.scala
@@ -5,26 +5,24 @@ import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 class ApiErrorsTest extends ApiWorksTestBase {
 
   it("returns a Not Found error if you try to get a non-existent API version") {
-    withApi {
-      case (_, routes) =>
-        assertJsonResponse(routes, "/catalogue/v567/works") {
-          Status.NotFound -> notFound(
-            getApiPrefix(),
-            "Page not found for URL /catalogue/v567/works"
-          )
-        }
+    withApi { routes =>
+      assertJsonResponse(routes, "/catalogue/v567/works") {
+        Status.NotFound -> notFound(
+          getApiPrefix(),
+          "Page not found for URL /catalogue/v567/works"
+        )
+      }
     }
   }
 
   it("returns a Not Found error if you try to get an unrecognised path") {
-    withApi {
-      case (_, routes) =>
-        assertJsonResponse(routes, "/foo/bar") {
-          Status.NotFound -> notFound(
-            getApiPrefix(),
-            "Page not found for URL /foo/bar"
-          )
-        }
+    withApi { routes =>
+      assertJsonResponse(routes, "/foo/bar") {
+        Status.NotFound -> notFound(
+          getApiPrefix(),
+          "Page not found for URL /foo/bar"
+        )
+      }
     }
   }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSearchTemplatesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSearchTemplatesTest.scala
@@ -23,12 +23,11 @@ class ApiSearchTemplatesTest
   }
 
   private def checkJson(f: Json => Unit): Unit =
-    withApi {
-      case (_, routes) =>
-        Get(s"/$apiPrefix/search-templates.json") ~> routes ~> check {
-          status shouldEqual Status.OK
-          contentType shouldEqual ContentTypes.`application/json`
-          f(parseJson(responseAs[String]).toOption.get)
-        }
+    withApi { routes =>
+      Get(s"/$apiPrefix/search-templates.json") ~> routes ~> check {
+        status shouldEqual Status.OK
+        contentType shouldEqual ContentTypes.`application/json`
+        f(parseJson(responseAs[String]).toOption.get)
+      }
     }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -228,12 +228,11 @@ class ApiSwaggerTest extends ApiWorksTestBase with Matchers with JsonHelpers {
   }
 
   private def checkSwaggerJson(f: Json => Unit) =
-    withApi {
-      case (_, routes) =>
-        Get(s"/$apiPrefix/swagger.json") ~> routes ~> check {
-          status shouldEqual Status.OK
-          contentType shouldEqual ContentTypes.`application/json`
-          f(parseJson(responseAs[String]).toOption.get)
-        }
+    withApi { routes =>
+      Get(s"/$apiPrefix/swagger.json") ~> routes ~> check {
+        status shouldEqual Status.OK
+        contentType shouldEqual ContentTypes.`application/json`
+        f(parseJson(responseAs[String]).toOption.get)
+      }
     }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiTestBase.scala
@@ -94,7 +94,7 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
     )
 
   def assertIsBadRequest(path: String, description: String): Assertion =
-    withApi {
+    withWorksApi {
       case (_, routes) =>
         assertJsonResponse(routes, s"/$apiPrefix$path")(
           Status.BadRequest ->
@@ -106,7 +106,7 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
     }
 
   def assertIsNotFound(path: String, description: String): Assertion =
-    withApi {
+    withWorksApi {
       case (_, routes) =>
         assertJsonResponse(routes, s"/$apiPrefix$path")(
           Status.NotFound ->

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiTestBase.scala
@@ -104,16 +104,4 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
             )
         )
     }
-
-  def assertIsNotFound(path: String, description: String): Assertion =
-    withWorksApi {
-      case (_, routes) =>
-        assertJsonResponse(routes, s"/$apiPrefix$path")(
-          Status.NotFound ->
-            notFound(
-              apiPrefix = apiPrefix,
-              description = description
-            )
-        )
-    }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -75,6 +75,18 @@ trait ApiFixture
       }
     }
 
+  def withImagesApi[R](testWith: TestWith[(Index, Route), R]): R =
+    withLocalImagesIndex { imagesIndex =>
+      val elasticConfig = ElasticConfig(
+        worksIndex = Index("worksIndex-notused"),
+        imagesIndex = imagesIndex
+      )
+
+      withRouter(elasticConfig) { route =>
+        testWith((imagesIndex, route))
+      }
+    }
+
   def assertJsonResponse(
     routes: Route,
     path: String,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -44,7 +44,8 @@ trait ApiFixture
   // of times we have to create it.
   lazy val swaggerDocs = new SwaggerDocs(apiConfig)
 
-  private def withRouter[R](elasticConfig: ElasticConfig)(testWith: TestWith[Route, R]): R = {
+  private def withRouter[R](elasticConfig: ElasticConfig)(
+    testWith: TestWith[Route, R]): R = {
     val router = new Router(
       elasticClient,
       elasticConfig,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -56,12 +56,16 @@ trait ApiFixture
     testWith(router.routes)
   }
 
-  def withApi[R](testWith: TestWith[(ElasticConfig, Route), R]): R =
-    withLocalIndices { elasticConfig =>
-      withRouter(elasticConfig) { route =>
-        testWith((elasticConfig, route))
-      }
+  def withApi[R](testWith: TestWith[Route, R]): R = {
+    val elasticConfig = ElasticConfig(
+      worksIndex = Index("worksIndex-notused"),
+      imagesIndex = Index("imagesIndex-notused")
+    )
+
+    withRouter(elasticConfig) { route =>
+      testWith(route)
     }
+  }
 
   def withWorksApi[R](testWith: TestWith[(Index, Route), R]): R =
     withLocalWorksIndex { worksIndex =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesErrorsTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.api.images
 
+import org.scalatest.Assertion
+
 class ImagesErrorsTest extends ApiImagesTestBase {
   describe("returns a 404 for missing resources") {
     it("looking up an image that doesn't exist") {
@@ -10,4 +12,16 @@ class ImagesErrorsTest extends ApiImagesTestBase {
       )
     }
   }
+
+  def assertIsNotFound(path: String, description: String): Assertion =
+    withImagesApi {
+      case (_, routes) =>
+        assertJsonResponse(routes, s"/$apiPrefix$path")(
+          Status.NotFound ->
+            notFound(
+              apiPrefix = apiPrefix,
+              description = description
+            )
+        )
+    }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.images
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.License
 
 class ImagesFiltersTest extends ApiImagesTestBase {
@@ -9,8 +8,8 @@ class ImagesFiltersTest extends ApiImagesTestBase {
     val ccByNcImage = createLicensedImage(License.CCBYNC)
 
     it("filters by license") {
-      withApi {
-        case (ElasticConfig(_, imagesIndex), routes) =>
+      withImagesApi {
+        case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(imagesIndex, ccByImage, ccByNcImage)
           assertJsonResponse(
             routes,
@@ -128,8 +127,8 @@ class ImagesFiltersTest extends ApiImagesTestBase {
           ))))
 
     it("filters by color") {
-      withApi {
-        case (ElasticConfig(_, imagesIndex), routes) =>
+      withImagesApi {
+        case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
           assertJsonResponse(routes, f"/$apiPrefix/images?color=ff0000") {
             Status.OK -> imagesListResponse(
@@ -140,8 +139,8 @@ class ImagesFiltersTest extends ApiImagesTestBase {
     }
 
     it("filters by multiple colors") {
-      withApi {
-        case (ElasticConfig(_, imagesIndex), routes) =>
+      withImagesApi {
+        case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(imagesIndex, redImage, blueImage)
           assertJsonResponse(
             routes,
@@ -155,8 +154,8 @@ class ImagesFiltersTest extends ApiImagesTestBase {
     }
 
     it("scores by number of color bin matches") {
-      withApi {
-        case (ElasticConfig(_, imagesIndex), routes) =>
+      withImagesApi {
+        case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(
             imagesIndex,
             redImage,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -1,13 +1,11 @@
 package uk.ac.wellcome.platform.api.images
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
-
 class ImagesSimilarityTest extends ApiImagesTestBase {
 
   it(
     "includes visually similar images on a single image if we pass ?include=visuallySimilar") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val images =
           createSimilarImages(6, similarFeatures = true, similarPalette = true)
         val image = images.head
@@ -35,8 +33,8 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
 
   it(
     "includes images with similar features on a single image if we pass ?include=withSimilarFeatures") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val images =
           createSimilarImages(6, similarFeatures = true, similarPalette = false)
         val image = images.head
@@ -64,8 +62,8 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
 
   it(
     "includes images with similar color palettes on a single image if we pass ?include=withSimilarColors") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val images =
           createSimilarImages(6, similarFeatures = false, similarPalette = true)
         val image = images.head
@@ -93,8 +91,8 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
   }
 
   it("never includes visually similar images on an images search") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val focacciaImage = createAugmentedImageWith(
           parentWork =
             identifiedWork().title("A Ligurian style of bread, Focaccia")

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.platform.api.images
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 
 class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
 
   it("returns a list of images") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val images =
           (1 to 5).map(_ => createAugmentedImage()).sortBy(_.id.canonicalId)
         insertImagesIntoElasticsearch(imagesIndex, images: _*)
@@ -19,8 +18,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
   }
 
   it("returns a single image when requested with ID") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val image = createAugmentedImage()
         insertImagesIntoElasticsearch(imagesIndex, image)
         assertJsonResponse(
@@ -42,8 +41,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
   }
 
   it("returns only linked images when a source work ID is requested") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val parentWork = sierraIdentifiedWork()
         val workImages =
           (0 to 3)
@@ -67,8 +66,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
   }
 
   it("returns matching results when using work data") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val baguetteImage = createAugmentedImageWith(
           imageId = IdState.Identified("a", createSourceIdentifier),
           parentWork = identifiedWork()
@@ -102,8 +101,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
   }
 
   it("returns matching results when using workdata from the redirected work") {
-    withApi {
-      case (ElasticConfig(_, imagesIndex), routes) =>
+    withImagesApi {
+      case (imagesIndex, routes) =>
         val baguetteImage = createAugmentedImageWith(
           imageId = IdState.Identified("a", createSourceIdentifier),
           parentWork = identifiedWork()
@@ -137,8 +136,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
   }
 
   it("searches different indices with the _index parameter") {
-    withApi {
-      case (ElasticConfig(_, defaultIndex), routes) =>
+    withImagesApi {
+      case (defaultIndex, routes) =>
         withLocalImagesIndex { alternativeIndex =>
           val defaultImage = createAugmentedImage()
           val alternativeImage = createAugmentedImage()

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.Format.{Books, Journals, Pictures}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
@@ -15,8 +14,8 @@ class WorksAggregationsTest
     with ProductionEventGenerators {
 
   it("supports fetching the format aggregation") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val formats = List(
           Books,
           Books,
@@ -82,8 +81,8 @@ class WorksAggregationsTest
   }
 
   it("supports fetching the genre aggregation") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val concept0 = Concept("conceptLabel")
         val concept1 = Place("placeLabel")
         val concept2 = Period(
@@ -153,8 +152,8 @@ class WorksAggregationsTest
   }
 
   it("supports aggregating on dates by from year") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val dates = List("1st May 1970", "1970", "1976", "1970-1979")
 
         val works = dates
@@ -212,8 +211,8 @@ class WorksAggregationsTest
 
     val works = languages.map { identifiedWork().language(_) }
 
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=language") {
           Status.OK -> s"""
@@ -270,8 +269,8 @@ class WorksAggregationsTest
     val works = subjectLists
       .map { identifiedWork().subjects(_) }
 
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=subjects") {
           Status.OK -> s"""
@@ -334,8 +333,8 @@ class WorksAggregationsTest
 
     val works = licenseLists.map { createLicensedWork(_) }
 
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(routes, s"/$apiPrefix/works?aggregations=license") {
           Status.OK -> s"""
@@ -393,8 +392,8 @@ class WorksAggregationsTest
         .items(List(createIdentifiedItemWith(locations = List(loc))))
     }
 
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.api.works
 
+import org.scalatest.Assertion
+
 class WorksErrorsTest extends ApiWorksTestBase {
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
@@ -280,4 +282,16 @@ class WorksErrorsTest extends ApiWorksTestBase {
         }
     }
   }
+
+  def assertIsNotFound(path: String, description: String): Assertion =
+    withWorksApi {
+      case (_, routes) =>
+        assertJsonResponse(routes, s"/$apiPrefix$path")(
+          Status.NotFound ->
+            notFound(
+              apiPrefix = apiPrefix,
+              description = description
+            )
+        )
+    }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -101,7 +101,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
   // And if there is a client with a deprecated value, we wouldn't want it to fail
   describe("returns a 200 for invalid values in the ?_queryType parameter") {
     it("200s despite being a unknown value") {
-      withApi {
+      withWorksApi {
         case (_, routes) =>
           assertJsonResponse(
             routes,
@@ -261,7 +261,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
     //
     // By creating an index without a mapping, we don't have a canonicalId field
     // to sort on.  Trying to query this index of these will trigger one such exception!
-    withApi {
+    withWorksApi {
       case (_, routes) =>
         withEmptyIndex { index =>
           val path = s"/${getApiPrefix()}/works?_index=${index.name}"

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.Language
 import uk.ac.wellcome.models.work.internal.Format._
 import uk.ac.wellcome.models.Implicits._
@@ -9,8 +8,8 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
 
   it(
     "filters an aggregation with a filter that is not paired to the aggregation") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = List(
           (Books, Language("Bark", Some("dogs"))),
           (Journals, Language("Meow", Some("cats"))),
@@ -78,8 +77,8 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
 
   it(
     "filters an aggregation with a filter that is paired to another aggregation") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = List(
           (Books, Language("Bark", Some("dogs"))),
           (Journals, Language("Meow", Some("cats"))),
@@ -187,8 +186,8 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
   }
 
   it("filters results but not aggregations paired with an applied filter") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = List(
           (Books, Language("Bark", Some("dogs"))),
           (Journals, Language("Meow", Some("cats"))),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.Format.{
   Books,
   CDRoms,
@@ -30,8 +29,8 @@ class WorksFiltersTest
 
     val works = Seq(work1, work2, work3)
 
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,
@@ -73,8 +72,8 @@ class WorksFiltersTest
     val works = digitalWorks ++ physicalWorks ++ comboWorks
 
     it("filters by PhysicalLocation when listing") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = physicalWorks ++ comboWorks
@@ -91,8 +90,8 @@ class WorksFiltersTest
     }
 
     it("filters by PhysicalLocation when searching") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = physicalWorks ++ comboWorks
@@ -109,8 +108,8 @@ class WorksFiltersTest
     }
 
     it("filters by DigitalLocation when listing") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = digitalWorks ++ comboWorks
@@ -127,8 +126,8 @@ class WorksFiltersTest
     }
 
     it("filters by DigitalLocation when searching") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = digitalWorks ++ comboWorks
@@ -182,8 +181,8 @@ class WorksFiltersTest
     val works = worksWithNoItem ++ Seq(work1, work2, work3)
 
     it("when listing works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = Seq(work1, work2)
@@ -200,8 +199,8 @@ class WorksFiltersTest
     }
 
     it("when searching works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           val matchingWorks = Seq(work2)
@@ -234,8 +233,8 @@ class WorksFiltersTest
     val works = noFormatWorks ++ Seq(bookWork, cdRomWork, manuscriptWork)
 
     it("when listing works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(
@@ -249,8 +248,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple formats") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(
@@ -267,8 +266,8 @@ class WorksFiltersTest
     }
 
     it("when searching works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(
@@ -296,8 +295,8 @@ class WorksFiltersTest
     val works = Seq(collectionWork, seriesWork, sectionWork)
 
     it("when listing works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(routes, s"/$apiPrefix/works?type=Collection") {
@@ -310,8 +309,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple types") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(
@@ -329,8 +328,8 @@ class WorksFiltersTest
     }
 
     it("when searching works") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
 
           assertJsonResponse(
@@ -359,8 +358,8 @@ class WorksFiltersTest
     val work2000 = createDatedWork(dateLabel = "2000")
 
     it("filters by date range") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
@@ -371,8 +370,8 @@ class WorksFiltersTest
     }
 
     it("filters by from date") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
@@ -386,8 +385,8 @@ class WorksFiltersTest
     }
 
     it("filters by to date") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
@@ -401,8 +400,8 @@ class WorksFiltersTest
     }
 
     it("errors on invalid date") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, work1709, work1950, work2000)
           assertJsonResponse(
             routes,
@@ -426,8 +425,8 @@ class WorksFiltersTest
     val works = List(englishWork, germanWork, noLanguageWork)
 
     it("filters by language") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng") {
             Status.OK -> worksListResponse(apiPrefix, works = Seq(englishWork))
@@ -436,8 +435,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple comma seperated languages") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?language=eng,ger") {
             Status.OK -> worksListResponse(
@@ -463,8 +462,8 @@ class WorksFiltersTest
     val works = List(horrorWork, romcomWork, romcomHorrorWork, noGenreWork)
 
     it("filters by genre with partial match") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
             Status.OK -> worksListResponse(
@@ -478,8 +477,8 @@ class WorksFiltersTest
     }
 
     it("filters by genre using multiple terms") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(
             routes,
@@ -510,8 +509,8 @@ class WorksFiltersTest
       noSubjectWork)
 
     it("filters by subjects") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
             Status.OK -> worksListResponse(
@@ -525,8 +524,8 @@ class WorksFiltersTest
     }
 
     it("filters by subjects using multiple terms") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(
             routes,
@@ -560,8 +559,8 @@ class WorksFiltersTest
     val works = List(ccByWork, ccByNcWork, bothLicenseWork, noLicenseWork)
 
     it("filters by license") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(routes, s"/$apiPrefix/works?license=cc-by") {
             Status.OK -> worksListResponse(
@@ -575,8 +574,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple licenses") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, works: _*)
           assertJsonResponse(
             routes,
@@ -596,8 +595,8 @@ class WorksFiltersTest
     val unknownWork = identifiedWork()
 
     it("filters by a sourceIdentifier") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work = identifiedWork()
           insertIntoElasticsearch(worksIndex, unknownWork, work)
 
@@ -613,8 +612,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple sourceIdentifiers") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work1 = identifiedWork()
           val work2 = identifiedWork()
 
@@ -632,8 +631,8 @@ class WorksFiltersTest
     }
 
     it("filters by an otherIdentifier") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work =
             identifiedWork().otherIdentifiers(List(createSourceIdentifier))
           insertIntoElasticsearch(worksIndex, unknownWork, work)
@@ -649,8 +648,8 @@ class WorksFiltersTest
     }
 
     it("filters by multiple otherIdentifiers") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work1 =
             identifiedWork().otherIdentifiers(List(createSourceIdentifier))
           val work2 =
@@ -669,8 +668,8 @@ class WorksFiltersTest
     }
 
     it("filters by mixed identifiers") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work1 = identifiedWork()
           val work2 =
             identifiedWork().otherIdentifiers(List(createSourceIdentifier))
@@ -714,8 +713,8 @@ class WorksFiltersTest
     val workE = work(AccessStatus.OpenWithAdvisory)
 
     it("includes works by access status") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, workA, workB, workC, workD, workE)
           assertJsonResponse(
             routes,
@@ -729,8 +728,8 @@ class WorksFiltersTest
     }
 
     it("excludes works by access status") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           insertIntoElasticsearch(worksIndex, workA, workB, workC, workD, workE)
           assertJsonResponse(
             routes,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.works
 
 import com.sksamuel.elastic4s.Index
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.generators.{
   ImageGenerators,
   ProductionEventGenerators,
@@ -20,8 +19,8 @@ class WorksIncludesTest
   describe("identifiers includes") {
     it(
       "includes a list of identifiers on a list endpoint if we pass ?include=identifiers") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val otherIdentifier0 = createSourceIdentifier
           val otherIdentifier1 = createSourceIdentifier
           val work0 = identifiedWork(canonicalId = "0")
@@ -65,8 +64,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of identifiers on a single work endpoint if we pass ?include=identifiers") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val otherIdentifier = createSourceIdentifier
           val work = identifiedWork().otherIdentifiers(List(otherIdentifier))
           insertIntoElasticsearch(worksIndex, work)
@@ -92,8 +91,8 @@ class WorksIncludesTest
   }
 
   it("renders the items if the items include is present") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work = identifiedWork()
           .items(
             List(
@@ -122,8 +121,8 @@ class WorksIncludesTest
   describe("subject includes") {
     it(
       "includes a list of subjects on a list endpoint if we pass ?include=subjects") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val subjects0 = List(createSubject)
           val subjects1 = List(createSubject)
           val work0 = identifiedWork(canonicalId = "0").subjects(subjects0)
@@ -159,8 +158,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of subjects on a single work endpoint if we pass ?include=subjects") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work = identifiedWork().subjects(List(createSubject))
 
           insertIntoElasticsearch(worksIndex, work)
@@ -185,8 +184,8 @@ class WorksIncludesTest
   describe("genre includes") {
     it(
       "includes a list of genres on a list endpoint if we pass ?include=genres") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val genres1 = List(Genre("ornithology", List(Concept("ornithology"))))
           val genres2 = List(Genre("flying cars", List(Concept("flying cars"))))
           val work1 = identifiedWork(canonicalId = "1").genres(genres1)
@@ -222,8 +221,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of genres on a single work endpoint if we pass ?include=genres") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work = identifiedWork().genres(
             List(Genre("ornithology", List(Concept("ornithology")))))
 
@@ -249,8 +248,8 @@ class WorksIncludesTest
   describe("contributor includes") {
     it(
       "includes a list of contributors on a list endpoint if we pass ?include=contributors") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val contributors1 =
             List(Contributor(Person("Ginger Rogers"), roles = Nil))
           val contributors2 =
@@ -290,8 +289,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of contributors on a single work endpoint if we pass ?include=contributors") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work = identifiedWork()
             .contributors(
               List(Contributor(Person("Ginger Rogers"), roles = Nil)))
@@ -318,8 +317,8 @@ class WorksIncludesTest
   describe("production includes") {
     it(
       "includes a list of production events on a list endpoint if we pass ?include=production") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val productionEvents1 = createProductionEventList()
           val productionEvents2 = createProductionEventList()
           val work1 =
@@ -357,8 +356,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of production on a single work endpoint if we pass ?include=production") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work = identifiedWork().production(createProductionEventList())
 
           insertIntoElasticsearch(worksIndex, work)
@@ -382,8 +381,8 @@ class WorksIncludesTest
 
   describe("notes includes") {
     it("includes notes on the list endpoint if we pass ?include=notes") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work1 = identifiedWork(canonicalId = "1")
             .notes(List(GeneralNote("GN1"), FundingInformation("FI1")))
           val work2 = identifiedWork(canonicalId = "2")
@@ -446,8 +445,8 @@ class WorksIncludesTest
     }
 
     it("includes notes on the single work endpoint if we pass ?include=notes") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val work =
             identifiedWork().notes(List(GeneralNote("A"), GeneralNote("B")))
           insertIntoElasticsearch(worksIndex, work)
@@ -481,8 +480,8 @@ class WorksIncludesTest
   describe("image includes") {
     it(
       "includes a list of images on the list endpoint if we pass ?include=images") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val works = List(
             identifiedWork()
               .images(
@@ -522,8 +521,8 @@ class WorksIncludesTest
 
     it(
       "includes a list of images on a single work endpoint if we pass ?include=images") {
-      withApi {
-        case (ElasticConfig(worksIndex, _), routes) =>
+      withWorksApi {
+        case (worksIndex, routes) =>
           val images =
             (1 to 3).map(_ => createUnmergedImage.toIdentified).toList
           val work = identifiedWork().images(images)
@@ -567,9 +566,9 @@ class WorksIncludesTest
       insertIntoElasticsearch(index, work0, workA, workB, workC, workD, workE)
 
     it("includes parts") {
-      withApi {
-        case (ElasticConfig(index, _), routes) =>
-          storeWorks(index)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          storeWorks(worksIndex)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works/${workC.state.canonicalId}?include=parts") {
@@ -592,9 +591,9 @@ class WorksIncludesTest
     }
 
     it("includes partOf") {
-      withApi {
-        case (ElasticConfig(index, _), routes) =>
-          storeWorks(index)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          storeWorks(worksIndex)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works/${workC.state.canonicalId}?include=partOf") {
@@ -626,9 +625,9 @@ class WorksIncludesTest
     }
 
     it("includes precededBy") {
-      withApi {
-        case (ElasticConfig(index, _), routes) =>
-          storeWorks(index)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          storeWorks(worksIndex)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works/${workC.state.canonicalId}?include=precededBy") {
@@ -651,9 +650,9 @@ class WorksIncludesTest
     }
 
     it("includes succeededBy") {
-      withApi {
-        case (ElasticConfig(index, _), routes) =>
-          storeWorks(index)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          storeWorks(worksIndex)
           assertJsonResponse(
             routes,
             s"/$apiPrefix/works/${workC.state.canonicalId}?include=succeededBy") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal.IdState
 import uk.ac.wellcome.models.Implicits._
 
@@ -15,8 +14,8 @@ class WorksRedirectsTest extends ApiWorksTestBase {
   val redirectId = redirectedWork.redirect.canonicalId
 
   it("returns a TemporaryRedirect if looking up a redirected work") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, redirectedWork)
         val path = s"/$apiPrefix/works/${redirectedWork.state.canonicalId}"
         assertRedirectResponse(routes, path) {
@@ -27,8 +26,8 @@ class WorksRedirectsTest extends ApiWorksTestBase {
   }
 
   it("preserves query parameters on a 302 Redirect") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, redirectedWork)
         val path =
           s"/$apiPrefix/works/${redirectedWork.state.canonicalId}?include=identifiers"

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ProductionEventGenerators
 
 class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   it("returns a list of works") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = identifiedWorks(count = 3).sortBy {
           _.state.canonicalId
         }
@@ -22,8 +21,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("returns a single work when requested with id") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work = identifiedWork()
 
         insertIntoElasticsearch(worksIndex, work)
@@ -44,8 +43,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("returns optional fields when they exist") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work = identifiedWork()
           .duration(3600)
           .edition("Special edition")
@@ -70,8 +69,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
 
   it(
     "returns the requested page of results when requested with page & pageSize") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = identifiedWorks(count = 3).sortBy {
           _.state.canonicalId
         }
@@ -130,7 +129,7 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("ignores parameters that are unused when making an API request") {
-    withApi {
+    withWorksApi {
       case (_, routes) =>
         assertJsonResponse(routes, s"/$apiPrefix/works?foo=bar") {
           Status.OK -> emptyJsonResult(apiPrefix)
@@ -139,8 +138,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("returns matching results if doing a full-text search") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val workDodo = identifiedWork().title("A drawing of a dodo")
         val workMouse = identifiedWork().title("A mezzotint of a mouse")
         insertIntoElasticsearch(worksIndex, workDodo, workMouse)
@@ -156,8 +155,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("searches different indices with the ?_index query parameter") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         withLocalWorksIndex { altIndex =>
           val work = identifiedWork()
           insertIntoElasticsearch(worksIndex, work)
@@ -195,8 +194,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("looks up works in different indices with the ?_index query parameter") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         withLocalWorksIndex { altIndex =>
           val work = identifiedWork().title("Playing with pangolins")
           insertIntoElasticsearch(worksIndex, work)
@@ -218,8 +217,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("shows the thumbnail field if available") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work = identifiedWork()
           .thumbnail(
             DigitalLocationDeprecated(
@@ -255,8 +254,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
       .production(List(createProductionEventWith(dateLabel = Some(dateLabel))))
 
   it("supports sorting by production date") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work1 = createDatedWork(canonicalId = "1", dateLabel = "1900")
         val work2 = createDatedWork(canonicalId = "2", dateLabel = "1976")
         val work3 = createDatedWork(canonicalId = "3", dateLabel = "1904")
@@ -274,8 +273,8 @@ class WorksTest extends ApiWorksTestBase with ProductionEventGenerators {
   }
 
   it("supports sorting of dates in descending order") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work1 = createDatedWork(canonicalId = "1", dateLabel = "1900")
         val work2 = createDatedWork(canonicalId = "2", dateLabel = "1976")
         val work3 = createDatedWork(canonicalId = "3", dateLabel = "1904")

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTestInvisible.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
 import WorkState.Identified
@@ -9,8 +8,8 @@ class WorksTestInvisible extends ApiWorksTestBase {
   val deletedWork: Work.Invisible[Identified] = identifiedWork().invisible()
 
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         insertIntoElasticsearch(worksIndex, deletedWork)
         val path = s"/$apiPrefix/works/${deletedWork.state.canonicalId}"
         assertJsonResponse(routes, path) {
@@ -20,8 +19,8 @@ class WorksTestInvisible extends ApiWorksTestBase {
   }
 
   it("excludes works with visible=false from list results") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val works = identifiedWorks(count = 2).sortBy {
           _.state.canonicalId
         }
@@ -36,8 +35,8 @@ class WorksTestInvisible extends ApiWorksTestBase {
   }
 
   it("excludes works with visible=false from search results") {
-    withApi {
-      case (ElasticConfig(worksIndex, _), routes) =>
+    withWorksApi {
+      case (worksIndex, routes) =>
         val work = identifiedWork().title("This shouldn't be deleted!")
         insertIntoElasticsearch(worksIndex, work, deletedWork)
 

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -289,7 +289,8 @@ trait ElasticsearchFixtures
     elasticClient
       .execute { count(index.name) }
       .await
-      .result.count
+      .result
+      .count
 
   def createIndex: Index =
     Index(name = createIndexName)


### PR DESCRIPTION
The API tests are noticeably slower than other services – often almost twice as long as anything else. This costs money in CI instances, and frustrates developers who want a fast edit-test-debug cycle. I did some investigation into why they're so slow:

* The `SwaggerDocs` class is *incredibly* expensive – as in, multiple seconds to create a new instance. We were creating a new instance every time we created a new `Router` instance, which happens in any test which runs against the public API.

   This is the big win.

* We create a whole stack of indexes we don't need – works indexes in an images API test, images indexes in a works API test, both indexes in tests that don't touch Elasticsearch at all.

   This is a smaller win – each new index costs ~0.3s to create (on my machine), but multiplied over several hundred tests that adds up.

* When we index documents before a tests start, we check they're all indexed by counting the number of documents returned. There's a dedicated API for counting the size of an index, which involves less JSON encoding/decoding – use that instead.

    I don't know how much of a difference this makes, but it surely can't make things worse.

Plus some other minor refactorings and clean ups.