### PR TITLE
Allow retrieving multiple documents in the Retriever

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -25,16 +25,16 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
       .execute {
         get(index, id)
       }
-      .flatMap {
-        case RequestFailure(_, _, _, error) => Future.failed(error.asException)
+      .map {
+        case RequestFailure(_, _, _, error) => throw error.asException
         case RequestSuccess(_, _, _, response) if !response.found =>
           warn(
             s"Asked to look up ID $id in index $index, got response $response")
-          Future.failed(new RetrieverNotFoundException(id))
+          throw new RetrieverNotFoundException(id)
         case RequestSuccess(_, _, _, response) =>
           response.safeTo[T] match {
-            case Success(item)  => Future.successful(item)
-            case Failure(error) => Future.failed(error)
+            case Success(item)  => item
+            case Failure(error) => throw error
           }
       }
   }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -33,6 +33,10 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
           warn(s"Asked for ${ids.size} IDs in index $index, only got ${result.docs.size}")
           throw new RetrieverNotFoundException(ids.mkString(", "))
         case RequestSuccess(_, _, _, result) =>
+
+          // Documents are guaranteed to be returned in the same order as the
+          // original IDs.
+          // See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-multi-get.html
           val documents = result
             .docs
             .map { _.safeTo[T] }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -2,11 +2,14 @@ package uk.ac.wellcome.pipeline_storage
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MemoryRetriever[T](index: Map[String, T] = Map.empty)(implicit val ec: ExecutionContext)
+class MemoryRetriever[T](index: Map[String, T] = Map.empty)(
+  implicit val ec: ExecutionContext)
     extends Retriever[T] {
 
   override def apply(ids: Seq[String]): Future[Map[String, T]] =
     Future {
-      ids.map { id => id -> index(id) }.toMap
+      ids.map { id =>
+        id -> index(id)
+      }.toMap
     }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.pipeline_storage
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class MemoryRetriever[T](index: Map[String, T] = Map.empty)
+class MemoryRetriever[T](index: Map[String, T] = Map.empty)(implicit val ec: ExecutionContext)
     extends Retriever[T] {
 
   def apply(id: String): Future[T] =

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -5,9 +5,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class MemoryRetriever[T](index: Map[String, T] = Map.empty)(implicit val ec: ExecutionContext)
     extends Retriever[T] {
 
-  def apply(id: String): Future[T] =
-    index.get(id) match {
-      case Some(t) => Future.successful(t)
-      case None    => Future.failed(new RetrieverNotFoundException(id))
+  override def apply(ids: Seq[String]): Future[Map[String, T]] =
+    Future {
+      ids.map { id => id -> index(id) }.toMap
     }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -11,11 +11,11 @@ trait Retriever[T] {
     * @param id The id of the document
     * @return A future containing the document
     */
-  def apply(id: String): Future[T]
+  def apply(id: String): Future[T] =
+    apply(Seq(id))
+      .map { _(id) }
+      .recover { case t: Throwable => throw new RetrieverNotFoundException(id) }
 
   /** Retrieves a series of documents from the store. */
-  def apply(ids: Seq[String]): Future[Map[String, T]] =
-    Future
-      .sequence(ids.map { apply })
-      .map { documents => ids.zip(documents).toMap }
+  def apply(ids: Seq[String]): Future[Map[String, T]]
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -1,8 +1,10 @@
 package uk.ac.wellcome.pipeline_storage
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait Retriever[T] {
+
+  implicit val ec: ExecutionContext
 
   /** Retrieves document with the given ID from the store
     *
@@ -10,4 +12,10 @@ trait Retriever[T] {
     * @return A future containing the document
     */
   def apply(id: String): Future[T]
+
+  /** Retrieves a series of documents from the store. */
+  def apply(ids: Seq[String]): Future[Map[String, T]] =
+    Future
+      .sequence(ids.map { apply })
+      .map { documents => ids.zip(documents).toMap }
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -52,7 +52,9 @@ trait RetrieverTestCases[Context, T]
 
     val documents = Seq(t1, t2, t3)
     val ids = documents.map { id.canonicalId }
-    val expectedResult = documents.map { t => id.canonicalId(t) -> t }.toMap
+    val expectedResult = documents.map { t =>
+      id.canonicalId(t) -> t
+    }.toMap
 
     withContext(documents = documents) { implicit context =>
       val future = withRetriever { _.apply(ids) }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/memory/MemoryRetrieverTest.scala
@@ -10,6 +10,8 @@ import uk.ac.wellcome.pipeline_storage.{
   RetrieverTestCases
 }
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class MemoryRetrieverTest extends RetrieverTestCases[Map[String, UUID], UUID] {
   override def withContext[R](documents: Seq[UUID])(
     testWith: TestWith[Map[String, UUID], R]): R =


### PR DESCRIPTION
Another piece for pipeline storage in the transformer (wellcomecollection/platform#4897).

The matcher needs to look up a potentially arbitrary number of documents. Currently it does this one at a time:

```scala
val works = workIdsToLookup.map { lookupWork }
```

but with Elasticsearch, we can fetch all the works in a single multi-get request.

This patch adds multi-get functionality to the retriever, so we don't have to make dozens of HTTP requests to Elasticsearch for every matcher operation.