### PR TITLE
Store a fast lookup of MARC tag -> varFields in the Sierra transformer (aka go faster)

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -28,17 +28,17 @@ case class SierraBibData(
   // through all the varFields to find it.  We record the original position
   // so we can recombine varFields with multiple tags in their original order.
   lazy val varFieldIndex: Map[String, List[(Int, VarField)]] =
-    varFields
-      .zipWithIndex
+    varFields.zipWithIndex
       .collect {
         case (vf @ VarField(_, Some(marcTag), _, _, _, _), position) =>
           (marcTag, position, vf)
       }
       .groupBy { case (marcTag, _, _) => marcTag }
-      .map { case (marcTag, varFieldsWithPosition) =>
-        marcTag ->
-          varFieldsWithPosition
-            .map { case (_, position, vf) => (position, vf) }
+      .map {
+        case (marcTag, varFieldsWithPosition) =>
+          marcTag ->
+            varFieldsWithPosition
+              .map { case (_, position, vf) => (position, vf) }
       }
 }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -27,7 +27,7 @@ case class SierraBibData(
   // It's more efficient to cache this lookup once, than repeatedly loop
   // through all the varFields to find it.  We record the original position
   // so we can recombine varFields with multiple tags in their original order.
-  val varFieldIndex: Map[String, List[(Int, VarField)]] =
+  lazy val varFieldIndex: Map[String, List[(Int, VarField)]] =
     varFields
       .zipWithIndex
       .collect {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
@@ -12,7 +12,9 @@ trait SierraQueryOps {
     // VarFields are returned in the same order as in the original bib.
     def varfieldsWithTags(tags: String*): List[VarField] =
       tags
-        .flatMap { t => bibData.varFieldIndex.get(t) }
+        .flatMap { t =>
+          bibData.varFieldIndex.get(t)
+        }
         .flatten
         .sortBy { case (position, _) => position }
         .collect { case (_, vf) => vf }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
@@ -2,10 +2,11 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
-  SierraBibData
+  SierraBibData,
+  SierraQueryOps
 }
 
-object SierraDescription extends SierraDataTransformer {
+object SierraDescription extends SierraDataTransformer with SierraQueryOps {
 
   type Output = Option[String]
 
@@ -48,17 +49,13 @@ object SierraDescription extends SierraDataTransformer {
     bibData: SierraBibData,
     marcTag: String,
     marcSubfieldTags: List[String]
-  ): List[Map[String, MarcSubfield]] = {
-    val matchingFields = bibData.varFields
-      .filter {
-        _.marcTag.contains(marcTag)
-      }
-
-    matchingFields.map(varField => {
-      varField.subfields
-        .filter(subfield => marcSubfieldTags.contains(subfield.tag))
-        .map(subfield => subfield.tag -> subfield)
-        .toMap
-    })
-  }
+  ): List[Map[String, MarcSubfield]] =
+    bibData
+      .varfieldsWithTag(marcTag)
+      .map(varField => {
+        varField.subfields
+          .filter(subfield => marcSubfieldTags.contains(subfield.tag))
+          .map(subfield => subfield.tag -> subfield)
+          .toMap
+      })
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
@@ -2,10 +2,13 @@ package uk.ac.wellcome.platform.transformer.sierra.source
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 
 class SierraQueryOpsTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with MarcGenerators
     with SierraDataGenerators

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.transformer.sierra.source
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+
+class SierraQueryOpsTest
+  extends AnyFunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators
+    with SierraQueryOps {
+
+  it("finds the varfields with given tags") {
+    val varFields = List(
+      createVarFieldWith(marcTag = "0", content = Some("Field 0A")),
+      createVarFieldWith(marcTag = "1", content = Some("Field 1")),
+      createVarFieldWith(marcTag = "0", content = Some("Field 0B")),
+    )
+
+    val bibData = createSierraBibDataWith(varFields = varFields)
+
+    bibData.varfieldsWithTag("0") shouldBe List(varFields(0), varFields(2))
+    bibData.varfieldsWithTag("1") shouldBe List(varFields(1))
+
+    bibData.varfieldsWithTags("0") shouldBe List(varFields(0), varFields(2))
+    bibData.varfieldsWithTags("1") shouldBe List(varFields(1))
+    bibData.varfieldsWithTags("0", "1") shouldBe varFields
+    bibData.varfieldsWithTags("1", "0") shouldBe varFields
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitlesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitlesTest.scala
@@ -42,8 +42,8 @@ class SierraAlternativeTitlesTest
   it("should extract all alternative titles when multiple fields defined") {
     val varFields = List(field130, field240, field246)
     getAlternativeTitles(varFields) shouldBe List(
-      "Apples",
       "Bananas",
+      "Apples",
       "Cherries")
   }
 


### PR DESCRIPTION
I was glancing at my reindex stats, and realised the Sierra transformer is a bit of a bottleneck. Partly because it has an order of magnitude more messages to chew through than anything else, but then I also realised that it's quite inefficient.

**The problem:** The Sierra bib data has a list of varfields, and different parts of the transformer loop through them to find varfields with a given MARC tag. This is a slow *O(N)* operation. By my count, we loop through all the varfields **62 times** to transform each Sierra record – and every transformation adds another iteration of this slow loop.

I don't know how many varfields a typical Sierra bib has, but anything more than a few and this loop is going to slow us down.

**The solution:** We store a map from (MARC tag) -> (matching varfields). This means that we run the loop once to build the map, and subsequent lookups of all the varfields with a given MARC tag is now an *O(1)* operation.

I don't have any profiling to back this up, but this seems like pretty low-hanging fruit that can only help.

As a bonus, if you aggregate over multiple MARC tags with SierraQueryOps, you now get them in the original order.

```
Bib: VF(3), VF(1), VF(2)

Before: varfieldsWithTags(1, 2, 3) => VF(1), VF(2), VF(3)
After:  varfieldsWithTags(1, 2, 3) => VF(3), VF(1), VF(2)
```

I don't know that it makes a huge difference, but it's nice to have and reduces the amount of transformation implementation that leaks into the pipeline.