### PR TITLE
Merge thumbnails onto Calm works

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
@@ -12,11 +12,21 @@ case class AccessCondition(
       case AccessCondition(None, None, None) => None
       case accessCondition                   => Some(accessCondition)
     }
+
+  def hasRestrictions: Boolean = status.exists(_.hasRestrictions)
 }
 
 sealed trait AccessStatus { this: AccessStatus =>
 
   def name = this.getClass.getSimpleName.stripSuffix("$")
+
+  def hasRestrictions: Boolean = this match {
+    case AccessStatus.OpenWithAdvisory   => true
+    case AccessStatus.Restricted         => true
+    case AccessStatus.Closed             => true
+    case AccessStatus.PermissionRequired => true
+    case _                               => false
+  }
 }
 
 object AccessStatus {

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
@@ -4,12 +4,14 @@ sealed trait LocationDeprecated {
   val locationType: LocationType
   val accessConditions: List[AccessCondition]
 
-  def isRestrictedOrClosed =
+  def hasRestrictions: Boolean =
     accessConditions.exists { accessCondition =>
-      accessCondition.status match {
-        case Some(AccessStatus.Restricted) => true
-        case Some(AccessStatus.Closed)     => true
-        case _                             => false
+      accessCondition.status exists {
+        case AccessStatus.OpenWithAdvisory   => true
+        case AccessStatus.Restricted         => true
+        case AccessStatus.Closed             => true
+        case AccessStatus.PermissionRequired => true
+        case _                               => false
       }
     }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/LocationDeprecated.scala
@@ -5,15 +5,7 @@ sealed trait LocationDeprecated {
   val accessConditions: List[AccessCondition]
 
   def hasRestrictions: Boolean =
-    accessConditions.exists { accessCondition =>
-      accessCondition.status exists {
-        case AccessStatus.OpenWithAdvisory   => true
-        case AccessStatus.Restricted         => true
-        case AccessStatus.Closed             => true
-        case AccessStatus.PermissionRequired => true
-        case _                               => false
-      }
-    }
+    accessConditions.exists(_.hasRestrictions)
 }
 
 case class DigitalLocationDeprecated(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/CalmWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/CalmWorkGenerators.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.models.work.generators
+
+import uk.ac.wellcome.models.work.internal.{Work, WorkState}
+
+trait CalmWorkGenerators extends WorkGenerators with ItemsGenerators {
+
+  def calmSourceWork(): Work.Visible[WorkState.Source] =
+    sourceWork(sourceIdentifier = createCalmSourceIdentifier)
+      .items(List(createCalmItem))
+
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -45,8 +45,13 @@ trait ItemsGenerators extends IdentifiersGenerators {
 
   def createPhysicalLocationWith(locationType: LocationType =
                                    createStoresLocationType,
+                                 accessConditions: List[AccessCondition] = Nil,
                                  label: String = "locationLabel") =
-    PhysicalLocationDeprecated(locationType, label)
+    PhysicalLocationDeprecated(
+      locationType = locationType,
+      label = label,
+      accessConditions = accessConditions
+    )
 
   def createDigitalLocation = createDigitalLocationWith()
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SourceWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/SourceWorkGenerators.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.models.work.generators
+
+trait SourceWorkGenerators
+    extends SierraWorkGenerators
+    with MiroWorkGenerators
+    with MetsWorkGenerators
+    with CalmWorkGenerators

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -22,6 +22,8 @@ import WorkState.Source
  * displaying something we are not meant to.
  */
 object ThumbnailRule extends FieldMergeRule with MergerLogging {
+  import WorkPredicates._
+
   type FieldData = Option[LocationDeprecated]
 
   override def merge(target: Work.Visible[Source],
@@ -47,9 +49,9 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
 
   val getMetsThumbnail =
     new PartialRule {
-      val isDefinedForTarget: WorkPredicate = WorkPredicates.sierraWork
-      val isDefinedForSource: WorkPredicate =
-        WorkPredicates.singleDigitalItemMetsWork
+      val isDefinedForTarget: WorkPredicate =
+        sierraWork or singlePhysicalItemCalmWork
+      val isDefinedForSource: WorkPredicate = singleDigitalItemMetsWork
 
       def rule(target: Work.Visible[Source],
                sources: NonEmptyList[Work[Source]]): FieldData = {
@@ -61,9 +63,8 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
   val getMinMiroThumbnail =
     new PartialRule {
       val isDefinedForTarget: WorkPredicate =
-        WorkPredicates.singleItemSierra or WorkPredicates.zeroItemSierra
-      val isDefinedForSource: WorkPredicate =
-        WorkPredicates.singleDigitalItemMiroWork
+        singleItemSierra or zeroItemSierra or singlePhysicalItemCalmWork
+      val isDefinedForSource: WorkPredicate = singleDigitalItemMiroWork
 
       def rule(target: Work.Visible[Source],
                sources: NonEmptyList[Work[Source]]): FieldData = {

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -91,7 +91,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
                               sources: Seq[Work[Source]]) =
     (target :: sources.toList).exists { work =>
       work.data.items.exists { item =>
-        item.locations.exists(_.isRestrictedOrClosed)
+        item.locations.exists(_.hasRestrictions)
       }
     }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -3,11 +3,7 @@ package uk.ac.wellcome.platform.merger
 import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.{
-  MetsWorkGenerators,
-  MiroWorkGenerators,
-  SierraWorkGenerators
-}
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.models.work.internal.Format
 import uk.ac.wellcome.platform.merger.fixtures.FeatureTestSugar
 import uk.ac.wellcome.platform.merger.services.PlatformMerger
@@ -17,9 +13,7 @@ class MergerFeatureTest
     with GivenWhenThen
     with Matchers
     with FeatureTestSugar
-    with SierraWorkGenerators
-    with MiroWorkGenerators
-    with MetsWorkGenerators {
+    with SourceWorkGenerators {
   val merger = PlatformMerger
 
   /*
@@ -127,8 +121,7 @@ class MergerFeatureTest
     Scenario("A Calm work and a Sierra work are matched") {
       Given("a Sierra work and a Calm work")
       val sierra = sierraPhysicalSourceWork()
-      val calm = sourceWork(sourceIdentifier = createCalmSourceIdentifier)
-        .items(List(createCalmItem))
+      val calm = calmSourceWork()
 
       When("the works are merged")
       val outcome = merger.merge(Seq(sierra, calm))

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -3,18 +3,14 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.{
-  MetsWorkGenerators,
-  MiroWorkGenerators
-}
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 
 class ItemsRuleTest
     extends AnyFunSpec
     with Matchers
-    with MetsWorkGenerators
-    with MiroWorkGenerators
+    with SourceWorkGenerators
     with Inside {
   val physicalPictureSierra: Work.Visible[WorkState.Source] =
     sierraPhysicalSourceWork()
@@ -36,9 +32,7 @@ class ItemsRuleTest
 
   val miroWork: Work.Visible[WorkState.Source] = miroSourceWork()
 
-  val calmWork: Work.Visible[WorkState.Source] =
-    sourceWork(sourceIdentifier = createCalmSourceIdentifier)
-      .items(List(createCalmItem))
+  val calmWork: Work.Visible[WorkState.Source] = calmSourceWork()
 
   it(
     "leaves items unchanged and returns a digitised version of a Sierra work as a merged source") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -3,18 +3,14 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inside, Inspectors}
-import uk.ac.wellcome.models.work.generators.{
-  MetsWorkGenerators,
-  MiroWorkGenerators
-}
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 
 class OtherIdentifiersRuleTest
     extends AnyFunSpec
     with Matchers
-    with MetsWorkGenerators
-    with MiroWorkGenerators
+    with SourceWorkGenerators
     with Inside
     with Inspectors {
   val nothingWork: Work.Visible[WorkState.Source] = sourceWork(
@@ -49,9 +45,7 @@ class OtherIdentifiersRuleTest
         createPhysicalItem
       }.toList)
 
-  val calmWork: Work.Visible[WorkState.Source] =
-    sourceWork(sourceIdentifier = createCalmSourceIdentifier)
-      .items(List(createCalmItem))
+  val calmWork: Work.Visible[WorkState.Source] = calmSourceWork()
 
   val mergeCandidate: Work.Visible[WorkState.Source] = sierraSourceWork()
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -22,6 +22,8 @@ class ThumbnailRuleTest
 
   val digitalSierraWork = sierraDigitalSourceWork()
 
+  val calmWork = calmSourceWork()
+
   val metsWork = metsSourceWork()
     .thumbnail(
       DigitalLocationDeprecated(
@@ -53,6 +55,14 @@ class ThumbnailRuleTest
   it(
     "chooses the METS thumbnail from a single-item digital METS work for a digital Sierra target") {
     inside(ThumbnailRule.merge(digitalSierraWork, miroWorks :+ metsWork)) {
+      case FieldMergeResult(thumbnail, _) =>
+        thumbnail shouldBe defined
+        thumbnail shouldBe metsWork.data.thumbnail
+    }
+  }
+
+  it("chooses the METS thumbnail for a Calm target") {
+    inside(ThumbnailRule.merge(calmWork, miroWorks :+ metsWork)) {
       case FieldMergeResult(thumbnail, _) =>
         thumbnail shouldBe defined
         thumbnail shouldBe metsWork.data.thumbnail

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.merger.rules
 import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.models.work.internal.{
   AccessCondition,
   AccessStatus,
@@ -15,15 +15,14 @@ import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 class ThumbnailRuleTest
     extends AnyFunSpec
     with Matchers
-    with SierraWorkGenerators
+    with SourceWorkGenerators
     with Inside {
 
   val physicalSierraWork = sierraPhysicalSourceWork()
 
   val digitalSierraWork = sierraDigitalSourceWork()
 
-  val metsWork = sourceWork(createMetsSourceIdentifier)
-    .items(List(createDigitalItem))
+  val metsWork = metsSourceWork()
     .thumbnail(
       DigitalLocationDeprecated(
         url = "mets.com/thumbnail.jpg",
@@ -32,31 +31,7 @@ class ThumbnailRuleTest
       )
     )
 
-  val miroWorks = (0 to 3)
-    .map { i =>
-      f"V$i%04d"
-    }
-    .map { id =>
-      sourceWork(createMiroSourceIdentifierWith(id))
-        .thumbnail(
-          DigitalLocationDeprecated(
-            url = s"https://iiif.wellcomecollection.org/$id.jpg",
-            locationType = LocationType("thumbnail-image"),
-            license = Some(License.CCBY)
-          )
-        )
-        .items(
-          List(
-            createUnidentifiableItemWith(
-              locations = List(
-                createDigitalLocationWith(
-                  locationType = createImageLocationType
-                )
-              )
-            )
-          )
-        )
-    }
+  val miroWorks = (0 to 3).map(_ => miroSourceWork())
 
   val restrictedDigitalWork =
     sierraSourceWork().items(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRuleTest.scala
@@ -24,6 +24,15 @@ class ThumbnailRuleTest
 
   val calmWork = calmSourceWork()
 
+  val calmWorkWithAdvisory = calmSourceWork().items(
+    List(
+      createUnidentifiableItemWith(locations = List(createPhysicalLocationWith(
+        locationType = LocationType("scmac"),
+        label = "Closed stores Arch. & MSS",
+        accessConditions =
+          List(AccessCondition(status = Some(AccessStatus.OpenWithAdvisory)))
+      )))))
+
   val metsWork = metsSourceWork()
     .thumbnail(
       DigitalLocationDeprecated(
@@ -100,6 +109,13 @@ class ThumbnailRuleTest
 
   it("suppresses thumbnails when restricted access status") {
     inside(ThumbnailRule.merge(restrictedDigitalWork, miroWorks :+ metsWork)) {
+      case FieldMergeResult(thumbnail, _) =>
+        thumbnail shouldBe None
+    }
+  }
+
+  it("suppresses thumbnails when an archive is open with advisory") {
+    inside(ThumbnailRule.merge(calmWorkWithAdvisory, miroWorks :+ metsWork)) {
       case FieldMergeResult(thumbnail, _) =>
         thumbnail shouldBe None
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -7,15 +7,11 @@ import uk.ac.wellcome.models.work.internal._
 import WorkState.{Merged, Source}
 import WorkFsm._
 import SourceWork._
-import uk.ac.wellcome.models.work.generators.{
-  MetsWorkGenerators,
-  MiroWorkGenerators
-}
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 
 class PlatformMergerTest
     extends AnyFunSpec
-    with MetsWorkGenerators
-    with MiroWorkGenerators
+    with SourceWorkGenerators
     with Matchers {
   import Merger.WorkMergingOps
 
@@ -88,9 +84,7 @@ class PlatformMergerTest
       )
       .invisible()
 
-  val calmWork: Work.Visible[Source] =
-    sourceWork(sourceIdentifier = createCalmSourceIdentifier)
-      .items(List(createCalmItem))
+  val calmWork: Work.Visible[Source] = calmSourceWork()
 
   private val merger = PlatformMerger
 


### PR DESCRIPTION
This also consolidates our branching on access statuses into one place, therefore enforcing that we make these decisions consistently across the pipeline (rather than separately in the METS transformer and the merger).

Resolves https://github.com/wellcomecollection/platform/issues/4892