### PR TITLE
Make the bulk_size parameter configurable in the snapshot generator

### DIFF
--- a/snapshots/snapshot_generator/src/main/resources/application.conf
+++ b/snapshots/snapshot_generator/src/main/resources/application.conf
@@ -6,3 +6,4 @@ es.port=${?es_port}
 es.username=${?es_username}
 es.password=${?es_password}
 es.protocol=${?es_protocol}
+es.bulk-size=${?es_bulk_size}

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.platform.snapshot_generator.services.{
 }
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.ExecutionContext
 
@@ -24,7 +25,8 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildExecutionContext()
 
     val snapshotConfig = SnapshotGeneratorConfig(
-      index = ElasticConfig().worksIndex
+      index = ElasticConfig().worksIndex,
+      bulkSize = config.getIntOption("es.bulk-size").getOrElse(1000)
     )
 
     val snapshotService = new SnapshotService(

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/Main.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.platform.snapshot_generator.config.builders.AkkaS3Builder
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 import uk.ac.wellcome.platform.snapshot_generator.services.{
   SnapshotGeneratorWorkerService,
   SnapshotService
@@ -22,10 +23,14 @@ object Main extends WellcomeTypesafeApp {
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
+    val snapshotConfig = SnapshotGeneratorConfig(
+      index = ElasticConfig().worksIndex
+    )
+
     val snapshotService = new SnapshotService(
       akkaS3Settings = AkkaS3Builder.buildAkkaS3Settings(config),
       elasticClient = ElasticBuilder.buildElasticClient(config),
-      elasticConfig = ElasticConfig()
+      snapshotConfig = snapshotConfig
     )
 
     new SnapshotGeneratorWorkerService(

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/graph/UploadSnapshotGraph.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/graph/UploadSnapshotGraph.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ClosedShape
 import akka.stream.alpakka.s3.{MultipartUploadResult, S3Settings}
 import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph}
-import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.ElasticClient
 import uk.ac.wellcome.display.models.DisplayWork
 import uk.ac.wellcome.platform.snapshot_generator.akkastreams.flow.{
   DisplayWorkToJsonStringFlow,
@@ -15,6 +15,7 @@ import uk.ac.wellcome.platform.snapshot_generator.akkastreams.sink.{
   S3Sink
 }
 import uk.ac.wellcome.platform.snapshot_generator.akkastreams.source.DisplayWorkSource
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
 import scala.concurrent.Future
@@ -22,13 +23,16 @@ import scala.concurrent.Future
 object UploadSnapshotGraph {
   def apply(
     elasticClient: ElasticClient,
-    index: Index,
+    snapshotConfig: SnapshotGeneratorConfig,
     s3Settings: S3Settings,
     s3ObjectLocation: S3ObjectLocation)(implicit actorSystem: ActorSystem)
     : RunnableGraph[(Future[Int], Future[MultipartUploadResult])] = {
 
     // We start with a "source" of display works
-    val displayWorkSource = DisplayWorkSource(elasticClient, index)
+    val displayWorkSource = DisplayWorkSource(
+      elasticClient = elasticClient,
+      snapshotConfig = snapshotConfig
+    )
 
     // We want to route to both a counter, and to S3
     val countingSink = CountingSink()

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
@@ -2,15 +2,16 @@ package uk.ac.wellcome.platform.snapshot_generator.akkastreams.source
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
-import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.ElasticClient
 import uk.ac.wellcome.display.models.{DisplayWork, WorksIncludes}
 import uk.ac.wellcome.platform.snapshot_generator.akkastreams.flow.IndexedWorkToVisibleDisplayWork
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
 object DisplayWorkSource {
   def apply(
     elasticClient: ElasticClient,
-    index: Index
+    snapshotConfig: SnapshotGeneratorConfig
   )(implicit actorSystem: ActorSystem): Source[DisplayWork, Any] =
-    ElasticsearchWorksSource(elasticClient = elasticClient, index = index)
+    ElasticsearchWorksSource(elasticClient = elasticClient, snapshotConfig = snapshotConfig)
       .via(IndexedWorkToVisibleDisplayWork(DisplayWork(_, WorksIncludes.all)))
 }

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/DisplayWorkSource.scala
@@ -12,6 +12,8 @@ object DisplayWorkSource {
     elasticClient: ElasticClient,
     snapshotConfig: SnapshotGeneratorConfig
   )(implicit actorSystem: ActorSystem): Source[DisplayWork, Any] =
-    ElasticsearchWorksSource(elasticClient = elasticClient, snapshotConfig = snapshotConfig)
+    ElasticsearchWorksSource(
+      elasticClient = elasticClient,
+      snapshotConfig = snapshotConfig)
       .via(IndexedWorkToVisibleDisplayWork(DisplayWork(_, WorksIncludes.all)))
 }

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.snapshot_generator.akkastreams.source
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Sink, Source}
-import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl.{search, termQuery}
 import com.sksamuel.elastic4s.requests.searches.SearchHit
@@ -13,23 +12,24 @@ import uk.ac.wellcome.json.JsonUtil.fromJson
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Indexed
 import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
 object ElasticsearchWorksSource extends Logging {
-  def apply(elasticClient: ElasticClient, index: Index)(
+  def apply(elasticClient: ElasticClient, snapshotConfig: SnapshotGeneratorConfig)(
     implicit
     actorSystem: ActorSystem
   ): Source[Work[Indexed], NotUsed] = {
     val loggingSink = Flow[Work[Indexed]]
       .grouped(10000)
       .map(works => {
-        logger.info(s"Received ${works.length} works from $index")
+        logger.info(s"Received ${works.length} works from ${snapshotConfig.index}")
         works
       })
       .to(Sink.ignore)
     Source
       .fromPublisher(
         elasticClient.publisher(
-          search(index)
+          search(snapshotConfig.index)
             .query(termQuery("type", "Visible"))
             .scroll(keepAlive = "5m")
             // Increasing the size of each request from the

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -32,9 +32,7 @@ object ElasticsearchWorksSource extends Logging {
           search(snapshotConfig.index)
             .query(termQuery("type", "Visible"))
             .scroll(keepAlive = "5m")
-            // Increasing the size of each request from the
-            // default 100 to 1000 as it makes it go significantly faster
-            .size(1000))
+            .size(snapshotConfig.bulkSize))
       )
       .map { searchHit: SearchHit =>
         fromJson[Work[Indexed]](searchHit.sourceAsString).get

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -15,14 +15,16 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
 object ElasticsearchWorksSource extends Logging {
-  def apply(elasticClient: ElasticClient, snapshotConfig: SnapshotGeneratorConfig)(
+  def apply(elasticClient: ElasticClient,
+            snapshotConfig: SnapshotGeneratorConfig)(
     implicit
     actorSystem: ActorSystem
   ): Source[Work[Indexed], NotUsed] = {
     val loggingSink = Flow[Work[Indexed]]
       .grouped(10000)
       .map(works => {
-        logger.info(s"Received ${works.length} works from ${snapshotConfig.index}")
+        logger.info(
+          s"Received ${works.length} works from ${snapshotConfig.index}")
         works
       })
       .to(Sink.ignore)

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
@@ -2,4 +2,19 @@ package uk.ac.wellcome.platform.snapshot_generator.models
 
 import com.sksamuel.elastic4s.Index
 
-case class SnapshotGeneratorConfig(index: Index)
+case class SnapshotGeneratorConfig(
+  index: Index,
+
+  // How many documents should be fetched in a single request?
+  //
+  //  - If this value is too small, we have to make extra requests and
+  //    snapshot creation will be slower.
+  //
+  //  - If this value is too big, we may exceed the heap memory on a single
+  //    request -- >100MB in one set of returned works, and we get an error:
+  //
+  //        org.apache.http.ContentTooLongException: entity content is too
+  //        long [167209080] for the configured buffer limit [104857600]
+  //
+  bulkSize: Int = 1000
+)

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.snapshot_generator.models
+
+import com.sksamuel.elastic4s.Index
+
+case class SnapshotGeneratorConfig(index: Index)

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/models/SnapshotGeneratorConfig.scala
@@ -4,7 +4,6 @@ import com.sksamuel.elastic4s.Index
 
 case class SnapshotGeneratorConfig(
   index: Index,
-
   // How many documents should be fetched in a single request?
   //
   //  - If this value is too small, we have to make extra requests and

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotService.scala
@@ -9,11 +9,11 @@ import akka.stream.scaladsl.Sink
 import com.sksamuel.elastic4s.ElasticClient
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.display.models._
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.platform.snapshot_generator.akkastreams.graph.UploadSnapshotGraph
 import uk.ac.wellcome.platform.snapshot_generator.akkastreams.source.S3ObjectMetadataSource
 import uk.ac.wellcome.platform.snapshot_generator.models.{
   CompletedSnapshotJob,
+  SnapshotGeneratorConfig,
   SnapshotJob,
   SnapshotResult
 }
@@ -23,7 +23,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SnapshotService(akkaS3Settings: S3Settings,
                       elasticClient: ElasticClient,
-                      elasticConfig: ElasticConfig)(
+                      snapshotConfig: SnapshotGeneratorConfig)(
   implicit actorSystem: ActorSystem,
   ec: ExecutionContext
 ) extends Logging {
@@ -44,7 +44,7 @@ class SnapshotService(akkaS3Settings: S3Settings,
         case ApiVersions.v2 =>
           UploadSnapshotGraph(
             elasticClient = elasticClient,
-            index = elasticConfig.worksIndex,
+            snapshotConfig = snapshotConfig,
             s3Settings = akkaS3Settings,
             s3ObjectLocation = snapshotJob.s3Location
           ).run()
@@ -60,7 +60,7 @@ class SnapshotService(akkaS3Settings: S3Settings,
       ).runWith(Sink.head)
 
       snapshotResult = SnapshotResult(
-        indexName = elasticConfig.worksIndex.name,
+        indexName = snapshotConfig.index.name,
         documentCount = documentCount,
         displayModel = DisplayWork.getClass.getCanonicalName,
         startedAt = startedAt,

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchSourceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchSourceTest.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
 class ElasticsearchSourceTest
     extends AnyFunSpec
@@ -62,7 +63,7 @@ class ElasticsearchSourceTest
     implicit actorSystem: ActorSystem): R = {
     val source = ElasticsearchWorksSource(
       elasticClient = elasticClient,
-      index = index
+      snapshotConfig = SnapshotGeneratorConfig(index = index)
     )
     testWith(source)
   }

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/fixtures/SnapshotServiceFixture.scala
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.ElasticClient
 import org.scalatest.Suite
-import uk.ac.wellcome.elasticsearch.ElasticConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.platform.snapshot_generator.services.SnapshotService
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -23,12 +23,11 @@ trait SnapshotServiceFixture extends ElasticsearchFixtures { this: Suite =>
                              elasticClient: ElasticClient = elasticClient)(
     testWith: TestWith[SnapshotService, R])(
     implicit actorSystem: ActorSystem): R = {
-    val elasticConfig = ElasticConfig(worksIndex, Index(""))
 
     val snapshotService = new SnapshotService(
+      akkaS3Settings = s3AkkaSettings,
       elasticClient = elasticClient,
-      elasticConfig = elasticConfig,
-      akkaS3Settings = s3AkkaSettings
+      snapshotConfig = SnapshotGeneratorConfig(index = worksIndex)
     )
 
     testWith(snapshotService)

--- a/snapshots/terraform/locals.tf
+++ b/snapshots/terraform/locals.tf
@@ -11,6 +11,8 @@ locals {
 
   snapshot_generator_image = data.terraform_remote_state.api_shared.outputs.ecr_snapshot_generator_repository_url
 
+  shared_logging_secrets = data.terraform_remote_state.shared.outputs.shared_secrets_logging
+
   lambda_error_alarm_arn = data.terraform_remote_state.shared.outputs.lambda_error_alarm_arn
   dlq_alarm_arn          = data.terraform_remote_state.shared.outputs.dlq_alarm_arn
 

--- a/snapshots/terraform/main.tf
+++ b/snapshots/terraform/main.tf
@@ -12,6 +12,8 @@ module "stack" {
   public_bucket_name   = local.public_data_bucket_name
   public_object_key_v2 = local.public_object_key_v2
 
+  shared_logging_secrets = local.shared_logging_secrets
+
   dlq_alarm_arn          = local.dlq_alarm_arn
   lambda_error_alarm_arn = local.lambda_error_alarm_arn
 

--- a/snapshots/terraform/main.tf
+++ b/snapshots/terraform/main.tf
@@ -12,6 +12,20 @@ module "stack" {
   public_bucket_name   = local.public_data_bucket_name
   public_object_key_v2 = local.public_object_key_v2
 
+  # How many documents to fetch in a single scroll request?  We choose this such that
+  #
+  #     #(number of works in request) × (size of a work) < Elasticsearch heap size
+  #
+  # otherwise a single scroll request blows the Elasticsearch heap, and snapshot
+  # generation fails.
+  #
+  # In general, the size of a work grows over time, so if we start hitting exceptions
+  # like 'ContentTooLongException', we should consider turning down this number.
+  # It used to be set to 1000, but that became too big in November 2020.
+  #
+  # See https://github.com/wellcomecollection/platform/issues/4901
+  es_bulk_size = 500
+
   shared_logging_secrets = local.shared_logging_secrets
 
   dlq_alarm_arn          = local.dlq_alarm_arn

--- a/snapshots/terraform/stack/main.tf
+++ b/snapshots/terraform/stack/main.tf
@@ -12,6 +12,8 @@ module "snapshot_generator" {
 
   snapshot_generator_input_topic_arn = module.snapshot_scheduler.topic_arn
 
+  shared_logging_secrets = var.shared_logging_secrets
+
   dlq_alarm_arn = var.dlq_alarm_arn
 
   vpc_id  = var.vpc_id

--- a/snapshots/terraform/stack/main.tf
+++ b/snapshots/terraform/stack/main.tf
@@ -8,6 +8,8 @@ module "snapshot_generator" {
   snapshot_generator_image = var.snapshot_generator_image
   deployment_service_env   = var.deployment_service_env
 
+  es_bulk_size = var.es_bulk_size
+
   public_bucket_name = var.public_bucket_name
 
   snapshot_generator_input_topic_arn = module.snapshot_scheduler.topic_arn

--- a/snapshots/terraform/stack/snapshot_generator/service.tf
+++ b/snapshots/terraform/stack/snapshot_generator/service.tf
@@ -14,11 +14,12 @@ module "snapshot_generator" {
   memory = 8192
 
   secret_env_vars = {
-    es_host     = "catalogue/api/es_host"
-    es_port     = "catalogue/api/es_port"
-    es_protocol = "catalogue/api/es_protocol"
-    es_username = "catalogue/api/es_username"
-    es_password = "catalogue/api/es_password"
+    es_host      = "catalogue/api/es_host"
+    es_port      = "catalogue/api/es_port"
+    es_protocol  = "catalogue/api/es_protocol"
+    es_username  = "catalogue/api/es_username"
+    es_password  = "catalogue/api/es_password"
+    es_bulk_size = var.es_bulk_size
   }
 
   subnets = var.subnets

--- a/snapshots/terraform/stack/snapshot_generator/variables.tf
+++ b/snapshots/terraform/stack/snapshot_generator/variables.tf
@@ -32,3 +32,8 @@ variable "public_bucket_name" {
 variable "shared_logging_secrets" {
   type = map(string)
 }
+
+variable "es_bulk_size" {
+  description = "How many works to fetch in a single scroll request"
+  type        = number
+}

--- a/snapshots/terraform/stack/snapshot_generator/variables.tf
+++ b/snapshots/terraform/stack/snapshot_generator/variables.tf
@@ -28,3 +28,7 @@ variable "subnets" {
 variable "public_bucket_name" {
   type = string
 }
+
+variable "shared_logging_secrets" {
+  type = map(string)
+}

--- a/snapshots/terraform/stack/variables.tf
+++ b/snapshots/terraform/stack/variables.tf
@@ -34,3 +34,7 @@ variable "public_bucket_name" {
 variable "public_object_key_v2" {
   type = string
 }
+
+variable "shared_logging_secrets" {
+  type = map(string)
+}

--- a/snapshots/terraform/stack/variables.tf
+++ b/snapshots/terraform/stack/variables.tf
@@ -38,3 +38,8 @@ variable "public_object_key_v2" {
 variable "shared_logging_secrets" {
   type = map(string)
 }
+
+variable "es_bulk_size" {
+  description = "How many works to fetch in a single scroll request"
+  type        = number
+}


### PR DESCRIPTION
Tentative fix for https://github.com/wellcomecollection/platform/issues/4901

Previously we'd fetch 1000 works in one go, and now it seems that's a bit too big. Let's try lowering it to 500 and see what happens.