### PR TITLE
Top level availableOnline on works

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -34,6 +34,7 @@ trait ApiWorksTestBase
       |   "type": "${formatOntologyType(work.data.workType)}",
       |   "id": "${work.state.canonicalId}",
       |   "title": "${work.data.title.get}",
+      |   "availableOnline": ${hasDigitalLocations(work)},
       |   "alternativeTitles": []
       |   ${optionalObject("workType", format, work.data.format)}
       |   ${optionalObject("language", language, work.data.language)}
@@ -58,4 +59,9 @@ trait ApiWorksTestBase
       case WorkType.Series     => "Series"
       case WorkType.Section    => "Section"
     }
+
+  def hasDigitalLocations(work: Work.Visible[Identified]): String =
+    work.data.items
+      .exists(_.locations.exists(_.isInstanceOf[DigitalLocationDeprecated]))
+      .toString
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -40,6 +40,7 @@ class WorksIncludesTest
                    "id": "${work0.state.canonicalId}",
                    "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "identifiers": [
                      ${identifier(work0.sourceIdentifier)},
                      ${identifier(otherIdentifier0)}
@@ -50,6 +51,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "identifiers": [
                      ${identifier(work1.sourceIdentifier)},
                      ${identifier(otherIdentifier1)}
@@ -79,6 +81,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "identifiers": [
                   ${identifier(work.sourceIdentifier)},
                   ${identifier(otherIdentifier)}
@@ -111,6 +114,7 @@ class WorksIncludesTest
               "id": "${work.state.canonicalId}",
               "title": "${work.data.title.get}",
               "alternativeTitles": [],
+              "availableOnline": true,
               "items": [ ${items(work.data.items)} ]
             }
           """
@@ -140,6 +144,7 @@ class WorksIncludesTest
                    "id": "${work0.state.canonicalId}",
                    "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "subjects": [ ${subjects(subjects0)}]
                  },
                  {
@@ -147,6 +152,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "subjects": [ ${subjects(subjects1)}]
                  }
                 ]
@@ -173,6 +179,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "subjects": [ ${subjects(work.data.subjects)}]
               }
             """
@@ -203,6 +210,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "genres": [ ${genres(genres1)}]
                  },
                  {
@@ -210,6 +218,7 @@ class WorksIncludesTest
                    "id": "${work2.state.canonicalId}",
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "genres": [ ${genres(genres2)}]
                  }
                 ]
@@ -237,6 +246,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "genres": [ ${genres(work.data.genres)}]
               }
             """
@@ -271,6 +281,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "contributors": [ ${contributors(contributors1)}]
                  },
                  {
@@ -278,6 +289,7 @@ class WorksIncludesTest
                    "id": "${work2.state.canonicalId}",
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "contributors": [ ${contributors(contributors2)}]
                  }
                 ]
@@ -306,6 +318,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "contributors": [ ${contributors(work.data.contributors)}]
               }
             """
@@ -338,6 +351,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "production": [ ${production(productionEvents1)}]
                  },
                  {
@@ -345,6 +359,7 @@ class WorksIncludesTest
                    "id": "${work2.state.canonicalId}",
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "production": [ ${production(productionEvents2)}]
                  }
                 ]
@@ -371,6 +386,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "production": [ ${production(work.data.production)}]
               }
             """
@@ -403,6 +419,7 @@ class WorksIncludesTest
                    "id": "${work1.state.canonicalId}",
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "languages": [ ${languages(work1.data.languages)}]
                  },
                  {
@@ -410,6 +427,7 @@ class WorksIncludesTest
                    "id": "${work2.state.canonicalId}",
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
+                   "availableOnline": false,
                    "languages": [ ${languages(work2.data.languages)}]
                  }
                 ]
@@ -439,6 +457,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "languages": [ ${languages(work.data.languages)}]
               }
             """
@@ -467,6 +486,7 @@ class WorksIncludesTest
                      "id": "${work1.state.canonicalId}",
                      "title": "${work1.data.title.get}",
                      "alternativeTitles": [],
