### PR TITLE
Fix an issue with ElasticRetriever which was breaking the matcher

### DIFF
--- a/common/pipeline_storage/docker-compose.yml
+++ b/common/pipeline_storage/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.6.1"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -41,17 +41,18 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
           // See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-multi-get.html
           val documents = result.docs
             .zip(ids)
-            .map { case (getResponse, id) =>
-              if (getResponse.found) {
-                id -> getResponse.safeTo[T]
-              } else {
-                id -> Failure(new RetrieverNotFoundException(id))
-              }
+            .map {
+              case (getResponse, id) =>
+                if (getResponse.found) {
+                  id -> getResponse.safeTo[T]
+                } else {
+                  id -> Failure(new RetrieverNotFoundException(id))
+                }
             }
             .toMap
 
           RetrieverMultiResult(
-            found = documents.collect { case (id, Success(t)) => id -> t },
+            found = documents.collect { case (id, Success(t))    => id -> t },
             notFound = documents.collect { case (id, Failure(e)) => id -> e }
           )
       }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -8,10 +8,16 @@ class MemoryRetriever[T](val index: mutable.Map[String, T] =
   implicit val ec: ExecutionContext)
     extends Retriever[T] {
 
-  override def apply(ids: Seq[String]): Future[Map[String, T]] =
+  override def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] =
     Future {
-      ids.map { id =>
-        id -> index(id)
-      }.toMap
+      val lookupResults =
+        ids
+          .map { id => id -> index.get(id) }
+          .toMap
+
+      RetrieverMultiResult(
+        found = lookupResults.collect { case (id, Some(t)) => (id, t) },
+        notFound = lookupResults.collect { case (id, None) => (id, new RetrieverNotFoundException(id)) }
+      )
     }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryRetriever.scala
@@ -11,13 +11,15 @@ class MemoryRetriever[T](val index: mutable.Map[String, T] =
   override def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] =
     Future {
       val lookupResults =
-        ids
-          .map { id => id -> index.get(id) }
-          .toMap
+        ids.map { id =>
+          id -> index.get(id)
+        }.toMap
 
       RetrieverMultiResult(
         found = lookupResults.collect { case (id, Some(t)) => (id, t) },
-        notFound = lookupResults.collect { case (id, None) => (id, new RetrieverNotFoundException(id)) }
+        notFound = lookupResults.collect {
+          case (id, None) => (id, new RetrieverNotFoundException(id))
+        }
       )
     }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -15,7 +15,8 @@ trait Retriever[T] {
     apply(Seq(id))
       .map { result =>
         result.found.getOrElse(
-          id, throw result.notFound(id)
+          id,
+          throw result.notFound(id)
         )
       }
 

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Retriever.scala
@@ -13,9 +13,12 @@ trait Retriever[T] {
     */
   def apply(id: String): Future[T] =
     apply(Seq(id))
-      .map { _(id) }
-      .recover { case t: Throwable => throw new RetrieverNotFoundException(id) }
+      .map { result =>
+        result.found.getOrElse(
+          id, throw result.notFound(id)
+        )
+      }
 
   /** Retrieves a series of documents from the store. */
-  def apply(ids: Seq[String]): Future[Map[String, T]]
+  def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]]
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.pipeline_storage
+
+case class RetrieverMultiResult[T](
+  found: Map[String, T],
+  notFound: Map[String, Throwable]
+) {
+  require(found.keySet.intersect(notFound.keySet).isEmpty)
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -52,9 +52,13 @@ trait RetrieverTestCases[Context, T]
 
     val documents = Seq(t1, t2, t3)
     val ids = documents.map { id.canonicalId }
-    val expectedResult = documents.map { t =>
-      id.canonicalId(t) -> t
-    }.toMap
+    val expectedResult = RetrieverMultiResult(
+      found =
+        documents
+          .map { t => id.canonicalId(t) -> t }
+          .toMap,
+      notFound = Map.empty
+    )
 
     withContext(documents = documents) { implicit context =>
       val future = withRetriever { _.apply(ids) }
@@ -76,8 +80,13 @@ trait RetrieverTestCases[Context, T]
     withContext(documents = Seq(t1, t2)) { implicit context =>
       val future = withRetriever { _.apply(ids) }
 
-      whenReady(future.failed) {
-        _ shouldBe a[Throwable]
+      whenReady(future) { result =>
+        result.found shouldBe Map(
+          id.canonicalId(t1) -> t1, id.canonicalId(t2) -> t2
+        )
+
+        result.notFound.keySet shouldBe Set(id.canonicalId(t3))
+        result.notFound(id.canonicalId(t3)) shouldBe a[RetrieverNotFoundException]
       }
     }
   }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/RetrieverTestCases.scala
@@ -53,10 +53,9 @@ trait RetrieverTestCases[Context, T]
     val documents = Seq(t1, t2, t3)
     val ids = documents.map { id.canonicalId }
     val expectedResult = RetrieverMultiResult(
-      found =
-        documents
-          .map { t => id.canonicalId(t) -> t }
-          .toMap,
+      found = documents.map { t =>
+        id.canonicalId(t) -> t
+      }.toMap,
       notFound = Map.empty
     )
 
@@ -82,11 +81,13 @@ trait RetrieverTestCases[Context, T]
 
       whenReady(future) { result =>
         result.found shouldBe Map(
-          id.canonicalId(t1) -> t1, id.canonicalId(t2) -> t2
+          id.canonicalId(t1) -> t1,
+          id.canonicalId(t2) -> t2
         )
 
         result.notFound.keySet shouldBe Set(id.canonicalId(t3))
-        result.notFound(id.canonicalId(t3)) shouldBe a[RetrieverNotFoundException]
+        result.notFound(id.canonicalId(t3)) shouldBe a[
+          RetrieverNotFoundException]
       }
     }
   }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.merger.services
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.Retriever
+import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverMultiResult, RetrieverNotFoundException}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,22 +18,38 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
 
     retriever
       .apply(workIdentifiers.map { _.identifier })
