### PR TITLE
Transformers should send the version from the store, not the triggering message

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 class MemoryIndexer[T: Indexable](
-  val index: mutable.Map[String, T] = mutable.Map.empty)
+  val index: mutable.Map[String, T] = mutable.Map[String, T]())
     extends Indexer[T] {
 
   def init(): Future[Unit] =

--- a/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/uk/ac/wellcome/platform/router/RouterWorkerServiceTest.scala
@@ -18,7 +18,6 @@ import uk.ac.wellcome.pipeline_storage.{
   MemoryIndexer
 }
 
-import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -31,8 +30,7 @@ class RouterWorkerServiceTest
 
   it("sends collectionPath to paths topic") {
     val work = identifiedWork().collectionPath(CollectionPath("a"))
-    val indexer = new MemoryIndexer[Work[Denormalised]](
-      mutable.Map[String, Work[Denormalised]]())
+    val indexer = new MemoryIndexer[Work[Denormalised]]()
     withWorkerService(indexer) {
       case (
           identifiedIndex,
@@ -53,8 +51,7 @@ class RouterWorkerServiceTest
 
   it("sends a work without collectionPath to works topic") {
     val work = identifiedWork()
-    val indexer = new MemoryIndexer[Work[Denormalised]](
-      mutable.Map[String, Work[Denormalised]]())
+    val indexer = new MemoryIndexer[Work[Denormalised]]()
     withWorkerService(indexer) {
       case (
           identifiedIndex,
@@ -79,8 +76,7 @@ class RouterWorkerServiceTest
     val work =
       identifiedWork().collectionPath(CollectionPath("a/2")).invisible()
 
-    val indexer = new MemoryIndexer[Work[Denormalised]](
-      mutable.Map[String, Work[Denormalised]]())
+    val indexer = new MemoryIndexer[Work[Denormalised]]()
     withWorkerService(indexer) {
       case (
           identifiedIndex,

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -4,7 +4,6 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
-import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
@@ -13,15 +12,12 @@ class CalmTransformerWorker(
   val pipelineStream: PipelineStorageStream[NotificationMessage,
                                             Work[Source],
                                             SNSConfig],
-  store: VersionedStore[String, Int, CalmRecord],
+  store: VersionedStore[String, Int, CalmRecord]
 ) extends Runnable
     with TransformerWorker[CalmRecord, SNSConfig] {
 
   val transformer: Transformer[CalmRecord] = CalmTransformer
 
-  override protected def lookupSourceData(
-    id: String): Either[ReadError, (CalmRecord, Int)] =
-    store
-      .getLatest(id)
-      .map { case Identified(Version(_, version), calmRecord) => (calmRecord, version) }
+  override protected def lookupSourceData(id: String): store.ReadEither =
+    store.getLatest(id)
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -19,6 +19,7 @@ class CalmTransformerWorker(
 
   val transformer: Transformer[CalmRecord] = CalmTransformer
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], CalmRecord]] =
+  override def lookupSourceData(id: String)
+    : Either[ReadError, Identified[Version[String, Int], CalmRecord]] =
     store.getLatest(id)
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
@@ -18,6 +19,6 @@ class CalmTransformerWorker(
 
   val transformer: Transformer[CalmRecord] = CalmTransformer
 
-  override protected def lookupSourceData(id: String): store.ReadEither =
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], CalmRecord]] =
     store.getLatest(id)
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
-import uk.ac.wellcome.storage.{Identified, ReadError}
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
@@ -20,8 +20,8 @@ class CalmTransformerWorker(
   val transformer: Transformer[CalmRecord] = CalmTransformer
 
   override protected def lookupSourceData(
-    key: StoreKey): Either[ReadError, CalmRecord] =
+    id: String): Either[ReadError, (CalmRecord, Int)] =
     store
-      .getLatest(key.id)
-      .map { case Identified(_, calmRecord) => calmRecord }
+      .getLatest(id)
+      .map { case Identified(Version(_, version), calmRecord) => (calmRecord, version) }
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorker.scala
@@ -40,7 +40,8 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
                                             Work[Source],
                                             SenderDest]
 
-  def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], SourceData]]
+  def lookupSourceData(
+    id: String): Either[ReadError, Identified[Version[String, Int], SourceData]]
 
   def process(message: NotificationMessage): Result[(Work[Source], StoreKey)] =
     for {
@@ -69,12 +70,14 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
       .map {
         case Identified(Version(storedId, storedVersion), sourceData) =>
           if (storedId != key.id) {
-            warn(s"Stored ID ($storedId) does not match ID from message (${key.id})")
+            warn(
+              s"Stored ID ($storedId) does not match ID from message (${key.id})")
           }
 
           (sourceData, storedVersion)
       }
-      .left.map { err =>
+      .left
+      .map { err =>
         StoreReadError(err, key)
       }
 

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, PipelineStorageStream}
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
@@ -37,9 +37,12 @@ class TestTransformerWorker(
   val pipelineStream: PipelineStorageStream[NotificationMessage,
                                             Work[Source],
                                             String],
-  val sourceStore: VersionedStore[String, Int, TestData]
+  sourceStore: VersionedStore[String, Int, TestData]
 ) extends TransformerWorker[TestData, String] {
   val transformer: Transformer[TestData] = TestTransformer
+
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], TestData]] =
+    sourceStore.getLatest(id)
 }
 
 class TransformerWorkerTest

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -41,7 +41,8 @@ class TestTransformerWorker(
 ) extends TransformerWorker[TestData, String] {
   val transformer: Transformer[TestData] = TestTransformer
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], TestData]] =
+  override def lookupSourceData(
+    id: String): Either[ReadError, Identified[Version[String, Int], TestData]] =
     sourceStore.getLatest(id)
 }
 
