### PR TITLE
Declare ecr_repos data blocks outside of stack module

### DIFF
--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -40,24 +40,24 @@ locals {
   vpc_id                       = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets              = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
   rds_access_security_group_id = data.terraform_remote_state.catalogue_infra_critical.outputs.rds_access_security_group_id
-    services = [
-      "ingestor_works",
-      "ingestor_images",
-      "matcher",
-      "merger",
-      "id_minter_works",
-      "id_minter_images",
-      "inference_manager",
-      "feature_inferrer",
-      "feature_training",
-      "palette_inferrer",
-      "recorder",
-      "relation_embedder",
-      "transformer_miro",
-      "transformer_mets",
-      "transformer_sierra",
-      "transformer_calm",
-    ]
+  services = [
+    "ingestor_works",
+    "ingestor_images",
+    "matcher",
+    "merger",
+    "id_minter_works",
+    "id_minter_images",
+    "inference_manager",
+    "feature_inferrer",
+    "feature_training",
+    "palette_inferrer",
+    "recorder",
+    "relation_embedder",
+    "transformer_miro",
+    "transformer_mets",
+    "transformer_sierra",
+    "transformer_calm",
+  ]
 
 
 }

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -40,4 +40,28 @@ locals {
   vpc_id                       = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets              = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
   rds_access_security_group_id = data.terraform_remote_state.catalogue_infra_critical.outputs.rds_access_security_group_id
+    services = [
+      "ingestor_works",
+      "ingestor_images",
+      "matcher",
+      "merger",
+      "id_minter_works",
+      "id_minter_images",
+      "inference_manager",
+      "feature_inferrer",
+      "feature_training",
+      "palette_inferrer",
+      "recorder",
+      "relation_embedder",
+      "transformer_miro",
+      "transformer_mets",
+      "transformer_sierra",
+      "transformer_calm",
+    ]
+
+
+}
+data "aws_ecr_repository" "service" {
+  count = length(local.services)
+  name  = "uk.ac.wellcome/${local.services[count.index]}"
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -74,6 +74,6 @@ module "stack" {
   inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
 
   shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
-  repository_urls = data.aws_ecr_repository.service.*.repository_url
-  services = local.services
+  repository_urls        = data.aws_ecr_repository.service.*.repository_url
+  services               = local.services
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -74,4 +74,6 @@ module "stack" {
   inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
 
   shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+  repository_urls = data.aws_ecr_repository.service.*.repository_url
+  services = local.services
 }

--- a/pipeline/terraform/stack/release_uris.tf
+++ b/pipeline/terraform/stack/release_uris.tf
@@ -1,24 +1,3 @@
-locals {
-  services = [
-    "ingestor_works",
-    "ingestor_images",
-    "matcher",
-    "merger",
-    "id_minter_works",
-    "id_minter_images",
-    "inference_manager",
-    "feature_inferrer",
-    "feature_training",
-    "palette_inferrer",
-    "recorder",
-    "relation_embedder",
-    "transformer_miro",
-    "transformer_mets",
-    "transformer_sierra",
-    "transformer_calm",
-  ]
-}
-
 data "aws_ssm_parameter" "inferrer_lsh_model_key" {
   name = "/catalogue_pipeline/config/models/${var.release_label}/lsh_model"
 }
@@ -27,14 +6,9 @@ data "aws_ssm_parameter" "latest_lsh_model_key" {
   name = "/catalogue_pipeline/config/models/latest/lsh_model"
 }
 
-data "aws_ecr_repository" "service" {
-  count = length(local.services)
-  name  = "uk.ac.wellcome/${local.services[count.index]}"
-}
-
 locals {
-  repo_urls = [for repo_url in data.aws_ecr_repository.service.*.repository_url : "${repo_url}:env.${var.release_label}"]
-  image_ids = zipmap(local.services, local.repo_urls)
+  repo_urls = [for repo_url in var.repository_urls : "${repo_url}:env.${var.release_label}"]
+  image_ids = zipmap(var.services, local.repo_urls)
 
   id_minter_images_image   = local.image_ids["id_minter_images"]
   id_minter_works_image    = local.image_ids["id_minter_works"]

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -8,6 +8,13 @@ variable "subnets" {
 variable "shared_logging_secrets" {
   type = map
 }
+variable "repository_urls" {
+  type = list(string)
+}
+
+variable "services" {
+  type = list(string)
+}
 
 variable "vpc_id" {}
 


### PR DESCRIPTION
This is an attempt at solving one of the issues we have with targeting individual pipelines. Currently, if we add services to on e pipeline, it causes the following error when planning (with target): ```Call to function "zipmap" failed: number of keys (18) does not match number of
values (0).```. This solves this problem by taking the data block out