### PR TITLE
Make image locations a list in the internal model

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -58,7 +58,7 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
   def buildImageFilterQuery(filters: Seq[ImageFilter]): Seq[Query] =
     filters.map {
       case LicenseFilter(licenseIds) =>
-        termsQuery(field = "location.license.id", values = licenseIds)
+        termsQuery(field = "locations.license.id", values = licenseIds)
     }
 
   def buildImageMustQuery(queries: List[ImageMustQuery]): Seq[Query] =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
@@ -38,7 +38,7 @@ trait ApiImagesTestBase
        |  {
        |    "type": "Image",
        |    "id": "${image.id.canonicalId}",
-       |    "locations": [${location(image.location)}],
+       |    "locations": [${location(image.locations)}],
        |    "source": ${imageSource(image.source)}
        |  }
      """.stripMargin

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
@@ -38,7 +38,7 @@ trait ApiImagesTestBase
        |  {
        |    "type": "Image",
        |    "id": "${image.id.canonicalId}",
-       |    "locations": [${location(image.locations)}],
+       |    "locations": [${locations(image.locations)}],
        |    "source": ${imageSource(image.source)}
        |  }
      """.stripMargin

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -35,7 +35,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id.canonicalId}",
-              |      "locations": [${location(image.locations)}],
+              |      "locations": [${locations(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
               |        "title": "Apple agitator",
@@ -64,7 +64,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id.canonicalId}",
-              |  "locations": [${location(image.locations)}],
+              |  "locations": [${locations(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",
               |    "title": "Apple agitator",
@@ -93,7 +93,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id.canonicalId}",
-              |      "locations": [${location(image.locations)}],
+              |      "locations": [${locations(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
               |        "title": "Apple agitator",
@@ -122,7 +122,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id.canonicalId}",
-              |  "locations": [${location(image.locations)}],
+              |  "locations": [${locations(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",
               |    "title": "Apple agitator",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -35,7 +35,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id.canonicalId}",
-              |      "locations": [${location(image.location)}],
+              |      "locations": [${location(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
               |        "title": "Apple agitator",
@@ -64,7 +64,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id.canonicalId}",
-              |  "locations": [${location(image.location)}],
+              |  "locations": [${location(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",
               |    "title": "Apple agitator",
@@ -93,7 +93,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id.canonicalId}",
-              |      "locations": [${location(image.location)}],
+              |      "locations": [${location(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
               |        "title": "Apple agitator",
@@ -122,7 +122,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id.canonicalId}",
-              |  "locations": [${location(image.location)}],
+              |  "locations": [${location(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",
               |    "title": "Apple agitator",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -19,7 +19,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.locations)}],
+               |  "locations": [${locations(image.locations)}],
                |  "visuallySimilar": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
@@ -46,7 +46,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.locations)}],
+               |  "locations": [${locations(image.locations)}],
                |  "withSimilarFeatures": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
@@ -73,7 +73,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.locations)}],
+               |  "locations": [${locations(image.locations)}],
                |  "withSimilarColors": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -19,7 +19,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.location)}],
+               |  "locations": [${digitalLocation(image.locations)}],
                |  "visuallySimilar": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
@@ -46,7 +46,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.location)}],
+               |  "locations": [${digitalLocation(image.locations)}],
                |  "withSimilarFeatures": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],
@@ -73,7 +73,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id.canonicalId}",
-               |  "locations": [${digitalLocation(image.location)}],
+               |  "locations": [${digitalLocation(image.locations)}],
                |  "withSimilarColors": [
                |    ${images.tail.map(imageResponse).mkString(",")}
                |  ],

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -30,7 +30,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
              |{
              |  $singleImageResult,
              |  "id": "${image.id.canonicalId}",
-             |  "locations": [${digitalLocation(image.location)}],
+             |  "locations": [${digitalLocation(image.locations)}],
              |  "source": ${imageSource(image.source)}
              |}""".stripMargin
         }
@@ -155,7 +155,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${defaultImage.id.canonicalId}",
-                 |  "locations": [${location(defaultImage.location)}],
+                 |  "locations": [${location(defaultImage.locations)}],
                  |  "source": ${imageSource(defaultImage.source)}
                  }""".stripMargin
           }
