### PR TITLE
Bump the API index to 2020-11-12

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "20201111"
+  val indexDate = "2020-11-12"
 
   def apply(): ElasticConfig =
     ElasticConfig(


### PR DESCRIPTION
The API code in master looks up language aggregations by code, but the data in the index is using the old, 2-character language codes. If you aggregate over language against the current prod index, it will break.

😢 

This updates the API to point to an index that uses the same language codes as it does.