### PR TITLE
Use more hashed lookups, less looping over lists

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Format.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Format.scala
@@ -30,7 +30,9 @@ object Format extends Enum[Format] {
     }
 
   private lazy val formatIdIndex: Map[String, Format] = {
-    val idPairs = values.map { format => format.id -> format }
+    val idPairs = values.map { format =>
+      format.id -> format
+    }
 
     // Check we don't have any duplicate IDs
     assert(idPairs.toMap.size == idPairs.size)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Format.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Format.scala
@@ -29,9 +29,17 @@ object Format extends Enum[Format] {
       maybeFormat.toRight(s"Invalid Format json $json")
     }
 
-  def fromCode(id: String): Option[Format] = {
-    values.find(format => format.id == id)
+  private lazy val formatIdIndex: Map[String, Format] = {
+    val idPairs = values.map { format => format.id -> format }
+
+    // Check we don't have any duplicate IDs
+    assert(idPairs.toMap.size == idPairs.size)
+
+    idPairs.toMap
   }
+
+  def fromCode(id: String): Option[Format] =
+    formatIdIndex.get(id)
 
   sealed trait Unlinked extends Format
   sealed trait Linked extends Format {

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -30,7 +30,9 @@ object License extends Enum[License] {
   }
 
   private val licenseIdIndex = {
-    val idPairs = values.map { license => license.id -> license }
+    val idPairs = values.map { license =>
+      license.id -> license
+    }
 
     // Check we don't have any duplicate IDs
     assert(idPairs.toMap.size == idPairs.size)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -29,8 +29,17 @@ object License extends Enum[License] {
       }
   }
 
+  private val licenseIdIndex = {
+    val idPairs = values.map { license => license.id -> license }
+
+    // Check we don't have any duplicate IDs
+    assert(idPairs.toMap.size == idPairs.size)
+
+    idPairs.toMap
+  }
+
   def createLicense(id: String): License =
-    values.find(l => l.id == id) match {
+    licenseIdIndex.get(id) match {
       case Some(license) => license
       case _             => throw new Exception(s"$id is not a valid license id")
     }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationType.scala
@@ -40,7 +40,7 @@ case object LocationType {
 
   def apply(id: String): LocationType = {
     locationTypeMap.get(id) match {
-      case Some(id) => id
+      case Some(locType) => locType
       case None =>
         throw new IllegalArgumentException(s"Unrecognised location type: [$id]")
     }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/FormatTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/FormatTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.work.internal.Format.CDRoms
 
 class FormatTest
     extends AnyFunSpec
@@ -24,6 +25,10 @@ class FormatTest
         fromJson[Format](formatJson(format.id, format.label)).get
       parsedConcept shouldBe format
     }
+  }
+
+  it("finds a format by code") {
+    Format.fromCode("m") shouldBe Some(CDRoms)
   }
 
   def formatJson(id: String, label: String) =


### PR DESCRIPTION
Following the same principle as https://github.com/wellcomecollection/catalogue/pull/1048

Hasn't made a noticeable impact on performance, but it's low-hanging fruit so we might as well.