@@ -168,7 +168,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${alternativeImage.id.canonicalId}",
-                 |  "locations": [${location(alternativeImage.location)}],
+                 |  "locations": [${location(alternativeImage.locations)}],
                  |  "source": ${imageSource(alternativeImage.source)}
                  }""".stripMargin
           }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -30,7 +30,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
              |{
              |  $singleImageResult,
              |  "id": "${image.id.canonicalId}",
-             |  "locations": [${digitalLocation(image.locations)}],
+             |  "locations": [${locations(image.locations)}],
              |  "source": ${imageSource(image.source)}
              |}""".stripMargin
         }
@@ -155,7 +155,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${defaultImage.id.canonicalId}",
-                 |  "locations": [${location(defaultImage.locations)}],
+                 |  "locations": [${locations(defaultImage.locations)}],
                  |  "source": ${imageSource(defaultImage.source)}
                  }""".stripMargin
           }
@@ -168,7 +168,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${alternativeImage.id.canonicalId}",
-                 |  "locations": [${location(alternativeImage.locations)}],
+                 |  "locations": [${locations(alternativeImage.locations)}],
                  |  "source": ${imageSource(alternativeImage.source)}
                  }""".stripMargin
           }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
@@ -41,7 +41,7 @@ object DisplayImage {
   def apply(image: AugmentedImage, includes: ImageIncludes): DisplayImage =
     new DisplayImage(
       id = image.id.canonicalId,
-      locations = Seq(DisplayDigitalLocationDeprecated(image.location)),
+      locations = Seq(DisplayDigitalLocationDeprecated(image.locations)),
       source = DisplayImageSource(image.source, includes),
       visuallySimilar = None,
       withSimilarColors = None,

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
@@ -41,7 +41,7 @@ object DisplayImage {
   def apply(image: AugmentedImage, includes: ImageIncludes): DisplayImage =
     new DisplayImage(
       id = image.id.canonicalId,
-      locations = Seq(DisplayDigitalLocationDeprecated(image.locations)),
+      locations = image.locations.map(DisplayDigitalLocationDeprecated(_)),
       source = DisplayImageSource(image.source, includes),
       visuallySimilar = None,
       withSimilarColors = None,

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -33,7 +33,7 @@ object ImagesIndexConfig extends IndexConfig with WorksIndexConfigFields {
     id(),
     version,
     modifiedTime,
-    location("location"),
+    location("locations"),
     source,
     inferredData
   ).dynamic(DynamicMapping.Strict)

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -131,7 +131,7 @@ trait WorksIndexConfigFields extends IndexConfigFields {
 
   def images(idState: ObjectField) = objectField("images").fields(
     idState,
-    location("location"),
+    location("locations"),
     version
   )
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Image.scala
@@ -4,13 +4,13 @@ import java.time.Instant
 
 sealed trait BaseImage[+State <: DataState] extends HasId[State#Id] {
   val id: State#Id
-  val location: DigitalLocationDeprecated
+  val locations: List[DigitalLocationDeprecated]
 }
 
 case class UnmergedImage[State <: DataState](
   id: State#Id,
   version: Int,
-  location: DigitalLocationDeprecated
+  locations: List[DigitalLocationDeprecated]
 ) extends BaseImage[State] {
   def mergeWith(canonicalWork: SourceWork[State],
                 redirectedWork: Option[SourceWork[State]] = None,
@@ -19,7 +19,7 @@ case class UnmergedImage[State <: DataState](
       id = id,
       version = version,
       modifiedTime = modifiedTime,
-      location = location,
+      locations = locations,
       source = SourceWorks[State](canonicalWork, redirectedWork)
     )
 
@@ -29,7 +29,7 @@ case class UnmergedImage[State <: DataState](
       id = id,
       version = version,
       modifiedTime = modifiedTime,
-      location = location,
+      locations = locations,
       source = source
     )
 }
@@ -38,7 +38,7 @@ case class MergedImage[State <: DataState](
   id: State#Id,
   version: Int,
   modifiedTime: Instant,
-  location: DigitalLocationDeprecated,
+  locations: List[DigitalLocationDeprecated],
   source: ImageSource[State]
 ) extends BaseImage[State]
 
@@ -50,7 +50,7 @@ object MergedImage {
         id = mergedImage.id,
         version = mergedImage.version,
         modifiedTime = mergedImage.modifiedTime,
-        location = mergedImage.location,
+        locations = mergedImage.locations,
         source = mergedImage.source,
         inferredData = inferredData
       )
@@ -61,7 +61,7 @@ case class AugmentedImage(
   id: IdState.Identified,
   version: Int,
   modifiedTime: Instant,
-  location: DigitalLocationDeprecated,
+  locations: List[DigitalLocationDeprecated],
   source: ImageSource[DataState.Identified],
   inferredData: Option[InferredData] = None
 ) extends BaseImage[DataState.Identified]
@@ -82,11 +82,11 @@ object InferredData {
 object UnmergedImage {
   def apply(sourceIdentifier: SourceIdentifier,
             version: Int,
-            location: DigitalLocationDeprecated)
+            locations: List[DigitalLocationDeprecated])
     : UnmergedImage[DataState.Unidentified] =
     UnmergedImage[DataState.Unidentified](
       id = IdState.Identifiable(sourceIdentifier),
       version = version,
-      location
+      locations
     )
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -45,7 +45,8 @@ trait ImageGenerators
   def createIdentifiedMergedImageWith(
     imageId: IdState.Identified =
       IdState.Identified(createCanonicalId, createSourceIdentifier),
-    locations: List[DigitalLocationDeprecated] = List(createDigitalLocation),
+    locations: List[DigitalLocationDeprecated] = List(
+      createDigitalLocationWith(locationType = createImageLocationType)),
     version: Int = 1,
     modifiedTime: Instant = instantInLast30Days,
     parentWork: Work.Visible[WorkState.Identified] = sierraIdentifiedWork(),

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -12,7 +12,7 @@ trait ImageGenerators
     with VectorGenerators
     with SierraWorkGenerators {
   def createUnmergedImageWith(
-    location: DigitalLocationDeprecated = createDigitalLocation,
+    locations: List[DigitalLocationDeprecated] = List(createDigitalLocation),
     version: Int = 1,
     identifierValue: String = randomAlphanumeric(10),
     identifierType: IdentifierType = IdentifierType("miro-image-number")
@@ -22,29 +22,30 @@ trait ImageGenerators
         identifierType = identifierType,
         value = identifierValue),
       version = version,
-      location = location
+      locations = locations
     )
 
   def createUnmergedImage: UnmergedImage[DataState.Unidentified] =
     createUnmergedImageWith()
 
   def createUnmergedMiroImage = createUnmergedImageWith(
-    location = DigitalLocationDeprecated(
-      url = "https://iiif.wellcomecollection.org/V01234.jpg",
-      locationType = LocationType("iiif-image"),
-      license = Some(License.CCBY)
-    )
+    locations = List(
+      DigitalLocationDeprecated(
+        url = "https://iiif.wellcomecollection.org/V01234.jpg",
+        locationType = LocationType("iiif-image"),
+        license = Some(License.CCBY)
+      ))
   )
 
   def createUnmergedMetsImage = createUnmergedImageWith(
-    location = createDigitalLocation,
+    locations = List(createDigitalLocation),
     identifierType = IdentifierType("mets-image")
   )
 
   def createIdentifiedMergedImageWith(
     imageId: IdState.Identified =
       IdState.Identified(createCanonicalId, createSourceIdentifier),
-    location: DigitalLocationDeprecated = createDigitalLocation,
+    locations: List[DigitalLocationDeprecated] = List(createDigitalLocation),
     version: Int = 1,
     modifiedTime: Instant = instantInLast30Days,
     parentWork: Work.Visible[WorkState.Identified] = sierraIdentifiedWork(),
@@ -54,7 +55,7 @@ trait ImageGenerators
       imageId,
       version,
       modifiedTime,
-      location,
+      locations,
       SourceWorks(parentWork.toSourceWork, redirectedWork.map(_.toSourceWork)))
 
   def createInferredData = {
@@ -80,13 +81,13 @@ trait ImageGenerators
     redirectedWork: Option[Work.Visible[WorkState.Identified]] = Some(
       identifiedWork()),
     inferredData: Option[InferredData] = createInferredData,
-    location: DigitalLocationDeprecated = createDigitalLocation,
+    locations: List[DigitalLocationDeprecated] = List(createDigitalLocation),
     version: Int = 1,
     modifiedTime: Instant = instantInLast30Days,
   ) =
     createIdentifiedMergedImageWith(
       imageId,
-      location,
+      locations,
       version,
       modifiedTime,
       parentWork,
@@ -97,7 +98,7 @@ trait ImageGenerators
 
   def createLicensedImage(license: License): AugmentedImage =
     createAugmentedImageWith(
-      location = createDigitalLocationWith(license = Some(license))
+      locations = List(createDigitalLocationWith(license = Some(license)))
     )
 
   // Create a set of images with intersecting LSH lists to ensure
@@ -144,7 +145,7 @@ trait ImageGenerators
           sourceIdentifier = image.id.allSourceIdentifiers.head
         ),
         version = image.version,
-        location = image.location
+        locations = image.locations
       )
 
     val toIdentified: UnmergedImage[DataState.Identified] =

--- a/pipeline/id_minter/id_minter_images/src/test/scala/uk/ac/wellcome/platform/id_minter_images/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/id_minter_images/src/test/scala/uk/ac/wellcome/platform/id_minter_images/IdMinterFeatureTest.scala
@@ -47,7 +47,7 @@ class IdMinterFeatureTest
             images.map(_.id.canonicalId).distinct should have size 1
             images.foreach { receivedImage =>
               receivedImage.id.sourceIdentifier shouldBe image.id.sourceIdentifier
-              receivedImage.location shouldBe image.location
+              receivedImage.locations shouldBe image.locations
             }
           }
         }

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloader.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloader.scala
@@ -57,7 +57,7 @@ class ImageDownloader[Ctx](
 
   private def createImageFileRequest(
     image: MergedIdentifiedImage): (HttpRequest, MergedIdentifiedImage) = {
-    val uri = getImageUri(image.location.url)
+    val uri = getImageUri(image.locations.url)
     (HttpRequest(method = HttpMethods.GET, uri = uri), image)
   }
 
@@ -75,7 +75,7 @@ class ImageDownloader[Ctx](
     case (Success(failedResponse), image) =>
       failedResponse.discardEntityBytes()
       Future.failed(throw new RuntimeException(
-        s"Image request for ${image.location.url} failed with status ${failedResponse.status}"))
+        s"Image request for ${image.locations.url} failed with status ${failedResponse.status}"))
     case (Failure(exception), _) => Future.failed(exception)
   }
 

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -52,9 +52,11 @@ class ManagerInferrerIntegrationTest
         }
 
         val image = createIdentifiedMergedImageWith(
-          location = createDigitalLocationWith(
-            url = s"http://localhost:$localImageServerPort/test-image.jpg"
-          )
+          locations = List(
+            createDigitalLocationWith(
+              locationType = createImageLocationType,
+              url = s"http://localhost:$localImageServerPort/test-image.jpg"
+            ))
         )
         sendMessage(queue, image)
         eventually {

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloaderTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloaderTest.scala
@@ -36,9 +36,11 @@ class ImageDownloaderTest
         withDownloaderAndFileWriter() {
           case (downloader, requestPool, _) =>
             val image = createIdentifiedMergedImageWith(
-              location = createDigitalLocationWith(
-                url = "http://images.com/this-image.jpg"
-              )
+              locations = List(
+                createDigitalLocationWith(
+                  locationType = createImageLocationType,
+                  url = "http://images.com/this-image.jpg"
+                ))
             )
             val result = Source
               .single(image)
@@ -49,7 +51,7 @@ class ImageDownloaderTest
             whenReady(result) { _ =>
               requestPool.requests should have size 1
               requestPool.requests.keys.head.uri.toString should be(
-                image.locations.url)
+                image.locations.head.url)
             }
         }
       }
@@ -87,6 +89,37 @@ class ImageDownloaderTest
               .runWith(Sink.ignore)
 
             result.failed.futureValue should not be null
+        }
+      }
+    }
+
+    it("selects iiif-image locations from a list of locations") {
+      withMaterializer { implicit materializer =>
+        withDownloaderAndFileWriter() {
+          case (downloader, requestPool, _) =>
+            val image = createIdentifiedMergedImageWith(
+              locations = List(
+                createDigitalLocationWith(
+                  locationType = createPresentationLocationType,
+                  url = "http://example.com/image/manifest"
+                ),
+                createDigitalLocationWith(
+                  locationType = createImageLocationType,
+                  url = "http://images.com/this-image.jpg"
+                )
+              )
+            )
+            val result = Source
+              .single(image)
+              .asSourceWithContext(_ => ())
+              .via(downloader.download)
+              .runWith(Sink.ignore)
+
+            whenReady(result) { _ =>
+              requestPool.requests should have size 1
+              requestPool.requests.keys.head.uri.toString should be(
+                image.locations(1).url)
+            }
         }
       }
     }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloaderTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/ImageDownloaderTest.scala
