### PR TITLE
Include source workdata otherIdentifiers in image search

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -34,7 +34,8 @@ case object ImagesMultiMatcher {
     val sourceWorkIdFields = Seq(
       "id.canonicalId",
       "id.sourceIdentifier.value",
-      "id.otherIdentifiers.value"
+      "id.otherIdentifiers.value",
+      "data.otherIdentifiers.value"
     )
 
     val idFields = (Seq(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -34,7 +34,6 @@ case object ImagesMultiMatcher {
     val sourceWorkIdFields = Seq(
       "id.canonicalId",
       "id.sourceIdentifier.value",
-      "id.otherIdentifiers.value",
       "data.otherIdentifiers.value"
     )
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -62,6 +62,12 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
           unordered = true) {
           Status.OK -> imagesListResponse(workImages)
         }
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/images?query=${parentWork.data.otherIdentifiers.head.value}",
+          unordered = true) {
+          Status.OK -> imagesListResponse(workImages)
+        }
     }
   }
 


### PR DESCRIPTION
Noticed this when testing digcodes - we weren't correctly searching the source work `otherIdentifiers` in the images query