### PR TITLE
Bump scala-libs to v25.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "24.6.1"
+  val defaultVersion = "25.0.0
 
   lazy val versions = new {
     val typesafe = defaultVersion


### PR DESCRIPTION
This brings in the changes that should reduce the number of Dynamo calls made by the pipeline.