### PR TITLE
Add an extra failure case test for PipelineStorageStream

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -53,7 +53,7 @@ class PipelineStorageStream[T, D, MsgDestination](
     } yield result
   }
 
-  private def batchAndSendFlow(implicit indexable: Indexable[D]) = {
+  private def batchAndSendFlow(implicit indexable: Indexable[D]) =
     Flow[(Message, Option[D])]
       .collect { case (message, Some(document)) => Bundle(message, document) }
       .groupedWithin(
@@ -69,7 +69,6 @@ class PipelineStorageStream[T, D, MsgDestination](
           _ <- Future.fromTry(messageSender.send(indexable.id(bundle.document)))
         } yield bundle.message
       }
-  }
 
   private def storeDocuments(bundles: List[Bundle]): FutureBundles =
     for {

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -16,7 +16,10 @@ import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.pipeline_storage.fixtures.{ElasticIndexerFixtures, SampleDocument}
+import uk.ac.wellcome.pipeline_storage.fixtures.{
+  ElasticIndexerFixtures,
+  SampleDocument
+}
 
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -16,14 +16,13 @@ import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.pipeline_storage.fixtures.{
-  ElasticIndexerFixtures,
-  SampleDocument
-}
+import uk.ac.wellcome.pipeline_storage.fixtures.{ElasticIndexerFixtures, SampleDocument}
 
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Try}
 
 class PipelineStorageStreamTest
     extends AnyFunSpec
@@ -42,10 +41,13 @@ class PipelineStorageStreamTest
   def indexer(index: Index, elasticClient: ElasticClient = elasticClient) =
     new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
 
-  def withPipelineStream[R](indexer: Indexer[SampleDocument],
-                            visibilityTimeout: Int = 1,
-                            pipelineStorageConfig: PipelineStorageConfig =
-                              pipelineStorageConfig)(
+  def withPipelineStream[R](
+    indexer: Indexer[SampleDocument] = new MemoryIndexer[SampleDocument](
+      index = mutable.Map[String, SampleDocument]()
+    ),
+    sender: MemoryMessageSender = new MemoryMessageSender(),
+    visibilityTimeout: Int = 1,
+    pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(
     testWith: TestWith[
       (PipelineStorageStream[NotificationMessage, SampleDocument, String],
        QueuePair,
@@ -55,13 +57,12 @@ class PipelineStorageStreamTest
       withLocalSqsQueuePair(visibilityTimeout) {
         case q @ QueuePair(queue, _) =>
           withSQSStream[NotificationMessage, R](queue) { stream =>
-            val messageSender = new MemoryMessageSender
             testWith(
               (
-                new PipelineStorageStream(stream, indexer, messageSender)(
+                new PipelineStorageStream(stream, indexer, sender)(
                   pipelineStorageConfig),
                 q,
-                messageSender))
+                sender))
           }
 
       }
@@ -248,6 +249,33 @@ class PipelineStorageStreamTest
           assertQueueHasSize(dlq, size = 5)
         }
     }
+  }
 
+  it("leaves a document on the queue if it can't send an onward message") {
+    val document = SampleDocument(
+      version = 1,
+      canonicalId = createCanonicalId,
+      title = randomAlphanumeric()
+    )
+
+    val brokenSender = new MemoryMessageSender() {
+      override def send(body: String): Try[Unit] =
+        Failure(new Throwable("BOOM!"))
+    }
+
+    withPipelineStream(sender = brokenSender) {
+      case (pipelineStream, QueuePair(queue, dlq), _) =>
+        sendNotificationToSQS(queue, document)
+
+        pipelineStream.foreach(
+          "test stream",
+          _ => Future.successful(Some(document))
+        )
+
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueHasSize(dlq, size = 1)
+        }
+    }
   }
 }


### PR DESCRIPTION
_“it leaves a document on the queue if it can't send an onward message”_

This is already what it does, but we weren't testing it. I added this test to help debug some changes for https://github.com/wellcomecollection/platform/issues/4897, but there's nothing that ties it to that issue. Pulling it out into its own PR to be reviewed and merged separately.