### PR TITLE
Refactoring and more testing in TransformerWorker

### DIFF
--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/Transformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/Transformer.scala
@@ -4,7 +4,6 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.internal.result.Result
 import WorkState.Source
 
-trait Transformer[T] {
-
-  def apply(input: T, version: Int): Result[Work[Source]]
+trait Transformer[SourceData] {
+  def apply(sourceData: SourceData, version: Int): Result[Work[Source]]
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -43,14 +43,13 @@ trait TransformerWorker[In, SenderDest] extends Logging {
   val concurrentTransformations: Int = 2
 
   def process(
-    message: NotificationMessage): Result[(Work[Source], StoreKey)] = {
+    message: NotificationMessage): Result[(Work[Source], StoreKey)] =
     for {
       key <- decodeKey(message)
       recordAndKey <- getRecord(key)
       work <- work(recordAndKey._1, key)
       done <- done(work, key)
     } yield done
-  }
 
   private def work(sourceData: In, key: StoreKey): Result[Work[Source]] =
     transformer(sourceData, key.version) match {

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -42,8 +42,7 @@ trait TransformerWorker[In, SenderDest] extends Logging {
   val transformer: Transformer[In]
   val concurrentTransformations: Int = 2
 
-  def process(
-    message: NotificationMessage): Result[(Work[Source], StoreKey)] =
+  def process(message: NotificationMessage): Result[(Work[Source], StoreKey)] =
     for {
       key <- decodeKey(message)
       record <- getRecord(key)

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -29,7 +29,7 @@ case class MessageSendError[T, Key](msg: String, work: Work[Source], key: Key)
   * - Takes an SQS stream that emits VHS keys
   * - Gets the record of type `In`
   * - Runs it through a transformer and transforms the `In` to `Work[Source]`
-  * - Emits the message via `BigMessageSender` to an SNS topic
+  * - Emits the message via `MessageSender` to SNS
   */
 trait TransformerWorker[In, SenderDest] extends Logging {
   type Result[T] = Either[TransformerWorkerError, T]

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -13,6 +13,8 @@ import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
 import WorkState.Source
 
+import scala.util.{Failure, Success}
+
 sealed abstract class TransformerWorkerError(msg: String) extends Exception(msg)
 case class DecodeKeyError[T](msg: String, message: NotificationMessage)
     extends TransformerWorkerError(msg)
@@ -65,9 +67,9 @@ trait TransformerWorker[In, SenderDest] extends Logging {
     }
 
   private def decodeKey(message: NotificationMessage): Result[StoreKey] =
-    fromJson[StoreKey](message.body).toEither match {
-      case Left(err)     => Left(DecodeKeyError(err.toString, message))
-      case Right(result) => Right(result)
+    fromJson[StoreKey](message.body) match {
+      case Failure(err)    => Left(DecodeKeyError(err.toString, message))
+      case Success(result) => Right(result)
     }
 
   private def getRecord(key: StoreKey): Result[In] =

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.transformer.common.worker
 import scala.concurrent.Future
 import akka.Done
 import grizzled.slf4j.Logging
-import software.amazon.awssdk.services.sqs.model.Message
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -33,7 +32,6 @@ case class MessageSendError[T, Key](msg: String, work: Work[Source], key: Key)
   * - Emits the message via `BigMessageSender` to an SNS topic
   */
 trait TransformerWorker[In, SenderDest] extends Logging {
-  type StreamMessage = (Message, NotificationMessage)
   type Result[T] = Either[TransformerWorkerError, T]
   type StoreKey = Version[String, Int]
 

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -66,8 +66,8 @@ trait TransformerWorker[In, SenderDest] extends Logging {
 
   private def decodeKey(message: NotificationMessage): Result[StoreKey] =
     fromJson[StoreKey](message.body) match {
-      case Failure(err)    => Left(DecodeKeyError(err.toString, message))
-      case Success(result) => Right(result)
+      case Failure(err)      => Left(DecodeKeyError(err.toString, message))
+      case Success(storeKey) => Right(storeKey)
     }
 
   private def getRecord(key: StoreKey): Result[In] =

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -59,9 +59,9 @@ trait TransformerWorker[In, SenderDest] extends Logging {
 
   private def done(work: Work[Source],
                    key: StoreKey): Result[(Work[Source], StoreKey)] =
-    sender.sendT(work) toEither match {
-      case Left(err) => Left(MessageSendError(err.toString, work, key))
-      case Right(_)  => Right((work, key))
+    sender.sendT(work) match {
+      case Failure(err) => Left(MessageSendError(err.toString, work, key))
+      case Success(_)   => Right((work, key))
     }
 
   private def decodeKey(message: NotificationMessage): Result[StoreKey] =

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -46,8 +46,8 @@ trait TransformerWorker[In, SenderDest] extends Logging {
     message: NotificationMessage): Result[(Work[Source], StoreKey)] =
     for {
       key <- decodeKey(message)
-      recordAndKey <- getRecord(key)
-      work <- work(recordAndKey._1, key)
+      record <- getRecord(key)
+      work <- work(record, key)
       done <- done(work, key)
     } yield done
 
@@ -70,10 +70,10 @@ trait TransformerWorker[In, SenderDest] extends Logging {
       case Right(result) => Right(result)
     }
 
-  private def getRecord(key: StoreKey): Result[(In, StoreKey)] =
+  private def getRecord(key: StoreKey): Result[In] =
     store.getLatest(key.id) match {
-      case Left(err)                     => Left(StoreReadError(err.toString, key))
-      case Right(Identified(key, entry)) => Right((entry, key))
+      case Left(err)                   => Left(StoreReadError(err.toString, key))
+      case Right(Identified(_, entry)) => Right(entry)
     }
 
   def run(): Future[Done] =

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -19,7 +19,9 @@ case class DecodeKeyError[T](t: Throwable, message: NotificationMessage)
     extends TransformerWorkerError(t.getMessage)
 case class StoreReadError[T](err: ReadError, key: T)
     extends TransformerWorkerError(err.toString)
-case class TransformerError[SourceData, Key](t: Throwable, sourceData: SourceData, key: Key)
+case class TransformerError[SourceData, Key](t: Throwable,
+                                             sourceData: SourceData,
+                                             key: Key)
     extends TransformerWorkerError(t.getMessage)
 case class MessageSendError[T, Key](t: Throwable, work: Work[Source], key: Key)
     extends TransformerWorkerError(t.getMessage)
@@ -50,7 +52,8 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
       done <- done(work, key)
     } yield done
 
-  private def work(sourceData: SourceData, key: StoreKey): Result[Work[Source]] =
+  private def work(sourceData: SourceData,
+                   key: StoreKey): Result[Work[Source]] =
     transformer(sourceData, key.version) match {
       case Left(err)     => Left(TransformerError(err, sourceData, key))
       case Right(result) => Right(result)

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -84,11 +84,11 @@ trait TransformerWorker[In, SenderDest] extends Logging {
         source.mapAsync(concurrentTransformations) {
           case (message, notification) =>
             process(notification) match {
-              case Left(err) => {
+              case Left(err) =>
                 // We do some slightly nicer logging here to give context to the errors
                 err match {
-                  case DecodeKeyError(_, message) =>
-                    error(s"$name: DecodeKeyError from $message")
+                  case DecodeKeyError(_, notificationMsg) =>
+                    error(s"$name: DecodeKeyError from $notificationMsg")
                   case StoreReadError(_, key) =>
                     error(s"$name: StoreReadError on $key")
                   case TransformerError(_, sourceData, key) =>
@@ -97,11 +97,9 @@ trait TransformerWorker[In, SenderDest] extends Logging {
                     error(s"$name: MessageSendError on $work with $key")
                 }
                 Future.failed(err)
-              }
-              case Right((work, key)) => {
+              case Right((work, key)) =>
                 info(s"$name: from $key transformed $work")
                 Future.successful(message)
-              }
             }
         }
       }

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -89,6 +89,20 @@ class TransformerWorkerTest
       }
     }
 
+    it("if it can't parse the notification as a Version[String, Int]") {
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue) { _ =>
+            sendNotificationToSQS(queue, "not-a-version")
+
+            eventually {
+              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(queue)
+            }
+          }
+      }
+    }
+
     it("if it can't find the source record in the store") {
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
-import uk.ac.wellcome.messaging.fixtures.{SNS, SQS}
+import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
@@ -49,8 +49,7 @@ class TransformerWorkerTest
     with Eventually
     with IntegrationPatience
     with Akka
-    with SQS
-    with SNS {
+    with SQS {
 
   it("empties the queue if it can process everything") {
     val records = Map(

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -62,9 +62,9 @@ class TransformerWorkerTest
     withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
         withWorker(queue, records = records) { _ =>
-          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
-          sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
-          sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
+          sendNotificationToSQS(queue, Version("A", 1))
+          sendNotificationToSQS(queue, Version("B", 2))
+          sendNotificationToSQS(queue, Version("C", 3))
 
           eventually {
             assertQueueEmpty(dlq)

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.transformer.common.worker
 
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
@@ -17,6 +17,9 @@ import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import WorkState.Source
+import io.circe.Encoder
+
+import scala.util.{Failure, Try}
 
 trait TestData
 case object ValidTestData extends TestData
@@ -43,6 +46,8 @@ class TransformerWorkerTest
     extends AnyFunSpec
     with ScalaFutures
     with Matchers
+    with Eventually
+    with IntegrationPatience
     with Akka
     with SQS
     with SNS {
@@ -61,51 +66,92 @@ class TransformerWorkerTest
           sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
           sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
 
-          Thread.sleep(500)
-
-          assertQueueEmpty(dlq)
-          assertQueueEmpty(queue)
+          eventually {
+            assertQueueEmpty(dlq)
+            assertQueueEmpty(queue)
+          }
         }
     }
   }
 
-  it("sends failed messages to the DLQ if it can't read from store") {
-    withLocalSqsQueuePair() {
-      case QueuePair(queue, dlq) =>
-        withWorker(queue, records = Map.empty) { _ =>
-          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
+  describe("sends failures to the DLQ") {
+    it("if it can't parse the JSON on the queue") {
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue) { _ =>
+            sendInvalidJSONto(queue)
 
-          Thread.sleep(2000)
+            eventually {
+              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(queue)
+            }
+          }
+      }
+    }
 
-          assertQueueHasSize(dlq, size = 1)
-          assertQueueEmpty(queue)
-        }
+    it("if it can't find the source record in the store") {
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue) { _ =>
+            sendNotificationToSQS(queue, Version("A", 1))
+
+            eventually {
+              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(queue)
+            }
+          }
+      }
+    }
+
+    it("if the work can't be transformed") {
+      val records = Map(
+        Version("A", 1) -> ValidTestData,
+        Version("B", 2) -> ValidTestData,
+        Version("C", 3) -> InvalidTestData
+      )
+
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue, records = records) { _ =>
+            sendNotificationToSQS(queue, Version("A", 1))
+            sendNotificationToSQS(queue, Version("B", 2))
+            sendNotificationToSQS(queue, Version("C", 3))
+
+            eventually {
+              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(queue)
+            }
+          }
+      }
+    }
+
+    it("if it can't send a message") {
+      val brokenSender = new MemoryMessageSender() {
+        override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+          Failure(new Throwable("BOOM!"))
+      }
+
+      val records = Map(Version("A", 1) -> ValidTestData)
+
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue, records = records, sender = brokenSender) { _ =>
+            sendNotificationToSQS(queue, Version("A", 1))
+
+            eventually {
+              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(queue)
+            }
+          }
+      }
     }
   }
 
-  it("sends failed messages to the DLQ if the transformer errors") {
-    val records = Map(
-      Version("A", 1) -> ValidTestData,
-      Version("B", 2) -> ValidTestData,
-      Version("C", 3) -> InvalidTestData
-    )
-
-    withLocalSqsQueuePair() {
-      case QueuePair(queue, dlq) =>
-        withWorker(queue, records = records) { _ =>
-          sendNotificationToSQS[Version[String, Int]](queue, Version("A", 1))
-          sendNotificationToSQS[Version[String, Int]](queue, Version("B", 2))
-          sendNotificationToSQS[Version[String, Int]](queue, Version("C", 3))
-
-          Thread.sleep(2000)
-
-          assertQueueHasSize(dlq, size = 1)
-          assertQueueEmpty(queue)
-        }
-    }
-  }
-
-  def withWorker[R](queue: Queue, records: Map[Version[String, Int], TestData])(
+  def withWorker[R](
+    queue: Queue,
+    records: Map[Version[String, Int], TestData] = Map.empty,
+    sender: MemoryMessageSender = new MemoryMessageSender()
+  )(
     testWith: TestWith[Unit, R]
   ): R =
     withActorSystem { implicit actorSystem =>
@@ -114,7 +160,7 @@ class TransformerWorkerTest
 
         val worker = new TestTransformerWorker(
           stream = stream,
-          sender = new MemoryMessageSender(),
+          sender = sender,
           store = store
         )
 


### PR DESCRIPTION
I was looking through TransformerWorker, to get an idea of how much work it would be to use pipeline_storage instead.

This patch is not that – it's some code tidies and extra test cases I spotted while reading the code.

This is laying the groundwork to use the same TransformerWorker pattern in all four transformers, and in turn adding pipeline_storage in one go.