-      .map { workMap =>
-        workIdentifiers.map { id =>
-          val work = workMap(id.identifier)
-
-          // We only want to get the exact versions of the works specified by
-          // the matcher.
-          //
-          // e.g. if the matcher said "combine Av1 and Bv2", and we look in the retriever
-          // and find {Av2, Bv3}, we shouldn't merge these -- we should wait for the matcher
-          // to confirm we should still be merging these two works.
-          if (id.version.contains(work.version)) {
-            Some(work)
-          } else {
-            None
-          }
-        }
+      .map { result =>
+        workIdentifiers
+          .map { id => getWorkFromResult(result, id) }
       }
   }
+
+  private def getWorkFromResult(
+    result: RetrieverMultiResult[Work[Source]],
+    id: WorkIdentifier
+  ): Option[Work[Source]] =
+    result.found.get(id.identifier) match {
+      case Some(work) =>
+        // We only want to get the exact versions of the works specified by
+        // the matcher.
+        //
+        // e.g. if the matcher said "combine Av1 and Bv2", and we look in the retriever
+        // and find {Av2, Bv3}, we shouldn't merge these -- we should wait for the matcher
+        // to confirm we should still be merging these two works.
+        if (id.version.contains(work.version)) {
+          Some(work)
+        } else {
+          None
+        }
+
+      case None =>
+        result.notFound.get(id.identifier) match {
+          case Some(t) if t.isInstanceOf[RetrieverNotFoundException] => None
+          case Some(t) => throw t
+
+          // This should be impossible, but handle it so the compiler's happy
+          // and we can spot it if it does occur.
+          case None => throw new RuntimeException(s"Could not find ID $id in retriever result")
+        }
+    }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
@@ -3,11 +3,7 @@ package uk.ac.wellcome.platform.merger.services
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.{
-  Retriever,
-  RetrieverMultiResult,
-  RetrieverNotFoundException
-}
+import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverMultiResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,44 +16,30 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
       "You should never look up an empty list of WorkIdentifiers!"
     )
 
