### PR TITLE
A slightly more pragmatic approach to spinning up new pipelines

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -30,6 +30,8 @@ locals {
       ]
     }
 
+    # A new pipeline with transformers that include support for multiple languages.
+    # See https://github.com/wellcomecollection/platform/issues/4864
     "2020-11-12" = {
       release_label = "stage"
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,34 +1,79 @@
-module "catalogue_pipeline_20201111" {
+locals {
+  stacks = {
+    "20201111" = {
+      release_label = "prod"
+
+      # Transformer config
+      #
+      # If this pipeline is meant to be reindexed, remember to uncomment the
+      # reindexer topic names.
+
+      sierra_adapter_topic_arns = [
+        //    local.sierra_reindexer_topic_arn,
+        local.sierra_merged_bibs_topic_arn,
+        local.sierra_merged_items_topic_arn,
+      ]
+
+      miro_adapter_topic_arns = [
+        //    local.miro_reindexer_topic_arn,
+        local.miro_updates_topic_arn,
+      ]
+
+      mets_adapter_topic_arns = [
+        //    local.mets_reindexer_topic_arn,
+        local.mets_adapter_topic_arn,
+      ]
+
+      calm_adapter_topic_arns = [
+        //    local.calm_reindexer_topic_arn,
+        local.calm_adapter_topic_arn,
+      ]
+    }
+
+    "2020-11-12" = {
+      release_label = "stage"
+
+      # Transformer config
+      #
+      # If this pipeline is meant to be reindexed, remember to uncomment the
+      # reindexer topic names.
+
+      sierra_adapter_topic_arns = [
+        local.sierra_reindexer_topic_arn,
+        local.sierra_merged_bibs_topic_arn,
+        local.sierra_merged_items_topic_arn,
+      ]
+
+      miro_adapter_topic_arns = [
+        local.miro_reindexer_topic_arn,
+        local.miro_updates_topic_arn,
+      ]
+
+      mets_adapter_topic_arns = [
+        local.mets_reindexer_topic_arn,
+        local.mets_adapter_topic_arn,
+      ]
+
+      calm_adapter_topic_arns = [
+        local.calm_reindexer_topic_arn,
+        local.calm_adapter_topic_arn,
+      ]
+    }
+  }
+}
+
+module "stack" {
   source = "./stack"
 
-  pipeline_date = "20201111"
-  release_label = "prod"
+  for_each = local.stacks
 
-  # Transformer config
-  #
-  # If this pipeline is meant to be reindexed, remember to uncomment the
-  # reindexer topic names.
+  pipeline_date = each.key
+  release_label = each.value.release_label
 
-  sierra_adapter_topic_arns = [
-    //    local.sierra_reindexer_topic_arn,
-    local.sierra_merged_bibs_topic_arn,
-    local.sierra_merged_items_topic_arn,
-  ]
-
-  miro_adapter_topic_arns = [
-    //    local.miro_reindexer_topic_arn,
-    local.miro_updates_topic_arn,
-  ]
-
-  mets_adapter_topic_arns = [
-    //    local.mets_reindexer_topic_arn,
-    local.mets_adapter_topic_arn,
-  ]
-
-  calm_adapter_topic_arns = [
-    //    local.calm_reindexer_topic_arn,
-    local.calm_adapter_topic_arn,
-  ]
+  sierra_adapter_topic_arns = each.value.sierra_adapter_topic_arns
+  miro_adapter_topic_arns   = each.value.miro_adapter_topic_arns
+  mets_adapter_topic_arns   = each.value.mets_adapter_topic_arns
+  calm_adapter_topic_arns   = each.value.calm_adapter_topic_arns
 
   # Boilerplate that shouldn't change between pipelines.
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -4,14 +4,6 @@ module "catalogue_pipeline_20201111" {
   pipeline_date = "20201111"
   release_label = "prod"
 
-  account_id      = data.aws_caller_identity.current.account_id
-  aws_region      = local.aws_region
-  vpc_id          = local.vpc_id
-  subnets         = local.private_subnets
-  private_subnets = local.private_subnets
-
-  dlq_alarm_arn = local.dlq_alarm_arn
-
   # Transformer config
   #
   # If this pipeline is meant to be reindexed, remember to uncomment the
@@ -37,6 +29,16 @@ module "catalogue_pipeline_20201111" {
     //    local.calm_reindexer_topic_arn,
     local.calm_adapter_topic_arn,
   ]
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  account_id      = data.aws_caller_identity.current.account_id
+  aws_region      = local.aws_region
+  vpc_id          = local.vpc_id
+  subnets         = local.private_subnets
+  private_subnets = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
 
   # RDS
   rds_ids_access_security_group_id = local.rds_access_security_group_id

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -38,15 +38,15 @@ module "matcher" {
     vhs_bucket_name   = module.vhs_recorder.bucket_name
     topic_arn         = module.matcher_topic.arn
 
-    dynamo_table            = "${aws_dynamodb_table.matcher_graph_table.id}"
+    dynamo_table            = aws_dynamodb_table.matcher_graph_table.id
     dynamo_index            = "work-sets-index"
-    dynamo_lock_table       = "${aws_dynamodb_table.matcher_lock_table.id}"
+    dynamo_lock_table       = aws_dynamodb_table.matcher_lock_table.id
     dynamo_lock_table_index = "context-ids-index"
 
     dynamo_lock_timeout = local.lock_timeout
 
-    vhs_recorder_dynamo_table_name = "${module.vhs_recorder.table_name}"
-    vhs_recorder_bucket_name       = "${module.vhs_recorder.bucket_name}"
+    vhs_recorder_dynamo_table_name = module.vhs_recorder.table_name
+    vhs_recorder_bucket_name       = module.vhs_recorder.bucket_name
   }
 
   secret_env_vars = {}


### PR DESCRIPTION
This takes the dynamism of #1047, and tamps it down a bit.

In particular, you can still add/remove individual topics rather than navigate a stack of boolean variables – but all the HCL you copy to spin up/down a new stack is “interesting” and something you might want to edit.

The idea is to give more prominence to the topics, so you'll notice they're waiting for you to edit them.

Fun fact: apparently there's a bug somewhere in #1047, because when I ran this it told me it wanted to add some reindexer topic subscriptions… which should have been enabled by the previous patch. 🤦‍♀️ 

The most conservative form of this is https://github.com/wellcomecollection/catalogue/commit/b8db0174b4e2523a29ebee8aaaa65151a7365fcd, which just consolidates the boilerplate at the bottom of the module definition.