### PR TITLE
Promote 2020-11-18 to prod

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,36 +1,7 @@
 locals {
   stacks = {
-    "2020-11-12" = {
-      release_label = "prod"
-
-      # Transformer config
-      #
-      # If this pipeline is meant to be reindexed, remember to uncomment the
-      # reindexer topic names.
-
-      sierra_adapter_topic_arns = [
-        //        local.sierra_reindexer_topic_arn,
-        local.sierra_merged_bibs_topic_arn,
-        local.sierra_merged_items_topic_arn,
-      ]
-
-      miro_adapter_topic_arns = [
-        //        local.miro_reindexer_topic_arn,
-        local.miro_updates_topic_arn,
-      ]
-
-      mets_adapter_topic_arns = [
-        //        local.mets_reindexer_topic_arn,
-        local.mets_adapter_topic_arn,
-      ]
-
-      calm_adapter_topic_arns = [
-        //        local.calm_reindexer_topic_arn,
-        local.calm_adapter_topic_arn,
-      ]
-    }
     "2020-11-18" = {
-      release_label = "stage"
+      release_label = "prod"
 
       # Transformer config
       #

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -38,7 +38,7 @@ module "ingestor_works" {
 
   subnets = var.subnets
 
-  max_capacity        = 5
+  max_capacity        = 3
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_works_queue.read_policy
 


### PR DESCRIPTION
I have also decreased the max_capacity of the works ingestor to 3 as we were still seeing issues with too-high throughput causing the ES cluster to time out indexing requests. There was still no bottleneck at this count (ie the services consumed messages at least as fast as they were received).