+                     "availableOnline": false,
                      "notes": [
                        {
                          "noteType": {
@@ -493,6 +513,7 @@ class WorksIncludesTest
                      "id": "${work2.state.canonicalId}",
                      "title": "${work2.data.title.get}",
                      "alternativeTitles": [],
+                     "availableOnline": false,
                      "notes": [
                        {
                          "noteType": {
@@ -527,6 +548,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "notes": [
                    {
                      "noteType": {
@@ -571,6 +593,7 @@ class WorksIncludesTest
                     "id": "${works.head.state.canonicalId}",
                     "title": "${works.head.data.title.get}",
                     "alternativeTitles": [],
+                    "availableOnline": false,
                     "images": [${workImageIncludes(works.head.data.images)}]
                   },
                   {
@@ -578,6 +601,7 @@ class WorksIncludesTest
                     "id": "${works(1).state.canonicalId}",
                     "title": "${works(1).data.title.get}",
                     "alternativeTitles": [],
+                    "availableOnline": false,
                     "images": [${workImageIncludes(works(1).data.images)}]
                   }
                 ]
@@ -606,6 +630,7 @@ class WorksIncludesTest
                 "id": "${work.state.canonicalId}",
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "images": [${workImageIncludes(images)}]
               }
             """
@@ -646,10 +671,12 @@ class WorksIncludesTest
               "id": "${workC.state.canonicalId}",
               "title": "0/a/c",
               "alternativeTitles": [],
+              "availableOnline": false,
               "parts": [{
                 "id": "${workE.state.canonicalId}",
                 "title": "0/a/c/e",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "type": "Work"
               }]
             }
@@ -671,16 +698,19 @@ class WorksIncludesTest
               "id": "${workC.state.canonicalId}",
               "title": "0/a/c",
               "alternativeTitles": [],
+              "availableOnline": false,
               "partOf": [
                 {
                   "id": "${workA.state.canonicalId}",
                   "title": "0/a",
                   "alternativeTitles": [],
+                  "availableOnline": false,
                   "type": "Section",
                   "partOf": [{
                     "id": "${work0.state.canonicalId}",
                     "title": "0",
                     "alternativeTitles": [],
+                    "availableOnline": false,
                     "type": "Collection",
                     "partOf": []
                   }
@@ -705,10 +735,12 @@ class WorksIncludesTest
               "id": "${workC.state.canonicalId}",
               "title": "0/a/c",
               "alternativeTitles": [],
+              "availableOnline": false,
               "precededBy": [{
                 "id": "${workB.state.canonicalId}",
                 "title": "0/a/b",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "type": "Work"
               }]
             }
@@ -730,10 +762,12 @@ class WorksIncludesTest
               "id": "${workC.state.canonicalId}",
               "title": "0/a/c",
               "alternativeTitles": [],
+              "availableOnline": false,
               "succeededBy": [{
                 "id": "${workD.state.canonicalId}",
                 "title": "0/a/d",
                 "alternativeTitles": [],
+                "availableOnline": false,
                 "type": "Work"
               }]
             }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -84,7 +84,7 @@ case class DisplayWork(
     description = "List of items related to this work."
   ) items: Option[List[DisplayItem]] = None,
   @Schema(
-    description = "Whether the work contains an item with a digital location",
+    description = "Whether the work contains an item which is available online",
     `type` = "Boolean"
   ) availableOnline: Boolean = false,
   @Schema(

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTestDeprecated.scala
@@ -31,7 +31,8 @@ class DisplayLocationsSerialisationTestDeprecated
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ${items(work.data.items)} ]
+      | "items": [ ${items(work.data.items)} ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -54,7 +55,8 @@ class DisplayLocationsSerialisationTestDeprecated
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ${items(work.data.items)} ]
+      | "items": [ ${items(work.data.items)} ],
+      | "availableOnline": true
       |}
     """.stripMargin
 
@@ -78,7 +80,8 @@ class DisplayLocationsSerialisationTestDeprecated
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ${items(work.data.items)} ]
+      | "items": [ ${items(work.data.items)} ],
+      | "availableOnline": true
       |}
     """.stripMargin
 
@@ -108,7 +111,8 @@ class DisplayLocationsSerialisationTestDeprecated
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ${items(work.data.items)} ]
+      | "items": [ ${items(work.data.items)} ],
+      | "availableOnline": true
       |}
     """.stripMargin
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -37,7 +37,8 @@ class DisplayWorkSerialisationTest
       | "workType" : ${format(work.data.format.get)},
       | "lettering": "${work.data.lettering.get}",
       | "alternativeTitles": [],
-      | "createdDate": ${period(work.data.createdDate.get)}
+      | "createdDate": ${period(work.data.createdDate.get)},
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -54,7 +55,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ${items(work.data.items)} ]
+      | "items": [ ${items(work.data.items)} ],
+      | "availableOnline": true
       |}
     """.stripMargin
 
@@ -73,7 +75,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "items": [ ]
+      | "items": [ ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -114,7 +117,8 @@ class DisplayWorkSerialisationTest
       |       }
       |     ]
       |   }
-      | ]
+      | ],
+      | "availableOnline": true
       |}
     """.stripMargin
 
@@ -139,7 +143,8 @@ class DisplayWorkSerialisationTest
       | "id": "${workWithSubjects.state.canonicalId}",
       | "title": "${workWithSubjects.data.title.get}",
       | "alternativeTitles": [],
-      | "subjects": [${subjects(workWithSubjects.data.subjects)}]
+      | "subjects": [${subjects(workWithSubjects.data.subjects)}],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -164,7 +169,8 @@ class DisplayWorkSerialisationTest
       | "id": "${workWithProduction.state.canonicalId}",
       | "title": "${workWithProduction.data.title.get}",
       | "alternativeTitles": [],
-      | "production": [${production(workWithProduction.data.production)}]
+      | "production": [${production(workWithProduction.data.production)}],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -200,7 +206,8 @@ class DisplayWorkSerialisationTest
       | "workType" : ${format(work.data.format.get)},
       | "lettering": "${work.data.lettering.get}",
       | "createdDate": ${period(work.data.createdDate.get)},
-      | "contributors": [${contributor(work.data.contributors.head)}]
+      | "contributors": [${contributor(work.data.contributors.head)}],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -227,7 +234,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "genres": [ ${genres(work.data.genres)} ]
+      | "genres": [ ${genres(work.data.genres)} ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -268,7 +276,8 @@ class DisplayWorkSerialisationTest
       |     "contents": ["B"],
       |     "type": "Note"
       |   }
-      | ]
+      | ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -291,7 +300,8 @@ class DisplayWorkSerialisationTest
       | "identifiers": [
       |   ${identifier(work.sourceIdentifier)},
       |   ${identifier(otherIdentifier)}
-      | ]
+      | ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -310,7 +320,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "identifiers": [ ${identifier(work.sourceIdentifier)} ]
+      | "identifiers": [ ${identifier(work.sourceIdentifier)} ],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -331,7 +342,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "images": [${workImageIncludes(work.data.images)}]
+      | "images": [${workImageIncludes(work.data.images)}],
+      | "availableOnline": false
       |}
     """.stripMargin
 
@@ -356,7 +368,8 @@ class DisplayWorkSerialisationTest
       | "id": "${work.state.canonicalId}",
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
-      | "thumbnail": ${location(work.data.thumbnail.get)}
+      | "thumbnail": ${location(work.data.thumbnail.get)},
+      | "availableOnline": false
       |}
     """.stripMargin
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -79,6 +79,7 @@ class SnapshotGeneratorFeatureTest
               |  "production": [ ],
               |  "languages": [ ],
               |  "alternativeTitles": [ ],
+              |  "availableOnline": false,
               |  "notes": [ ],
               |  "images": [ ],
               |  "type": "Work"


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/catalogue/issues/1052, and is a prerequisite for https://github.com/wellcomecollection/wellcomecollection.org/issues/5741

`availableOnline` is a boolean indicating whether any of the work's items have a digital location, therefore matching the availability filtering.

One question is - would we want this behind an `include` rather than being always present? Both for neatness and/or because we might not want to search the locations for every result.