### PR TITLE
Pull elasticmq from ECR, not Docker Hub

### DIFF
--- a/pipeline/relation_embedder/batcher/docker-compose.yml
+++ b/pipeline/relation_embedder/batcher/docker-compose.yml
@@ -1,4 +1,4 @@
 sqs:
- image: s12v/elasticmq
+ image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
  ports:
    - "9324:9324"


### PR DESCRIPTION
It's causing build failures on master, because we're hitting rate limits.