### PR TITLE
Show all contributors on image sources

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -23,7 +23,7 @@ object SingleImageParams extends QueryParamsUtils {
       "visuallySimilar" -> ImageInclude.VisuallySimilar,
       "withSimilarFeatures" -> ImageInclude.WithSimilarFeatures,
       "withSimilarColors" -> ImageInclude.WithSimilarColors,
-      "source.contributor" -> ImageInclude.SourceContributor,
+      "source.contributors" -> ImageInclude.SourceContributors,
       "source.languages" -> ImageInclude.SourceLanguages,
     ).emap(values => Right(SingleImageIncludes(values: _*)))
 }
@@ -79,7 +79,7 @@ object MultipleImagesParams extends QueryParamsUtils {
 
   implicit val includesDecoder: Decoder[MultipleImagesIncludes] =
     decodeOneOfCommaSeparated(
-      "source.contributor" -> ImageInclude.SourceContributor,
+      "source.contributors" -> ImageInclude.SourceContributors,
       "source.languages" -> ImageInclude.SourceLanguages,
     ).emap(values => Right(MultipleImagesIncludes(values: _*)))
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -77,7 +77,7 @@ trait SingleImageSwagger {
             "visuallySimilar",
             "withSimilarFeatures",
             "withSimilarColors",
-            "source.contributor",
+            "source.contributors",
             "source.languages")
         ),
         required = false
@@ -238,7 +238,7 @@ trait MultipleImagesSwagger {
         in = ParameterIn.QUERY,
         description = "A comma-separated list of extra fields to include",
         schema = new Schema(
-          allowableValues = Array("source.contributor", "source.languages")
+          allowableValues = Array("source.contributors", "source.languages")
         )
       ),
       new Parameter(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -20,14 +20,14 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
     val image = createAugmentedImageWith(parentWork = source)
 
     it(
-      "includes the first source contributor on results from the list endpoint if we pass ?include=source.contributor") {
+      "includes the source contributors on results from the list endpoint if we pass ?include=source.contributors") {
       withImagesApi {
         case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(imagesIndex, image)
 
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/images?include=source.contributor") {
+            s"/$apiPrefix/images?include=source.contributors") {
             Status.OK -> s"""
               |{
               |  ${resultList(apiPrefix, totalResults = 1)},
@@ -39,8 +39,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |      "source": {
               |        "id": "${source.id}",
               |        "title": "Apple agitator",
-              |        "contributor": ${contributor(
-                              source.data.contributors.head)},
+              |        "contributors": [${contributors(source.data.contributors)}],
               |        "type": "Work"
               |      }
               |    }
@@ -52,14 +51,14 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
     }
 
     it(
-      "includes the source contributor on a result from the single image endpoint if we pass ?include=source.contributor") {
+      "includes the source contributors on a result from the single image endpoint if we pass ?include=source.contributors") {
       withImagesApi {
         case (imagesIndex, routes) =>
           insertImagesIntoElasticsearch(imagesIndex, image)
 
           assertJsonResponse(
             routes,
-            s"/$apiPrefix/images/${image.id.canonicalId}?include=source.contributor") {
+            s"/$apiPrefix/images/${image.id.canonicalId}?include=source.contributors") {
             Status.OK -> s"""
               |{
               |  $singleImageResult,
@@ -69,7 +68,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  "source": {
               |    "id": "${source.id}",
               |    "title": "Apple agitator",
-              |    "contributor": ${contributor(source.data.contributors.head)},
+              |    "contributors": [${contributors(source.data.contributors)}],
               |    "type": "Work"
               |  }
               |}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -97,7 +97,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
           s"/$apiPrefix/images?query=focaccia&include=visuallySimilar") {
           Status.BadRequest -> badRequest(
             apiPrefix,
-            "include: 'visuallySimilar' is not a valid value. Please choose one of: ['source.contributor', 'source.languages']")
+            "include: 'visuallySimilar' is not a valid value. Please choose one of: ['source.contributors', 'source.languages']")
         }
     }
   }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImageSource.scala
@@ -16,8 +16,8 @@ case class DisplayImageSource(
     description = "The title of the image source"
   ) title: Option[String],
   @Schema(
-    description = "The primary contributor associated with the image source"
-  ) contributor: Option[DisplayContributor],
+    description = "The contributors associated with the image source"
+  ) contributors: Option[List[DisplayContributor]],
   @Schema(
     description = "The languages of the image source"
   ) languages: Option[List[DisplayLanguage]],
@@ -41,10 +41,11 @@ object DisplayImageSource {
     new DisplayImageSource(
       id = source.id.canonicalId,
       title = source.canonicalWork.data.title,
-      contributor =
-        if (includes.`source.contributor`)
-          source.canonicalWork.data.contributors.headOption
-            .map(DisplayContributor(_, includesIdentifiers = false))
+      contributors =
+        if (includes.`source.contributors`)
+          Some(
+            source.canonicalWork.data.contributors
+              .map(DisplayContributor(_, includesIdentifiers = false)))
         else None,
       languages =
         if (includes.`source.languages`)

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/ImagesIncludes.scala
@@ -6,7 +6,7 @@ object ImageInclude {
   case object VisuallySimilar extends ImageInclude
   case object WithSimilarFeatures extends ImageInclude
   case object WithSimilarColors extends ImageInclude
-  case object SourceContributor extends ImageInclude
+  case object SourceContributors extends ImageInclude
   case object SourceLanguages extends ImageInclude
 }
 
@@ -14,7 +14,7 @@ sealed trait ImageIncludes {
   val visuallySimilar: Boolean
   val withSimilarFeatures: Boolean
   val withSimilarColors: Boolean
-  val `source.contributor`: Boolean
+  val `source.contributors`: Boolean
   val `source.languages`: Boolean
 }
 
@@ -22,7 +22,7 @@ case class SingleImageIncludes(
   visuallySimilar: Boolean,
   withSimilarFeatures: Boolean,
   withSimilarColors: Boolean,
-  `source.contributor`: Boolean,
+  `source.contributors`: Boolean,
   `source.languages`: Boolean
 ) extends ImageIncludes
 
@@ -34,7 +34,7 @@ object SingleImageIncludes {
       visuallySimilar = includes.contains(VisuallySimilar),
       withSimilarFeatures = includes.contains(WithSimilarFeatures),
       withSimilarColors = includes.contains(WithSimilarColors),
-      `source.contributor` = includes.contains(SourceContributor),
+      `source.contributors` = includes.contains(SourceContributors),
       `source.languages` = includes.contains(SourceLanguages),
     )
 
@@ -42,7 +42,7 @@ object SingleImageIncludes {
 }
 
 case class MultipleImagesIncludes(
-  `source.contributor`: Boolean,
+  `source.contributors`: Boolean,
   `source.languages`: Boolean
 ) extends ImageIncludes {
   val visuallySimilar: Boolean = false
@@ -55,7 +55,7 @@ object MultipleImagesIncludes {
 
   def apply(includes: ImageInclude*): MultipleImagesIncludes =
     MultipleImagesIncludes(
-      `source.contributor` = includes.contains(SourceContributor),
+      `source.contributors` = includes.contains(SourceContributors),
       `source.languages` = includes.contains(SourceLanguages),
     )
 


### PR DESCRIPTION
It was confusing to have slightly different fields on works and images - this puts _all_ contributors on `image.source.contributors`