-    retriever
-      .apply(workIdentifiers.map { _.identifier })
-      .map { result =>
-        workIdentifiers
-          .map { id =>
-            getWorkFromResult(result, id)
-          }
+    val workIds = workIdentifiers
+      .collect {
+        case WorkIdentifier(identifier, Some(_)) => identifier
+      }
+
+    retriever(workIds)
+      .map {
+        case RetrieverMultiResult(works, notFound) if notFound.isEmpty =>
+          workIdentifiers
+            .map {
+              case WorkIdentifier(_, None) => None
+              case WorkIdentifier(id, Some(version)) =>
+                val work = works(id)
+                // We only want to get the exact versions of the works specified
+                // by the matcher.
+                //
+                // e.g. if the matcher said "combine Av1 and Bv2", and we look
+                // in the retriever and find {Av2, Bv3}, we shouldn't merge
+                // these -- we should wait for the matcher to confirm we should
+                // still be merging these two works.
+                if (work.version == version) Some(work) else None
+            }
+        case RetrieverMultiResult(_, notFound) =>
+          throw new RuntimeException(s"Works not found: $notFound")
       }
   }
-
-  private def getWorkFromResult(
-    result: RetrieverMultiResult[Work[Source]],
-    id: WorkIdentifier
-  ): Option[Work[Source]] =
-    result.found.get(id.identifier) match {
-      case Some(work) =>
-        // We only want to get the exact versions of the works specified by
-        // the matcher.
-        //
-        // e.g. if the matcher said "combine Av1 and Bv2", and we look in the retriever
-        // and find {Av2, Bv3}, we shouldn't merge these -- we should wait for the matcher
-        // to confirm we should still be merging these two works.
-        if (id.version.contains(work.version)) {
-          Some(work)
-        } else {
-          None
-        }
-
-      case None =>
-        result.notFound.get(id.identifier) match {
-          case Some(t) if t.isInstanceOf[RetrieverNotFoundException] => None
-          case Some(t)                                               => throw t
-
-          // This should be impossible, but handle it so the compiler's happy
-          // and we can spot it if it does occur.
-          case None =>
-            throw new RuntimeException(
-              s"Could not find ID $id in retriever result")
-        }
-    }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.merger.services
 import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverMultiResult, RetrieverNotFoundException}
+import uk.ac.wellcome.pipeline_storage.{
+  Retriever,
+  RetrieverMultiResult,
+  RetrieverNotFoundException
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +24,9 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
       .apply(workIdentifiers.map { _.identifier })
       .map { result =>
         workIdentifiers
-          .map { id => getWorkFromResult(result, id) }
+          .map { id =>
+            getWorkFromResult(result, id)
+          }
       }
   }
 
@@ -45,11 +51,13 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
       case None =>
         result.notFound.get(id.identifier) match {
           case Some(t) if t.isInstanceOf[RetrieverNotFoundException] => None
-          case Some(t) => throw t
+          case Some(t)                                               => throw t
 
           // This should be impossible, but handle it so the compiler's happy
           // and we can spot it if it does occur.
-          case None => throw new RuntimeException(s"Could not find ID $id in retriever result")
+          case None =>
+            throw new RuntimeException(
+              s"Could not find ID $id in retriever result")
         }
     }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
@@ -95,7 +95,8 @@ class SourceWorkLookupTest
     }
   }
 
