### PR TITLE
Add IIIF manifest location to METS images, add thumbnail to display images

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ApiImagesTestBase.scala
@@ -39,6 +39,7 @@ trait ApiImagesTestBase
        |  {
        |    "type": "Image",
        |    "id": "${image.id}",
+       |    "thumbnail": ${location(image.state.derivedData.thumbnail)},
        |    "locations": [${locations(image.locations)}],
        |    "source": ${imageSource(image.source)}
        |  }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -35,6 +35,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id}",
+              |      "thumbnail": ${location(image.state.derivedData.thumbnail)},
               |      "locations": [${locations(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
@@ -64,6 +65,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id}",
+              |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
               |  "locations": [${locations(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",
@@ -93,6 +95,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |    {
               |      "type": "Image",
               |      "id": "${image.id}",
+              |      "thumbnail": ${location(image.state.derivedData.thumbnail)},
               |      "locations": [${locations(image.locations)}],
               |      "source": {
               |        "id": "${source.id}",
@@ -122,6 +125,7 @@ class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
               |  $singleImageResult,
               |  "type": "Image",
               |  "id": "${image.id}",
+              |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
               |  "locations": [${locations(image.locations)}],
               |  "source": {
               |    "id": "${source.id}",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -19,6 +19,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id}",
+               |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
                |  "locations": [${locations(image.locations)}],
                |  "visuallySimilar": [
                |    ${images.tail.map(imageResponse).mkString(",")}
@@ -46,6 +47,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id}",
+               |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
                |  "locations": [${locations(image.locations)}],
                |  "withSimilarFeatures": [
                |    ${images.tail.map(imageResponse).mkString(",")}
@@ -73,6 +75,7 @@ class ImagesSimilarityTest extends ApiImagesTestBase {
                |{
                |  $singleImageResult,
                |  "id": "${image.id}",
+               |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
                |  "locations": [${locations(image.locations)}],
                |  "withSimilarColors": [
                |    ${images.tail.map(imageResponse).mkString(",")}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -27,6 +27,7 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
              |{
              |  $singleImageResult,
              |  "id": "${image.id}",
+             |  "thumbnail": ${location(image.state.derivedData.thumbnail)},
              |  "locations": [${locations(image.locations)}],
              |  "source": ${imageSource(image.source)}
              |}""".stripMargin
@@ -151,6 +152,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${defaultImage.id}",
+                 |  "thumbnail": ${location(
+                   defaultImage.state.derivedData.thumbnail)},
                  |  "locations": [${locations(defaultImage.locations)}],
                  |  "source": ${imageSource(defaultImage.source)}
                  }""".stripMargin
@@ -164,6 +167,8 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
                  |{
                  |  $singleImageResult,
                  |  "id": "${alternativeImage.id}",
+                 |  "thumbnail": ${location(
+                   alternativeImage.state.derivedData.thumbnail)},
                  |  "locations": [${locations(alternativeImage.locations)}],
                  |  "source": ${imageSource(alternativeImage.source)}
                  }""".stripMargin

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayImage.scala
@@ -15,6 +15,11 @@ case class DisplayImage(
   ) id: String,
   @Schema(
     `type` = "uk.ac.wellcome.Display.models.DisplayDigitalLocation",
+    description =
+      "The location which provides access to an image that can be displayed directly as a thumbnnail"
+  ) thumbnail: DisplayDigitalLocationDeprecated,
+  @Schema(
+    `type` = "uk.ac.wellcome.Display.models.DisplayDigitalLocation",
     description = "The locations which provide access to the image"
   ) locations: Seq[DisplayDigitalLocationDeprecated],
   @Schema(
@@ -42,6 +47,8 @@ object DisplayImage {
             includes: ImageIncludes): DisplayImage =
     new DisplayImage(
       id = image.id,
+      thumbnail =
+        DisplayDigitalLocationDeprecated(image.state.derivedData.thumbnail),
       locations = image.locations.map(DisplayDigitalLocationDeprecated(_)),
       source = DisplayImageSource(image.source, includes),
       visuallySimilar = None,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -42,7 +42,7 @@ trait ImageGenerators
   )
 
   def createMetsImageData = createImageDataWith(
-    locations = List(createDigitalLocation),
+    locations = List(createImageLocation, createManifestLocation),
     identifierType = IdentifierType("mets-image")
   )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -59,6 +59,10 @@ trait ItemsGenerators extends IdentifiersGenerators {
     locationType = createImageLocationType
   )
 
+  def createManifestLocation = createDigitalLocationWith(
+    locationType = createPresentationLocationType
+  )
+
   def createDigitalLocationWith(
     locationType: LocationType = createPresentationLocationType,
     url: String = defaultLocationUrl,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -1,0 +1,60 @@
+package uk.ac.wellcome.models.work.internal
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.{ImageGenerators, WorkGenerators}
+
+class DerivedDataTest
+    extends AnyFunSpec
+    with Matchers
+    with WorkGenerators
+    with ImageGenerators {
+
+  describe("DerivedWorkData") {
+
+    it("sets availableOnline = true if there is a digital location on an item") {
+      val work = mergedWork().items(List(createDigitalItem, createPhysicalItem))
+      val derivedWorkData = DerivedWorkData(work.data)
+
+      derivedWorkData.availableOnline shouldBe true
+    }
+
+    it(
+      "sets availableOnline = false if there is no digital location on any items") {
+      val work = mergedWork().items(List(createPhysicalItem))
+      val derivedWorkData = DerivedWorkData(work.data)
+
+      derivedWorkData.availableOnline shouldBe false
+    }
+
+    it("handles empty items list") {
+      val work = mergedWork().items(Nil)
+      val derivedWorkData = DerivedWorkData(work.data)
+
+      derivedWorkData.availableOnline shouldBe false
+    }
+
+  }
+
+  describe("DerivedImageData") {
+
+    it(
+      "sets the thumbnail to the first iiif-image location it finds in locations") {
+      val imageLocation = createImageLocation
+      val image = createImageDataWith(locations =
+        List(createManifestLocation, imageLocation)).toAugmentedImage
+      val derivedImageData = DerivedImageData(image)
+
+      derivedImageData.thumbnail shouldBe imageLocation
+    }
+
+    it("throws an error if there is no iiif-image location") {
+      val image =
+        createImageDataWith(locations = List(createManifestLocation)).toAugmentedImage
+
+      assertThrows[RuntimeException] {
+        DerivedImageData(image)
+      }
+    }
+  }
+}

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -165,7 +165,9 @@ case class MetsData(
                   locationType = LocationType("iiif-image"),
                   license = license,
                   accessConditions = accessConditions(accessStatus)
-                ))
+                ),
+                digitalLocation(license, accessStatus)
+              )
             )
           }
         }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -326,7 +326,7 @@ class MetsDataTest
     result.right.get.data.thumbnail shouldBe None
   }
 
-  it("uses the IIIF info.json for image URLs") {
+  it("uses both the IIIF manifest and image for imageData locations") {
     val metsData = MetsData(
       recordIdentifier = randomAlphanumeric(10),
       accessConditionDz = Some("CC-BY-NC"),
@@ -341,7 +341,14 @@ class MetsDataTest
         url = s"https://dlcs.io/iiif-img/wellcome/5/location.jp2/info.json",
         locationType = LocationType("iiif-image"),
         license = Some(License.CCBYNC)
-      ))
+      ),
+      DigitalLocationDeprecated(
+        url =
+          s"https://wellcomelibrary.org/iiif/${metsData.recordIdentifier}/manifest",
+        locationType = LocationType("iiif-presentation"),
+        license = Some(License.CCBYNC)
+      )
+    )
   }
 
   it("creates a work with a single accessCondition") {


### PR DESCRIPTION
I also added a test for the derived data types - they ended up getting tested elsewhere indirectly, but nice to narrow it down.