### PR TITLE
Remove visible filter from relation embedder query

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsRequestBuilder.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationsRequestBuilder.scala
@@ -34,7 +34,7 @@ case class RelationsRequestBuilder(index: Index,
 
   def affectedWorks(batch: Batch, scrollSize: Int): SearchRequest =
     search(index)
-      .query(must(visibleQuery, should(batch.selectors.map(_.query))))
+      .query(should(batch.selectors.map(_.query)))
       .from(0)
       .scroll(keepAlive = scrollKeepAlive)
       .size(scrollSize)

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationEmbedderWorkerServiceTest.scala
@@ -152,7 +152,9 @@ class RelationEmbedderWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
-        msgSender.messages.map(_.body).toSet shouldBe (invisibleWork :: works).map(_.id).toSet
+        msgSender.messages.map(_.body).toSet shouldBe (invisibleWork :: works)
+          .map(_.id)
+          .toSet
         relations(index) shouldBe Map(
           workA.id -> relationsA,
           work1.id -> relations1,

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationsServiceTest.scala
@@ -166,7 +166,10 @@ class RelationsServiceTest
             rootPath = "A",
             List(Children("A/C/X"), Descendents("A/C/X"), Node("A/C/X/5")))
           whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(work3, work4, invisibleWork)
+            result should contain theSameElementsAs List(
+              work3,
+              work4,
+              invisibleWork)
           }
         }
       }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/uk/ac/wellcome/relation_embedder/RelationsServiceTest.scala
@@ -157,15 +157,16 @@ class RelationsServiceTest
       }
     }
 
-    it("Ignores invisible works") {
+    it("Returns invisible works") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index, work("A/C/X/5").invisible() :: works)
+        val invisibleWork = work("A/C/X/5").invisible()
+        storeWorks(index, invisibleWork :: works)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(
             rootPath = "A",
             List(Children("A/C/X"), Descendents("A/C/X"), Node("A/C/X/5")))
           whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(work3, work4)
+            result should contain theSameElementsAs List(work3, work4, invisibleWork)
           }
         }
       }


### PR DESCRIPTION
This is a mistake, it means non visible works won't make it through the pipeline.