### PR TITLE
Various improvements to how we handle Language and serialise JSON

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSearchTemplatesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSearchTemplatesTest.scala
@@ -27,7 +27,7 @@ class ApiSearchTemplatesTest
       Get(s"/$apiPrefix/search-templates.json") ~> routes ~> check {
         status shouldEqual Status.OK
         contentType shouldEqual ContentTypes.`application/json`
-        f(parseJson(responseAs[String]).toOption.get)
+        f(parseJson(responseAs[String]))
       }
     }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -232,7 +232,7 @@ class ApiSwaggerTest extends ApiWorksTestBase with Matchers with JsonHelpers {
       Get(s"/$apiPrefix/swagger.json") ~> routes ~> check {
         status shouldEqual Status.OK
         contentType shouldEqual ContentTypes.`application/json`
-        f(parseJson(responseAs[String]).toOption.get)
+        f(parseJson(responseAs[String]))
       }
     }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -121,11 +121,13 @@ trait ApiFixture
       }
     }
 
-  def parseJson(string: String, unordered: Boolean = false) =
-    parse(string).left
-      .map(_ => s"Invalid JSON")
-      .right
-      .map(sortedJson(unordered))
+  def parseJson(string: String, unordered: Boolean = false): Json =
+    parse(string) match {
+      case Right(json) => sortedJson(unordered)(json)
+      case Left(err) => throw new RuntimeException(
+        s"Asked to compare a string that wasn't JSON. Error: $err. JSON:\n$string"
+      )
+    }
 
   def sortedJson(unordered: Boolean)(json: Json): Json =
     json.arrayOrObject(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/fixtures/ApiFixture.scala
@@ -124,9 +124,10 @@ trait ApiFixture
   def parseJson(string: String, unordered: Boolean = false): Json =
     parse(string) match {
       case Right(json) => sortedJson(unordered)(json)
-      case Left(err) => throw new RuntimeException(
-        s"Asked to compare a string that wasn't JSON. Error: $err. JSON:\n$string"
-      )
+      case Left(err) =>
+        throw new RuntimeException(
+          s"Asked to compare a string that wasn't JSON. Error: $err. JSON:\n$string"
+        )
     }
 
   def sortedJson(unordered: Boolean)(json: Json): Json =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -34,9 +34,9 @@ trait ApiWorksTestBase
       |   "type": "${formatOntologyType(work.data.workType)}",
       |   "id": "${work.state.canonicalId}",
       |   "title": "${work.data.title.get}",
-      |   ${work.data.format.map(formatResponse).getOrElse("")}
-      |   ${work.data.language.map(languageResponse).getOrElse("")}
       |   "alternativeTitles": []
+      |   ${optionalObject("workType", format, work.data.format)}
+      |   ${optionalObject("language", language, work.data.language)}
       | }
     """.stripMargin
 
@@ -58,22 +58,4 @@ trait ApiWorksTestBase
       case WorkType.Series     => "Series"
       case WorkType.Section    => "Section"
     }
-
-  def formatResponse(format: Format): String =
-    s"""
-      | "workType": {
-      |   "id": "${format.id}",
-      |   "label": "${format.label}",
-      |   "type": "Format"
-      | },
-    """.stripMargin
-
-  def languageResponse(language: Language): String =
-    s"""
-      | "language": {
-      |   ${language.id.map(lang => s""""id": "$lang",""").getOrElse("")}
-      |   "label": "${language.label}",
-      |   "type": "Language"
-      | },
-    """.stripMargin
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -203,8 +203,8 @@ class WorksAggregationsTest
   }
 
   it("supports aggregating on language") {
-    val english = Language("English", Some("eng"))
-    val german = Language("German", Some("ger"))
+    val english = Language(label = "English", id = "eng")
+    val german = Language(label = "German", id = "ger")
 
     val languages = List(english, german, german)
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -278,7 +278,9 @@ class WorksAggregationsTest
                       "type" : "AggregationBucket"
                     },
                     {
-                      "data" : ${subject(paleoNeuroBiology, showConcepts = false)},
+                      "data" : ${subject(
+                            paleoNeuroBiology,
+                            showConcepts = false)},
                       "count" : 2,
                       "type" : "AggregationBucket"
                     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -203,11 +203,10 @@ class WorksAggregationsTest
   }
 
   it("supports aggregating on language") {
-    val languages = List(
-      Language("English", Some("eng")),
-      Language("German", Some("ger")),
-      Language("German", Some("ger"))
-    )
+    val english = Language("English", Some("eng"))
+    val german = Language("German", Some("ger"))
+
+    val languages = List(english, german, german)
 
     val works = languages.map { identifiedWork().language(_) }
 
@@ -224,20 +223,12 @@ class WorksAggregationsTest
                   "type" : "Aggregation",
                   "buckets": [
                     {
-                      "data" : {
-                        "id": "ger",
-                        "label": "German",
-                        "type": "Language"
-                      },
+                      "data" : ${language(german)},
                       "count" : 2,
                       "type" : "AggregationBucket"
                     },
                     {
-                      "data" : {
-                        "id": "eng",
-                        "label": "English",
-                        "type": "Language"
-                      },
+                      "data" : ${language(english)},
                       "count" : 1,
                       "type" : "AggregationBucket"
                     }
@@ -282,20 +273,12 @@ class WorksAggregationsTest
                   "type" : "Aggregation",
                   "buckets": [
                     {
-                      "data" : {
-                        "label": "realAnalysis",
-                        "concepts": [],
-                        "type": "Subject"
-                      },
+                      "data" : ${subject(realAnalysis, showConcepts = false)},
                       "count" : 3,
                       "type" : "AggregationBucket"
                     },
                     {
-                      "data" : {
-                        "label": "paleoNeuroBiology",
-                        "concepts": [],
-                        "type": "Subject"
-                      },
+                      "data" : ${subject(paleoNeuroBiology, showConcepts = false)},
                       "count" : 2,
                       "type" : "AggregationBucket"
                     }
@@ -347,22 +330,12 @@ class WorksAggregationsTest
                   "buckets": [
                     {
                       "count" : 3,
-                      "data" : {
-                        "id" : "cc-by",
-                        "label" : "Attribution 4.0 International (CC BY 4.0)",
-                        "type" : "License",
-                        "url" : "http://creativecommons.org/licenses/by/4.0/"
-                      },
+                      "data" : ${license(License.CCBY)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 2,
-                      "data" : {
-                        "id" : "cc-by-nc",
-                        "label" : "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
-                        "type" : "License",
-                        "url" : "https://creativecommons.org/licenses/by-nc/4.0/"
-                      },
+                      "data" : ${license(License.CCBYNC)},
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksAggregationsTest.scala
@@ -255,14 +255,14 @@ class WorksAggregationsTest
   }
 
   it("supports aggregating on subject, ordered by frequency") {
-    val paeleoNeuroBiology = createSubjectWith(label = "paeleoNeuroBiology")
+    val paleoNeuroBiology = createSubjectWith(label = "paleoNeuroBiology")
     val realAnalysis = createSubjectWith(label = "realAnalysis")
 
     val subjectLists = List(
-      List(paeleoNeuroBiology),
+      List(paleoNeuroBiology),
       List(realAnalysis),
       List(realAnalysis),
-      List(paeleoNeuroBiology, realAnalysis),
+      List(paleoNeuroBiology, realAnalysis),
       List.empty
     )
 
@@ -292,7 +292,7 @@ class WorksAggregationsTest
                     },
                     {
                       "data" : {
-                        "label": "paeleoNeuroBiology",
+                        "label": "paleoNeuroBiology",
                         "concepts": [],
                         "type": "Subject"
                       },

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -50,20 +50,12 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 3,
-                      "data" : {
-                        "id" : "dogs",
-                        "label" : "Bark",
-                        "type" : "Language"
-                      },
+                      "data" : ${language(bark)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : {
-                        "id" : "cats",
-                        "label" : "Meow",
-                        "type" : "Language"
-                      },
+                      "data" : ${language(meow)},
                       "type" : "AggregationBucket"
                     }
                   ]
@@ -101,20 +93,12 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 3,
-                      "data" : {
-                        "id" : "dogs",
-                        "label" : "Bark",
-                        "type" : "Language"
-                      },
+                      "data" : ${language(bark)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : {
-                        "id" : "cats",
-                        "label" : "Meow",
-                        "type" : "Language"
-                      },
+                      "data" : ${language(meow)},
                       "type" : "AggregationBucket"
                     }
                   ]
@@ -124,38 +108,22 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets" : [
                     {
                       "count" : 4,
-                      "data" : {
-                        "id" : "a",
-                        "label" : "Books",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Books)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 3,
-                      "data" : {
-                        "id" : "d",
-                        "label" : "Journals",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Journals)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 2,
-                      "data" : {
-                        "id" : "i",
-                        "label" : "Audio",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Audio)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : {
-                        "id" : "k",
-                        "label" : "Pictures",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Pictures)},
                       "type" : "AggregationBucket"
                     }
                   ]
@@ -192,38 +160,22 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   "buckets": [
                     {
                       "count" : 4,
-                      "data" : {
-                        "id" : "a",
-                        "label" : "Books",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Books)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 3,
-                      "data" : {
-                        "id" : "d",
-                        "label" : "Journals",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Journals)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 2,
-                      "data" : {
-                        "id" : "i",
-                        "label" : "Audio",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Audio)},
                       "type" : "AggregationBucket"
                     },
                     {
                       "count" : 1,
-                      "data" : {
-                        "id" : "k",
-                        "label" : "Pictures",
-                        "type" : "Format"
-                      },
+                      "data" : ${format(Pictures)},
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -6,10 +6,10 @@ import uk.ac.wellcome.models.Implicits._
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
 
-  val bark = Language("Bark", Some("dogs"))
-  val meow = Language("Meow", Some("cats"))
-  val quack = Language("Quack", Some("ducks"))
-  val croak = Language("Croak", Some("frogs"))
+  val bark = Language(label = "Bark", id = "dogs")
+  val meow = Language(label = "Meow", id = "cats")
+  val quack = Language(label = "Quack", id = "ducks")
+  val croak = Language(label = "Croak", id = "frogs")
 
   val works: List[Work.Visible[WorkState.Identified]] = List(
     (Books, bark),

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -1,33 +1,38 @@
 package uk.ac.wellcome.platform.api.works
 
-import uk.ac.wellcome.models.work.internal.Language
+import uk.ac.wellcome.models.work.internal.{Language, Work, WorkState}
 import uk.ac.wellcome.models.work.internal.Format._
 import uk.ac.wellcome.models.Implicits._
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
 
+  val bark = Language("Bark", Some("dogs"))
+  val meow = Language("Meow", Some("cats"))
+  val quack = Language("Quack", Some("ducks"))
+  val croak = Language("Croak", Some("frogs"))
+
+  val works: List[Work.Visible[WorkState.Identified]] = List(
+    (Books, bark),
+    (Journals, meow),
+    (Pictures, quack),
+    (Audio, bark),
+    (Books, bark),
+    (Books, bark),
+    (Journals, quack),
+    (Books, meow),
+    (Journals, quack),
+    (Audio, croak)
+  ).map {
+    case (format, language) =>
+      identifiedWork()
+        .format(format)
+        .language(language)
+  }
+
   it(
     "filters an aggregation with a filter that is not paired to the aggregation") {
     withWorksApi {
       case (worksIndex, routes) =>
-        val works = List(
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Meow", Some("cats"))),
-          (Pictures, Language("Quack", Some("ducks"))),
-          (Audio, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Books, Language("Meow", Some("cats"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Audio, Language("Croak", Some("frogs")))
-        ).map {
-          case (format, language) =>
-            identifiedWork()
-              .format(format)
-              .language(language)
-        }
-
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,
@@ -79,24 +84,6 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     "filters an aggregation with a filter that is paired to another aggregation") {
     withWorksApi {
       case (worksIndex, routes) =>
-        val works = List(
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Meow", Some("cats"))),
-          (Pictures, Language("Quack", Some("ducks"))),
-          (Audio, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Books, Language("Meow", Some("cats"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Audio, Language("Croak", Some("frogs")))
-        ).map {
-          case (format, language) =>
-            identifiedWork()
-              .format(format)
-              .language(language)
-        }
-
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,
@@ -188,24 +175,6 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
   it("filters results but not aggregations paired with an applied filter") {
     withWorksApi {
       case (worksIndex, routes) =>
-        val works = List(
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Meow", Some("cats"))),
-          (Pictures, Language("Quack", Some("ducks"))),
-          (Audio, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Books, Language("Bark", Some("dogs"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Books, Language("Meow", Some("cats"))),
-          (Journals, Language("Quack", Some("ducks"))),
-          (Audio, Language("Croak", Some("frogs")))
-        ).map {
-          case (format, language) =>
-            identifiedWork()
-              .format(format)
-              .language(language)
-        }
-
         insertIntoElasticsearch(worksIndex, works: _*)
         assertJsonResponse(
           routes,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -418,8 +418,8 @@ class WorksFiltersTest
 
   describe("filtering works by language") {
     val englishWork =
-      identifiedWork().language(Language("English", Some("eng")))
-    val germanWork = identifiedWork().language(Language("German", Some("ger")))
+      identifiedWork().language(Language(label = "English", id = "eng"))
+    val germanWork = identifiedWork().language(Language(label = "German", id = "ger"))
     val noLanguageWork = identifiedWork()
 
     val works = List(englishWork, germanWork, noLanguageWork)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -419,7 +419,8 @@ class WorksFiltersTest
   describe("filtering works by language") {
     val englishWork =
       identifiedWork().language(Language(label = "English", id = "eng"))
-    val germanWork = identifiedWork().language(Language(label = "German", id = "ger"))
+    val germanWork =
+      identifiedWork().language(Language(label = "German", id = "ger"))
     val noLanguageWork = identifiedWork()
 
     val works = List(englishWork, germanWork, noLanguageWork)

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -176,7 +176,8 @@ trait DisplaySerialisationTestBase {
   def concepts(concepts: List[AbstractRootConcept[IdState.Minted]]) =
     concepts.map(abstractRootConcept).mkString(",")
 
-  def subject(s: Subject[IdState.Minted], showConcepts: Boolean = true): String =
+  def subject(s: Subject[IdState.Minted],
+              showConcepts: Boolean = true): String =
     s"""
     {
       "label": "${s.label}",

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -176,17 +176,17 @@ trait DisplaySerialisationTestBase {
   def concepts(concepts: List[AbstractRootConcept[IdState.Minted]]) =
     concepts.map(abstractRootConcept).mkString(",")
 
-  def subject(s: Subject[IdState.Minted]): String =
+  def subject(s: Subject[IdState.Minted], showConcepts: Boolean = true): String =
     s"""
     {
       "label": "${s.label}",
       "type" : "Subject",
-      "concepts": [ ${concepts(s.concepts)} ]
+      "concepts": [ ${if (showConcepts) concepts(s.concepts) else ""} ]
     }
     """
 
   def subjects(subjects: List[Subject[IdState.Minted]]): String =
-    subjects.map(subject).mkString(",")
+    subjects.map(subject(_)).mkString(",")
 
   def genre(genre: Genre[IdState.Minted]) =
     s"""
@@ -238,14 +238,23 @@ trait DisplaySerialisationTestBase {
       }
     """.stripMargin
 
-  def format(w: Format) =
+  def format(fmt: Format): String =
     s"""
       {
-        "id": "${w.id}",
-        "label": "${w.label}",
+        "id": "${fmt.id}",
+        "label": "${fmt.label}",
         "type": "Format"
       }
     """.stripMargin
+
+  def language(lang: Language): String =
+    s"""
+       |{
+       |  ${optionalString("id", lang.id)}
+       |  "label": "${lang.label}",
+       |  "type": "Language"
+       |}
+     """.stripMargin
 
   def license(license: License) =
     s"""{

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -132,10 +132,7 @@ class DisplayWorkTest
   }
 
   it("gets the language from a Work") {
-    val language = Language(
-      id = Some("bsl"),
-      label = "British Sign Language"
-    )
+    val language = Language(id = "bsl", label = "British Sign Language")
 
     val work = identifiedWork().language(language)
 
@@ -147,8 +144,8 @@ class DisplayWorkTest
 
   it("gets the languages from a Work") {
     val languages = List(
-      Language(id = Some("bsl"), label = "British Sign Language"),
-      Language(id = Some("ger"), label = "German")
+      Language(id = "bsl", label = "British Sign Language"),
+      Language(id = "ger", label = "German")
     )
 
     val work = identifiedWork().languages(languages)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
@@ -10,11 +10,13 @@ case class Language(
 )
 
 object Language {
+  def apply(label: String, id: String): Language =
+    Language(label = label, id = Some(id))
 
   def fromCode(code: String): Result[Language] =
     languageCodeMap
       .get(code)
-      .map(label => Right(Language(label, Some(code))))
+      .map(label => Right(Language(label = label, id = code)))
       .getOrElse {
         Left(new Exception(s"Invalid ISO 693-2 language code: $code"))
       }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
@@ -20,10 +20,12 @@ object Language {
       }
 
   def fromLabel(label: String): Result[Language] =
-    languageLabelMap.get(label) match {
-      case Some(code) => Right(Language(label, Some(code)))
-      case None       => Right(Language(label, None))
-    }
+    Right(
+      Language(
+        label = label,
+        id = languageLabelMap.get(label)
+      )
+    )
 
   private def languageCodes: List[(String, String)] =
     Source

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Language.scala
@@ -4,10 +4,7 @@ import scala.io.Source
 
 import uk.ac.wellcome.models.work.internal.result.Result
 
-case class Language(
-  label: String,
-  id: Option[String] = None
-)
+case class Language(label: String, id: Option[String])
 
 object Language {
   def apply(label: String, id: String): Language =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
@@ -1,27 +1,30 @@
 package uk.ac.wellcome.models.work.internal
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 
-class LanguageTest extends AnyFunSpec with Matchers {
-  it("gets labels for known code or errors") {
-    val withValidCode = Language.fromCode("yo")
-    val withInvalidCode = Language.fromCode("no such code")
-
-    withValidCode should be(Right(Language(label = "Yoruba", id = "yo")))
-    withInvalidCode shouldBe a[Left[_, _]]
+class LanguageTest extends AnyFunSpec with Matchers with EitherValues with TableDrivenPropertyChecks {
+  it("gets the language from a known code") {
+    Language.fromCode("yo").right.value shouldBe Language(label = "Yoruba", id = "yo")
   }
 
-  it(
-    "gets Language with code from known labels and omits code for unknown labels") {
-    val withValidLabel = Language.fromLabel("Yoruba")
-    val withMultiLabel1 = Language.fromLabel("Haitian")
-    val withMultiLabel2 = Language.fromLabel("Haitian Creole")
-    val withInvalidLabel = Language.fromLabel("no such label")
+  it("errors if asked to retrieve an unknown code") {
+    Language.fromCode("no such code").left.value shouldBe a[Exception]
+  }
 
-    withValidLabel shouldBe Right(Language(label = "Yoruba", id = "yo"))
-    withMultiLabel1 shouldBe Right(Language(label = "Haitian", id = "ht"))
-    withMultiLabel2 shouldBe Right(Language(label = "Haitian Creole", id = "ht"))
-    withInvalidLabel shouldBe Right(Language(label = "no such label", id = None))
+  val labelTestCases = Table(
+    ("label", "expectedLanguage"),
+    ("Yoruba", Language(label = "Yoruba", id = "yo")),
+    ("Haitian", Language(label = "Haitian", id = "ht")),
+    ("Haitian Creole", Language(label = "Haitian Creole", id = "ht")),
+    ("no such label", Language(label = "no such label", id = None)),
+  )
+
+  it("gets the language from a label") {
+    forAll(labelTestCases) { case (label, expectedLanguage) =>
+      Language.fromLabel(label).right.value shouldBe expectedLanguage
+    }
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
@@ -8,7 +8,7 @@ class LanguageTest extends AnyFunSpec with Matchers {
     val withValidCode = Language.fromCode("yo")
     val withInvalidCode = Language.fromCode("no such code")
 
-    withValidCode should be(Right(Language("Yoruba", Some("yo"))))
+    withValidCode should be(Right(Language(label = "Yoruba", id = "yo")))
     withInvalidCode shouldBe a[Left[_, _]]
   }
 
@@ -19,9 +19,9 @@ class LanguageTest extends AnyFunSpec with Matchers {
     val withMultiLabel2 = Language.fromLabel("Haitian Creole")
     val withInvalidLabel = Language.fromLabel("no such label")
 
-    withValidLabel shouldBe Right(Language("Yoruba", Some("yo")))
-    withMultiLabel1 shouldBe Right(Language("Haitian", Some("ht")))
-    withMultiLabel2 shouldBe Right(Language("Haitian Creole", Some("ht")))
-    withInvalidLabel shouldBe Right(Language("no such label", None))
+    withValidLabel shouldBe Right(Language(label = "Yoruba", id = "yo"))
+    withMultiLabel1 shouldBe Right(Language(label = "Haitian", id = "ht"))
+    withMultiLabel2 shouldBe Right(Language(label = "Haitian Creole", id = "ht"))
+    withInvalidLabel shouldBe Right(Language(label = "no such label", id = None))
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/LanguageTest.scala
@@ -5,9 +5,15 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class LanguageTest extends AnyFunSpec with Matchers with EitherValues with TableDrivenPropertyChecks {
+class LanguageTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with TableDrivenPropertyChecks {
   it("gets the language from a known code") {
-    Language.fromCode("yo").right.value shouldBe Language(label = "Yoruba", id = "yo")
+    Language.fromCode("yo").right.value shouldBe Language(
+      label = "Yoruba",
+      id = "yo")
   }
 
   it("errors if asked to retrieve an unknown code") {
@@ -23,8 +29,9 @@ class LanguageTest extends AnyFunSpec with Matchers with EitherValues with Table
   )
 
   it("gets the language from a label") {
-    forAll(labelTestCases) { case (label, expectedLanguage) =>
-      Language.fromLabel(label).right.value shouldBe expectedLanguage
+    forAll(labelTestCases) {
+      case (label, expectedLanguage) =>
+        Language.fromLabel(label).right.value shouldBe expectedLanguage
     }
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -218,7 +218,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.language shouldBe Some(
-      Language("English", Some("en"))
+      Language(label = "English", id = "en")
     )
   }
 
@@ -254,7 +254,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
-      Language("English", Some("en"))
+      Language(label = "English", id = "en")
     )
     CalmTransformer(recordB, version).right.get.data.language shouldBe None
   }
@@ -277,10 +277,10 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(recordA, version).right.get.data.language shouldBe Some(
-      Language("Dutch", Some("nl"))
+      Language(label = "Dutch", id = "nl")
     )
     CalmTransformer(recordB, version).right.get.data.language shouldBe Some(
-      Language("Flemish", Some("nl"))
+      Language(label = "Flemish", id = "nl")
     )
   }
 
@@ -485,7 +485,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.language shouldBe Some(
-      Language("Lolol", None))
+      Language(label = "Lolol", id = None))
   }
 
   it("suppresses Archives and Manuscrupts Resource Guide works") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguage.scala
@@ -19,9 +19,6 @@ object SierraLanguage extends SierraDataTransformer {
   //
   def apply(bibData: SierraBibData) =
     bibData.lang.map { lang =>
-      Language(
-        label = lang.name,
-        id = Some(lang.code)
-      )
+      Language(label = lang.name, id = lang.code)
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguageTest.scala
@@ -26,9 +26,6 @@ class SierraLanguageTest
     )
 
     SierraLanguage(bibData) shouldBe Some(
-      Language(
-        id = Some("eng"),
-        label = "English"
-      ))
+      Language(id = "eng", label = "English"))
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -508,10 +508,7 @@ class SierraTransformerTest
          |  }
          |}""".stripMargin
 
-    val expectedLanguage = Language(
-      id = Some("fra"),
-      label = "French"
-    )
+    val expectedLanguage = Language(id = "fra", label = "French")
 
     val work = transformDataToSourceWork(id = id, data = data)
     work.data.language.get shouldBe expectedLanguage


### PR DESCRIPTION
This started because I wanted to add an apply method to Language that didn't require use of Some:

```diff
 case class Language(label: String, id: Option[String] = None)

 object Language {
+  def apply(label: String, id: String): Language =
+    Language(label = label, id = Some(id))
   ...
 }
```

and as I started looking through where I could tidy up uses of the old constructor, I tugged on a couple of other bits.

Other improvements:

* When we compare JSON in the API tests, passing invalid JSON for comparison is an immediate error *and* we log the error and the string you were trying to parse. This makes it easier to debug JSON issues.
* Reduce repetition in the serialisation helpers in the API tests
* Be more explicit about the results we're outputting in the aggregation tests (e.g. no concepts on subjects)