### PR TITLE
Deduplicate AIDS posters images

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -84,4 +84,11 @@ trait IdentifiersGenerators extends RandomGenerators {
       identifierType = IdentifierType("calm-record-id"),
       ontologyType = "Work"
     )
+
+  def createDigcodeIdentifier(digcode: String): SourceIdentifier =
+    SourceIdentifier(
+      value = digcode,
+      identifierType = IdentifierType("wellcome-digcode"),
+      ontologyType = "Work"
+    )
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImagesRule.scala
@@ -26,6 +26,8 @@ object ImagesRule extends FieldMergeRule {
       }
     )
 
+  // In future this may be changed to `digmiro` for all works
+  // where we know that the Miro and METS images are identical
   private lazy val getOnlyMetsDigaidsImages = new FlatImageMergeRule {
     val isDefinedForTarget: WorkPredicate =
       sierraDigaids and sierraPictureOrEphemera

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -63,6 +63,8 @@ object WorkPredicates {
         format(Format.Pictures)
     )
 
+  // In future this may be changed to `digmiro` for all works
+  // where we know that the Miro and METS images are identical
   val sierraDigaids: WorkPredicate =
     satisfiesAll(sierraWork, hasDigcode("digaids"))
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -63,6 +63,9 @@ object WorkPredicates {
         format(Format.Pictures)
     )
 
+  val sierraDigaids: WorkPredicate =
+    satisfiesAll(sierraWork, hasDigcode("digaids"))
+
   def not(pred: WorkPredicate): WorkPredicate = !pred(_)
 
   def sierraWorkWithId(id: SourceIdentifier)(work: Work[Source]): Boolean =
@@ -96,6 +99,11 @@ object WorkPredicates {
     work.data.items.forall { item =>
       item.locations.size == 1
     }
+
+  private def hasDigcode(digcode: String)(work: Work[Source]): Boolean =
+    work.data.otherIdentifiers
+      .find(_.identifierType.id == "wellcome-digcode")
+      .exists(_.value == digcode)
 
   private def identifierTypeId(id: String)(work: Work[Source]): Boolean =
     work.sourceIdentifier.identifierType == IdentifierType(id)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -109,6 +109,30 @@ class MergerFeatureTest
         .images should contain only mets.singleImage
     }
 
+    Scenario("An AIDS poster Sierra picture, a METS and a Miro are matched") {
+      Given(
+        "a Sierra picture with digcode `digaids`, a METS work and a Miro work")
+      val sierraDigaidsPicture = sierraSourceWork()
+        .items(List(createPhysicalItem))
+        .format(Format.Pictures)
+        .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
+      val mets = metsSourceWork()
+      val miro = miroSourceWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierraDigaidsPicture, mets, miro))
+
+      Then("the METS work and the Miro work are redirected to the Sierra work")
+      outcome.getMerged(mets) should beRedirectedTo(sierraDigaidsPicture)
+      outcome.getMerged(miro) should beRedirectedTo(sierraDigaidsPicture)
+
+      And("the Sierra work contains only the METS images")
+      outcome
+        .getMerged(sierraDigaidsPicture)
+        .data
+        .images should contain only mets.singleImage
+    }
+
     Scenario("A physical and a digital Sierra work are matched") {
       Given("a pair of a physical Sierra work and a digital Sierra work")
       val (digitalSierra, physicalSierra) = sierraSourceWorkPair()

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
@@ -102,6 +102,33 @@ class ImagesRuleTest
       result.map(_.location) should contain theSameElementsAs
         miroWorks.map(_.data.images.head.location)
     }
+
+    it(
+      "does not use Miro images when a METS image is present for a digaids Sierra work") {
+      val metsWork = createInvisibleMetsSourceWorkWith(numImages = 1)
+      val miroWork = miroSourceWork()
+      val sierraDigaidsWork = sierraSourceWork()
+        .format(Format.Pictures)
+        .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
+      val result =
+        ImagesRule.merge(sierraDigaidsWork, List(miroWork, metsWork)).data
+
+      result should have length 1
+      result.map(_.location) should contain only metsWork.data.images.head.location
+    }
+
+    it(
+      "will use Miro images for digaids Sierra works when no METS image is present") {
+      val miroWork = miroSourceWork()
+      val sierraDigaidsWork = sierraSourceWork()
+        .format(Format.Pictures)
+        .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
+      val result =
+        ImagesRule.merge(sierraDigaidsWork, List(miroWork)).data
+
+      result should have length 1
+      result.map(_.location) should contain only miroWork.data.images.head.location
+    }
   }
 
   describe("the flat image merging rule") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicatesTest.scala
@@ -44,6 +44,8 @@ class WorkPredicatesTest
     sierraSourceWork().format(Format.DigitalImages),
     sierraSourceWork().format(Format.Pictures),
     sierraSourceWork().format(Format.Music),
+    sierraSourceWork().otherIdentifiers(
+      List(createDigcodeIdentifier("digaids")))
   )
 
   it("selects Sierra works") {
@@ -103,6 +105,16 @@ class WorkPredicatesTest
         (Format.Pictures,
         Format.DigitalImages,
         Format.`3DObjects`)
+    }
+  }
+
+  it("selects Sierra works with the `digaids` digcode") {
+    val filtered = works.filter(WorkPredicates.sierraDigaids)
+    filtered should not be empty
+    forAll(filtered) { work =>
+      work.data.otherIdentifiers.map(_.identifierType.id) should contain(
+        "wellcome-digcode")
+      work.data.otherIdentifiers.map(_.value) should contain("digaids")
     }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -155,12 +155,7 @@ class SierraIdentifiersTest
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
-      otherIdentifiers should contain(
-        SourceIdentifier(
-          identifierType = IdentifierType("wellcome-digcode"),
-          ontologyType = "Work",
-          value = digcode
-        ))
+      otherIdentifiers should contain(createDigcodeIdentifier(digcode))
     }
 
     it("multiple identifiers") {
@@ -174,18 +169,8 @@ class SierraIdentifiersTest
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
-      otherIdentifiers should contain(
-        SourceIdentifier(
-          identifierType = IdentifierType("wellcome-digcode"),
-          ontologyType = "Work",
-          value = digcode1
-        ))
-      otherIdentifiers should contain(
-        SourceIdentifier(
-          identifierType = IdentifierType("wellcome-digcode"),
-          ontologyType = "Work",
-          value = digcode2
-        ))
+      otherIdentifiers should contain(createDigcodeIdentifier(digcode1))
+      otherIdentifiers should contain(createDigcodeIdentifier(digcode2))
     }
 
     it("deduplicates identifiers") {
@@ -235,12 +220,7 @@ class SierraIdentifiersTest
         )
       )
       val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
-      otherIdentifiers should contain(
-        SourceIdentifier(
-          identifierType = IdentifierType("wellcome-digcode"),
-          ontologyType = "Work",
-          value = parsedDigcode
-        ))
+      otherIdentifiers should contain(createDigcodeIdentifier(parsedDigcode))
     }
 
     it("deduplicates based on the actual digcode") {


### PR DESCRIPTION
aka; if there are METS and Miro images for `digaids` works, then only use the METS images.

Resolves https://github.com/wellcomecollection/platform/issues/4875