### PR TITLE
Router fixes

### DIFF
--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
@@ -39,7 +39,6 @@ object Main extends WellcomeTypesafeApp {
           namespace = "path-sender",
           subject = "Sent from the router"),
       workRetriever = new ElasticRetriever(esClient, mergedIndex),
-
       workIndexer = new ElasticIndexer(
         esClient,
         denormalisedIndex,

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
@@ -3,11 +3,12 @@ package uk.ac.wellcome.platform.router
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
+import uk.ac.wellcome.elasticsearch.DenormalisedWorkIndexConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.pipeline_storage.ElasticRetriever
+import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -24,6 +25,7 @@ object Main extends WellcomeTypesafeApp {
     val esClient = ElasticBuilder.buildElasticClient(config)
     val mergedIndex = Index(config.requireString("es.merged_index"))
 
+    val denormalisedIndex = Index(config.requireString("es.denormalised_index"))
     new RouterWorkerService(
       sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       worksMsgSender = SNSBuilder
@@ -36,7 +38,12 @@ object Main extends WellcomeTypesafeApp {
           config,
           namespace = "path-sender",
           subject = "Sent from the router"),
-      workRetriever = new ElasticRetriever(esClient, mergedIndex)
+      workRetriever = new ElasticRetriever(esClient, mergedIndex),
+
+      workIndexer = new ElasticIndexer(
+        esClient,
+        denormalisedIndex,
+        DenormalisedWorkIndexConfig)
     )
   }
 }

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
@@ -29,12 +29,14 @@ class RouterWorkerService[MsgDestination](
       work.data.collectionPath
         .fold(ifEmpty = {
           for {
-           worksEither <- workIndexer.index(work.transition[Denormalised] (Relations.none))
-           _ <- worksEither match {
-             case Left(failedWorks) => Future.failed(new Exception(s"Failed indexing $failedWorks"))
-             case Right(_) => Future.successful(())
-           }
-            _ <-Future.fromTry(worksMsgSender.send(work.id))
+            worksEither <- workIndexer.index(
+              work.transition[Denormalised](Relations.none))
+            _ <- worksEither match {
+              case Left(failedWorks) =>
+                Future.failed(new Exception(s"Failed indexing $failedWorks"))
+              case Right(_) => Future.successful(())
+            }
+            _ <- Future.fromTry(worksMsgSender.send(work.id))
           } yield ()
         }) { path =>
           Future.fromTry(pathsMsgSender.send(path.path))

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
@@ -34,10 +34,10 @@ class RouterWorkerService[MsgDestination](
              case Left(failedWorks) => Future.failed(new Exception(s"Failed indexing $failedWorks"))
              case Right(_) => Future.successful(())
            }
-            _ <-Future.fromTry(worksMsgSender.sendT(work.id))
+            _ <-Future.fromTry(worksMsgSender.send(work.id))
           } yield ()
         }) { path =>
-          Future.fromTry(pathsMsgSender.sendT(path))
+          Future.fromTry(pathsMsgSender.send(path.path))
         }
     }
   }

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/RouterWorkerService.scala
@@ -5,9 +5,9 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
-import uk.ac.wellcome.models.work.internal.WorkState.Merged
+import uk.ac.wellcome.models.work.internal.WorkState.{Denormalised, Merged}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.Retriever
+import uk.ac.wellcome.pipeline_storage.{Indexer, Retriever}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +16,8 @@ class RouterWorkerService[MsgDestination](
   sqsStream: SQSStream[NotificationMessage],
   worksMsgSender: MessageSender[MsgDestination],
   pathsMsgSender: MessageSender[MsgDestination],
-  workRetriever: Retriever[Work[Merged]]
+  workRetriever: Retriever[Work[Merged]],
+  workIndexer: Indexer[Work[Denormalised]]
 )(implicit ec: ExecutionContext)
     extends Runnable {
 
@@ -26,7 +27,16 @@ class RouterWorkerService[MsgDestination](
   private def processMessage(message: NotificationMessage): Future[Unit] = {
     workRetriever.apply(message.body).flatMap { work =>
       work.data.collectionPath
-        .fold(ifEmpty = Future.fromTry(worksMsgSender.sendT(work.id))) { path =>
+        .fold(ifEmpty = {
+          for {
+           worksEither <- workIndexer.index(work.transition[Denormalised] (Relations.none))
+           _ <- worksEither match {
+             case Left(failedWorks) => Future.failed(new Exception(s"Failed indexing $failedWorks"))
+             case Right(_) => Future.successful(())
+           }
+            _ <-Future.fromTry(worksMsgSender.sendT(work.id))
+          } yield ()
+        }) { path =>
           Future.fromTry(pathsMsgSender.sendT(path))
         }
     }

--- a/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
@@ -36,9 +36,8 @@ class RouterWorkerServiceTest
      eventually {
        assertQueueEmpty(queue)
        assertQueueEmpty(dlq)
-       pathsMessageSender.getMessages[CollectionPath]() should contain(
-         CollectionPath("a"))
-       worksMessageSender.getMessages[String] shouldBe empty
+       pathsMessageSender.messages.map(_.body) should contain("a")
+       worksMessageSender.messages shouldBe empty
        indexer.index shouldBe empty
      }
    }
@@ -54,8 +53,8 @@ class RouterWorkerServiceTest
               eventually {
                 assertQueueEmpty(queue)
                 assertQueueEmpty(dlq)
-                worksMessageSender.getMessages[String]() should contain(work.id)
-                pathsMessageSender.getMessages[CollectionPath]() shouldBe empty
+                worksMessageSender.messages.map(_.body) should contain(work.id)
+                pathsMessageSender.messages shouldBe empty
                 indexer.index should contain (work.id -> work.transition[Denormalised](Relations.none))
               }
             }
@@ -72,9 +71,8 @@ class RouterWorkerServiceTest
               eventually {
                 assertQueueEmpty(queue)
                 assertQueueEmpty(dlq)
-                worksMessageSender.getMessages[String]() shouldBe empty
-                pathsMessageSender.getMessages[CollectionPath]() should contain(
-                  CollectionPath("a/2"))
+                worksMessageSender.messages shouldBe empty
+                pathsMessageSender.messages.map(_.body) should contain("a/2")
                 indexer.index shouldBe empty
               }
             }
@@ -93,8 +91,8 @@ class RouterWorkerServiceTest
               eventually{
                 assertQueueEmpty(queue)
                 assertQueueHasSize(dlq,1)
-                worksMessageSender.getMessages[String]() shouldBe empty
-                pathsMessageSender.getMessages[CollectionPath]() shouldBe empty
+                worksMessageSender.messages shouldBe empty
+                pathsMessageSender.messages shouldBe empty
               }
             }
           }

