### PR TITLE
A Bold And Exciting New Era of Pipeline Creation

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,10 +1,26 @@
-module "catalogue_pipeline_20201111" {
+locals {
+  stacks = {
+    "20201111" = {
+      release_label     = "prod"
+      enable_reindexing = false
+    }
+  }
+}
+
+module "stack" {
   source = "./stack"
 
-  pipeline_date = "20201111"
-  release_label = "prod"
+  for_each = local.stacks
 
-  enable_reindexing = false
+  pipeline_date = each.key
+  release_label = each.value.release_label
+
+  enable_reindexing = each.value.enable_reindexing
+
+  enable_sierra_reindexing = lookup(each.value, "enable_sierra_reindexing", false)
+  enable_miro_reindexing   = lookup(each.value, "enable_miro_reindexing", false)
+  enable_calm_reindexing   = lookup(each.value, "enable_calm_reindexing", false)
+  enable_mets_reindexing   = lookup(each.value, "enable_mets_reindexing", false)
 
   account_id      = data.aws_caller_identity.current.account_id
   aws_region      = local.aws_region

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -4,6 +4,13 @@ locals {
       release_label     = "prod"
       enable_reindexing = false
     }
+
+    # A new pipeline with transformers that include support for multiple languages.
+    # See https://github.com/wellcomecollection/platform/issues/4864
+    "2020-11-12" = {
+      release_label     = "stage"
+      enable_reindexing = true
+    }
   }
 }
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -4,6 +4,8 @@ module "catalogue_pipeline_20201111" {
   pipeline_date = "20201111"
   release_label = "prod"
 
+  enable_reindexing = false
+
   account_id      = data.aws_caller_identity.current.account_id
   aws_region      = local.aws_region
   vpc_id          = local.vpc_id
@@ -13,30 +15,39 @@ module "catalogue_pipeline_20201111" {
   dlq_alarm_arn = local.dlq_alarm_arn
 
   # Transformer config
-  #
-  # If this pipeline is meant to be reindexed, remember to uncomment the
-  # reindexer topic names.
 
-  sierra_adapter_topic_arns = [
-    //    local.sierra_reindexer_topic_arn,
-    local.sierra_merged_bibs_topic_arn,
-    local.sierra_merged_items_topic_arn,
-  ]
+  sierra_adapter_topic_arns = {
+    reindexer_topic = local.sierra_reindexer_topic_arn
 
-  miro_adapter_topic_arns = [
-    //    local.miro_reindexer_topic_arn,
-    local.miro_updates_topic_arn,
-  ]
+    updates_topics = [
+      local.sierra_merged_bibs_topic_arn,
+      local.sierra_merged_items_topic_arn,
+    ]
+  }
 
-  mets_adapter_topic_arns = [
-    //    local.mets_reindexer_topic_arn,
-    local.mets_adapter_topic_arn,
-  ]
+  miro_adapter_topic_arns = {
+    reindexer_topic = local.miro_reindexer_topic_arn
 
-  calm_adapter_topic_arns = [
-    //    local.calm_reindexer_topic_arn,
-    local.calm_adapter_topic_arn,
-  ]
+    updates_topics = [
+      local.miro_updates_topic_arn,
+    ]
+  }
+
+  mets_adapter_topic_arns = {
+    reindexer_topic = local.mets_reindexer_topic_arn
+
+    updates_topics = [
+      local.mets_adapter_topic_arn,
+    ]
+  }
+
+  calm_adapter_topic_arns = {
+    reindexer_topic = local.calm_reindexer_topic_arn
+
+    updates_topics = [
+      local.calm_adapter_topic_arn,
+    ]
+  }
 
   # RDS
   rds_ids_access_security_group_id = local.rds_access_security_group_id

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -38,15 +38,15 @@ module "matcher" {
     vhs_bucket_name   = module.vhs_recorder.bucket_name
     topic_arn         = module.matcher_topic.arn
 
-    dynamo_table            = "${aws_dynamodb_table.matcher_graph_table.id}"
+    dynamo_table            = aws_dynamodb_table.matcher_graph_table.id
     dynamo_index            = "work-sets-index"
-    dynamo_lock_table       = "${aws_dynamodb_table.matcher_lock_table.id}"
+    dynamo_lock_table       = aws_dynamodb_table.matcher_lock_table.id
     dynamo_lock_table_index = "context-ids-index"
 
     dynamo_lock_timeout = local.lock_timeout
 
-    vhs_recorder_dynamo_table_name = "${module.vhs_recorder.table_name}"
-    vhs_recorder_bucket_name       = "${module.vhs_recorder.bucket_name}"
+    vhs_recorder_dynamo_table_name = module.vhs_recorder.table_name
+    vhs_recorder_bucket_name       = module.vhs_recorder.bucket_name
   }
 
   secret_env_vars = {}

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -1,7 +1,7 @@
 module "calm_transformer_queue" {
   source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name      = "${local.namespace_hyphen}_calm_transformer"
-  topic_arns      = var.calm_adapter_topic_arns
+  topic_arns      = local.calm_topics
   alarm_topic_arn = var.dlq_alarm_arn
   aws_region      = var.aws_region
 }

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -1,7 +1,7 @@
 module "mets_transformer_queue" {
   source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name      = "${local.namespace_hyphen}_mets_transformer"
-  topic_arns      = var.mets_adapter_topic_arns
+  topic_arns      = local.mets_topics
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 }

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -1,7 +1,7 @@
 module "miro_transformer_queue" {
   source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name      = "${local.namespace_hyphen}_miro_transformer"
-  topic_arns      = var.miro_adapter_topic_arns
+  topic_arns      = local.miro_topics
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 }

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -1,7 +1,7 @@
 module "sierra_transformer_queue" {
   source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name      = "${local.namespace_hyphen}_sierra_transformer"
-  topic_arns      = var.sierra_adapter_topic_arns
+  topic_arns      = local.sierra_topics
   alarm_topic_arn = var.dlq_alarm_arn
   aws_region      = var.aws_region
 }

--- a/pipeline/terraform/stack/topics.tf
+++ b/pipeline/terraform/stack/topics.tf
@@ -1,0 +1,30 @@
+locals {
+  enable_sierra_reindexing = var.enable_reindexing || var.enable_sierra_reindexing
+  enable_miro_reindexing   = var.enable_reindexing || var.enable_miro_reindexing
+  enable_calm_reindexing   = var.enable_reindexing || var.enable_calm_reindexing
+  enable_mets_reindexing   = var.enable_reindexing || var.enable_mets_reindexing
+
+  sierra_topics = (
+    local.enable_sierra_reindexing
+    ? concat(var.sierra_adapter_topic_arns["updates_topics"], [var.sierra_adapter_topic_arns["reindexer_topic"]])
+    : concat(var.sierra_adapter_topic_arns["updates_topics"], [])
+  )
+
+  miro_topics = (
+    local.enable_miro_reindexing
+    ? concat(var.miro_adapter_topic_arns["updates_topics"], [var.miro_adapter_topic_arns["reindexer_topic"]])
+    : concat(var.miro_adapter_topic_arns["updates_topics"], [])
+  )
+
+  calm_topics = (
+    local.enable_calm_reindexing
+    ? concat(var.calm_adapter_topic_arns["updates_topics"], [var.calm_adapter_topic_arns["reindexer_topic"]])
+    : concat(var.calm_adapter_topic_arns["updates_topics"], [])
+  )
+
+  mets_topics = (
+    local.enable_mets_reindexing
+    ? concat(var.mets_adapter_topic_arns["updates_topics"], [var.mets_adapter_topic_arns["reindexer_topic"]])
+    : concat(var.mets_adapter_topic_arns["updates_topics"], [])
+  )
+}

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -24,18 +24,31 @@ variable "release_label" {
   }
 }
 
+variable "enable_reindexing" {
+  type = bool
+}
+
 # Miro
 variable "miro_adapter_topic_arns" {
-  type = list(string)
+  type = object({reindexer_topic=string, updates_topics=list(string)})
 }
 variable "vhs_miro_read_policy" {}
+variable "enable_miro_reindexing" {
+  type    = bool
+  default = false
+}
 
 # Sierra
 variable "vhs_sierra_read_policy" {}
 variable "vhs_sierra_sourcedata_bucket_name" {}
 variable "vhs_sierra_sourcedata_table_name" {}
 variable "sierra_adapter_topic_arns" {
-  type = list(string)
+  type = object({reindexer_topic=string, updates_topics=list(string)})
+}
+
+variable "enable_sierra_reindexing" {
+  type    = bool
+  default = false
 }
 
 # Calm
@@ -43,14 +56,24 @@ variable "vhs_calm_read_policy" {}
 variable "vhs_calm_sourcedata_bucket_name" {}
 variable "vhs_calm_sourcedata_table_name" {}
 variable "calm_adapter_topic_arns" {
-  type = list(string)
+  type = object({reindexer_topic=string, updates_topics=list(string)})
+}
+
+variable "enable_calm_reindexing" {
+  type    = bool
+  default = false
 }
 
 # Mets
 variable "mets_adapter_read_policy" {}
 variable "mets_adapter_table_name" {}
 variable "mets_adapter_topic_arns" {
-  type = list(string)
+  type = object({reindexer_topic=string, updates_topics=list(string)})
+}
+
+variable "enable_mets_reindexing" {
+  type    = bool
+  default = false
 }
 
 variable "private_subnets" {

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -30,7 +30,7 @@ variable "enable_reindexing" {
 
 # Miro
 variable "miro_adapter_topic_arns" {
-  type = object({reindexer_topic=string, updates_topics=list(string)})
+  type = object({ reindexer_topic = string, updates_topics = list(string) })
 }
 variable "vhs_miro_read_policy" {}
 variable "enable_miro_reindexing" {
@@ -43,7 +43,7 @@ variable "vhs_sierra_read_policy" {}
 variable "vhs_sierra_sourcedata_bucket_name" {}
 variable "vhs_sierra_sourcedata_table_name" {}
 variable "sierra_adapter_topic_arns" {
-  type = object({reindexer_topic=string, updates_topics=list(string)})
+  type = object({ reindexer_topic = string, updates_topics = list(string) })
 }
 
 variable "enable_sierra_reindexing" {
@@ -56,7 +56,7 @@ variable "vhs_calm_read_policy" {}
 variable "vhs_calm_sourcedata_bucket_name" {}
 variable "vhs_calm_sourcedata_table_name" {}
 variable "calm_adapter_topic_arns" {
-  type = object({reindexer_topic=string, updates_topics=list(string)})
+  type = object({ reindexer_topic = string, updates_topics = list(string) })
 }
 
 variable "enable_calm_reindexing" {
@@ -68,7 +68,7 @@ variable "enable_calm_reindexing" {
 variable "mets_adapter_read_policy" {}
 variable "mets_adapter_table_name" {}
 variable "mets_adapter_topic_arns" {
-  type = object({reindexer_topic=string, updates_topics=list(string)})
+  type = object({ reindexer_topic = string, updates_topics = list(string) })
 }
 
 variable "enable_mets_reindexing" {


### PR DESCRIPTION
I was going to add a new pipeline for https://github.com/wellcomecollection/platform/issues/4864, and it felt like a process with a few rough edges. This patch tries to make the process of creating pipelines a bit smoother:

* I wrote a script to expire objects in the old recorder buckets, so the "terraform plan" output isn't so noisy. See https://github.com/wellcomecollection/catalogue/pull/1046

* Remembering to comment/uncomment individual reindexer topics is clunky and non-obvious. Now, the module gets a structured collection of topics that never changes, and has five new boolean flags to control the behaviour:

   - `enable_reindexing`
   - `enable_miro_reindexing`
   - `enable_sierra_reindexing`
   - `enable_mets_reindexing`
   - `enable_calm_reindexing`

   The module uses these variables to decide whether to include the reindexer topic. This is more explicit at the top level, so we can see what's going on.

   Setting `true` on an individual source overrides the global setting, e.g. you can enable Miro-only reindexing with

    ```hcl
    enable_reindexing      = false
    enable_miro_reindexing = true
    ```

* Copying large blocks of Terraform around to create/destroy stacks is clunky. I can't see two pipelines on my screen at once. Eww!

    I've switched us to using the support for [multiple instances of a module](https://www.terraform.io/docs/configuration/modules.html#multiple-instances-of-a-module) that was added in Terraform 0.13. This substantially reduces the amount of copy/paste we'll need to do when creating new pipelines, and gives you a much better "at a glance" view of the pipelines we have.