### PR TITLE
Simplify the store implementations in big_messaging

### DIFF
--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -22,15 +22,10 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
 
 class VHSInternalStore[T](
   prefix: S3ObjectLocationPrefix,
-  indexStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String,
-                                                                        Int],
-  dataStore: TypedStore[S3ObjectLocation, T]
+  val indexedStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String,
+                                                                              Int],
+  val typedStore: TypedStore[S3ObjectLocation, T]
 ) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
-
-  override val indexedStore
-    : Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Int] =
-    indexStore
-  override val typedStore: TypedStore[S3ObjectLocation, T] = dataStore
 
   override protected def createTypeStoreId(
     id: Version[String, Int]): S3ObjectLocation =

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -16,10 +16,9 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
       T,
     ](hybridStore)
 
-class VHSInternalStore[T](
-  prefix: S3ObjectLocationPrefix)(
+class VHSInternalStore[T](prefix: S3ObjectLocationPrefix)(
   implicit
   indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
   typedStore: S3TypedStore[T]
 ) extends DynamoHybridStore[T](prefix)(indexedStore, typedStore)
-  with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]
+    with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -20,7 +20,8 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
     ](hybridStore)
 
 class VHSInternalStore[T](
-  prefix: S3ObjectLocationPrefix,
+  prefix: S3ObjectLocationPrefix)(
+  implicit
   val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
   val typedStore: S3TypedStore[T]
 ) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -4,9 +4,9 @@ import java.util.UUID
 
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.{
   HybridStoreWithMaxima,
-  TypedStore,
   VersionedHybridStore
 }
 import uk.ac.wellcome.storage.Version
@@ -22,7 +22,7 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
 class VHSInternalStore[T](
   prefix: S3ObjectLocationPrefix,
   val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
-  val typedStore: TypedStore[S3ObjectLocation, T]
+  val typedStore: S3TypedStore[T]
 ) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
 
   override protected def createTypeStoreId(

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -1,15 +1,12 @@
 package uk.ac.wellcome.bigmessaging
 
-import java.util.UUID
-
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
-import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
+import uk.ac.wellcome.storage.store.dynamo.{DynamoHashStore, DynamoHybridStore}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.{
   HybridStoreWithMaxima,
   VersionedHybridStore
 }
-import uk.ac.wellcome.storage.Version
 
 class VHS[T](val hybridStore: VHSInternalStore[T])
     extends VersionedHybridStore[
@@ -22,11 +19,7 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
 class VHSInternalStore[T](
   prefix: S3ObjectLocationPrefix)(
   implicit
-  val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
-  val typedStore: S3TypedStore[T]
-) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
-
-  override protected def createTypeStoreId(
-    id: Version[String, Int]): S3ObjectLocation =
-    prefix.asLocation(id.id, id.version.toString, UUID.randomUUID().toString)
-}
+  indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
+  typedStore: S3TypedStore[T]
+) extends DynamoHybridStore[T](prefix)(indexedStore, typedStore)
+  with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -3,14 +3,13 @@ package uk.ac.wellcome.bigmessaging
 import java.util.UUID
 
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
 import uk.ac.wellcome.storage.store.{
   HybridStoreWithMaxima,
-  Store,
   TypedStore,
   VersionedHybridStore
 }
 import uk.ac.wellcome.storage.Version
