### PR TITLE
Batching in Router and PipelineStorageStream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,8 @@ lazy val big_messaging_typesafe = setupProject(
 lazy val pipeline_storage = setupProject(
   project,
   "common/pipeline_storage",
-  localDependencies = Seq(elasticsearch_typesafe)
+  localDependencies = Seq(elasticsearch_typesafe),
+  externalDependencies = CatalogueDependencies.pipelineStorageDependencies
 )
 
 lazy val api = setupProject(

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -44,7 +44,7 @@ class PipelineStorageStream[T, D, MsgDestination](messageStream: SQSStream[T], d
       config.batchSize,
       config.flushInterval
     )
-      .mapAsyncUnordered(10) { msgs =>
+      .mapAsyncUnordered(config.parallelism) { msgs =>
         storeDocuments(msgs.toList)
       }
       .mapConcat(identity).mapAsyncUnordered(config.parallelism) { bundle =>

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -1,0 +1,64 @@
+package uk.ac.wellcome.pipeline_storage
+
+import akka.{Done, NotUsed}
+import akka.stream.scaladsl.Source
+import grizzled.slf4j.Logging
+import io.circe.Decoder
+import software.amazon.awssdk.services.sqs.model.Message
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.sqs.SQSStream
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+case class PipelineStorageConfig(batchSize: Int, flushInterval: FiniteDuration, parallelism: Int)
+
+class PipelineStorageStream[T, D, MsgDestination](messageStream: SQSStream[T], documentIndexer: Indexer[D], messageSender: MessageSender[MsgDestination])(config: PipelineStorageConfig)(implicit ec: ExecutionContext) extends Logging{
+  type FutureBundles = Future[List[Bundle]]
+  case class Bundle(message: Message, document: D)
+
+  def foreach(streamName: String, process: T => Future[Option[D]])(
+    implicit decoderT: Decoder[T]): Future[Done] =
+    run(
+      streamName = streamName,
+      source =>
+        source
+          .mapAsyncUnordered(parallelism = config.parallelism) {
+            case (message, t) =>
+              debug(s"Processing message ${message.messageId()}")
+              process(t).map(w => (message, w))
+          }
+    )
+
+  private def run(streamName: String, modifySource: Source[(Message, T), NotUsed] => Source[(Message,Option[D]), NotUsed])(implicit decoder: Decoder[T]) = {
+
+    for {
+      _ <- documentIndexer.init()
+      result <- messageStream.runStream(
+      streamName,
+      modifySource(_).map {
+        case (msg, Some(document)) => Bundle(msg, document)
+        case (msg, None) => ???
+      }
+        .groupedWithin(
+          config.batchSize,
+          config.flushInterval
+        )
+        .mapAsyncUnordered(10) { msgs =>
+          for { bundles <- storeDocuments(msgs.toList) } yield
+            bundles.map(_.message)
+        }
+        .mapConcat(identity)
+    )
+    } yield result
+  }
+
+  private def storeDocuments(bundles: List[Bundle]): FutureBundles =
+    for {
+      either <- documentIndexer.index(documents = bundles.map(m => m.document))
+    } yield {
+      val failedWorks = either.left.getOrElse(Nil)
+      bundles.filterNot {
+        case Bundle(_, document) => failedWorks.contains(document)
+      }
+    }
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -16,70 +16,102 @@ import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.pipeline_storage.fixtures.{ElasticIndexerFixtures, SampleDocument}
+import uk.ac.wellcome.pipeline_storage.fixtures.{
+  ElasticIndexerFixtures,
+  SampleDocument
+}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PipelineStorageStreamTest
-  extends AnyFunSpec
-  with ElasticIndexerFixtures
-  with IdentifiersGenerators
-  with RandomGenerators with ElasticsearchFixtures with SQS with Akka{
+    extends AnyFunSpec
+    with ElasticIndexerFixtures
+    with IdentifiersGenerators
+    with RandomGenerators
+    with ElasticsearchFixtures
+    with SQS
+    with Akka {
 
-  val pipelineStorageConfig = PipelineStorageConfig(batchSize = 1, flushInterval = 1 seconds, parallelism = 10)
+  val pipelineStorageConfig = PipelineStorageConfig(
+    batchSize = 1,
+    flushInterval = 1 seconds,
+    parallelism = 10)
 
-  def indexer(index: Index,elasticClient:ElasticClient = elasticClient) =  new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
+  def indexer(index: Index, elasticClient: ElasticClient = elasticClient) =
+    new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
 
-  def withPipelineStream[R](indexer: Indexer[SampleDocument], visibilityTimeout: Int = 1, pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(testWith: TestWith[(PipelineStorageStream[NotificationMessage,SampleDocument, String], QueuePair, MemoryMessageSender), R]): R =
-  withActorSystem { implicit ac =>
-      withLocalSqsQueuePair(visibilityTimeout) { case q@QueuePair(queue, _) =>
-        withSQSStream[NotificationMessage, R](queue) { stream =>
-          val messageSender = new MemoryMessageSender
-          testWith((new PipelineStorageStream(stream, indexer, messageSender)(pipelineStorageConfig),q, messageSender))
-        }
+  def withPipelineStream[R](indexer: Indexer[SampleDocument],
+                            visibilityTimeout: Int = 1,
+                            pipelineStorageConfig: PipelineStorageConfig =
+                              pipelineStorageConfig)(
+    testWith: TestWith[
+      (PipelineStorageStream[NotificationMessage, SampleDocument, String],
+       QueuePair,
+       MemoryMessageSender),
+      R]): R =
+    withActorSystem { implicit ac =>
+      withLocalSqsQueuePair(visibilityTimeout) {
+        case q @ QueuePair(queue, _) =>
+          withSQSStream[NotificationMessage, R](queue) { stream =>
+            val messageSender = new MemoryMessageSender
+            testWith(
+              (
+                new PipelineStorageStream(stream, indexer, messageSender)(
+                  pipelineStorageConfig),
+                q,
+                messageSender))
+          }
 
+      }
+    }
+
+  it("creates the index at startup if it doesn't already exist") {
+    val index = createIndex
+    val response: Response[IndexExistsResponse] =
+      elasticClient
+        .execute(indexExists(index.name))
+        .await
+    response.result.isExists shouldBe false
+    withPipelineStream(indexer(index)) {
+      case (pipelineStream, _, _) =>
+        pipelineStream.foreach("test_stream", _ => Future.successful(None))
+        eventuallyIndexExists(index)
     }
   }
 
-    it("creates the index at startup if it doesn't already exist") {
-      val index = createIndex
-      val response: Response[IndexExistsResponse] =
-        elasticClient
-          .execute(indexExists(index.name))
-          .await
-      response.result.isExists shouldBe false
-      withPipelineStream(indexer(index)){
-        case (pipelineStream, _, _) =>
-              pipelineStream.foreach("test_stream", _ => Future.successful(None))
-              eventuallyIndexExists(index)
-            }
-    }
-
-    it("ingests a single document and sends it on") {
-      val index = createIndex
-      val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
-      withPipelineStream(indexer(index), visibilityTimeout = 10) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+  it("ingests a single document and sends it on") {
+    val index = createIndex
+    val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
+    withPipelineStream(indexer(index), visibilityTimeout = 10) {
+      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(
           queue = queue,
           message = document
         )
-        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+        pipelineStream.foreach(
+          "test stream",
+          message =>
+            Future
+              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+              .map(Option(_)))
         assertElasticsearchEventuallyHas(index = index, document)
         eventually {
-          messageSender.messages.map(_.body) should contain(document.canonicalId)
+          messageSender.messages.map(_.body) should contain(
+            document.canonicalId)
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
-      }
-
     }
 
-    it("processes a message and does not ingest if result of process is a None") {
-      val index = createIndex
-      val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
-      withPipelineStream(indexer(index), visibilityTimeout = 10) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+  }
+
+  it("processes a message and does not ingest if result of process is a None") {
+    val index = createIndex
+    val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
+    withPipelineStream(indexer(index), visibilityTimeout = 10) {
+      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
         sendNotificationToSQS(
           queue = queue,
           message = document
@@ -92,88 +124,130 @@ class PipelineStorageStreamTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
-      }
-
     }
 
-    it("ingests lots of documents") {
-      val index = createIndex
-      val documents = (1 to 250).map(_ =>
-        SampleDocument(1, createCanonicalId, randomAlphanumeric()))
-      withPipelineStream(indexer(index), visibilityTimeout = 30, pipelineStorageConfig = PipelineStorageConfig(batchSize = 150, flushInterval = 10 seconds, parallelism = 10)) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
-        documents.foreach(doc => sendNotificationToSQS(
-          queue = queue,
-          message = doc
-        ))
-        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+  }
+
+  it("ingests lots of documents") {
+    val index = createIndex
+    val documents = (1 to 250).map(_ =>
+      SampleDocument(1, createCanonicalId, randomAlphanumeric()))
+    withPipelineStream(
+      indexer(index),
+      visibilityTimeout = 30,
+      pipelineStorageConfig = PipelineStorageConfig(
+        batchSize = 150,
+        flushInterval = 10 seconds,
+        parallelism = 10)) {
+      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        documents.foreach(
+          doc =>
+            sendNotificationToSQS(
+              queue = queue,
+              message = doc
+          ))
+        pipelineStream.foreach(
+          "test stream",
+          message =>
+            Future
+              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+              .map(Option(_)))
         assertElasticsearchEventuallyHas(index = index, documents: _*)
         eventually(Timeout(scaled(60 seconds))) {
-          messageSender.messages.map(_.body) should contain theSameElementsAs (documents.map(_.canonicalId))
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+          messageSender.messages.map(_.body) should contain theSameElementsAs (documents
+            .map(_.canonicalId))
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
         }
-      }
     }
+  }
 
-    it("leaves a message on the queue if it fails processing") {
-      val index = createIndex
-      withPipelineStream(indexer(index)) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+  it("leaves a message on the queue if it fails processing") {
+    val index = createIndex
+    withPipelineStream(indexer(index)) {
+      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
         sendInvalidJSONto(queue)
-        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+        pipelineStream.foreach(
+          "test stream",
+          message =>
+            Future
+              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+              .map(Option(_)))
         eventually {
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, size = 1)
           messageSender.messages shouldBe empty
         }
-      }
     }
+  }
 
-    it("when we cannot verify an index exists throw an exception") {
-      val index = createIndex
-      val brokenClient = ElasticClientBuilder.create(
-        hostname = "localhost",
-        port = 9800,
-        protocol = "http",
-        username = "elastic",
-        password = "dontletmein"
-      )
-      withPipelineStream(indexer(index, brokenClient)){case (pipelineStream, _, _) =>
-        whenReady(pipelineStream.foreach("test stream", _ => Future.successful(None)).failed){ exception =>
+  it("when we cannot verify an index exists throw an exception") {
+    val index = createIndex
+    val brokenClient = ElasticClientBuilder.create(
+      hostname = "localhost",
+      port = 9800,
+      protocol = "http",
+      username = "elastic",
+      password = "dontletmein"
+    )
+    withPipelineStream(indexer(index, brokenClient)) {
+      case (pipelineStream, _, _) =>
+        whenReady(
+          pipelineStream
+            .foreach("test stream", _ => Future.successful(None))
+            .failed) { exception =>
           exception shouldBe a[RuntimeException]
         }
-      }
-
     }
 
-      it("does not delete from the queue documents that failed indexing") {
-        val successfulDocuments = (1 to 5).map { _ =>
-          SampleDocument(version = 1, canonicalId = createCanonicalId, title = randomAlphanumeric())
-        }
-        val failingDocuments = (1 to 5).map { _ =>
-          val canonicalId = createCanonicalId
-          val doc = SampleDocument(version = 1, canonicalId = canonicalId, title = randomAlphanumeric())
-          (canonicalId, doc)
-        }.toMap
-        val documents = successfulDocuments ++ failingDocuments.values
-        val indexer = new Indexer[SampleDocument] {
-          override def init(): Future[Unit] = Future.successful(())
-
-          override def index(documents: Seq[SampleDocument]): Future[Either[Seq[SampleDocument], Seq[SampleDocument]]] = {
-            Future.successful(Left(documents.filter(d => failingDocuments.keySet.contains(d.canonicalId))))
-          }
-        }
-        withPipelineStream(indexer){case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
-          documents.foreach(doc => sendNotificationToSQS(
-            queue = queue,
-            message = doc
-          ))
-          pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
-          eventually {
-            messageSender.messages.map(_.body) should contain theSameElementsAs (successfulDocuments.map(_.canonicalId))
-            assertQueueEmpty(queue)
-            assertQueueHasSize(dlq, size = 5)
-          }
-        }
-
-      }
   }
+
+  it("does not delete from the queue documents that failed indexing") {
+    val successfulDocuments = (1 to 5).map { _ =>
+      SampleDocument(
+        version = 1,
+        canonicalId = createCanonicalId,
+        title = randomAlphanumeric())
+    }
+    val failingDocuments = (1 to 5).map { _ =>
+      val canonicalId = createCanonicalId
+      val doc = SampleDocument(
+        version = 1,
+        canonicalId = canonicalId,
+        title = randomAlphanumeric())
+      (canonicalId, doc)
+    }.toMap
+    val documents = successfulDocuments ++ failingDocuments.values
+    val indexer = new Indexer[SampleDocument] {
+      override def init(): Future[Unit] = Future.successful(())
+
+      override def index(documents: Seq[SampleDocument])
+        : Future[Either[Seq[SampleDocument], Seq[SampleDocument]]] = {
+        Future.successful(Left(documents.filter(d =>
+          failingDocuments.keySet.contains(d.canonicalId))))
+      }
+    }
+    withPipelineStream(indexer) {
+      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        documents.foreach(
+          doc =>
+            sendNotificationToSQS(
+              queue = queue,
+              message = doc
+          ))
+        pipelineStream.foreach(
+          "test stream",
+          message =>
+            Future
+              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+              .map(Option(_)))
+        eventually {
+          messageSender.messages.map(_.body) should contain theSameElementsAs (successfulDocuments
+            .map(_.canonicalId))
+          assertQueueEmpty(queue)
+          assertQueueHasSize(dlq, size = 5)
+        }
+    }
+
+  }
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -28,9 +28,11 @@ class PipelineStorageStreamTest
   with IdentifiersGenerators
   with RandomGenerators with ElasticsearchFixtures with SQS with Akka{
 
-  val pipelineStorageConfig = PipelineStorageConfig(1, 1 seconds, 10)
+  val pipelineStorageConfig = PipelineStorageConfig(batchSize = 1, flushInterval = 1 seconds, parallelism = 10)
+
   def indexer(index: Index,elasticClient:ElasticClient = elasticClient) =  new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
-def withPipelineStream[R](indexer: Indexer[SampleDocument], visibilityTimeout: Int = 1, pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(testWith: TestWith[(PipelineStorageStream[NotificationMessage,SampleDocument, String], QueuePair, MemoryMessageSender), R]): R =
+
+  def withPipelineStream[R](indexer: Indexer[SampleDocument], visibilityTimeout: Int = 1, pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(testWith: TestWith[(PipelineStorageStream[NotificationMessage,SampleDocument, String], QueuePair, MemoryMessageSender), R]): R =
   withActorSystem { implicit ac =>
       withLocalSqsQueuePair(visibilityTimeout) { case q@QueuePair(queue, _) =>
         withSQSStream[NotificationMessage, R](queue) { stream =>

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -1,0 +1,177 @@
+package uk.ac.wellcome.pipeline_storage
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
+import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.elasticsearch.{ElasticClientBuilder, NoStrictMapping}
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
+import uk.ac.wellcome.json.JsonUtil
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.pipeline_storage.fixtures.{ElasticIndexerFixtures, SampleDocument}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PipelineStorageStreamTest
+  extends AnyFunSpec
+  with ElasticIndexerFixtures
+  with IdentifiersGenerators
+  with RandomGenerators with ElasticsearchFixtures with SQS with Akka{
+
+  val pipelineStorageConfig = PipelineStorageConfig(1, 1 seconds, 10)
+  def indexer(index: Index,elasticClient:ElasticClient = elasticClient) =  new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
+def withPipelineStream[R](indexer: Indexer[SampleDocument], visibilityTimeout: Int = 1, pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(testWith: TestWith[(PipelineStorageStream[NotificationMessage,SampleDocument, String], QueuePair, MemoryMessageSender), R]): R =
+  withActorSystem { implicit ac =>
+      withLocalSqsQueuePair(visibilityTimeout) { case q@QueuePair(queue, _) =>
+        withSQSStream[NotificationMessage, R](queue) { stream =>
+          val messageSender = new MemoryMessageSender
+          testWith((new PipelineStorageStream(stream, indexer, messageSender)(pipelineStorageConfig),q, messageSender))
+        }
+
+    }
+  }
+
+    it("creates the index at startup if it doesn't already exist") {
+      val index = createIndex
+      val response: Response[IndexExistsResponse] =
+        elasticClient
+          .execute(indexExists(index.name))
+          .await
+      response.result.isExists shouldBe false
+      withPipelineStream(indexer(index)){
+        case (pipelineStream, _, _) =>
+              pipelineStream.foreach("test_stream", _ => Future.successful(None))
+              eventuallyIndexExists(index)
+            }
+    }
+
+    it("ingests a single document and sends it on") {
+      val index = createIndex
+      val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
+      withPipelineStream(indexer(index), visibilityTimeout = 10) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        sendNotificationToSQS(
+          queue = queue,
+          message = document
+        )
+        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+        assertElasticsearchEventuallyHas(index = index, document)
+        eventually {
+          messageSender.messages.map(_.body) should contain(document.canonicalId)
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+        }
+      }
+
+    }
+
+    it("processes a message and does not ingest if result of process is a None") {
+      val index = createIndex
+      val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
+      withPipelineStream(indexer(index), visibilityTimeout = 10) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        sendNotificationToSQS(
+          queue = queue,
+          message = document
+        )
+        pipelineStream.foreach("test stream", _ => Future.successful(None))
+
+        eventually {
+          assertElasticsearchEmpty(index = index)
+          messageSender.messages.map(_.body) shouldBe empty
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+        }
+      }
+
+    }
+
+    it("ingests lots of documents") {
+      val index = createIndex
+      val documents = (1 to 250).map(_ =>
+        SampleDocument(1, createCanonicalId, randomAlphanumeric()))
+      withPipelineStream(indexer(index), visibilityTimeout = 30, pipelineStorageConfig = PipelineStorageConfig(batchSize = 150, flushInterval = 10 seconds, parallelism = 10)) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        documents.foreach(doc => sendNotificationToSQS(
+          queue = queue,
+          message = doc
+        ))
+        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+        assertElasticsearchEventuallyHas(index = index, documents: _*)
+        eventually(Timeout(scaled(60 seconds))) {
+          messageSender.messages.map(_.body) should contain theSameElementsAs (documents.map(_.canonicalId))
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+        }
+      }
+    }
+
+    it("leaves a message on the queue if it fails processing") {
+      val index = createIndex
+      withPipelineStream(indexer(index)) { case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+        sendInvalidJSONto(queue)
+        pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueHasSize(dlq, size = 1)
+          messageSender.messages shouldBe empty
+        }
+      }
+    }
+
+    it("when we cannot verify an index exists throw an exception") {
+      val index = createIndex
+      val brokenClient = ElasticClientBuilder.create(
+        hostname = "localhost",
+        port = 9800,
+        protocol = "http",
+        username = "elastic",
+        password = "dontletmein"
+      )
+      withPipelineStream(indexer(index, brokenClient)){case (pipelineStream, _, _) =>
+        whenReady(pipelineStream.foreach("test stream", _ => Future.successful(None)).failed){ exception =>
+          exception shouldBe a[RuntimeException]
+        }
+      }
+
+    }
+
+      it("does not delete from the queue documents that failed indexing") {
+        val successfulDocuments = (1 to 5).map { _ =>
+          SampleDocument(version = 1, canonicalId = createCanonicalId, title = randomAlphanumeric())
+        }
+        val failingDocuments = (1 to 5).map { _ =>
+          val canonicalId = createCanonicalId
+          val doc = SampleDocument(version = 1, canonicalId = canonicalId, title = randomAlphanumeric())
+          (canonicalId, doc)
+        }.toMap
+        val documents = successfulDocuments ++ failingDocuments.values
+        val indexer = new Indexer[SampleDocument] {
+          override def init(): Future[Unit] = Future.successful(())
+
+          override def index(documents: Seq[SampleDocument]): Future[Either[Seq[SampleDocument], Seq[SampleDocument]]] = {
+            Future.successful(Left(documents.filter(d => failingDocuments.keySet.contains(d.canonicalId))))
+          }
+        }
+        withPipelineStream(indexer){case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+          documents.foreach(doc => sendNotificationToSQS(
+            queue = queue,
+            message = doc
+          ))
+          pipelineStream.foreach("test stream", message => Future.fromTry(JsonUtil.fromJson[SampleDocument](message.body)).map(Option(_)))
+          eventually {
+            messageSender.messages.map(_.body) should contain theSameElementsAs (successfulDocuments.map(_.canonicalId))
+            assertQueueEmpty(queue)
+            assertQueueHasSize(dlq, size = 5)
+          }
+        }
+
+      }
+  }

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
@@ -10,7 +10,12 @@ import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Denormalised
-import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever, PipelineStorageConfig, PipelineStorageStream}
+import uk.ac.wellcome.pipeline_storage.{
+  ElasticIndexer,
+  ElasticRetriever,
+  PipelineStorageConfig,
+  PipelineStorageStream
+}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -30,14 +35,18 @@ object Main extends WellcomeTypesafeApp {
 
     val denormalisedIndex = Index(config.requireString("es.denormalised_index"))
 
-    val stream = new PipelineStorageStream(SQSBuilder.buildSQSStream[NotificationMessage](config), new ElasticIndexer[Work[Denormalised]](
-      esClient,
-      denormalisedIndex,
-      DenormalisedWorkIndexConfig), SNSBuilder
-      .buildSNSMessageSender(
-        config,
-        namespace = "work-sender",
-        subject = "Sent from the router"))(PipelineStorageConfig(100, 2 minutes, 10))
+    val stream = new PipelineStorageStream(
+      SQSBuilder.buildSQSStream[NotificationMessage](config),
+      new ElasticIndexer[Work[Denormalised]](
+        esClient,
+        denormalisedIndex,
+        DenormalisedWorkIndexConfig),
+      SNSBuilder
+        .buildSNSMessageSender(
+          config,
+          namespace = "work-sender",
+          subject = "Sent from the router")
+    )(PipelineStorageConfig(100, 2 minutes, 10))
 
     new RouterWorkerService(
       pathsMsgSender = SNSBuilder
@@ -45,7 +54,8 @@ object Main extends WellcomeTypesafeApp {
           config,
           namespace = "path-sender",
           subject = "Sent from the router"),
-      workRetriever = new ElasticRetriever(esClient, mergedIndex), pipelineStream = stream
+      workRetriever = new ElasticRetriever(esClient, mergedIndex),
+      pipelineStream = stream
     )
   }
 }

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
@@ -8,12 +8,15 @@ import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever}
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Denormalised
+import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever, PipelineStorageConfig, PipelineStorageStream}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -26,23 +29,23 @@ object Main extends WellcomeTypesafeApp {
     val mergedIndex = Index(config.requireString("es.merged_index"))
 
     val denormalisedIndex = Index(config.requireString("es.denormalised_index"))
+
+    val stream = new PipelineStorageStream(SQSBuilder.buildSQSStream[NotificationMessage](config), new ElasticIndexer[Work[Denormalised]](
+      esClient,
+      denormalisedIndex,
+      DenormalisedWorkIndexConfig), SNSBuilder
+      .buildSNSMessageSender(
+        config,
+        namespace = "work-sender",
+        subject = "Sent from the router"))(PipelineStorageConfig(100, 2 minutes, 10))
+
     new RouterWorkerService(
-      sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      worksMsgSender = SNSBuilder
-        .buildSNSMessageSender(
-          config,
-          namespace = "work-sender",
-          subject = "Sent from the router"),
       pathsMsgSender = SNSBuilder
         .buildSNSMessageSender(
           config,
           namespace = "path-sender",
           subject = "Sent from the router"),
-      workRetriever = new ElasticRetriever(esClient, mergedIndex),
-      workIndexer = new ElasticIndexer(
-        esClient,
-        denormalisedIndex,
-        DenormalisedWorkIndexConfig)
+      workRetriever = new ElasticRetriever(esClient, mergedIndex), pipelineStream = stream
     )
   }
 }

--- a/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
@@ -15,7 +15,13 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal.WorkState.Denormalised
 import uk.ac.wellcome.models.work.internal.{CollectionPath, Relations, Work}
-import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, Indexer, MemoryIndexer, PipelineStorageConfig, PipelineStorageStream}
+import uk.ac.wellcome.pipeline_storage.{
+  ElasticRetriever,
+  Indexer,
+  MemoryIndexer,
+  PipelineStorageConfig,
+  PipelineStorageStream
+}
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -137,7 +143,11 @@ class RouterWorkerServiceTest
         val worksMessageSender = new MemoryMessageSender
         val pathsMessageSender = new MemoryMessageSender
         withSQSStream[NotificationMessage, R](queue) { stream =>
-        val pipelineStream = new PipelineStorageStream(messageStream = stream, documentIndexer = indexer, messageSender = worksMessageSender)(PipelineStorageConfig(1, 1 second, 10))
+          val pipelineStream = new PipelineStorageStream(
+            messageStream = stream,
+            documentIndexer = indexer,
+            messageSender = worksMessageSender)(
+            PipelineStorageConfig(1, 1 second, 10))
           withLocalMergedWorksIndex { mergedIndex =>
             val service =
               new RouterWorkerService(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -226,6 +226,8 @@ object CatalogueDependencies {
     WellcomeDependencies.storageTypesafeLibrary ++
       WellcomeDependencies.messagingTypesafeLibrary
 
+  val pipelineStorageDependencies = WellcomeDependencies.messagingLibrary
+
   val elasticsearchTypesafeDependencies: Seq[ModuleID] =
     WellcomeDependencies.typesafeLibrary
 


### PR DESCRIPTION
The router is currently sending documents to index in elastic search using the batching API, but it sends then one at a time, so it's effectively not batching. Because messages can only be deleted from the queue when indexing and sending on the id has succeeded, batching affects the whole stream, as we need to hold on to the original message to be able to delete it.

This PR is adding logic to group the messages into batches in a `PipelineStorageStream` which is a decorator for `SQSStream`. In this PR `PipelineStorageStream` is used in the router, but it should be easy to swap usages of SQSStream for `PipelineStorageStream` without having to change the code except for configuration and infrastructure