### PR TITLE
Add source's languages, title and first contributor to images

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -23,8 +23,8 @@ object SingleImageParams extends QueryParamsUtils {
       "visuallySimilar" -> ImageInclude.VisuallySimilar,
       "withSimilarFeatures" -> ImageInclude.WithSimilarFeatures,
       "withSimilarColors" -> ImageInclude.WithSimilarColors,
-      "sourceContributor" -> ImageInclude.SourceContributor,
-      "sourceLanguages" -> ImageInclude.SourceLanguages,
+      "source.contributor" -> ImageInclude.SourceContributor,
+      "source.languages" -> ImageInclude.SourceLanguages,
     ).emap(values => Right(SingleImageIncludes(values: _*)))
 }
 
@@ -79,7 +79,7 @@ object MultipleImagesParams extends QueryParamsUtils {
 
   implicit val includesDecoder: Decoder[MultipleImagesIncludes] =
     decodeOneOfCommaSeparated(
-      "sourceContributor" -> ImageInclude.SourceContributor,
-      "sourceLanguages" -> ImageInclude.SourceLanguages,
+      "source.contributor" -> ImageInclude.SourceContributor,
+      "source.languages" -> ImageInclude.SourceLanguages,
     ).emap(values => Right(MultipleImagesIncludes(values: _*)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -23,7 +23,9 @@ object SingleImageParams extends QueryParamsUtils {
       "visuallySimilar" -> ImageInclude.VisuallySimilar,
       "withSimilarFeatures" -> ImageInclude.WithSimilarFeatures,
       "withSimilarColors" -> ImageInclude.WithSimilarColors,
-    ).emap(values => Right(SingleImageIncludes(values)))
+      "sourceContributor" -> ImageInclude.SourceContributor,
+      "sourceLanguages" -> ImageInclude.SourceLanguages,
+    ).emap(values => Right(SingleImageIncludes(values: _*)))
 }
 
 case class MultipleImagesParams(
@@ -32,6 +34,7 @@ case class MultipleImagesParams(
   query: Option[String],
   license: Option[LicenseFilter],
   color: Option[ColorMustQuery],
+  include: Option[MultipleImagesIncludes],
   _index: Option[String]
 ) extends QueryParams
     with Paginated {
@@ -63,6 +66,7 @@ object MultipleImagesParams extends QueryParamsUtils {
         "query".as[String].?,
         "locations.license".as[LicenseFilter].?,
         "color".as[ColorMustQuery].?,
+        "include".as[MultipleImagesIncludes].?,
         "_index".as[String].?
       )
     ).tflatMap { args =>
@@ -72,4 +76,10 @@ object MultipleImagesParams extends QueryParamsUtils {
 
   implicit val colorMustQuery: Decoder[ColorMustQuery] =
     decodeCommaSeparated.emap(strs => Right(ColorMustQuery(strs)))
+
+  implicit val includesDecoder: Decoder[MultipleImagesIncludes] =
+    decodeOneOfCommaSeparated(
+      "sourceContributor" -> ImageInclude.SourceContributor,
+      "sourceLanguages" -> ImageInclude.SourceLanguages,
+    ).emap(values => Right(MultipleImagesIncludes(values: _*)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -67,7 +67,7 @@ object DisplayResultList {
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = resultList.results.map(DisplayWork.apply(_, includes)),
+          results = resultList.results.map(DisplayWork(_, includes)),
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations = resultList.aggregations.map(DisplayAggregations.apply)
@@ -76,6 +76,7 @@ object DisplayResultList {
 
   def apply(resultList: ResultList[AugmentedImage, Unit],
             searchOptions: SearchOptions,
+            includes: MultipleImagesIncludes,
             requestUri: Uri,
             contextUri: String): DisplayResultList[DisplayImage, Unit] =
     PaginationResponse(resultList, searchOptions, requestUri) match {
@@ -85,7 +86,7 @@ object DisplayResultList {
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = resultList.results.map(DisplayImage.apply),
+          results = resultList.results.map(DisplayImage(_, includes)),
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations = resultList.aggregations

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -43,7 +43,7 @@ class WorksController(elasticsearchService: ElasticsearchService,
                   DisplayResultList(
                     resultList = resultList,
                     searchOptions = searchOptions,
-                    includes = params.include.getOrElse(WorksIncludes()),
+                    includes = params.include.getOrElse(WorksIncludes.none),
                     requestUri = requestUri,
                     contextUri = contextUri
                   )
@@ -58,7 +58,7 @@ class WorksController(elasticsearchService: ElasticsearchService,
       transactFuture("GET /works/{workId}") {
         val index =
           params._index.map(Index(_)).getOrElse(worksIndex)
-        val includes = params.include.getOrElse(WorksIncludes())
+        val includes = params.include.getOrElse(WorksIncludes.none)
         worksService
           .findWorkById(id)(index)
           .flatMap {

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -73,8 +73,12 @@ trait SingleImageSwagger {
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
         schema = new Schema(
-          allowableValues =
-            Array("visuallySimilar", "withSimilarFeatures", "withSimilarColors")
+          allowableValues = Array(
+            "visuallySimilar",
+            "withSimilarFeatures",
+            "withSimilarColors",
+            "source.contributor",
+            "source.languages")
         ),
         required = false
       )
@@ -228,6 +232,14 @@ trait MultipleImagesSwagger {
         in = ParameterIn.QUERY,
         description = "Filter the images by colors.",
         required = false
+      ),
+      new Parameter(
+        name = "include",
+        in = ParameterIn.QUERY,
+        description = "A comma-separated list of extra fields to include",
+        schema = new Schema(
+          allowableValues = Array("source.contributor", "source.languages")
+        )
       ),
       new Parameter(
         name = "page",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.platform.api.images
 
 import uk.ac.wellcome.display.models.DisplaySerialisationTestBase
 import uk.ac.wellcome.models.work.generators.ImageGenerators
-import uk.ac.wellcome.models.work.internal.AugmentedImage
+import uk.ac.wellcome.models.work.internal.{
+  AugmentedImage,
+  DataState,
+  ImageSource,
+  SourceWorks
+}
 import uk.ac.wellcome.platform.api.ApiTestBase
 
 trait ApiImagesTestBase
@@ -16,16 +21,25 @@ trait ApiImagesTestBase
        |  "type": "Image"
      """.stripMargin
 
+  def imageSource(source: ImageSource[DataState.Identified]): String =
+    source match {
+      case SourceWorks(work, _) =>
+        s"""
+             | {
+             |   "id": "${source.id.canonicalId}",
+             |   ${optionalString("title", work.data.title)}
+             |   "type": "Work"
+             | }
+           """.stripMargin
+    }
+
   def imageResponse(image: AugmentedImage): String =
     s"""
        |  {
        |    "type": "Image",
        |    "id": "${image.id.canonicalId}",
        |    "locations": [${location(image.location)}],
-       |    "source": {
-       |      "id": "${image.source.id.canonicalId}",
-       |      "type": "Work"
-       |    }
+       |    "source": ${imageSource(image.source)}
        |  }
      """.stripMargin
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -1,0 +1,139 @@
+package uk.ac.wellcome.platform.api.images
+
+import uk.ac.wellcome.models.work.generators.ContributorGenerators
+import uk.ac.wellcome.models.work.internal.Language
+
+class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
+  describe("images includes") {
+    val source = identifiedWork()
+      .title("Apple agitator")
+      .languages(
+        List(
+          Language(label = "English", id = "en"),
+          Language(label = "Turkish", id = "tur")
+        ))
+      .contributors(
+        List(
+          createPersonContributorWith("Adrian Aardvark"),
+          createPersonContributorWith("Beatrice Buffalo")
+        ))
+    val image = createAugmentedImageWith(parentWork = source)
+
+    it(
+      "includes the first source contributor on results from the list endpoint if we pass ?include=source.contributor") {
+      withImagesApi {
+        case (imagesIndex, routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, image)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/images?include=source.contributor") {
+            Status.OK -> s"""
+              |{
+              |  ${resultList(apiPrefix, totalResults = 1)},
+              |  "results": [
+              |    {
+              |      "type": "Image",
+              |      "id": "${image.id.canonicalId}",
+              |      "locations": [${location(image.location)}],
+              |      "source": {
+              |        "id": "${source.id}",
+              |        "title": "Apple agitator",
+              |        "contributor": ${contributor(
+                              source.data.contributors.head)},
+              |        "type": "Work"
+              |      }
+              |    }
+              |  ]
+              |}
+            """.stripMargin
+          }
+      }
+    }
+
+    it(
+      "includes the source contributor on a result from the single image endpoint if we pass ?include=source.contributor") {
+      withImagesApi {
+        case (imagesIndex, routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, image)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/images/${image.id.canonicalId}?include=source.contributor") {
+            Status.OK -> s"""
+              |{
+              |  $singleImageResult,
+              |  "type": "Image",
+              |  "id": "${image.id.canonicalId}",
+              |  "locations": [${location(image.location)}],
+              |  "source": {
+              |    "id": "${source.id}",
+              |    "title": "Apple agitator",
+              |    "contributor": ${contributor(source.data.contributors.head)},
+              |    "type": "Work"
+              |  }
+              |}
+            """.stripMargin
+          }
+      }
+    }
+
+    it(
+      "includes the source languages on results from the list endpoint if we pass ?include=source.languages") {
+      withImagesApi {
+        case (imagesIndex, routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, image)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/images?include=source.languages") {
+            Status.OK -> s"""
+              |{
+              |  ${resultList(apiPrefix, totalResults = 1)},
+              |  "results": [
+              |    {
+              |      "type": "Image",
+              |      "id": "${image.id.canonicalId}",
+              |      "locations": [${location(image.location)}],
+              |      "source": {
+              |        "id": "${source.id}",
+              |        "title": "Apple agitator",
+              |        "languages": [${languages(source.data.languages)}],
+              |        "type": "Work"
+              |      }
+              |    }
+              |  ]
+              |}
+            """.stripMargin
+          }
+      }
+    }
+
+    it(
+      "includes the source languages on a result from the single image endpoint if we pass ?include=source.languages") {
+      withImagesApi {
+        case (imagesIndex, routes) =>
+          insertImagesIntoElasticsearch(imagesIndex, image)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/images/${image.id.canonicalId}?include=source.languages") {
+            Status.OK -> s"""
+              |{
+              |  $singleImageResult,
+              |  "type": "Image",
+              |  "id": "${image.id.canonicalId}",
+              |  "locations": [${location(image.location)}],
+              |  "source": {
+              |    "id": "${source.id}",
+              |    "title": "Apple agitator",
+              |    "languages": [${languages(source.data.languages)}],
+              |    "type": "Work"
+              |  }
+              |}
+            """.stripMargin
+          }
+      }
+    }
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -23,10 +23,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |  "visuallySimilar": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
-               |  "source": {
-               |    "id": "${image.source.id.canonicalId}",
-               |    "type": "Work"
-               |  }
+               |  "source": ${imageSource(image.source)}
                |}""".stripMargin
         }
     }
@@ -53,10 +50,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |  "withSimilarFeatures": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
-               |  "source": {
-               |    "id": "${image.source.id.canonicalId}",
-               |    "type": "Work"
-               |  }
+               |  "source": ${imageSource(image.source)}
                |}""".stripMargin
         }
     }
@@ -83,10 +77,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |  "withSimilarColors": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
-               |  "source": {
-               |    "id": "${image.source.id.canonicalId}",
-               |    "type": "Work"
-               |  }
+               |  "source": ${imageSource(image.source)}
                |}""".stripMargin
         }
     }
@@ -104,7 +95,9 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
         assertJsonResponse(
           routes,
           s"/$apiPrefix/images?query=focaccia&include=visuallySimilar") {
-          Status.OK -> imagesListResponse(List(focacciaImage))
+          Status.BadRequest -> badRequest(
+            apiPrefix,
+            "include: 'visuallySimilar' is not a valid value. Please choose one of: ['source.contributor', 'source.languages']")
         }
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -31,10 +31,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
              |  $singleImageResult,
              |  "id": "${image.id.canonicalId}",
              |  "locations": [${digitalLocation(image.location)}],
-             |  "source": {
-             |    "id": "${image.source.id.canonicalId}",
-             |    "type": "Work"
-             |   }
+             |  "source": ${imageSource(image.source)}
              |}""".stripMargin
         }
     }
@@ -159,11 +156,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |  $singleImageResult,
                  |  "id": "${defaultImage.id.canonicalId}",
                  |  "locations": [${location(defaultImage.location)}],
-                 |  "source": {
-                 |    "id": "${defaultImage.source.id.canonicalId}",
-                 |    "type": "Work"
-                 |  }
-                 |}""".stripMargin
+                 |  "source": ${imageSource(defaultImage.source)}
+                 }""".stripMargin
           }
 
           assertJsonResponse(
@@ -175,11 +169,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |  $singleImageResult,
                  |  "id": "${alternativeImage.id.canonicalId}",
                  |  "locations": [${location(alternativeImage.location)}],
-                 |  "source": {
-                 |    "id": "${alternativeImage.source.id.canonicalId}",
-                 |    "type": "Work"
-                 |  }
-                 |}""".stripMargin
+                 |  "source": ${imageSource(alternativeImage.source)}
+                 }""".stripMargin
           }
         }
     }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
@@ -38,23 +38,27 @@ case class DisplayImage(
 
 object DisplayImage {
 
-  def apply(image: AugmentedImage): DisplayImage =
+  def apply(image: AugmentedImage, includes: ImageIncludes): DisplayImage =
     new DisplayImage(
       id = image.id.canonicalId,
       locations = Seq(DisplayDigitalLocationDeprecated(image.location)),
-      source = DisplayImageSource(image.source),
+      source = DisplayImageSource(image.source, includes),
       visuallySimilar = None,
       withSimilarColors = None,
       withSimilarFeatures = None,
     )
 
   def apply(image: AugmentedImage,
+            includes: ImageIncludes,
             visuallySimilar: Option[Seq[AugmentedImage]],
             withSimilarColors: Option[Seq[AugmentedImage]],
             withSimilarFeatures: Option[Seq[AugmentedImage]]): DisplayImage =
-    DisplayImage(image).copy(
-      visuallySimilar = visuallySimilar.map(_.map(DisplayImage.apply)),
-      withSimilarColors = withSimilarColors.map(_.map(DisplayImage.apply)),
-      withSimilarFeatures = withSimilarFeatures.map(_.map(DisplayImage.apply)),
+    DisplayImage(image, includes).copy(
+      visuallySimilar =
+        visuallySimilar.map(_.map(DisplayImage.apply(_, includes))),
+      withSimilarColors =
+        withSimilarColors.map(_.map(DisplayImage.apply(_, includes))),
+      withSimilarFeatures =
+        withSimilarFeatures.map(_.map(DisplayImage.apply(_, includes))),
     )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -50,6 +50,6 @@ object DisplayImageSource {
         if (includes.sourceLanguages)
           Some(source.canonicalWork.data.languages.map(DisplayLanguage(_)))
         else None,
-      ontologyType = "works"
+      ontologyType = "Work"
     )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -42,12 +42,12 @@ object DisplayImageSource {
       id = source.id.canonicalId,
       title = source.canonicalWork.data.title,
       contributor =
-        if (includes.sourceContributor)
+        if (includes.`source.contributor`)
           source.canonicalWork.data.contributors.headOption
             .map(DisplayContributor(_, includesIdentifiers = false))
         else None,
       languages =
-        if (includes.sourceLanguages)
+        if (includes.`source.languages`)
           Some(source.canonicalWork.data.languages.map(DisplayLanguage(_)))
         else None,
       ontologyType = "Work"

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -12,6 +12,15 @@ case class DisplayImageSource(
   @Schema(
     description = "Identifer of the image source"
   ) id: String,
+  @Schema(
+    description = "The title of the image source"
+  ) title: Option[String],
+  @Schema(
+    description = "The primary contributor associated with the image source"
+  ) contributor: Option[DisplayContributor],
+  @Schema(
+    description = "The languages of the image source"
+  ) languages: Option[List[DisplayLanguage]],
   @JsonKey("type") @Schema(
     name = "type",
     description = "What kind of source this is"
@@ -22,10 +31,18 @@ object DisplayImageSource {
 
   def apply(
     imageSource: ImageSource[DataState.Identified]): DisplayImageSource =
+    imageSource match {
+      case works: SourceWorks[DataState.Identified] => DisplayImageSource(works)
+    }
+
+  def apply(source: SourceWorks[DataState.Identified]): DisplayImageSource =
     new DisplayImageSource(
-      id = imageSource.id.canonicalId,
-      ontologyType = imageSource match {
-        case SourceWorks(_, _) => "Work"
-      }
+      id = source.id.canonicalId,
+      title = source.canonicalWork.data.title,
+      contributor = source.canonicalWork.data.contributors.headOption
+        .map(DisplayContributor(_, includesIdentifiers = false)),
+      languages =
+        Some(source.canonicalWork.data.languages.map(DisplayLanguage(_))),
+      ontologyType = "works"
     )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -29,20 +29,27 @@ case class DisplayImageSource(
 
 object DisplayImageSource {
 
-  def apply(
-    imageSource: ImageSource[DataState.Identified]): DisplayImageSource =
+  def apply(imageSource: ImageSource[DataState.Identified],
+            includes: ImageIncludes): DisplayImageSource =
     imageSource match {
-      case works: SourceWorks[DataState.Identified] => DisplayImageSource(works)
+      case works: SourceWorks[DataState.Identified] =>
+        DisplayImageSource(works, includes)
     }
 
-  def apply(source: SourceWorks[DataState.Identified]): DisplayImageSource =
+  def apply(source: SourceWorks[DataState.Identified],
+            includes: ImageIncludes): DisplayImageSource =
     new DisplayImageSource(
       id = source.id.canonicalId,
       title = source.canonicalWork.data.title,
-      contributor = source.canonicalWork.data.contributors.headOption
-        .map(DisplayContributor(_, includesIdentifiers = false)),
+      contributor =
+        if (includes.sourceContributor)
+          source.canonicalWork.data.contributors.headOption
+            .map(DisplayContributor(_, includesIdentifiers = false))
+        else None,
       languages =
-        Some(source.canonicalWork.data.languages.map(DisplayLanguage(_))),
+        if (includes.sourceLanguages)
+          Some(source.canonicalWork.data.languages.map(DisplayLanguage(_)))
+        else None,
       ontologyType = "works"
     )
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -195,7 +195,7 @@ case object DisplayWork {
     )
 
   def apply(work: Work.Visible[Indexed]): DisplayWork =
-    DisplayWork(work = work, includes = WorksIncludes())
+    DisplayWork(work = work, includes = WorksIncludes.none)
 
   def apply(work: Work.Visible[Indexed],
             includes: WorksIncludes,

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
@@ -14,16 +14,16 @@ sealed trait ImageIncludes {
   val visuallySimilar: Boolean
   val withSimilarFeatures: Boolean
   val withSimilarColors: Boolean
-  val sourceContributor: Boolean
-  val sourceLanguages: Boolean
+  val `source.contributor`: Boolean
+  val `source.languages`: Boolean
 }
 
 case class SingleImageIncludes(
   visuallySimilar: Boolean,
   withSimilarFeatures: Boolean,
   withSimilarColors: Boolean,
-  sourceContributor: Boolean,
-  sourceLanguages: Boolean
+  `source.contributor`: Boolean,
+  `source.languages`: Boolean
 ) extends ImageIncludes
 
 object SingleImageIncludes {
@@ -34,16 +34,16 @@ object SingleImageIncludes {
       visuallySimilar = includes.contains(VisuallySimilar),
       withSimilarFeatures = includes.contains(WithSimilarFeatures),
       withSimilarColors = includes.contains(WithSimilarColors),
-      sourceContributor = includes.contains(SourceContributor),
-      sourceLanguages = includes.contains(SourceLanguages),
+      `source.contributor` = includes.contains(SourceContributor),
+      `source.languages` = includes.contains(SourceLanguages),
     )
 
   def none: SingleImageIncludes = SingleImageIncludes()
 }
 
 case class MultipleImagesIncludes(
-  sourceContributor: Boolean,
-  sourceLanguages: Boolean
+  `source.contributor`: Boolean,
+  `source.languages`: Boolean
 ) extends ImageIncludes {
   val visuallySimilar: Boolean = false
   val withSimilarFeatures: Boolean = false
@@ -55,8 +55,8 @@ object MultipleImagesIncludes {
 
   def apply(includes: ImageInclude*): MultipleImagesIncludes =
     MultipleImagesIncludes(
-      sourceContributor = includes.contains(SourceContributor),
-      sourceLanguages = includes.contains(SourceLanguages),
+      `source.contributor` = includes.contains(SourceContributor),
+      `source.languages` = includes.contains(SourceLanguages),
     )
 
   def none: MultipleImagesIncludes = MultipleImagesIncludes()

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
@@ -6,30 +6,58 @@ object ImageInclude {
   case object VisuallySimilar extends ImageInclude
   case object WithSimilarFeatures extends ImageInclude
   case object WithSimilarColors extends ImageInclude
+  case object SourceContributor extends ImageInclude
+  case object SourceLanguages extends ImageInclude
+}
+
+sealed trait ImageIncludes {
+  val visuallySimilar: Boolean
+  val withSimilarFeatures: Boolean
+  val withSimilarColors: Boolean
+  val sourceContributor: Boolean
+  val sourceLanguages: Boolean
 }
 
 case class SingleImageIncludes(
   visuallySimilar: Boolean,
   withSimilarFeatures: Boolean,
-  withSimilarColors: Boolean
-) {
-  import ImageInclude._
-
-  def includes: List[ImageInclude] =
-    List(
-      if (visuallySimilar) Some(VisuallySimilar) else None,
-      if (withSimilarFeatures) Some(WithSimilarFeatures) else None,
-      if (withSimilarColors) Some(WithSimilarColors) else None,
-    ).flatten
-}
+  withSimilarColors: Boolean,
+  sourceContributor: Boolean,
+  sourceLanguages: Boolean
+) extends ImageIncludes
 
 object SingleImageIncludes {
   import ImageInclude._
 
-  def apply(includes: List[ImageInclude]): SingleImageIncludes =
+  def apply(includes: ImageInclude*): SingleImageIncludes =
     SingleImageIncludes(
       visuallySimilar = includes.contains(VisuallySimilar),
       withSimilarFeatures = includes.contains(WithSimilarFeatures),
-      withSimilarColors = includes.contains(WithSimilarColors)
+      withSimilarColors = includes.contains(WithSimilarColors),
+      sourceContributor = includes.contains(SourceContributor),
+      sourceLanguages = includes.contains(SourceLanguages),
     )
+
+  def none: SingleImageIncludes = SingleImageIncludes()
+}
+
+case class MultipleImagesIncludes(
+  sourceContributor: Boolean,
+  sourceLanguages: Boolean
+) extends ImageIncludes {
+  val visuallySimilar: Boolean = false
+  val withSimilarFeatures: Boolean = false
+  val withSimilarColors: Boolean = false
+}
+
+object MultipleImagesIncludes {
+  import ImageInclude._
+
+  def apply(includes: ImageInclude*): MultipleImagesIncludes =
+    MultipleImagesIncludes(
+      sourceContributor = includes.contains(SourceContributor),
+      sourceLanguages = includes.contains(SourceLanguages),
+    )
+
+  def none: MultipleImagesIncludes = MultipleImagesIncludes()
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -54,7 +54,9 @@ case object WorksIncludes {
       succeededBy = includes.contains(WorkInclude.SucceededBy),
     )
 
-  def includeAll(): WorksIncludes =
+  def none: WorksIncludes = WorksIncludes()
+
+  def all: WorksIncludes =
     WorksIncludes(
       identifiers = true,
       items = true,

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayImageTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayImageTest.scala
@@ -17,6 +17,7 @@ class DisplayImageTest
 
     val displayImage = DisplayImage(
       image,
+      includes = SingleImageIncludes.none,
       visuallySimilar = Some(similarImages),
       withSimilarColors = None,
       withSimilarFeatures = None)

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -374,7 +374,7 @@ class DisplayWorkSerialisationTest
     """.stripMargin
 
     assertObjectMapsToJson(
-      DisplayWork(work, includes = WorksIncludes()),
+      DisplayWork(work, includes = WorksIncludes.none),
       expectedJson = expectedJson
     )
   }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -150,8 +150,8 @@ class DisplayWorkTest
 
     val work = indexedWork().languages(languages)
 
-    val noLanguagesInclude = WorksIncludes().copy(languages = false)
-    val languagesInclude = WorksIncludes().copy(languages = true)
+    val noLanguagesInclude = WorksIncludes.none.copy(languages = false)
+    val languagesInclude = WorksIncludes.none.copy(languages = true)
 
     DisplayWork(work, includes = noLanguagesInclude).languages shouldBe None
 
@@ -233,7 +233,7 @@ class DisplayWorkTest
 
   it("does not extract includes set to false") {
     forAll { work: Work.Visible[Indexed] =>
-      val displayWork = DisplayWork(work, includes = WorksIncludes())
+      val displayWork = DisplayWork(work, includes = WorksIncludes.none)
 
       displayWork.production shouldNot be(defined)
       displayWork.subjects shouldNot be(defined)
@@ -353,7 +353,7 @@ class DisplayWorkTest
       )
 
     describe("omits identifiers if WorksIncludes.identifiers is false") {
-      val displayWork = DisplayWork(work, includes = WorksIncludes())
+      val displayWork = DisplayWork(work, includes = WorksIncludes.none)
 
       it("the top-level Work") {
         displayWork.identifiers shouldBe None
@@ -528,7 +528,7 @@ class DisplayWorkTest
     }
 
     it("does not include relations when not requested") {
-      val displayWork = DisplayWork(work, WorksIncludes(), relatedWorks)
+      val displayWork = DisplayWork(work, WorksIncludes.none, relatedWorks)
       displayWork.parts shouldBe None
       displayWork.partOf shouldBe None
       displayWork.precededBy shouldBe None

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
@@ -12,7 +12,5 @@ object DisplayWorkSource {
     index: Index
   )(implicit actorSystem: ActorSystem): Source[DisplayWork, Any] =
     ElasticsearchWorksSource(elasticClient = elasticClient, index = index)
-      .via(
-        IndexedWorkToVisibleDisplayWork(
-          DisplayWork(_, WorksIncludes.includeAll())))
+      .via(IndexedWorkToVisibleDisplayWork(DisplayWork(_, WorksIncludes.all)))
 }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/flow/IdentifiedWorkToVisibleDisplayWorkFlowTest.scala
@@ -19,7 +19,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
   it("creates DisplayWorks from IndexedWorks") {
     withMaterializer { implicit materializer =>
       val flow = IndexedWorkToVisibleDisplayWork(
-        toDisplayWork = DisplayWork.apply(_, WorksIncludes.includeAll()))
+        toDisplayWork = DisplayWork.apply(_, WorksIncludes.all))
 
       val works = indexedWorks(count = 3)
 
@@ -29,7 +29,7 @@ class IdentifiedWorkToVisibleDisplayWorkFlowTest
 
       whenReady(eventualDisplayWorks) { displayWorks =>
         val expectedDisplayWorks = works.map {
-          DisplayWork(_, includes = WorksIncludes.includeAll())
+          DisplayWork(_, includes = WorksIncludes.all)
         }
         displayWorks shouldBe expectedDisplayWorks
       }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -86,7 +86,7 @@ class SnapshotServiceTest
 
           val expectedContents = visibleWorks
             .map {
-              DisplayWork(_, includes = WorksIncludes.includeAll())
+              DisplayWork(_, includes = WorksIncludes.all)
             }
             .map(toJson[DisplayWork])
             .mkString("\n") + "\n"
@@ -138,7 +138,7 @@ class SnapshotServiceTest
 
           val expectedContents = works
             .map {
-              DisplayWork(_, includes = WorksIncludes.includeAll())
+              DisplayWork(_, includes = WorksIncludes.all)
             }
             .map(toJson[DisplayWork])
             .mkString("\n") + "\n"


### PR DESCRIPTION
This adds the `languages`, the `title` and the first of the `contributors` from a source work to the `source` field on images. The `contributor` and `languages` are behind an `include` to match the behaviour of works. 

We'll also need additional locations on images, but that will require a bit more thought / a separate PR.