@@ -120,7 +121,8 @@ class TransformerWorkerTest
         sendNotificationToSQS(queue, Version("A", messageVersion))
 
         eventually {
-          workIndexer.index.values.map { _.version }.toSeq shouldBe Seq(storeVersion)
+          workIndexer.index.values.map { _.version }.toSeq shouldBe Seq(
+            storeVersion)
         }
       }
     }

--- a/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/uk/ac/wellcome/transformer/common/worker/TransformerWorkerTest.scala
@@ -17,7 +17,6 @@ import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
-import scala.collection.mutable
 import scala.concurrent.Future
 import scala.util.{Failure, Try}
 
@@ -63,9 +62,7 @@ class TransformerWorkerTest
         Version("C", 3) -> ValidTestData
       )
 
-      val workIndexer =
-        new MemoryIndexer[Work[Source]](
-          index = mutable.Map[String, Work[Source]]())
+      val workIndexer = new MemoryIndexer[Work[Source]]()
       val workKeySender = new MemoryMessageSender()
 
       withLocalSqsQueuePair() {
@@ -171,9 +168,7 @@ class TransformerWorkerTest
     }
 
     it("if it can't index the work") {
-      val brokenIndexer = new MemoryIndexer[Work[Source]](
-        index = mutable.Map[String, Work[Source]]()
-      ) {
+      val brokenIndexer = new MemoryIndexer[Work[Source]]() {
         override def index(documents: Seq[Work[Source]])
           : Future[Either[Seq[Work[Source]], Seq[Work[Source]]]] =
           Future.failed(new Throwable("BOOM!"))
@@ -228,8 +223,7 @@ class TransformerWorkerTest
   def withWorker[R](
     queue: Queue,
     records: Map[Version[String, Int], TestData] = Map.empty,
-    workIndexer: MemoryIndexer[Work[Source]] = new MemoryIndexer[Work[Source]](
-      index = mutable.Map[String, Work[Source]]()),
+    workIndexer: MemoryIndexer[Work[Source]] = new MemoryIndexer[Work[Source]](),
     workKeySender: MemoryMessageSender = new MemoryMessageSender()
   )(
     testWith: TestWith[Unit, R]

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -24,6 +24,7 @@ class MetsTransformerWorkerService[MsgDestination](
   override val transformer: Transformer[MetsSourceData] =
     new MetsXmlTransformer(metsXmlStore)
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], MetsSourceData]] =
+  override def lookupSourceData(id: String)
+    : Either[ReadError, Identified[Version[String, Int], MetsSourceData]] =
     adapterStore.getLatest(id)
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
@@ -23,6 +24,6 @@ class MetsTransformerWorkerService[MsgDestination](
   override val transformer: Transformer[MetsSourceData] =
     new MetsXmlTransformer(metsXmlStore)
 
-  override protected def lookupSourceData(id: String): adapterStore.ReadEither =
-    adapterStore.getLatest(key.id)
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], MetsSourceData]] =
+    adapterStore.getLatest(id)
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -8,7 +8,6 @@ import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
-import uk.ac.wellcome.storage.{Identified, ReadError}
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -24,9 +23,6 @@ class MetsTransformerWorkerService[MsgDestination](
   override val transformer: Transformer[MetsSourceData] =
     new MetsXmlTransformer(metsXmlStore)
 
-  override protected def lookupSourceData(
-    key: StoreKey): Either[ReadError, MetsSourceData] =
-    adapterStore
-      .getLatest(key.id)
-      .map { case Identified(_, metsLocation) => metsLocation }
+  override protected def lookupSourceData(id: String): adapterStore.ReadEither =
+    adapterStore.getLatest(key.id)
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -26,11 +26,11 @@ class MiroRecordTransformer
     with MiroTitleAndDescription
     with MiroFormat
     with Logging
-    with Transformer[(MiroRecord, MiroMetadata, Int)] {
+    with Transformer[(MiroRecord, MiroMetadata)] {
 
-  override def apply(sourceData: (MiroRecord, MiroMetadata, Int),
+  override def apply(sourceData: (MiroRecord, MiroMetadata),
                      version: Int): Result[Work[Source]] = {
-    val (miroRecord, miroMetadata, version) = sourceData
+    val (miroRecord, miroMetadata) = sourceData
 
     transform(miroRecord, miroMetadata, version).toEither
   }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -93,7 +93,7 @@ class MiroRecordTransformer
         contributors = getContributors(miroRecord),
         thumbnail = Some(getThumbnail(miroRecord)),
         items = getItems(miroRecord),
-        images = List(getImage(miroRecord, version))
+        images = List(getImage(miroRecord, version = version))
       )
 
       Work.Visible[Source](

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookup.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookup.scala
@@ -13,8 +13,9 @@ class MiroLookup(
   miroVhsReader: Readable[String, MiroVHSRecord],
   typedStore: Readable[S3ObjectLocation, MiroRecord]
 ) {
-  def lookupRecord(
-    id: String): Either[ReadError, Identified[Version[String, Int], (MiroRecord, MiroMetadata)]] =
+  def lookupRecord(id: String)
+    : Either[ReadError,
+             Identified[Version[String, Int], (MiroRecord, MiroMetadata)]] =
     for {
       vhsRecord <- miroVhsReader.get(id)
       miroMetadata = vhsRecord.identifiedT.toMiroMetadata

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookup.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookup.scala
@@ -14,15 +14,14 @@ class MiroLookup(
   typedStore: Readable[S3ObjectLocation, MiroRecord]
 ) {
   def lookupRecord(
-    id: String): Either[ReadError, (MiroRecord, MiroMetadata, Int)] =
+    id: String): Either[ReadError, (MiroRecord, MiroMetadata)] =
     for {
       vhsRecord <- miroVhsReader.get(id)
       miroMetadata = vhsRecord.identifiedT.toMiroMetadata
-      version = vhsRecord.identifiedT.version
 
       typedStoreRecord <- typedStore.get(vhsRecord.identifiedT.location)
       miroRecord = typedStoreRecord.identifiedT
 
-      result = (miroRecord, miroMetadata, version)
+      result = (miroRecord, miroMetadata)
     } yield result
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -23,14 +23,14 @@ class MiroTransformerWorkerService[MsgDestination](
   miroVhsReader: Readable[String, MiroVHSRecord],
   typedStore: Readable[S3ObjectLocation, MiroRecord]
 ) extends Runnable
-    with TransformerWorker[(MiroRecord, MiroMetadata, Int), MsgDestination] {
+    with TransformerWorker[(MiroRecord, MiroMetadata), MsgDestination] {
 
-  override val transformer: Transformer[(MiroRecord, MiroMetadata, Int)] =
+  override val transformer: Transformer[(MiroRecord, MiroMetadata)] =
     new MiroRecordTransformer
 
   private val miroLookup = new MiroLookup(miroVhsReader, typedStore)
 
   override protected def lookupSourceData(
-    key: StoreKey): Either[ReadError, (MiroRecord, MiroMetadata, Int)] =
+    key: StoreKey): Either[ReadError, (MiroRecord, MiroMetadata)] =
     miroLookup.lookupRecord(key.id)
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.platform.transformer.miro.models.{
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
-import uk.ac.wellcome.storage.ReadError
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -30,7 +30,6 @@ class MiroTransformerWorkerService[MsgDestination](
 
   private val miroLookup = new MiroLookup(miroVhsReader, typedStore)
 
-  override protected def lookupSourceData(
-    key: StoreKey): Either[ReadError, (MiroRecord, MiroMetadata)] =
-    miroLookup.lookupRecord(key.id)
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], (MiroRecord, MiroMetadata)]] =
+    miroLookup.lookupRecord(id)
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -30,6 +30,8 @@ class MiroTransformerWorkerService[MsgDestination](
 
   private val miroLookup = new MiroLookup(miroVhsReader, typedStore)
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], (MiroRecord, MiroMetadata)]] =
+  override def lookupSourceData(id: String)
+    : Either[ReadError,
+             Identified[Version[String, Int], (MiroRecord, MiroMetadata)]] =
     miroLookup.lookupRecord(id)
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.transformer.miro.models.{
   MiroVHSRecord
 }
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.storage.DoesNotExistError
+import uk.ac.wellcome.storage.{DoesNotExistError, Identified, Version}
 import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStore
@@ -45,7 +45,7 @@ class MiroLookupTest
     )
     vhsReader.put(id)(vhsRecord) shouldBe a[Right[_, _]]
 
-    lookup.lookupRecord(id).value shouldBe ((record, metadata))
+    lookup.lookupRecord(id).value shouldBe Identified(Version(id, version), (record, metadata))
   }
 
   it("fails if asked to lookup a non-existent ID") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
@@ -45,7 +45,9 @@ class MiroLookupTest
     )
     vhsReader.put(id)(vhsRecord) shouldBe a[Right[_, _]]
 
-    lookup.lookupRecord(id).value shouldBe Identified(Version(id, version), (record, metadata))
+    lookup.lookupRecord(id).value shouldBe Identified(
+      Version(id, version),
+      (record, metadata))
   }
 
   it("fails if asked to lookup a non-existent ID") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroLookupTest.scala
