### PR TITLE
Suppress codes that don't correspond to languages

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
@@ -14,6 +14,14 @@ object SierraLanguages
     with Logging {
   type Output = List[Language]
 
+  // We only want to display languages that actually correspond to languages.
+  // These language codes don't tell us anything useful, so we suppress them.
+  private val suppressedLanguageCodes: Set[String] = Set(
+    "mul",  // Multiple languages
+    "und",  // Undetermined
+    "zxx",  // No linguistic content
+  )
+
   // Populate wwork:language.
   //
   // Rules:
@@ -49,6 +57,9 @@ object SierraLanguages
             None
         }
 
-    (List(primaryLanguage) ++ additionalLanguages).flatten.distinct
+    (List(primaryLanguage) ++ additionalLanguages)
+      .flatten
+      .filterNot { lang => suppressedLanguageCodes.contains(lang.id) }
+      .distinct
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -125,4 +125,30 @@ class SierraLanguagesTest
       Language(label = "English", id = "eng")
     )
   }
+
+  it("suppresses codes that don't correspond to languages") {
+    val bibData = createSierraBibDataWith(
+      lang = Some(
+        SierraSourceLanguage(code = "chi", name = "Chinese")
+      ),
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "041",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "mul"),  // Multiple languages
+            MarcSubfield(tag = "a", content = "eng"),
+            MarcSubfield(tag = "a", content = "und"),  // Undetermined
+            MarcSubfield(tag = "a", content = "fre"),
+            MarcSubfield(tag = "a", content = "zxx")   // No linguistic content
+          )
+        )
+      )
+    )
+
+    SierraLanguages(bibData) shouldBe List(
+      Language(label = "Chinese", id = "chi"),
+      Language(label = "English", id = "eng"),
+      Language(label = "French", id = "fre")
+    )
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -135,11 +135,11 @@ class SierraLanguagesTest
         createVarFieldWith(
           marcTag = "041",
           subfields = List(
-            MarcSubfield(tag = "a", content = "mul"),  // Multiple languages
+            MarcSubfield(tag = "a", content = "mul"), // Multiple languages
             MarcSubfield(tag = "a", content = "eng"),
-            MarcSubfield(tag = "a", content = "und"),  // Undetermined
+            MarcSubfield(tag = "a", content = "und"), // Undetermined
             MarcSubfield(tag = "a", content = "fre"),
-            MarcSubfield(tag = "a", content = "zxx")   // No linguistic content
+            MarcSubfield(tag = "a", content = "zxx") // No linguistic content
           )
         )
       )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4864

Reviewers:

- @wellcomecollection/scala-devs for the Scala change
- @jtweed to confirm these are the right codes to be suppressing