### PR TITLE
Add a fixture for PipelineStorageStream

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -40,7 +40,7 @@ class PipelineStorageStream[In, Out, MsgDestination](
   def run(streamName: String,
           processFlow: Flow[(Message, In), (Message, Option[Out]), NotUsed])(
     implicit decoder: Decoder[In],
-    indexable: Indexable[Out]) = {
+    indexable: Indexable[Out]): Future[Done] = {
     val identityFlow = Flow[(Message, Option[Out])].collect {
       case (message, None) => message
     }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -15,21 +15,21 @@ case class PipelineStorageConfig(batchSize: Int,
                                  flushInterval: FiniteDuration,
                                  parallelism: Int)
 
-class PipelineStorageStream[T, D, MsgDestination](
-  messageStream: SQSStream[T],
-  documentIndexer: Indexer[D],
+class PipelineStorageStream[In, Out, MsgDestination](
+  messageStream: SQSStream[In],
+  documentIndexer: Indexer[Out],
   messageSender: MessageSender[MsgDestination])(config: PipelineStorageConfig)(
   implicit ec: ExecutionContext)
     extends Logging {
   type FutureBundles = Future[List[Bundle]]
-  case class Bundle(message: Message, document: D)
+  case class Bundle(message: Message, document: Out)
 
-  def foreach(streamName: String, process: T => Future[Option[D]])(
-    implicit decoderT: Decoder[T],
-    indexable: Indexable[D]): Future[Done] =
+  def foreach(streamName: String, process: In => Future[Option[Out]])(
+    implicit decoderT: Decoder[In],
+    indexable: Indexable[Out]): Future[Done] =
     run(
       streamName = streamName,
-      Flow[(Message, T)]
+      Flow[(Message, In)]
         .mapAsyncUnordered(parallelism = config.parallelism) {
           case (message, t) =>
             debug(s"Processing message ${message.messageId()}")
@@ -38,10 +38,10 @@ class PipelineStorageStream[T, D, MsgDestination](
     )
 
   def run(streamName: String,
-          processFlow: Flow[(Message, T), (Message, Option[D]), NotUsed])(
-    implicit decoder: Decoder[T],
-    indexable: Indexable[D]) = {
-    val identityFlow = Flow[(Message, Option[D])].collect {
+          processFlow: Flow[(Message, In), (Message, Option[Out]), NotUsed])(
+    implicit decoder: Decoder[In],
+    indexable: Indexable[Out]) = {
+    val identityFlow = Flow[(Message, Option[Out])].collect {
       case (message, None) => message
     }
     for {
@@ -53,8 +53,8 @@ class PipelineStorageStream[T, D, MsgDestination](
     } yield result
   }
 
-  private def batchAndSendFlow(implicit indexable: Indexable[D]) =
-    Flow[(Message, Option[D])]
+  private def batchAndSendFlow(implicit indexable: Indexable[Out]) =
+    Flow[(Message, Option[Out])]
       .collect { case (message, Some(document)) => Bundle(message, document) }
       .groupedWithin(
         config.batchSize,

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStreamTest.scala
@@ -5,23 +5,19 @@ import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
 import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.elasticsearch.{ElasticClientBuilder, NoStrictMapping}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.fixtures.{RandomGenerators, TestWith}
 import uk.ac.wellcome.json.JsonUtil
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
 import uk.ac.wellcome.pipeline_storage.fixtures.{
   ElasticIndexerFixtures,
+  PipelineStorageStreamFixtures,
   SampleDocument
 }
 
-import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,45 +27,11 @@ class PipelineStorageStreamTest
     extends AnyFunSpec
     with ElasticIndexerFixtures
     with IdentifiersGenerators
-    with RandomGenerators
     with ElasticsearchFixtures
-    with SQS
-    with Akka {
-
-  val pipelineStorageConfig = PipelineStorageConfig(
-    batchSize = 1,
-    flushInterval = 1 seconds,
-    parallelism = 10)
+    with PipelineStorageStreamFixtures {
 
   def indexer(index: Index, elasticClient: ElasticClient = elasticClient) =
     new ElasticIndexer[SampleDocument](elasticClient, index, NoStrictMapping)
-
-  def withPipelineStream[R](
-    indexer: Indexer[SampleDocument] = new MemoryIndexer[SampleDocument](
-      index = mutable.Map[String, SampleDocument]()
-    ),
-    sender: MemoryMessageSender = new MemoryMessageSender(),
-    visibilityTimeout: Int = 1,
-    pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(
-    testWith: TestWith[
-      (PipelineStorageStream[NotificationMessage, SampleDocument, String],
-       QueuePair,
-       MemoryMessageSender),
-      R]): R =
-    withActorSystem { implicit ac =>
-      withLocalSqsQueuePair(visibilityTimeout) {
-        case q @ QueuePair(queue, _) =>
-          withSQSStream[NotificationMessage, R](queue) { stream =>
-            testWith(
-              (
-                new PipelineStorageStream(stream, indexer, sender)(
-                  pipelineStorageConfig),
-                q,
-                sender))
-          }
-
-      }
-    }
 
   it("creates the index at startup if it doesn't already exist") {
     val index = createIndex
@@ -78,72 +40,90 @@ class PipelineStorageStreamTest
         .execute(indexExists(index.name))
         .await
     response.result.isExists shouldBe false
-    withPipelineStream(indexer(index)) {
-      case (pipelineStream, _, _) =>
-        pipelineStream.foreach("test_stream", _ => Future.successful(None))
-        eventuallyIndexExists(index)
+    withLocalSqsQueue() { queue =>
+      withPipelineStream(queue = queue, indexer = indexer(index)) {
+        pipelineStream =>
+          pipelineStream.foreach("test_stream", _ => Future.successful(None))
+          eventuallyIndexExists(index)
+      }
     }
   }
 
   it("ingests a single document and sends it on") {
     val index = createIndex
     val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
-    withPipelineStream(indexer(index), visibilityTimeout = 10) {
-      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
-        sendNotificationToSQS(
-          queue = queue,
-          message = document
-        )
-        pipelineStream.foreach(
-          "test stream",
-          message =>
-            Future
-              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
-              .map(Option(_)))
-        assertElasticsearchEventuallyHas(index = index, document)
-        eventually {
-          messageSender.messages.map(_.body) should contain(
-            document.canonicalId)
-          assertQueueEmpty(queue)
-          assertQueueEmpty(dlq)
-        }
-    }
 
+    val sender = new MemoryMessageSender
+
+    withLocalSqsQueuePair(visibilityTimeout = 10) { case QueuePair(queue, dlq) =>
+      withPipelineStream(queue = queue, indexer = indexer(index), sender = sender) {
+        pipelineStream =>
+          sendNotificationToSQS(
+            queue = queue,
+            message = document
+          )
+          pipelineStream.foreach(
+            "test stream",
+            message =>
+              Future
+                .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+                .map(Option(_)))
+          assertElasticsearchEventuallyHas(index = index, document)
+          eventually {
+            sender.messages.map(_.body) should contain(
+              document.canonicalId)
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+          }
+      }
+    }
   }
 
   it("processes a message and does not ingest if result of process is a None") {
     val index = createIndex
     val document = SampleDocument(1, createCanonicalId, randomAlphanumeric())
-    withPipelineStream(indexer(index), visibilityTimeout = 10) {
-      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
-        sendNotificationToSQS(
-          queue = queue,
-          message = document
-        )
-        pipelineStream.foreach("test stream", _ => Future.successful(None))
 
-        eventually {
-          assertElasticsearchEmpty(index = index)
-          messageSender.messages.map(_.body) shouldBe empty
-          assertQueueEmpty(queue)
-          assertQueueEmpty(dlq)
-        }
+    val sender = new MemoryMessageSender
+
+    withLocalSqsQueuePair(visibilityTimeout = 10) { case QueuePair(queue, dlq) =>
+      withPipelineStream(queue = queue, indexer = indexer(index), sender = sender) {
+        pipelineStream =>
+          sendNotificationToSQS(
+            queue = queue,
+            message = document
+          )
+          pipelineStream.foreach("test stream", _ => Future.successful(None))
+
+          eventually {
+            assertElasticsearchEmpty(index = index)
+            sender.messages.map(_.body) shouldBe empty
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+          }
+      }
     }
-
   }
 
   it("ingests lots of documents") {
     val index = createIndex
     val documents = (1 to 250).map(_ =>
       SampleDocument(1, createCanonicalId, randomAlphanumeric()))
-    withPipelineStream(
-      indexer(index),
-      visibilityTimeout = 30,
-      pipelineStorageConfig = PipelineStorageConfig(
-        batchSize = 150,
-        flushInterval = 10 seconds,
-        parallelism = 10)) {
-      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+
+    val pipelineStorageConfig = PipelineStorageConfig(
+      batchSize = 150,
+      flushInterval = 10 seconds,
+      parallelism = 10
+    )
+
+    val sender = new MemoryMessageSender
+
+    withLocalSqsQueuePair(visibilityTimeout = 30) { case QueuePair(queue, dlq) =>
+      withPipelineStream(
+        queue = queue,
+        indexer = indexer(index),
+        sender = sender,
+        pipelineStorageConfig = pipelineStorageConfig
+      ) { pipelineStream =>
         documents.foreach(
           doc =>
             sendNotificationToSQS(
@@ -158,18 +138,21 @@ class PipelineStorageStreamTest
               .map(Option(_)))
         assertElasticsearchEventuallyHas(index = index, documents: _*)
         eventually(Timeout(scaled(60 seconds))) {
-          messageSender.messages.map(_.body) should contain theSameElementsAs (documents
-            .map(_.canonicalId))
+          sender.messages.map(_.body) should contain theSameElementsAs documents
+            .map(_.canonicalId)
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
         }
+      }
     }
   }
 
   it("leaves a message on the queue if it fails processing") {
     val index = createIndex
-    withPipelineStream(indexer(index)) {
-      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
+    val sender = new MemoryMessageSender
+
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withPipelineStream(queue = queue, indexer = indexer(index)) { pipelineStream =>
         sendInvalidJSONto(queue)
         pipelineStream.foreach(
           "test stream",
@@ -180,8 +163,9 @@ class PipelineStorageStreamTest
         eventually {
           assertQueueEmpty(queue)
           assertQueueHasSize(dlq, size = 1)
-          messageSender.messages shouldBe empty
+          sender.messages shouldBe empty
         }
+      }
     }
   }
 
@@ -194,16 +178,18 @@ class PipelineStorageStreamTest
       username = "elastic",
       password = "dontletmein"
     )
-    withPipelineStream(indexer(index, brokenClient)) {
-      case (pipelineStream, _, _) =>
-        whenReady(
-          pipelineStream
-            .foreach("test stream", _ => Future.successful(None))
-            .failed) { exception =>
-          exception shouldBe a[RuntimeException]
-        }
-    }
 
+    withLocalSqsQueue() { queue =>
+      withPipelineStream(queue = queue, indexer = indexer(index, brokenClient)) {
+        pipelineStream =>
+          whenReady(
+            pipelineStream
+              .foreach("test stream", _ => Future.successful(None))
+              .failed) { exception =>
+            exception shouldBe a[RuntimeException]
+          }
+      }
+    }
   }
 
   it("does not delete from the queue documents that failed indexing") {
@@ -231,26 +217,31 @@ class PipelineStorageStreamTest
           failingDocuments.keySet.contains(d.canonicalId))))
       }
     }
-    withPipelineStream(indexer) {
-      case (pipelineStream, QueuePair(queue, dlq), messageSender) =>
-        documents.foreach(
-          doc =>
-            sendNotificationToSQS(
-              queue = queue,
-              message = doc
-          ))
-        pipelineStream.foreach(
-          "test stream",
-          message =>
-            Future
-              .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
-              .map(Option(_)))
-        eventually {
-          messageSender.messages.map(_.body) should contain theSameElementsAs (successfulDocuments
-            .map(_.canonicalId))
-          assertQueueEmpty(queue)
-          assertQueueHasSize(dlq, size = 5)
-        }
+
+    val sender = new MemoryMessageSender
+
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withPipelineStream(queue = queue, indexer = indexer, sender = sender) {
+        pipelineStream =>
+          documents.foreach(
+            doc =>
+              sendNotificationToSQS(
+                queue = queue,
+                message = doc
+              ))
+          pipelineStream.foreach(
+            "test stream",
+            message =>
+              Future
+                .fromTry(JsonUtil.fromJson[SampleDocument](message.body))
+                .map(Option(_)))
+          eventually {
+            sender.messages.map(_.body) should contain theSameElementsAs successfulDocuments
+              .map(_.canonicalId)
+            assertQueueEmpty(queue)
+            assertQueueHasSize(dlq, size = 5)
+          }
+      }
     }
   }
 
@@ -266,19 +257,21 @@ class PipelineStorageStreamTest
         Failure(new Throwable("BOOM!"))
     }
 
-    withPipelineStream(sender = brokenSender) {
-      case (pipelineStream, QueuePair(queue, dlq), _) =>
-        sendNotificationToSQS(queue, document)
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withPipelineStream(queue = queue, indexer = indexer(createIndex), sender = brokenSender) {
+        pipelineStream =>
+          sendNotificationToSQS(queue, document)
 
-        pipelineStream.foreach(
-          "test stream",
-          _ => Future.successful(Some(document))
-        )
+          pipelineStream.foreach(
+            "test stream",
+            _ => Future.successful(Some(document))
+          )
 
-        eventually {
-          assertQueueEmpty(queue)
-          assertQueueHasSize(dlq, size = 1)
-        }
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueHasSize(dlq, size = 1)
+          }
+      }
     }
   }
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
@@ -23,16 +23,18 @@ trait PipelineStorageStreamFixtures extends Akka with SQS {
     indexer: Indexer[T],
     sender: MemoryMessageSender = new MemoryMessageSender(),
     pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(
-    testWith: TestWith[PipelineStorageStream[NotificationMessage, T, String], R]): R =
+    testWith: TestWith[PipelineStorageStream[NotificationMessage, T, String],
+                       R]): R =
     withActorSystem { implicit actorSystem =>
       withSQSStream[NotificationMessage, R](queue) { messageStream =>
-        val pipelineStream = new PipelineStorageStream[NotificationMessage, T, String](
-          messageStream = messageStream,
-          documentIndexer = indexer,
-          messageSender = sender
-        )(
-          config = pipelineStorageConfig
-        )
+        val pipelineStream =
+          new PipelineStorageStream[NotificationMessage, T, String](
+            messageStream = messageStream,
+            documentIndexer = indexer,
+            messageSender = sender
+          )(
+            config = pipelineStorageConfig
+          )
 
         testWith(pipelineStream)
       }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.pipeline_storage.fixtures
+
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.pipeline_storage._
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait PipelineStorageStreamFixtures extends Akka with SQS {
+  val pipelineStorageConfig = PipelineStorageConfig(
+    batchSize = 1,
+    flushInterval = 1 seconds,
+    parallelism = 10
+  )
+
+  def withPipelineStream[T: Indexable, R](
+    queue: Queue,
+    indexer: Indexer[T],
+    sender: MemoryMessageSender = new MemoryMessageSender(),
+    pipelineStorageConfig: PipelineStorageConfig = pipelineStorageConfig)(
+    testWith: TestWith[PipelineStorageStream[NotificationMessage, T, String], R]): R =
+    withActorSystem { implicit actorSystem =>
+      withSQSStream[NotificationMessage, R](queue) { messageStream =>
+        val pipelineStream = new PipelineStorageStream[NotificationMessage, T, String](
+          messageStream = messageStream,
+          documentIndexer = indexer,
+          messageSender = sender
+        )(
+          config = pipelineStorageConfig
+        )
+
+        testWith(pipelineStream)
+      }
+    }
+}

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
@@ -17,8 +17,10 @@ object PipelineStorageStreamBuilder {
   def buildPipelineStorageConfig(config: Config): PipelineStorageConfig =
     PipelineStorageConfig(
       batchSize = config.requireInt("pipeline_storage.batch_size"),
-      flushInterval = config.requireInt("pipeline_storage.flush_interval_seconds").seconds,
-      parallelism = config.getIntOption("pipeline_storage.parallelism").getOrElse(10)
+      flushInterval =
+        config.requireInt("pipeline_storage.flush_interval_seconds").seconds,
+      parallelism =
+        config.getIntOption("pipeline_storage.parallelism").getOrElse(10)
     )
 
   def buildPipelineStorageStream[In, Out, MsgDestination](

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
@@ -16,9 +16,9 @@ import scala.concurrent.duration.DurationInt
 object PipelineStorageStreamBuilder {
   def buildPipelineStorageConfig(config: Config): PipelineStorageConfig =
     PipelineStorageConfig(
-      config.requireInt("pipeline_storage.batch_size"),
-      config.requireInt("pipeline_storage.flush_interval_seconds").seconds,
-      config.getIntOption("pipeline_storage.parallelism").getOrElse(10)
+      batchSize = config.requireInt("pipeline_storage.batch_size"),
+      flushInterval = config.requireInt("pipeline_storage.flush_interval_seconds").seconds,
+      parallelism = config.getIntOption("pipeline_storage.parallelism").getOrElse(10)
     )
 
   def buildPipelineStorageStream[In, Out, MsgDestination](

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
@@ -22,13 +22,13 @@ object PipelineStorageStreamBuilder {
     )
   }
 
-  def buildPipelineStorageStream[T, D, MsgDestination](
-    sqsStream: SQSStream[T],
-    indexer: Indexer[D],
+  def buildPipelineStorageStream[In, Out, MsgDestination](
+    sqsStream: SQSStream[In],
+    indexer: Indexer[Out],
     messageSender: MessageSender[MsgDestination])(config: Config)(
     implicit ec: ExecutionContext)
-    : PipelineStorageStream[T, D, MsgDestination] = {
-    new PipelineStorageStream[T, D, MsgDestination](
+    : PipelineStorageStream[In, Out, MsgDestination] = {
+    new PipelineStorageStream[In, Out, MsgDestination](
       sqsStream,
       indexer,
       messageSender)(buildPipelineStorageConfig(config))

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/PipelineStorageStreamBuilder.scala
@@ -12,25 +12,23 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
-object PipelineStorageStreamBuilder {
 
-  def buildPipelineStorageConfig(config: Config): PipelineStorageConfig = {
+object PipelineStorageStreamBuilder {
+  def buildPipelineStorageConfig(config: Config): PipelineStorageConfig =
     PipelineStorageConfig(
       config.requireInt("pipeline_storage.batch_size"),
       config.requireInt("pipeline_storage.flush_interval_seconds").seconds,
       config.getIntOption("pipeline_storage.parallelism").getOrElse(10)
     )
-  }
 
   def buildPipelineStorageStream[In, Out, MsgDestination](
     sqsStream: SQSStream[In],
     indexer: Indexer[Out],
     messageSender: MessageSender[MsgDestination])(config: Config)(
     implicit ec: ExecutionContext)
-    : PipelineStorageStream[In, Out, MsgDestination] = {
+    : PipelineStorageStream[In, Out, MsgDestination] =
     new PipelineStorageStream[In, Out, MsgDestination](
       sqsStream,
       indexer,
       messageSender)(buildPipelineStorageConfig(config))
-  }
 }

--- a/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
@@ -141,18 +141,17 @@ class RouterWorkerServiceTest
           queue = queue,
           indexer = indexer,
           sender = worksMessageSender
-        ) {
-          pipelineStream =>
-            withLocalMergedWorksIndex { mergedIndex =>
-              val service =
-                new RouterWorkerService(
-                  pathsMsgSender = pathsMessageSender,
-                  workRetriever = new ElasticRetriever(elasticClient, mergedIndex),
-                  pipelineStream = pipelineStream
-                )
-              service.run()
-              testWith((mergedIndex, q, worksMessageSender, pathsMessageSender))
-            }
+        ) { pipelineStream =>
+          withLocalMergedWorksIndex { mergedIndex =>
+            val service =
+              new RouterWorkerService(
+                pathsMsgSender = pathsMessageSender,
+                workRetriever = new ElasticRetriever(elasticClient, mergedIndex),
+                pipelineStream = pipelineStream
+              )
+            service.run()
+            testWith((mergedIndex, q, worksMessageSender, pathsMessageSender))
+          }
         }
     }
 }


### PR DESCRIPTION
Some more refactoring ahead of https://github.com/wellcomecollection/platform/issues/4897

Specifically, the transformers are going to start using PipelineStorageStream, and the constructor is a bit repetitive (in particular, I’m unlikely to want to tune PipelineStorageConfig in transformer tests). This patch adds a fixture for creating a PipelineStorageStream, then applies the new fixture in the existing tests.