@@ -49,7 +49,7 @@ class ImageDownloaderTest
             whenReady(result) { _ =>
               requestPool.requests should have size 1
               requestPool.requests.keys.head.uri.toString should be(
-                image.location.url)
+                image.locations.url)
             }
         }
       }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -132,13 +132,14 @@ class InferenceManagerWorkerServiceTest
 
   it("places images that fail inference on the DLQ") {
     val image404 = createIdentifiedMergedImageWith(
-      location = createDigitalLocationWith(url = "lost_image")
+      locations = List(createDigitalLocationWith(url = "lost_image"))
     )
     val image400 = createIdentifiedMergedImageWith(
-      location = createDigitalLocationWith(url = "malformed_image_url")
+      locations = List(createDigitalLocationWith(url = "malformed_image_url"))
     )
     val image500 = createIdentifiedMergedImageWith(
-      location = createDigitalLocationWith(url = "extremely_cursed_image")
+      locations =
+        List(createDigitalLocationWith(url = "extremely_cursed_image"))
     )
     withResponsesAndFixtures(
       inferrer = url =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ImagesRuleTest.scala
@@ -30,8 +30,8 @@ class ImagesRuleTest
       val result = ImagesRule.merge(sierraWork, miroWorks.toList).data
 
       result should have length n
-      result.map(_.location) should contain theSameElementsAs
-        miroWorks.map(_.data.images.head.location)
+      result.map(_.locations) should contain theSameElementsAs
+        miroWorks.map(_.data.images.head.locations)
     }
 
     it(
@@ -42,8 +42,8 @@ class ImagesRuleTest
       val result = ImagesRule.merge(sierraPictureWork, List(metsWork)).data
 
       result should have length n
-      result.map(_.location) should contain theSameElementsAs
-        metsWork.data.images.map(_.location)
+      result.map(_.locations) should contain theSameElementsAs
+        metsWork.data.images.map(_.locations)
     }
 
     it(
@@ -54,8 +54,8 @@ class ImagesRuleTest
       val result = ImagesRule.merge(sierraEphemeraWork, List(metsWork)).data
 
       result should have length n
-      result.map(_.location) should contain theSameElementsAs
-        metsWork.data.images.map(_.location)
+      result.map(_.locations) should contain theSameElementsAs
+        metsWork.data.images.map(_.locations)
     }
 
     it(
@@ -69,9 +69,9 @@ class ImagesRuleTest
         ImagesRule.merge(sierraPictureWork, miroWorks :+ metsWork).data
 
       result should have length n + m
-      result.map(_.location) should contain theSameElementsAs
-        metsWork.data.images.map(_.location) ++
-          miroWorks.map(_.data.images.head.location)
+      result.map(_.locations) should contain theSameElementsAs
+        metsWork.data.images.map(_.locations) ++
+          miroWorks.map(_.data.images.head.locations)
     }
 
     it(
@@ -85,9 +85,9 @@ class ImagesRuleTest
         ImagesRule.merge(sierraEphemeraWork, miroWorks :+ metsWork).data
 
       result should have length n + m
-      result.map(_.location) should contain theSameElementsAs
-        metsWork.data.images.map(_.location) ++
-          miroWorks.map(_.data.images.head.location)
+      result.map(_.locations) should contain theSameElementsAs
+        metsWork.data.images.map(_.locations) ++
+          miroWorks.map(_.data.images.head.locations)
     }
 
     it(
@@ -99,8 +99,8 @@ class ImagesRuleTest
       val result = ImagesRule.merge(sierraWork, miroWorks :+ metsWork).data
 
       result should have length n
-      result.map(_.location) should contain theSameElementsAs
-        miroWorks.map(_.data.images.head.location)
+      result.map(_.locations) should contain theSameElementsAs
+        miroWorks.map(_.data.images.head.locations)
     }
   }
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -150,12 +150,13 @@ case class MetsData(
               sourceIdentifier = ImageUtils
                 .getImageSourceId(recordIdentifier, fileReference.id),
               version = version,
-              location = DigitalLocationDeprecated(
-                url = url,
-                locationType = LocationType("iiif-image"),
-                license = license,
-                accessConditions = accessConditions(accessStatus)
-              )
+              locations = List(
+                DigitalLocationDeprecated(
+                  url = url,
+                  locationType = LocationType("iiif-image"),
+                  license = license,
+                  accessConditions = accessConditions(accessStatus)
+                ))
             )
           }
         }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -315,11 +315,12 @@ class MetsDataTest
     )
     val result = metsData.toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