-  it("fails if the retriever fails with something other than RetrieverNotFoundException") {
+  it(
+    "fails if the retriever fails with something other than RetrieverNotFoundException") {
     val workId = WorkIdentifier(randomAlphanumeric(), version = None)
 
     val exception = new Throwable("BOOM!")
@@ -103,18 +104,22 @@ class SourceWorkLookupTest
     val retriever = new MemoryRetriever[Work[Source]](
       index = mutable.Map[String, Work[Source]]()
     ) {
-      override def apply(ids: Seq[String]): Future[RetrieverMultiResult[Work[Source]]] =
+      override def apply(
+        ids: Seq[String]): Future[RetrieverMultiResult[Work[Source]]] =
         Future.successful(
           RetrieverMultiResult(
             found = Map.empty,
-            notFound = ids.map { id => id -> exception }.toMap
+            notFound = ids.map { id =>
+              id -> exception
+            }.toMap
           )
         )
     }
 
     val sourceWorkLookup = new SourceWorkLookup(retriever)
 
-    whenReady(sourceWorkLookup.fetchAllWorks(workIdentifiers = List(workId)).failed) {
+    whenReady(
+      sourceWorkLookup.fetchAllWorks(workIdentifiers = List(workId)).failed) {
       _ shouldBe exception
     }
   }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.models.matcher.WorkIdentifier
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Source
-import uk.ac.wellcome.pipeline_storage.{MemoryRetriever, RetrieverMultiResult}
+import uk.ac.wellcome.pipeline_storage.MemoryRetriever
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,8 +36,8 @@ class SourceWorkLookupTest
 
     val retriever = new MemoryRetriever[Work[Source]]()
 
-    whenReady(fetchAllWorks(retriever = retriever, work)) {
-      _ shouldBe Seq(None)
+    whenReady(fetchAllWorks(retriever = retriever, work).failed) {
+      _ shouldBe a[Exception]
     }
   }
 
@@ -92,35 +92,6 @@ class SourceWorkLookupTest
 
     whenReady(fetchAllWorks(retriever = retriever, lookupWorks: _*)) {
       _ shouldBe expectedLookupResult
-    }
-  }
-
-  it(
-    "fails if the retriever fails with something other than RetrieverNotFoundException") {
-    val workId = WorkIdentifier(randomAlphanumeric(), version = None)
-
-    val exception = new Throwable("BOOM!")
-
-    val retriever = new MemoryRetriever[Work[Source]](
-      index = mutable.Map[String, Work[Source]]()
-    ) {
-      override def apply(
-        ids: Seq[String]): Future[RetrieverMultiResult[Work[Source]]] =
-        Future.successful(
-          RetrieverMultiResult(
-            found = Map.empty,
-            notFound = ids.map { id =>
-              id -> exception
-            }.toMap
-          )
-        )
-    }
-
-    val sourceWorkLookup = new SourceWorkLookup(retriever)
-
-    whenReady(
-      sourceWorkLookup.fetchAllWorks(workIdentifiers = List(workId)).failed) {
-      _ shouldBe exception
     }
   }
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
@@ -36,8 +36,8 @@ class SourceWorkLookupTest
 
     val retriever = new MemoryRetriever[Work[Source]]()
 
-    whenReady(fetchAllWorks(retriever = retriever, work).failed) {
-      _ shouldBe a[NoSuchElementException]
+    whenReady(fetchAllWorks(retriever = retriever, work)) {
+      _ shouldBe Seq(None)
     }
   }
 


### PR DESCRIPTION
I discussed this with @warrd in Slack; a brief recap:

* The matcher tells the merger about all the works that _could_ be merged together, and the merger tries to retrieve all of them. This is done by the new SourceWorkLookup class (it uses Retriever[Source[Work]], and replaces the old RecorderPlaybackService. It returns a `Seq[Option[Work]]`, and whether the Option is filled in depends on whether:

     - The work is found
     - The work matches the version sent by the matcher

* The Retriever would previously throw an exception if _any_ of the IDs it was asked to retrieve didn't exist. This is wrong – the merger can use a partially filled in set of works, but only if it knows about them! So I changed the Retriever interface to include a list of:

     - Documents which were found
     - Documents which weren't found, and the throwable that meant they weren't there

* The ElasticRetriever had an additional bug where it would misinterpret documents that weren't in the index, and try to decode them rather than reading `found = false`. This was being masked by the `Retriever.apply()` method, which Nick noticed was swallowing the original exception.