### PR TITLE
More efficient use of the Retriever in SourceWorkLookup

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookup.scala
@@ -25,7 +25,7 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
         // We only want the exact versions of works from the matcher; if an identifier
         // doesn't have a version, don't both trying to retrieve it.
         workIdentifiers
-          .filter{ _.version.isDefined }
+          .filter { _.version.isDefined }
           .map { _.identifier }
       )
       .map { result =>
@@ -40,7 +40,8 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
             // e.g. if the matcher said "combine Av1 and Bv2", and we look in the retriever
             // and find {Av2, Bv3}, we shouldn't merge these -- we should wait for the matcher
             // to confirm we should still be merging these two works.
-            case (id, Some(work)) if id.version.contains(work.version) => Some(work)
+            case (id, Some(work)) if id.version.contains(work.version) =>
+              Some(work)
             case _ => None
           }
       }
@@ -56,11 +57,13 @@ class SourceWorkLookup(retriever: Retriever[Work[Source]])(
       case None =>
         result.notFound.get(id.identifier) match {
           case Some(t) if t.isInstanceOf[RetrieverNotFoundException] => None
-          case Some(t) => throw t
+          case Some(t)                                               => throw t
 
           // We didn't look up this identifier, because it doesn't have a version.
           case None =>
-            assert(id.version.isEmpty, s"Retriever failed to find an identifier: $id")
+            assert(
+              id.version.isEmpty,
+              s"Retriever failed to find an identifier: $id")
             None
         }
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/SourceWorkLookupTest.scala
@@ -97,7 +97,7 @@ class SourceWorkLookupTest
 
   it(
     "fails if the retriever fails with something other than RetrieverNotFoundException") {
-    val workId = WorkIdentifier(randomAlphanumeric(), version = None)
+    val workId = WorkIdentifier(randomAlphanumeric(), version = Some(1))
 
     val exception = new Throwable("BOOM!")
 


### PR DESCRIPTION
Follows #1146 

The matcher gives the merger a collection of identifiers which could be merged together. These identifiers may have a version, but it's not required. (I'm not entirely sure why this happens, but it's how the models are set up. I think possibly if a source record says “match this other source identifier”, and the other identifier isn’t in the pipeline yet?)

<img width="408" alt="Screenshot 2020-12-02 at 11 34 42" src="https://user-images.githubusercontent.com/301220/100867648-63d97f80-3492-11eb-9231-aa102e18be25.png">

If an identifier doesn't have a version, we can't use it in the merger – the merger will only combine the exact set of identifiers/versions it was given by the matcher.

<img width="417" alt="Screenshot 2020-12-02 at 11 33 44" src="https://user-images.githubusercontent.com/301220/100867873-b5820a00-3492-11eb-92fa-61d2497ebb65.png">

If we know we're not going to use it, then it's pointless looking up the work associated with this identifier – we'll discard it as soon as it's retrieved. We used to do this in the RecorderPlaybackService, but it got dropped when I added bulk retrievals. This puts it back.

Value: unsure. It will definitely reduce the amount of data we shuttle between us and Elasticsearch, but I don't know by how much.