### PR TITLE
Stop building scaladocs

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -21,6 +21,9 @@ object Common {
       "-Xcheckinit"
     ),
     updateOptions := updateOptions.value.withCachedResolution(true),
-    parallelExecution in Test := false
+    parallelExecution in Test := false,
+    // Don't build scaladocs
+    // https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
+    mappings in (Compile, packageDoc) := Nil
   )
 }


### PR DESCRIPTION
I was impatiently watching a build in CI and noticed that we're building scaladocs for everything, which we probably don't want

https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
https://github.com/sbt/sbt-native-packager/issues/651