-    result.right.get.data.images.head.locations shouldBe DigitalLocationDeprecated(
-      url = s"https://dlcs.io/iiif-img/wellcome/5/location.jp2/info.json",
-      locationType = LocationType("iiif-image"),
-      license = Some(License.CCBYNC)
-    )
+    result.right.get.data.images.head.locations shouldBe List(
+      DigitalLocationDeprecated(
+        url = s"https://dlcs.io/iiif-img/wellcome/5/location.jp2/info.json",
+        locationType = LocationType("iiif-image"),
+        license = Some(License.CCBYNC)
+      ))
   }
 
   it("creates a work with a single accessCondition") {

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -315,7 +315,7 @@ class MetsDataTest
     )
     val result = metsData.toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
-    result.right.get.data.images.head.location shouldBe DigitalLocationDeprecated(
+    result.right.get.data.images.head.locations shouldBe DigitalLocationDeprecated(
       url = s"https://dlcs.io/iiif-img/wellcome/5/location.jp2/info.json",
       locationType = LocationType("iiif-image"),
       license = Some(License.CCBYNC)

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImage.scala
@@ -14,6 +14,6 @@ trait MiroImage extends MiroLocation {
         value = miroRecord.imageNumber
       ),
       version = version,
-      location = getLocation(miroRecord)
+      locations = List(getLocation(miroRecord))
     )
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageTest.scala
@@ -36,13 +36,14 @@ class MiroImageTest
           value = "B0011308"
         ),
         version = 1,
-        location = DigitalLocationDeprecated(
-          url =
-            "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
-          locationType = LocationType("iiif-image"),
-          license = Some(License.CC0),
-          credit = Some("Ezra Feilden")
-        )
+        locations = List(
+          DigitalLocationDeprecated(
+            url =
+              "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+            locationType = LocationType("iiif-image"),
+            license = Some(License.CC0),
+            credit = Some("Ezra Feilden")
+          ))
       )
     }
   }


### PR DESCRIPTION
Image locations have always been a list on the display model, but we kept it as a single value on the internal model because up until now we've only had one - my next PR will be adding IIIF presentation locations to this list.