### PR TITLE
Use PipelineStorageStream to index works in the transformer

### DIFF
--- a/.sbt_metadata/transformer_common.json
+++ b/.sbt_metadata/transformer_common.json
@@ -3,6 +3,7 @@
   "folder" : "pipeline/transformer/transformer_common",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe"
+    "big_messaging_typesafe",
+    "pipeline_storage_typesafe"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,7 @@ lazy val reindex_worker = setupProject(
 lazy val transformer_common = setupProject(
   project,
   "pipeline/transformer/transformer_common",
-  localDependencies = Seq(internal_model, big_messaging_typesafe)
+  localDependencies = Seq(internal_model, big_messaging_typesafe, pipeline_storage_typesafe)
 )
 
 lazy val transformer_miro = setupProject(

--- a/pipeline/terraform/stack/locals.tf
+++ b/pipeline/terraform/stack/locals.tf
@@ -4,6 +4,7 @@ locals {
 
   es_works_index              = "works-${var.pipeline_date}"
   es_images_index             = "images-${var.pipeline_date}"
+  es_works_source_index       = "works-source-${var.pipeline_date}"
   es_works_merged_index       = "works-merged-${var.pipeline_date}"
   es_works_denormalised_index = "works-denormalised-${var.pipeline_date}"
 

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -24,6 +24,7 @@ module "matcher_input_queue" {
 
   topic_arns = [
     module.calm_transformer_output_topic.arn,
+    module.mets_transformer_output_topic.arn,
   ]
 
   aws_region      = var.aws_region

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -18,6 +18,24 @@ module "matcher_queue" {
   max_receive_count          = 20
 }
 
+module "matcher_input_queue" {
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  queue_name = "${local.namespace_hyphen}_matcher_input"
+
+  topic_arns = [
+    module.calm_transformer_output_topic.arn,
+  ]
+
+  aws_region      = var.aws_region
+  alarm_topic_arn = var.dlq_alarm_arn
+
+  # The records in the locktable expire after local.lock_timeout
+  # The matcher is able to override locks that have expired
+  # Wait slightly longer to make sure locks are expired
+  visibility_timeout_seconds = local.lock_timeout + 30
+  max_receive_count          = 20
+}
+
 # Service
 
 module "matcher" {

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -25,6 +25,7 @@ module "matcher_input_queue" {
   topic_arns = [
     module.calm_transformer_output_topic.arn,
     module.mets_transformer_output_topic.arn,
+    module.miro_transformer_output_topic.arn,
   ]
 
   aws_region      = var.aws_region

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -26,6 +26,7 @@ module "matcher_input_queue" {
     module.calm_transformer_output_topic.arn,
     module.mets_transformer_output_topic.arn,
     module.miro_transformer_output_topic.arn,
+    module.sierra_transformer_output_topic.arn,
   ]
 
   aws_region      = var.aws_region

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -25,9 +25,22 @@ module "calm_transformer" {
     messages_bucket_name = aws_s3_bucket.messages.id
     vhs_calm_bucket_name = var.vhs_calm_sourcedata_bucket_name
     vhs_calm_table_name  = var.vhs_calm_sourcedata_table_name
+
+    sns_topic_arn = module.calm_transformer_output_topic.arn
+
+    es_index = local.es_works_source_index
+
+    batch_size             = 100
+    flush_interval_seconds = 30
   }
 
-  secret_env_vars = {}
+  secret_env_vars = {
+    es_host     = "catalogue/pipeline_storage/es_host"
+    es_port     = "catalogue/pipeline_storage/es_port"
+    es_protocol = "catalogue/pipeline_storage/es_protocol"
+    es_username = "catalogue/pipeline_storage/transformer/es_username"
+    es_password = "catalogue/pipeline_storage/transformer/es_password"
+  }
 
   subnets             = var.subnets
   max_capacity        = 10
@@ -52,6 +65,17 @@ module "calm_transformer_topic" {
   role_names = [module.calm_transformer.task_role_name]
 
   messages_bucket_arn = aws_s3_bucket.messages.arn
+}
+
+module "calm_transformer_output_topic" {
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
+
+  name = "${local.namespace_hyphen}_calm_transformer_output"
+}
+
+resource "aws_iam_role_policy" "allow_calm_transformer_sns_publish" {
+  role   = module.calm_transformer.task_role_name
+  policy = module.calm_transformer_output_topic.publish_policy
 }
 
 module "calm_transformer_scaling_alarm" {

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -25,9 +25,22 @@ module "mets_transformer" {
     messages_bucket_name = aws_s3_bucket.messages.id
 
     mets_adapter_dynamo_table_name = var.mets_adapter_table_name
+
+    sns_topic_arn = module.mets_transformer_output_topic.arn
+
+    es_index = local.es_works_source_index
+
+    batch_size             = 100
+    flush_interval_seconds = 30
   }
 
-  secret_env_vars = {}
+  secret_env_vars = {
+    es_host     = "catalogue/pipeline_storage/es_host"
+    es_port     = "catalogue/pipeline_storage/es_port"
+    es_protocol = "catalogue/pipeline_storage/es_protocol"
+    es_username = "catalogue/pipeline_storage/transformer/es_username"
+    es_password = "catalogue/pipeline_storage/transformer/es_password"
+  }
 
   subnets             = var.subnets
   max_capacity        = 10
@@ -50,6 +63,17 @@ module "mets_transformer_topic" {
   module.mets_transformer.task_role_name]
 
   messages_bucket_arn = aws_s3_bucket.messages.arn
+}
+
+module "mets_transformer_output_topic" {
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
+
+  name = "${local.namespace_hyphen}_mets_transformer_output"
+}
+
+resource "aws_iam_role_policy" "allow_mets_transformer_sns_publish" {
+  role   = module.mets_transformer.task_role_name
+  policy = module.mets_transformer_output_topic.publish_policy
 }
 
 module "mets_transformer_scaling_alarm" {

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -25,9 +25,22 @@ module "sierra_transformer" {
     messages_bucket_name   = aws_s3_bucket.messages.id
     vhs_sierra_bucket_name = var.vhs_sierra_sourcedata_bucket_name
     vhs_sierra_table_name  = var.vhs_sierra_sourcedata_table_name
+
+    sns_topic_arn = module.sierra_transformer_output_topic.arn
+
+    es_index = local.es_works_source_index
+
+    batch_size             = 100
+    flush_interval_seconds = 30
   }
 
-  secret_env_vars = {}
+  secret_env_vars = {
+    es_host     = "catalogue/pipeline_storage/es_host"
+    es_port     = "catalogue/pipeline_storage/es_port"
+    es_protocol = "catalogue/pipeline_storage/es_protocol"
+    es_username = "catalogue/pipeline_storage/transformer/es_username"
+    es_password = "catalogue/pipeline_storage/transformer/es_password"
+  }
 
   subnets             = var.subnets
   max_capacity        = 10
@@ -52,6 +65,17 @@ module "sierra_transformer_topic" {
   role_names = [module.sierra_transformer.task_role_name]
 
   messages_bucket_arn = aws_s3_bucket.messages.arn
+}
+
+module "sierra_transformer_output_topic" {
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
+
+  name = "${local.namespace_hyphen}_sierra_transformer_output"
+}
+
+resource "aws_iam_role_policy" "allow_sierra_transformer_sns_publish" {
+  role   = module.sierra_transformer.task_role_name
+  policy = module.sierra_transformer_output_topic.publish_policy
 }
 
 module "sierra_transformer_scaling_alarm" {

--- a/pipeline/transformer/transformer_calm/src/main/resources/application.conf
+++ b/pipeline/transformer/transformer_calm/src/main/resources/application.conf
@@ -4,3 +4,15 @@ aws.message.writer.sns.topic.arn=${?sns_arn}
 aws.message.writer.s3.bucketName=${?messages_bucket_name}
 aws.vhs.s3.bucketName=${?vhs_calm_bucket_name}
 aws.vhs.dynamo.tableName=${?vhs_calm_table_name}
+
+aws.sns.topic.arn=${?sns_topic_arn}
+
+es.host=${?es_host}
+es.port=${?es_port}
+es.protocol=${?es_protocol}
+es.username=${?es_username}
+es.password=${?es_password}
+es.index=${?es_index}
+
+pipeline_storage.batch_size=${?batch_size}
+pipeline_storage.flush_interval_seconds=${?flush_interval_seconds}

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -2,14 +2,18 @@ package uk.ac.wellcome.platform.transformer.calm
 
 import uk.ac.wellcome.bigmessaging.BigMessageSender
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
-import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.storage.{Identified, ReadError}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 
 class CalmTransformerWorker(
-  val stream: SQSStream[NotificationMessage],
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            SNSConfig],
   val sender: BigMessageSender[SNSConfig],
   store: VersionedStore[String, Int, CalmRecord],
 ) extends Runnable

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -1,24 +1,25 @@
 package uk.ac.wellcome.transformer.common.worker
 
+import io.circe.Encoder
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.storage.{Identified, ReadError, Version}
+import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
+import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, PipelineStorageStream}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import WorkState.Source
-import io.circe.Encoder
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 
+import scala.collection.mutable
+import scala.concurrent.Future
 import scala.util.{Failure, Try}
 
 trait TestData
@@ -35,8 +36,10 @@ object TestTransformer extends Transformer[TestData] with WorkGenerators {
 }
 
 class TestTransformerWorker(
-  val stream: SQSStream[NotificationMessage],
   val sender: MemoryMessageSender,
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            String],
   store: VersionedStore[String, Int, TestData]
 ) extends TransformerWorker[TestData, String] {
   val transformer: Transformer[TestData] = TestTransformer
@@ -52,50 +55,71 @@ class TransformerWorkerTest
     with Matchers
     with Eventually
     with IntegrationPatience
-    with Akka
-    with SQS {
+    with PipelineStorageStreamFixtures {
 
-  it("empties the queue if it can process everything") {
-    val records = Map(
-      Version("A", 1) -> ValidTestData,
-      Version("B", 2) -> ValidTestData,
-      Version("C", 3) -> ValidTestData
-    )
+  describe("it sends a transformed work") {
+    def withTransformedWork[R](
+      testWith: TestWith[(QueuePair,
+                          MemoryMessageSender,
+                          MemoryIndexer[Work[Source]],
+                          MemoryMessageSender),
+                         R]): R = {
+      val records = Map(
+        Version("A", 1) -> ValidTestData,
+        Version("B", 2) -> ValidTestData,
+        Version("C", 3) -> ValidTestData
+      )
 
-    withLocalSqsQueuePair() {
-      case QueuePair(queue, dlq) =>
-        withWorker(queue, records = records) { _ =>
-          sendNotificationToSQS(queue, Version("A", 1))
-          sendNotificationToSQS(queue, Version("B", 2))
-          sendNotificationToSQS(queue, Version("C", 3))
+      val completeWorkSender = new MemoryMessageSender()
+      val workIndexer =
+        new MemoryIndexer[Work[Source]](
+          index = mutable.Map[String, Work[Source]]())
+      val workKeySender = new MemoryMessageSender()
 
+      withLocalSqsQueuePair() {
+        case queuePair @ QueuePair(queue, _) =>
+          withWorker(
+            queue,
+            completeWorkSender = completeWorkSender,
+            workIndexer = workIndexer,
+            workKeySender = workKeySender,
+            records = records) { _ =>
+            sendNotificationToSQS(queue, Version("A", 1))
+            sendNotificationToSQS(queue, Version("B", 2))
+            sendNotificationToSQS(queue, Version("C", 3))
+
+            testWith(
+              (queuePair, completeWorkSender, workIndexer, workKeySender))
+          }
+      }
+    }
+
+    it("empties the queue") {
+      withTransformedWork {
+        case (QueuePair(queue, dlq), _, _, _) =>
           eventually {
             assertQueueEmpty(dlq)
             assertQueueEmpty(queue)
           }
-        }
+      }
     }
-  }
 
-  it("sends a message to the next service") {
-    val records = Map(
-      Version("A", 1) -> ValidTestData,
-      Version("B", 2) -> ValidTestData,
-      Version("C", 3) -> ValidTestData
-    )
+    it("sends the complete work to the recorder") {
+      withTransformedWork {
+        case (_, completeWorkSender, _, _) =>
+          eventually {
+            completeWorkSender.getMessages[Work[Source]] should have size 3
+          }
+      }
+    }
 
-    val sender = new MemoryMessageSender()
-
-    withLocalSqsQueue() { queue =>
-      withWorker(queue, records = records, sender = sender) { _ =>
-        sendNotificationToSQS(queue, Version("A", 1))
-        sendNotificationToSQS(queue, Version("B", 2))
-        sendNotificationToSQS(queue, Version("C", 3))
-
-        eventually {
-          assertQueueEmpty(queue)
-          sender.getMessages[Work[Source]] should have size 3
-        }
+    it("indexes the work and sends the index IDs") {
+      withTransformedWork {
+        case (_, _, workIndexer, workKeySender) =>
+          eventually {
+            workIndexer.index should have size 3
+            workKeySender.messages.map { _.body } should contain theSameElementsAs workIndexer.index.keys
+          }
       }
     }
   }
@@ -165,7 +189,7 @@ class TransformerWorkerTest
       }
     }
 
-    it("if it can't send a message") {
+    it("if it can't send the complete work to the recorder") {
       val brokenSender = new MemoryMessageSender() {
         override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
           Failure(new Throwable("BOOM!"))
@@ -175,7 +199,10 @@ class TransformerWorkerTest
 
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
-          withWorker(queue, records = records, sender = brokenSender) { _ =>
+          withWorker(
+            queue,
+            records = records,
+            completeWorkSender = brokenSender) { _ =>
             sendNotificationToSQS(queue, Version("A", 1))
 
             eventually {
@@ -185,27 +212,85 @@ class TransformerWorkerTest
           }
       }
     }
+
+    it("if it can't index the work") {
+      val brokenIndexer = new MemoryIndexer[Work[Source]](
+        index = mutable.Map[String, Work[Source]]()
+      ) {
+        override def index(documents: Seq[Work[Source]])
+          : Future[Either[Seq[Work[Source]], Seq[Work[Source]]]] =
+          Future.failed(new Throwable("BOOM!"))
+      }
+
+      val workKeySender = new MemoryMessageSender
+
+      val records = Map(Version("A", 1) -> ValidTestData)
+
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(
+            queue,
+            records = records,
+            workIndexer = brokenIndexer,
+            workKeySender = workKeySender) { _ =>
+            sendNotificationToSQS(queue, Version("A", 1))
+
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueHasSize(dlq, size = 1)
+
+              workKeySender.messages shouldBe empty
+            }
+          }
+      }
+    }
+
+    it("if it can't send the key of the indexed work") {
+      val brokenSender = new MemoryMessageSender() {
+        override def send(body: String): Try[Unit] =
+          Failure(new Throwable("BOOM!"))
+      }
+
+      val records = Map(Version("A", 1) -> ValidTestData)
+
+      withLocalSqsQueuePair() {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue, records = records, workKeySender = brokenSender) {
+            _ =>
+              sendNotificationToSQS(queue, Version("A", 1))
+
+              eventually {
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq, size = 1)
+              }
+          }
+      }
+    }
   }
 
   def withWorker[R](
     queue: Queue,
     records: Map[Version[String, Int], TestData] = Map.empty,
-    sender: MemoryMessageSender = new MemoryMessageSender()
+    completeWorkSender: MemoryMessageSender = new MemoryMessageSender(),
+    workIndexer: MemoryIndexer[Work[Source]] = new MemoryIndexer[Work[Source]](
+      index = mutable.Map[String, Work[Source]]()),
+    workKeySender: MemoryMessageSender = new MemoryMessageSender()
   )(
     testWith: TestWith[Unit, R]
   ): R =
-    withActorSystem { implicit actorSystem =>
-      withSQSStream[NotificationMessage, R](queue) { stream =>
-        val store = MemoryVersionedStore[String, TestData](records)
+    withPipelineStream[Work[Source], R](
+      queue = queue,
+      indexer = workIndexer,
+      sender = workKeySender) { pipelineStream =>
+      val store = MemoryVersionedStore[String, TestData](records)
 
-        val worker = new TestTransformerWorker(
-          stream = stream,
-          sender = sender,
-          store = store
-        )
+      val worker = new TestTransformerWorker(
+        sender = completeWorkSender,
+        pipelineStream = pipelineStream,
+        store = store
+      )
 
-        worker.run()
-        testWith(())
-      }
+      worker.run()
+      testWith(())
     }
 }

--- a/pipeline/transformer/transformer_mets/src/main/resources/application.conf
+++ b/pipeline/transformer/transformer_mets/src/main/resources/application.conf
@@ -3,3 +3,15 @@ aws.metrics.namespace=${?metrics_namespace}
 aws.message.writer.sns.topic.arn=${?sns_arn}
 aws.message.writer.s3.bucketName=${?messages_bucket_name}
 aws.mets.dynamo.tableName=${?mets_adapter_dynamo_table_name}
+
+aws.sns.topic.arn=${?sns_topic_arn}
+
+es.host=${?es_host}
+es.port=${?es_port}
+es.protocol=${?es_protocol}
+es.username=${?es_username}
+es.password=${?es_password}
+es.index=${?es_index}
+
+pipeline_storage.batch_size=${?batch_size}
+pipeline_storage.flush_interval_seconds=${?flush_interval_seconds}

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -5,8 +5,9 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.typesafe.SQSBuilder
+import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
 import uk.ac.wellcome.platform.transformer.mets.service.MetsTransformerWorkerService
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore
@@ -17,6 +18,13 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import scala.concurrent.ExecutionContext
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
+import uk.ac.wellcome.elasticsearch.SourceWorkIndexConfig
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.typesafe.{
+  ElasticIndexerBuilder,
+  PipelineStorageStreamBuilder
+}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.typesafe.config.builders.AWSClientConfigBuilder
 
@@ -32,8 +40,21 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 
+    val pipelineStream = PipelineStorageStreamBuilder
+      .buildPipelineStorageStream(
+        sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
+        indexer = ElasticIndexerBuilder[Work[Source]](
+          config,
+          indexConfig = SourceWorkIndexConfig
+        ),
+        messageSender = SNSBuilder
+          .buildSNSMessageSender(
+            config,
+            subject = "Sent from the METS transformer")
+      )(config)
+
     new MetsTransformerWorkerService(
-      SQSBuilder.buildSQSStream[NotificationMessage](config),
+      pipelineStream = pipelineStream,
       sender = BigMessagingBuilder.buildBigMessageSender(config),
       adapterStore = new DynamoSingleVersionStore[String, MetsLocation](
         DynamoBuilder.buildDynamoConfig(config, namespace = "mets")

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.platform.transformer.mets.service
 
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.mets_adapter.models.MetsLocation
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
@@ -12,7 +14,9 @@ import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 
 class MetsTransformerWorkerService[MsgDestination](
-  val stream: SQSStream[NotificationMessage],
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            MsgDestination],
   val sender: MessageSender[MsgDestination],
   adapterStore: VersionedStore[String, Int, MetsLocation],
   metsXmlStore: Readable[S3ObjectLocation, String]

--- a/pipeline/transformer/transformer_miro/src/main/resources/application.conf
+++ b/pipeline/transformer/transformer_miro/src/main/resources/application.conf
@@ -3,3 +3,15 @@ aws.metrics.namespace=${?metrics_namespace}
 aws.message.writer.sns.topic.arn=${?sns_arn}
 aws.message.writer.s3.bucketName=${?messages_bucket_name}
 aws.dynamo.tableName=${?miro_vhs_table_name}
+
+aws.sns.topic.arn=${?sns_topic_arn}
+
+es.host=${?es_host}
+es.port=${?es_port}
+es.protocol=${?es_protocol}
+es.username=${?es_username}
+es.password=${?es_password}
+es.index=${?es_index}
+
+pipeline_storage.batch_size=${?batch_size}
+pipeline_storage.flush_interval_seconds=${?flush_interval_seconds}

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -2,7 +2,9 @@ package uk.ac.wellcome.platform.transformer.miro.services
 
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.miro.MiroRecordTransformer
 import uk.ac.wellcome.platform.transformer.miro.models.{
   MiroMetadata,
@@ -16,7 +18,9 @@ import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 
 class MiroTransformerWorkerService[MsgDestination](
-  val stream: SQSStream[NotificationMessage],
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            MsgDestination],
   val sender: MessageSender[MsgDestination],
   miroVhsReader: Readable[String, MiroVHSRecord],
   typedStore: Readable[S3ObjectLocation, MiroRecord]

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/MiroTransformerFeatureTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.miro
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import uk.ac.wellcome.platform.transformer.miro.transformers.MiroTransformableWrapper
@@ -11,12 +10,12 @@ import uk.ac.wellcome.platform.transformer.miro.services.MiroTransformerWorkerSe
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import WorkState.Source
 import org.scalatest.Assertion
-import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.pipeline_storage.MemoryIndexer
+import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.platform.transformer.miro.models.MiroVHSRecord
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.storage.Version
@@ -25,6 +24,8 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 
+import scala.collection.mutable
+
 class MiroTransformerFeatureTest
     extends AnyFunSpec
     with Matchers
@@ -32,8 +33,7 @@ class MiroTransformerFeatureTest
     with IntegrationPatience
     with MiroRecordGenerators
     with MiroTransformableWrapper
-    with Akka
-    with SQS
+    with PipelineStorageStreamFixtures
     with S3ObjectLocationGenerators {
 
   it("transforms miro records and sends on the transformed result") {
@@ -97,18 +97,21 @@ class MiroTransformerFeatureTest
     typedStore: Readable[S3ObjectLocation, MiroRecord] =
       new MemoryStore[S3ObjectLocation, MiroRecord](initialEntries = Map.empty)
   )(testWith: TestWith[MiroTransformerWorkerService[String], R]): R =
-    withActorSystem { implicit actorSystem =>
-      withSQSStream[NotificationMessage, R](queue) { sqsStream =>
-        val workerService = new MiroTransformerWorkerService(
-          stream = sqsStream,
-          sender = messageSender,
-          miroVhsReader = miroVhsReader,
-          typedStore = typedStore
-        )
+    withPipelineStream(
+      queue = queue,
+      indexer = new MemoryIndexer[Work[Source]](
+        index = mutable.Map[String, Work[Source]]()
+      )
+    ) { pipelineStream =>
+      val workerService = new MiroTransformerWorkerService(
+        pipelineStream = pipelineStream,
+        sender = messageSender,
+        miroVhsReader = miroVhsReader,
+        typedStore = typedStore
+      )
 
-        workerService.run()
+      workerService.run()
 
-        testWith(workerService)
-      }
+      testWith(workerService)
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/resources/application.conf
+++ b/pipeline/transformer/transformer_sierra/src/main/resources/application.conf
@@ -4,3 +4,15 @@ aws.message.writer.sns.topic.arn=${?sns_arn}
 aws.message.writer.s3.bucketName=${?messages_bucket_name}
 aws.vhs.s3.bucketName=${?vhs_sierra_bucket_name}
 aws.vhs.dynamo.tableName=${?vhs_sierra_table_name}
+
+aws.sns.topic.arn=${?sns_topic_arn}
+
+es.host=${?es_host}
+es.port=${?es_port}
+es.protocol=${?es_protocol}
+es.username=${?es_username}
+es.password=${?es_password}
+es.index=${?es_index}
+
+pipeline_storage.batch_size=${?batch_size}
+pipeline_storage.flush_interval_seconds=${?flush_interval_seconds}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -3,8 +3,16 @@ package uk.ac.wellcome.platform.transformer.sierra
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.{BigMessagingBuilder, VHSBuilder}
+import uk.ac.wellcome.elasticsearch.SourceWorkIndexConfig
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.typesafe.SQSBuilder
+import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.typesafe.{
+  ElasticIndexerBuilder,
+  PipelineStorageStreamBuilder
+}
 import uk.ac.wellcome.platform.transformer.sierra.services.SierraTransformerWorkerService
 import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -21,8 +29,21 @@ object Main extends WellcomeTypesafeApp {
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
+    val pipelineStream = PipelineStorageStreamBuilder
+      .buildPipelineStorageStream(
+        sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
+        indexer = ElasticIndexerBuilder[Work[Source]](
+          config,
+          indexConfig = SourceWorkIndexConfig
+        ),
+        messageSender = SNSBuilder
+          .buildSNSMessageSender(
+            config,
+            subject = "Sent from the Sierra transformer")
+      )(config)
+
     new SierraTransformerWorkerService(
-      stream = SQSBuilder.buildSQSStream[NotificationMessage](config),
+      pipelineStream = pipelineStream,
       sender = BigMessagingBuilder.buildBigMessageSender(config),
       store = VHSBuilder.build[SierraTransformable](config)
     )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -2,7 +2,9 @@ package uk.ac.wellcome.platform.transformer.sierra.services
 
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
 import uk.ac.wellcome.storage.{Identified, ReadError}
@@ -11,7 +13,9 @@ import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 
 class SierraTransformerWorkerService[MsgDestination](
-  val stream: SQSStream[NotificationMessage],
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            MsgDestination],
   val sender: MessageSender[MsgDestination],
   store: VersionedStore[String, Int, SierraTransformable],
 ) extends Runnable


### PR DESCRIPTION
The first substantial step towards https://github.com/wellcomecollection/platform/issues/4897

This patch modifies the transformer to index works in the catalogue pipeline storage cluster, and sends the ID to a new queue. It *also* sends the complete work via big messaging – to downstream apps, there's no change. Hat tip to @alicefuzier – the PipelineStorageStream made this really easy to add. ✨ 

<img width="774" alt="Screenshot 2020-12-01 at 12 52 09" src="https://user-images.githubusercontent.com/301220/100743309-0d0d7080-33d4-11eb-8abd-ec78dd463bcb.png">

I've deployed these changes into a new pipeline, and verified that:

1. Works are indexed correctly in the works-source index for pipeline_storage
2. Works come all through the pipeline to https://api-stage.wellcomecollection.org/catalogue/v2/works?_index=works-alex-12-01

The next step is to modify the matcher to read the index IDs and retrieve the works from pipeline_storage, bypassing the recorder – I'll do that as a separate PR.