@@ -45,7 +45,7 @@ class MiroLookupTest
     )
     vhsReader.put(id)(vhsRecord) shouldBe a[Right[_, _]]
 
-    lookup.lookupRecord(id).value shouldBe ((record, metadata, version))
+    lookup.lookupRecord(id).value shouldBe ((record, metadata))
   }
 
   it("fails if asked to lookup a non-existent ID") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -23,6 +23,7 @@ class SierraTransformerWorkerService[MsgDestination](
     (input: SierraTransformable, version: Int) =>
       SierraTransformer(input, version).toEither
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], SierraTransformable]] =
+  override def lookupSourceData(id: String)
+    : Either[ReadError, Identified[Version[String, Int], SierraTransformable]] =
     store.getLatest(id)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
@@ -22,6 +23,6 @@ class SierraTransformerWorkerService[MsgDestination](
     (input: SierraTransformable, version: Int) =>
       SierraTransformer(input, version).toEither
 
-  override protected def lookupSourceData(id: String): store.ReadEither =
-    store.getLatest(key.id)
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], SierraTransformable]] =
+    store.getLatest(id)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
-import uk.ac.wellcome.storage.{Identified, ReadError}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
@@ -23,9 +22,6 @@ class SierraTransformerWorkerService[MsgDestination](
     (input: SierraTransformable, version: Int) =>
       SierraTransformer(input, version).toEither
 
-  override protected def lookupSourceData(
-    key: StoreKey): Either[ReadError, SierraTransformable] =
-    store
-      .getLatest(key.id)
-      .map { case Identified(_, sierraTransformable) => sierraTransformable }
+  override protected def lookupSourceData(id: String): store.ReadEither =
+    store.getLatest(key.id)
 }


### PR DESCRIPTION
AIUI, the `version` on the Work model is meant to correspond to the version in the original store – so we can trace a work to the data is was generated from.

It turns out this isn't working correctly – right now we get a version from the notification _"hey, please transform record XYZ"_, and blat the version we got from the store. This patch updates the transformers to send the correct version in transformed works.

This hints at a deeper question about how the transformers should work.

If a transformer is asked to transform `id=A1234 version=1`, and the store now contains `id=A1234 version=2`, should it try to transform the original version, or the current version? I think the latter is more appropriate, which means we do want `getLatest()` – but we should ensure the versioning reflects that.

I spotted this while digging into https://github.com/wellcomecollection/platform/issues/4913