### PR TITLE
Remove a dependency between the Calm adapter and big_messaging

### DIFF
--- a/.sbt_metadata/calm_adapter.json
+++ b/.sbt_metadata/calm_adapter.json
@@ -2,7 +2,6 @@
   "id" : "calm_adapter",
   "folder" : "calm_adapter/calm_adapter",
   "dependencyIds" : [
-    "internal_model",
-    "big_messaging_typesafe"
+    "internal_model"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -256,7 +256,7 @@ lazy val mets_adapter = setupProject(
 lazy val calm_adapter = setupProject(
   project,
   folder = "calm_adapter/calm_adapter",
-  localDependencies = Seq(internal_model, big_messaging_typesafe),
+  localDependencies = Seq(internal_model),
   externalDependencies = CatalogueDependencies.calmAdapterDependencies
 )
 


### PR DESCRIPTION
The Calm adapter isn't actually using the big_messaging lib, so it doesn't need to be rebuilt if/when big_messaging changes.