### PR TITLE
Pull out the Calm notes transformation into a separate trait, and test it more thoroughly

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -78,9 +78,12 @@ trait IdentifiersGenerators extends RandomGenerators {
   def createMiroSourceIdentifier: SourceIdentifier =
     createMiroSourceIdentifierWith()
 
+  def createCalmRecordID: String =
+    randomUUID.toString
+
   def createCalmSourceIdentifier: SourceIdentifier =
     SourceIdentifier(
-      value = randomAlphanumeric(length = 6),
+      value = createCalmRecordID,
       identifierType = IdentifierType("calm-record-id"),
       ontologyType = "Work"
     )

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
@@ -22,7 +22,8 @@ object CalmNotes extends CalmOps {
     ("Arrangement", ArrangementNote(_))
   )
 
-  def apply(record: CalmRecord, languageNote: Option[LanguageNote]): List[Note] =
+  def apply(record: CalmRecord,
+            languageNote: Option[LanguageNote]): List[Note] =
     notesMapping.flatMap {
       case (key, createNote) =>
         record

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.transformer.calm.transformers
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.calm.{
+  CalmOps,
+  CalmRecord,
+  NormaliseText
+}
+
+object CalmNotes extends CalmOps {
+  private val notesMapping = List(
+    ("AdminHistory", BiographicalNote(_)),
+    ("CustodHistory", OwnershipNote(_)),
+    ("Acquisition", AcquisitionNote(_)),
+    ("Appraisal", AppraisalNote(_)),
+    ("Accruals", AccrualsNote(_)),
+    ("RelatedMaterial", RelatedMaterial(_)),
+    ("PubInNote", PublicationsNote(_)),
+    ("UserWrapped4", FindingAids(_)),
+    ("Copyright", CopyrightNote(_)),
+    ("ReproductionConditions", TermsOfUse(_)),
+    ("Arrangement", ArrangementNote(_))
+  )
+
+  def apply(record: CalmRecord, languageNote: Option[LanguageNote]): List[Note] =
+    notesMapping.flatMap {
+      case (key, createNote) =>
+        record
+          .getList(key)
+          .map(NormaliseText(_))
+          .map(createNote)
+    } ++ List(languageNote).flatten
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -1,20 +1,20 @@
 package uk.ac.wellcome.platform.transformer.calm
 
-import java.time.{Instant, LocalDate}
+import java.time.LocalDate
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Source
+import uk.ac.wellcome.platform.transformer.calm.generators.CalmRecordGenerators
 
-class CalmTransformerTest extends AnyFunSpec with Matchers {
+class CalmTransformerTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
 
   val version = 3
-  val id = "123"
 
   it("transforms to a work") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -27,7 +27,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
         version = version,
         state = Source(
           SourceIdentifier(
-            value = id,
+            value = record.id,
             identifierType = CalmIdentifierTypes.recordId,
             ontologyType = "SourceIdentifier"
           ),
@@ -79,7 +79,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms multiple identifiers") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -105,7 +105,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms merge candidates") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -126,7 +126,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms access conditions") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -148,7 +148,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms description") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -161,7 +161,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms physical description") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -175,7 +175,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms production dates") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -201,7 +201,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms subjects, stripping all HTML") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -217,7 +217,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("finds a single language") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -231,7 +231,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("only preserves i HTML tags when transforming title") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "<p> The <i>title</i> of the <strong>work</strong>",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -245,7 +245,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("strips whitespace from the langauge") {
-    val recordA = calmRecord(
+    val recordA = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -253,7 +253,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Language" -> "English ",
       "CatalogueStatus" -> "Catalogued"
     )
-    val recordB = calmRecord(
+    val recordB = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -268,7 +268,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("parses language codes that can have various labels") {
-    val recordA = calmRecord(
+    val recordA = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -276,7 +276,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       "Language" -> "Dutch",
       "CatalogueStatus" -> "Catalogued"
     )
-    val recordB = calmRecord(
+    val recordB = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -293,7 +293,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms multiple contributors") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -309,7 +309,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms multiple notes") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -327,7 +327,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("ignores case when transforming level") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Subseries",
       "RefNo" -> "a/b/c",
@@ -340,49 +340,49 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("transforms to invisible work when CatalogueStatus is suppressible") {
-    val recordA = calmRecord(
+    val recordA = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Catalogued"
     )
-    val recordB = calmRecord(
+    val recordB = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Not yet available"
     )
-    val recordC = calmRecord(
+    val recordC = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Partially catalogued"
     )
-    val recordD = calmRecord(
+    val recordD = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "   caTAlogued  "
     )
-    val recordE = calmRecord(
+    val recordE = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "pArtialLy catalogued "
     )
-    val recordF = calmRecord(
+    val recordF = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Third-party metadata"
     )
-    val suppressibleRecordA = calmRecord(
+    val suppressibleRecordA = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Blonk"
     )
-    val suppressibleRecordB = calmRecord(
+    val suppressibleRecordB = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -409,17 +409,17 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("Returns Work.Invisible[Source] when missing required source fields") {
-    val noTitle = calmRecord(
+    val noTitle = createCalmRecordWith(
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Catalogued"
     )
-    val noLevel = calmRecord(
+    val noLevel = createCalmRecordWith(
       "Title" -> "Stay calm",
       "RefNo" -> "a/b/c",
       "CatalogueStatus" -> "Catalogued"
     )
-    val noRefNo = calmRecord(
+    val noRefNo = createCalmRecordWith(
       "Title" -> "Stay calm",
       "Level" -> "Collection",
       "CatalogueStatus" -> "Catalogued"
@@ -431,7 +431,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("returns a Work.Invisible[Source] if invalid access status") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -443,7 +443,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("returns a Work.Invisible[Source] if no title") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
@@ -453,7 +453,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("returns a Work.Invisible[Source] if no format") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
@@ -463,7 +463,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("returns a Work.Invisible[Source] if invalid format") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "TopLevel",
       "RefNo" -> "a/b/c",
@@ -474,7 +474,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("returns a Work.Invisible[Source] if no RefNo") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "AltRefNo" -> "a.b.c",
@@ -484,7 +484,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
   }
 
   it("does not add language code if language not recognised") {
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "abc",
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
@@ -503,7 +503,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
 
   it("suppresses Archives and Manuscripts Resource Guide works") {
     import InvisibilityReason._
-    val record = calmRecord(
+    val record = createCalmRecordWith(
       "Title" -> "Should suppress",
       "Level" -> "Section",
       "RefNo" -> "AMSG/X/Y",
@@ -513,7 +513,7 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       Work.Invisible[Source](
         state = Source(
           SourceIdentifier(
-            value = id,
+            value = record.id,
             identifierType = CalmIdentifierTypes.recordId,
             ontologyType = "SourceIdentifier"
           ),
@@ -553,14 +553,4 @@ class CalmTransformerTest extends AnyFunSpec with Matchers {
       )
     )
   }
-
-  def calmRecord(fields: (String, String)*): CalmRecord =
-    CalmRecord(
-      id = id,
-      retrievedAt = Instant.ofEpochSecond(123456789),
-      data = fields.foldLeft(Map.empty[String, List[String]]) {
-        case (map, (key, value)) =>
-          map + (key -> (value :: map.get(key).getOrElse(Nil)))
-      }
-    )
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -9,7 +9,10 @@ import uk.ac.wellcome.models.work.internal._
 import WorkState.Source
 import uk.ac.wellcome.platform.transformer.calm.generators.CalmRecordGenerators
 
-class CalmTransformerTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+class CalmTransformerTest
+    extends AnyFunSpec
+    with Matchers
+    with CalmRecordGenerators {
 
   val version = 3
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/generators/CalmRecordGenerators.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/generators/CalmRecordGenerators.scala
@@ -31,7 +31,10 @@ trait CalmRecordGenerators extends IdentifiersGenerators {
   }
 }
 
-class CalmRecordGeneratorsTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+class CalmRecordGeneratorsTest
+    extends AnyFunSpec
+    with Matchers
+    with CalmRecordGenerators {
   it("assembles the data correctly") {
     val record = createCalmRecordWith(
       "Place" -> "London",
@@ -39,6 +42,8 @@ class CalmRecordGeneratorsTest extends AnyFunSpec with Matchers with CalmRecordG
       "Date" -> "2020"
     )
 
-    record.data shouldBe Map("Place" -> List("London", "Paris"), "Date" -> List("2020"))
+    record.data shouldBe Map(
+      "Place" -> List("London", "Paris"),
+      "Date" -> List("2020"))
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/generators/CalmRecordGenerators.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/generators/CalmRecordGenerators.scala
@@ -1,0 +1,44 @@
+package uk.ac.wellcome.platform.transformer.calm.generators
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.platform.transformer.calm.CalmRecord
+
+trait CalmRecordGenerators extends IdentifiersGenerators {
+
+  def createCalmRecordWith(fields: (String, String)*): CalmRecord = {
+    // Roll up the fields into Map[String, List[String]]
+    // e.g.
+    //
+    //      fields = ("Place" -> "London", "Place" -> "Paris", "Date" -> "2020")
+    //
+    // becomes
+    //
+    //    data = Map("Place" -> List("London", "Paris"), "Date" -> List("2020"))
+    //
+    val data = fields.foldLeft(Map.empty[String, List[String]]) {
+      case (existingData, (key, value)) =>
+        val existingValue: List[String] = existingData.getOrElse(key, Nil)
+        existingData + (key -> (existingValue :+ value))
+    }
+
+    CalmRecord(
+      id = createCalmRecordID,
+      retrievedAt = randomInstant,
+      data = data
+    )
+  }
+}
+
+class CalmRecordGeneratorsTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+  it("assembles the data correctly") {
+    val record = createCalmRecordWith(
+      "Place" -> "London",
+      "Place" -> "Paris",
+      "Date" -> "2020"
+    )
+
+    record.data shouldBe Map("Place" -> List("London", "Paris"), "Date" -> List("2020"))
+  }
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
@@ -1,0 +1,69 @@
+package uk.ac.wellcome.platform.transformer.calm.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.platform.transformer.calm.generators.CalmRecordGenerators
+
+class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+  it("extracts all the notes fields") {
+    val record = createCalmRecordWith(
+      ("AdminHistory", "Administered by the Active Administrator"),
+      ("CustodHistory", "Collected by the Careful Custodian"),
+      ("Acquisition", "Acquired by the Academic Archivists"),
+      ("Appraisal", "Appraised by the Affable Appraiser"),
+      ("Accruals", "Accrued by the Alliterative Acquirer"),
+      ("RelatedMaterial", "Related to the Radiant Records"),
+      ("PubInNote", "Published in the Public Pamphlet"),
+      ("UserWrapped4", "Wrapped in the Worldly Words"),
+      ("Copyright", "Copyright the Creative Consortium"),
+      ("ReproductionConditions", "Reproduction is Rarely Regulated"),
+      ("Arrangement", "Arranged in an Adorable Alignment")
+    )
+
+    val notes = CalmNotes(record, languageNote = None)
+
+    // The ordering of the Notes field is arbitrary, because the underlying
+    // Calm data is arbitrary.
+    notes should contain theSameElementsAs List(
+      BiographicalNote("Administered by the Active Administrator"),
+      OwnershipNote("Collected by the Careful Custodian"),
+      AcquisitionNote("Acquired by the Academic Archivists"),
+      AppraisalNote("Appraised by the Affable Appraiser"),
+      AccrualsNote("Accrued by the Alliterative Acquirer"),
+      RelatedMaterial("Related to the Radiant Records"),
+      PublicationsNote("Published in the Public Pamphlet"),
+      FindingAids("Wrapped in the Worldly Words"),
+      CopyrightNote("Copyright the Creative Consortium"),
+      TermsOfUse("Reproduction is Rarely Regulated"),
+      ArrangementNote("Arranged in an Adorable Alignment")
+    )
+  }
+
+  it("includes the language note, if supplied") {
+    val record = createCalmRecordWith(
+      ("Arrangement", "Aligned Across the Axis"),
+    )
+
+    val languageNote = LanguageNote("Listed in Lampung and Lavongai")
+
+    val notes = CalmNotes(record, languageNote = Some(languageNote))
+
+    // The ordering of the Notes field is arbitrary, because the underlying
+    // Calm data is arbitrary.
+    notes should contain theSameElementsAs List(
+      ArrangementNote("Aligned Across the Axis"),
+      languageNote
+    )
+  }
+
+  it("returns an empty list if none of the fields contain notes") {
+    val record = createCalmRecordWith(
+      "Title" -> "abc",
+      "Level" -> "Collection",
+      "RefNo" -> "a/b/c"
+    )
+
+    CalmNotes(record, languageNote = None) shouldBe empty
+  }
+}


### PR DESCRIPTION
Some preliminary refactoring for https://github.com/wellcomecollection/platform/issues/4773

We weren't testing that we bring through all the notes fields correctly. This PR adds more tests around the notes field, but it doesn't change any of the behaviour.

Changing the behaviour to match the ticket will be a separate PR.