-import uk.ac.wellcome.storage.maxima.Maxima
 
 class VHS[T](val hybridStore: VHSInternalStore[T])
     extends VersionedHybridStore[
@@ -22,8 +21,7 @@ class VHS[T](val hybridStore: VHSInternalStore[T])
 
 class VHSInternalStore[T](
   prefix: S3ObjectLocationPrefix,
-  val indexedStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String,
-                                                                              Int],
+  val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
   val typedStore: TypedStore[S3ObjectLocation, T]
 ) extends HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
 

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -23,12 +23,15 @@ object VHSBuilder {
     val dynamoConfig =
       DynamoBuilder.buildDynamoConfig(config, namespace = namespace)
 
+    implicit val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation] =
+      new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig)
+
+    implicit val typedStore: S3TypedStore[T] = S3TypedStore[T]
+
     new VHS(
       new VHSInternalStore(
-        prefix = buildObjectLocationPrefix(config, namespace = namespace),
-        indexedStore =
-          new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig),
-        typedStore = S3TypedStore[T])
+        prefix = buildObjectLocationPrefix(config, namespace = namespace)
+      )
     )
   }
 

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -32,9 +32,9 @@ object VHSBuilder {
     new VHS(
       new VHSInternalStore(
         prefix = buildObjectLocationPrefix(config, namespace = namespace),
-        indexStore =
+        indexedStore =
           new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig),
-        dataStore = S3TypedStore[T])
+        typedStore = S3TypedStore[T])
     )
   }
 

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
-import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.store.Store
 import uk.ac.wellcome.storage.maxima.Maxima
@@ -22,24 +21,20 @@ object VHSBuilder {
     Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Int]
 
   def build[T](config: Config, namespace: String = "vhs")(
-    implicit codec: Codec[T]): VHS[T] =
-    VHSBuilder.build(
-      buildObjectLocationPrefix(config, namespace = namespace),
-      DynamoBuilder.buildDynamoConfig(config, namespace = namespace),
-      DynamoBuilder.buildDynamoClient(config),
-      S3Builder.buildS3Client(config)
-    )
+    implicit codec: Codec[T]): VHS[T] = {
+    implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
+    implicit val dynamoClient: AmazonDynamoDB =
+      DynamoBuilder.buildDynamoClient(config)
 
-  def build[T](objectLocationPrefix: S3ObjectLocationPrefix,
-               dynamoConfig: DynamoConfig,
-               dynamoClient: AmazonDynamoDB,
-               s3Client: AmazonS3)(implicit codec: Codec[T]): VHS[T] = {
-    implicit val s3 = s3Client;
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = namespace)
+
     new VHS(
       new VHSInternalStore(
-        objectLocationPrefix,
-        createIndexStore(dynamoClient, dynamoConfig),
-        S3TypedStore[T])
+        prefix = buildObjectLocationPrefix(config, namespace = namespace),
+        indexStore =
+          new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig),
+        dataStore = S3TypedStore[T])
     )
   }
 
@@ -51,10 +46,4 @@ object VHSBuilder {
         .getStringOption(s"aws.$namespace.s3.globalPrefix")
         .getOrElse("")
     )
-
-  private def createIndexStore(dynamoClient: AmazonDynamoDB,
-                               dynamoConfig: DynamoConfig): IndexStore = {
-    implicit val dynamo = dynamoClient;
-    new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig)
-  }
 }

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -7,18 +7,12 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.storage.store.dynamo.DynamoHashStore
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.store.Store
-import uk.ac.wellcome.storage.maxima.Maxima
-import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 import uk.ac.wellcome.storage.streaming.Codec
 import uk.ac.wellcome.bigmessaging.{VHS, VHSInternalStore}
 import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 
 object VHSBuilder {
-
-  type IndexStore =
-    Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Int]
 
   def build[T](config: Config, namespace: String = "vhs")(
     implicit codec: Codec[T]): VHS[T] = {

--- a/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
+++ b/common/big_messaging_typesafe/src/main/scala/uk/ac/wellcome/bigmessaging/typesafe/VHSBuilder.scala
@@ -46,9 +46,9 @@ object VHSBuilder {
   private def buildObjectLocationPrefix(config: Config, namespace: String) =
     S3ObjectLocationPrefix(
       bucket = config
-        .requireString(s"aws.${namespace}.s3.bucketName"),
+        .requireString(s"aws.$namespace.s3.bucketName"),
       keyPrefix = config
-        .getStringOption(s"aws.${namespace}.s3.globalPrefix")
+        .getStringOption(s"aws.$namespace.s3.globalPrefix")
         .getOrElse("")
     )
 


### PR DESCRIPTION
I was looking at these internal VHS classes in the catalogue, and they look eerily similar to ones in the scala-storage lib. I'm not quite ready to wholesale replace them, but this reduces the duplicated code.