### PR TITLE
Make test logging output more user friendly

### DIFF
--- a/api/api/src/test/resources/logback-test.xml
+++ b/api/api/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/api/api/src/test/resources/logback-test.xml
+++ b/api/api/src/test/resources/logback-test.xml
@@ -1,21 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="com.sksamuel.elastic4s" level="INFO" />
-  <logger name="io.swagger" level="WARN" />
-  <logger name="uk.ac.wellcome.platform.api.Server" level="WARN" />
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/api/api/src/test/resources/logback-test.xml
+++ b/api/api/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
+++ b/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
+++ b/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
+++ b/calm_adapter/calm_adapter/src/test/resources/logback-test.xml
@@ -1,19 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="org.eclipse.jetty" level="WARN"/>
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/common/big_messaging/src/test/resources/logback-test.xml
+++ b/common/big_messaging/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/common/big_messaging/src/test/resources/logback-test.xml
+++ b/common/big_messaging/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/common/big_messaging/src/test/resources/logback-test.xml
+++ b/common/big_messaging/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/common/pipeline_storage/src/test/resources/logback-test.xml
+++ b/common/pipeline_storage/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/common/pipeline_storage/src/test/resources/logback-test.xml
+++ b/common/pipeline_storage/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/common/pipeline_storage/src/test/resources/logback-test.xml
+++ b/common/pipeline_storage/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
+++ b/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
+++ b/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
+++ b/mets_adapter/mets_adapter/src/test/resources/logback-test.xml
@@ -1,19 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="org.eclipse.jetty" level="WARN"/>
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_common/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_images/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
+++ b/pipeline/id_minter/id_minter_works/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_common/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
+++ b/pipeline/ingestor/ingestor_works/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/matcher/src/test/resources/logback-test.xml
+++ b/pipeline/matcher/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/matcher/src/test/resources/logback-test.xml
+++ b/pipeline/matcher/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/matcher/src/test/resources/logback-test.xml
+++ b/pipeline/matcher/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/merger/src/test/resources/logback-test.xml
+++ b/pipeline/merger/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/merger/src/test/resources/logback-test.xml
+++ b/pipeline/merger/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/merger/src/test/resources/logback-test.xml
+++ b/pipeline/merger/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/recorder/src/test/resources/logback-test.xml
+++ b/pipeline/recorder/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/recorder/src/test/resources/logback-test.xml
+++ b/pipeline/recorder/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/recorder/src/test/resources/logback-test.xml
+++ b/pipeline/recorder/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/batcher/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/relation_embedder/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
+++ b/pipeline/relation_embedder/router/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_calm/src/test/resources/logback-test.xml
@@ -1,19 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="org.eclipse.jetty" level="WARN"/>
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_mets/src/test/resources/logback-test.xml
@@ -1,19 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+  <root level="DEBUG">
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="org.eclipse.jetty" level="WARN"/>
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_miro/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
+++ b/pipeline/transformer/transformer_sierra/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/reindexer/reindex_worker/src/test/resources/logback-test.xml
+++ b/reindexer/reindex_worker/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/reindexer/reindex_worker/src/test/resources/logback-test.xml
+++ b/reindexer/reindex_worker/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/reindexer/reindex_worker/src/test/resources/logback-test.xml
+++ b/reindexer/reindex_worker/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/sierra_adapter/common/src/test/resources/logback-test.xml
+++ b/sierra_adapter/common/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/common/src/test/resources/logback-test.xml
+++ b/sierra_adapter/common/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/common/src/test/resources/logback-test.xml
+++ b/sierra_adapter/common/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_bib_merger/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_item_merger/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_reader/src/test/resources/logback-test.xml
@@ -1,17 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 
   <root level="DEBUG">
     <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
-    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -2,15 +2,17 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
   <root level="DEBUG">
-    <!-- Uncomment the following line to display stdout of tests -->
-    <!-- <appender-ref ref="STDOUT"/> -->
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-standard}"/>
   </root>
 
   <!-- Edit these to change the log levels for external libraries -->

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -1,19 +1,21 @@
 <configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
     </encoder>
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <!-- Uncomment the following line to display stdout of tests -->
+    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
-  <logger name="com.sksamuel.elastic4s" level="INFO" />
-
-  <!-- reduce external logging -->
-  <logger name="org.apache.http" level="ERROR"/>
-  <logger name="io.netty" level="ERROR"/>
-  <logger name="com.amazonaws" level="WARN"/>
-  <logger name="software.amazon.awssdk" level="WARN"/>
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
 </configuration>


### PR DESCRIPTION
Currently the test logging is really really noisy making it much harder than it needs to be for parsing the test output both locally and on CI.

IMO 95% of the time or more you are only interested in the test output: whether something has passed, or failed and with what failure / error. So here we make the standard in tests to suppress stdout from inside the tests.

In the certain cases where you do need to see the standard out (such as debugging) it is possible to uncomment a line in `logback-test.xml` to get this displaying. I have improved the output here in a few ways:
1) Make the output coloured
2) Simplify time display so seconds is smallest resolution
3) Display a simplified class name rather than the fully namespaced one
4) Don't display what thread which as this useful is rarely helpful (e.g. `default-akka.actor.default-dispatcher-7`)
5) Don't display output from external libs by default (can be enabled by the user if needed).
6) Don't display the verbose logback status upon startup

## Before:
![2020-11-19-174235_959x808_scrot](https://user-images.githubusercontent.com/921101/99705641-e70dd500-2a91-11eb-96f1-3515f255703d.png)

## Standard:
![2020-11-19-172022_958x382_scrot](https://user-images.githubusercontent.com/921101/99705728-0ad11b00-2a92-11eb-8cc6-66108221d18e.png)

## With STDOUT enabled:
![2020-11-19-175904_959x679_scrot](https://user-images.githubusercontent.com/921101/99705757-13295600-2a92-11eb-982b-d2b38ea32cbd.png)