--- a/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
@@ -1,18 +1,23 @@
 package uk.ac.wellcome.platform.router
 
-import org.scalatest.Assertion
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.Eventually
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
-import uk.ac.wellcome.models.work.internal.CollectionPath
-import uk.ac.wellcome.pipeline_storage.ElasticRetriever
+import uk.ac.wellcome.models.work.internal.WorkState.Denormalised
+import uk.ac.wellcome.models.work.internal.{CollectionPath, Relations, Work}
+import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, Indexer, MemoryIndexer}
+
+import scala.collection.mutable
+import scala.concurrent.Future
 
 class RouterWorkerServiceTest
     extends AnyFunSpec
@@ -24,100 +29,99 @@ class RouterWorkerServiceTest
 
   it("sends collectionPath to paths topic") {
     val work = mergedWork().collectionPath(CollectionPath("a"))
-    withActorSystem { implicit as =>
-      implicit val es = as.dispatcher
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          val worksMessageSender = new MemoryMessageSender
-          val pathsMessageSender = new MemoryMessageSender
-          withSQSStream[NotificationMessage, Assertion](queue) { stream =>
-            withLocalMergedWorksIndex { mergedIndex =>
-              insertIntoElasticsearch(mergedIndex, work)
-              sendNotificationToSQS(queue = queue, body = work.id)
-              val service =
-                new RouterWorkerService(
-                  sqsStream = stream,
-                  worksMsgSender = worksMessageSender,
-                  pathsMsgSender = pathsMessageSender,
-                  workRetriever =
-                    new ElasticRetriever(elasticClient, mergedIndex))
-              service.run()
-              eventually {
-                assertQueueEmpty(queue)
-                assertQueueEmpty(dlq)
-                pathsMessageSender.getMessages[CollectionPath]() should contain(
-                  CollectionPath("a"))
-                worksMessageSender.getMessages[String] shouldBe empty
-              }
-            }
-          }
-      }
-    }
+    val indexer = new MemoryIndexer[Work[Denormalised]](mutable.Map[String,Work[Denormalised]]())
+   withWorkerService(indexer){ case (mergedIndex, QueuePair(queue, dlq), worksMessageSender, pathsMessageSender) =>
+     insertIntoElasticsearch(mergedIndex, work)
+     sendNotificationToSQS(queue = queue, body = work.id)
+     eventually {
+       assertQueueEmpty(queue)
+       assertQueueEmpty(dlq)
+       pathsMessageSender.getMessages[CollectionPath]() should contain(
+         CollectionPath("a"))
+       worksMessageSender.getMessages[String] shouldBe empty
+       indexer.index shouldBe empty
+     }
+   }
   }
 
   it("sends a work without collectionPath to works topic") {
     val work = mergedWork()
-    withActorSystem { implicit as =>
-      implicit val es = as.dispatcher
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          val worksMessageSender = new MemoryMessageSender
-          val pathsMessageSender = new MemoryMessageSender
-          withSQSStream[NotificationMessage, Assertion](queue) { stream =>
-            withLocalMergedWorksIndex { mergedIndex =>
+    val indexer = new MemoryIndexer[Work[Denormalised]](mutable.Map[String,Work[Denormalised]]())
+    withWorkerService(indexer){ case (mergedIndex, QueuePair(queue, dlq), worksMessageSender, pathsMessageSender) =>
               insertIntoElasticsearch(mergedIndex, work)
               sendNotificationToSQS(queue = queue, body = work.id)
-              val service =
-                new RouterWorkerService(
-                  sqsStream = stream,
-                  worksMsgSender = worksMessageSender,
-                  pathsMsgSender = pathsMessageSender,
-                  workRetriever =
-                    new ElasticRetriever(elasticClient, mergedIndex))
-              service.run()
+
               eventually {
                 assertQueueEmpty(queue)
                 assertQueueEmpty(dlq)
                 worksMessageSender.getMessages[String]() should contain(work.id)
                 pathsMessageSender.getMessages[CollectionPath]() shouldBe empty
+                indexer.index should contain (work.id -> work.transition[Denormalised](Relations.none))
               }
             }
           }
-      }
-    }
-  }
 
   it("sends on an invisible work") {
     val work = mergedWork().collectionPath(CollectionPath("a/2")).invisible()
-    withActorSystem { implicit as =>
-      implicit val es = as.dispatcher
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          val worksMessageSender = new MemoryMessageSender
-          val pathsMessageSender = new MemoryMessageSender
-          withSQSStream[NotificationMessage, Assertion](queue) { stream =>
-            withLocalMergedWorksIndex { mergedIndex =>
+
+    val indexer = new MemoryIndexer[Work[Denormalised]](mutable.Map[String,Work[Denormalised]]())
+    withWorkerService(indexer){ case (mergedIndex, QueuePair(queue, dlq), worksMessageSender, pathsMessageSender) =>
               insertIntoElasticsearch(mergedIndex, work)
               sendNotificationToSQS(queue = queue, body = work.id)
-              val service =
-                new RouterWorkerService(
-                  sqsStream = stream,
-                  worksMsgSender = worksMessageSender,
-                  pathsMsgSender = pathsMessageSender,
-                  workRetriever =
-                    new ElasticRetriever(elasticClient, mergedIndex))
-              service.run()
+
               eventually {
                 assertQueueEmpty(queue)
                 assertQueueEmpty(dlq)
                 worksMessageSender.getMessages[String]() shouldBe empty
                 pathsMessageSender.getMessages[CollectionPath]() should contain(
                   CollectionPath("a/2"))
+                indexer.index shouldBe empty
               }
             }
           }
-      }
+
+  it("sends the message to the dlq and doesn't send anything on if elastic indexing fails") {
+    val work = mergedWork()
+    val failingIndexer = new Indexer[Work[Denormalised]] {
+      override def init(): Future[Unit] = Future.successful(())
+      override def index(documents: Seq[Work[Denormalised]]): Future[Either[Seq[Work[Denormalised]], Seq[Work[Denormalised]]]] = Future.successful(Left(documents))
+    }
+    withWorkerService(failingIndexer){ case (mergedIndex, QueuePair(queue, dlq), worksMessageSender, pathsMessageSender) =>
+              insertIntoElasticsearch(mergedIndex, work)
+              sendNotificationToSQS(queue = queue, body = work.id)
+
+              eventually{
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq,1)
+                worksMessageSender.getMessages[String]() shouldBe empty
+                pathsMessageSender.getMessages[CollectionPath]() shouldBe empty
+              }
+            }
+          }
+
+
+  def withWorkerService[R](indexer: Indexer[Work[Denormalised]])(testWith: TestWith[(Index, QueuePair, MemoryMessageSender,MemoryMessageSender), R])= withActorSystem { implicit as =>
+    implicit val es = as.dispatcher
+    withLocalSqsQueuePair(visibilityTimeout = 1) {
+      case q@QueuePair(queue, _) =>
+        val worksMessageSender = new MemoryMessageSender
+        val pathsMessageSender = new MemoryMessageSender
+        withSQSStream[NotificationMessage, R](queue) { stream =>
+          withLocalMergedWorksIndex{ mergedIndex =>
+
+            val service =
+              new RouterWorkerService(
+                sqsStream = stream,
+                worksMsgSender = worksMessageSender,
+                pathsMsgSender = pathsMessageSender,
+                workRetriever =
+                  new ElasticRetriever(elasticClient, mergedIndex),
+                workIndexer = indexer)
+            service.run()
+            testWith((mergedIndex, q, worksMessageSender, pathsMessageSender))
+
+          }
+        }
     }
   }
-
 }


### PR DESCRIPTION
- [x] Make the router index the denormalized work if it doesn't belong to an archive
- [x] Send a `String` instead of `CollectionPath` to the batcher