### PR TITLE
Don't trigger an update from the Sierra item merger if nothing has changed

### DIFF
--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
@@ -13,7 +13,7 @@ object ItemLinker {
     * Returns the merged record.
     */
   def linkItemRecord(sierraTransformable: SierraTransformable,
-                     itemRecord: SierraItemRecord): SierraTransformable = {
+                     itemRecord: SierraItemRecord): Option[SierraTransformable] = {
     if (!itemRecord.bibIds.contains(sierraTransformable.sierraId)) {
       throw new RuntimeException(
         s"Non-matching bib id ${sierraTransformable.sierraId} in item bib ${itemRecord.bibIds}")
@@ -35,9 +35,9 @@ object ItemLinker {
 
     if (isNewerData) {
       val itemData = sierraTransformable.itemRecords + (itemRecord.id -> itemRecord)
-      sierraTransformable.copy(itemRecords = itemData)
+      Some(sierraTransformable.copy(itemRecords = itemData))
     } else {
-      sierraTransformable
+      None
     }
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinker.scala
@@ -12,8 +12,9 @@ object ItemLinker {
     *
     * Returns the merged record.
     */
-  def linkItemRecord(sierraTransformable: SierraTransformable,
-                     itemRecord: SierraItemRecord): Option[SierraTransformable] = {
+  def linkItemRecord(
+    sierraTransformable: SierraTransformable,
+    itemRecord: SierraItemRecord): Option[SierraTransformable] = {
     if (!itemRecord.bibIds.contains(sierraTransformable.sierraId)) {
       throw new RuntimeException(
         s"Non-matching bib id ${sierraTransformable.sierraId} in item bib ${itemRecord.bibIds}")

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
@@ -7,8 +7,9 @@ import uk.ac.wellcome.sierra_adapter.model.{
 
 object ItemUnlinker {
 
-  def unlinkItemRecord(sierraTransformable: SierraTransformable,
-                       itemRecord: SierraItemRecord): Option[SierraTransformable] = {
+  def unlinkItemRecord(
+    sierraTransformable: SierraTransformable,
+    itemRecord: SierraItemRecord): Option[SierraTransformable] = {
     if (!itemRecord.unlinkedBibIds.contains(sierraTransformable.sierraId)) {
       throw new RuntimeException(
         s"Non-matching bib id ${sierraTransformable.sierraId} in item unlink bibs ${itemRecord.unlinkedBibIds}")

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinker.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.sierra_adapter.model.{
 object ItemUnlinker {
 
   def unlinkItemRecord(sierraTransformable: SierraTransformable,
-                       itemRecord: SierraItemRecord): SierraTransformable = {
+                       itemRecord: SierraItemRecord): Option[SierraTransformable] = {
     if (!itemRecord.unlinkedBibIds.contains(sierraTransformable.sierraId)) {
       throw new RuntimeException(
         s"Non-matching bib id ${sierraTransformable.sierraId} in item unlink bibs ${itemRecord.unlinkedBibIds}")
@@ -27,6 +27,10 @@ object ItemUnlinker {
             matchesCurrentItemRecord && modifiedAfter
         }
 
-    sierraTransformable.copy(itemRecords = itemRecords)
+    if (sierraTransformable.itemRecords != itemRecords) {
+      Some(sierraTransformable.copy(itemRecords = itemRecords))
+    } else {
+      None
+    }
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterService.scala
@@ -1,8 +1,20 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
-import uk.ac.wellcome.platform.sierra_item_merger.links.{ItemLinker, ItemUnlinker}
-import uk.ac.wellcome.sierra_adapter.model.{SierraBibNumber, SierraItemRecord, SierraTransformable}
-import uk.ac.wellcome.storage.{Identified, UpdateError, UpdateNotApplied, Version}
+import uk.ac.wellcome.platform.sierra_item_merger.links.{
+  ItemLinker,
+  ItemUnlinker
+}
+import uk.ac.wellcome.sierra_adapter.model.{
+  SierraBibNumber,
+  SierraItemRecord,
+  SierraTransformable
+}
+import uk.ac.wellcome.storage.{
+  Identified,
+  UpdateError,
+  UpdateNotApplied,
+  Version
+}
 import uk.ac.wellcome.storage.store.VersionedStore
 import cats.implicits._
 
@@ -18,15 +30,15 @@ class SierraItemMergerUpdaterService(
     val unlinkUpdates: List[Either[UpdateError, Version[String, Int]]] =
       itemRecord.unlinkedBibIds.map { unlinkBib(_, itemRecord) }
 
-    (linkUpdates ++ unlinkUpdates)
-      .filter {
-        case Left(_: UpdateNotApplied) => false
-        case _ => true
-      }
-      .sequence
+    (linkUpdates ++ unlinkUpdates).filter {
+      case Left(_: UpdateNotApplied) => false
+      case _                         => true
+    }.sequence
   }
 
-  private def linkBib(bibId: SierraBibNumber, itemRecord: SierraItemRecord): Either[UpdateError, Version[String, Int]] = {
+  private def linkBib(
+    bibId: SierraBibNumber,
+    itemRecord: SierraItemRecord): Either[UpdateError, Version[String, Int]] = {
     val newTransformable =
       SierraTransformable(
         sierraId = bibId,
@@ -38,18 +50,26 @@ class SierraItemMergerUpdaterService(
         existingTransformable =>
           ItemLinker.linkItemRecord(existingTransformable, itemRecord) match {
             case Some(updatedRecord) => Right(updatedRecord)
-            case None                => Left(UpdateNotApplied(new Throwable(s"Bib $bibId is already up to date")))
+            case None =>
+              Left(
+                UpdateNotApplied(
+                  new Throwable(s"Bib $bibId is already up to date")))
           }
       }
       .map { case Identified(id, _) => id }
   }
 
-  private def unlinkBib(unlinkedBibId: SierraBibNumber, itemRecord: SierraItemRecord): Either[UpdateError, Version[String, Int]] =
+  private def unlinkBib(
+    unlinkedBibId: SierraBibNumber,
+    itemRecord: SierraItemRecord): Either[UpdateError, Version[String, Int]] =
     versionedHybridStore
       .update(unlinkedBibId.withoutCheckDigit) { existingTransformable =>
         ItemUnlinker.unlinkItemRecord(existingTransformable, itemRecord) match {
           case Some(updatedRecord) => Right(updatedRecord)
-          case None                => Left(UpdateNotApplied(new Throwable(s"Bib $unlinkedBibId is already up to date")))
+          case None =>
+            Left(
+              UpdateNotApplied(
+                new Throwable(s"Bib $unlinkedBibId is already up to date")))
         }
       }
       .map { case Identified(id, _) => id }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemLinkerTest.scala
@@ -15,7 +15,7 @@ class ItemLinkerTest extends AnyFunSpec with Matchers with SierraGenerators {
     val sierraTransformable = createSierraTransformableWith(sierraId = bibId)
     val result = ItemLinker.linkItemRecord(sierraTransformable, record)
 
-    result.itemRecords shouldBe Map(record.id -> record)
+    result.get.itemRecords shouldBe Map(record.id -> record)
   }
 
   it("updates itemData when merging item records with newer data") {
@@ -37,11 +37,25 @@ class ItemLinkerTest extends AnyFunSpec with Matchers with SierraGenerators {
     )
     val result = ItemLinker.linkItemRecord(sierraTransformable, newerRecord)
 
-    result shouldBe sierraTransformable.copy(
+    result.get shouldBe sierraTransformable.copy(
       itemRecords = Map(itemRecord.id -> newerRecord))
   }
 
-  it("returns itself when merging item records with stale data") {
+  it("returns None if you apply the same update more than once") {
+    val bibId = createSierraBibNumber
+    val record = createSierraItemRecordWith(
+      bibIds = List(bibId)
+    )
+
+    val sierraTransformable = createSierraTransformableWith(sierraId = bibId)
+
+    val transformable1 = ItemLinker.linkItemRecord(sierraTransformable, record)
+    val transformable2 = ItemLinker.linkItemRecord(transformable1.get, record)
+
+    transformable2 shouldBe None
+  }
+
+  it("returns None when merging item records with stale data") {
     val bibId = createSierraBibNumber
     val itemRecord = createSierraItemRecordWith(
       modifiedDate = newerDate,
@@ -58,7 +72,7 @@ class ItemLinkerTest extends AnyFunSpec with Matchers with SierraGenerators {
       data = """{"older": "data goes here"}"""
     )
     val result = ItemLinker.linkItemRecord(sierraTransformable, oldRecord)
-    result shouldBe sierraTransformable
+    result shouldBe None
   }
 
   it("supports adding multiple items to a merged record") {
@@ -72,10 +86,10 @@ class ItemLinkerTest extends AnyFunSpec with Matchers with SierraGenerators {
 
     val sierraTransformable = createSierraTransformableWith(sierraId = bibId)
     val result1 = ItemLinker.linkItemRecord(sierraTransformable, record1)
-    val result2 = ItemLinker.linkItemRecord(result1, record2)
+    val result2 = ItemLinker.linkItemRecord(result1.get, record2)
 
-    result1.itemRecords(record1.id) shouldBe record1
-    result2.itemRecords(record2.id) shouldBe record2
+    result1.get.itemRecords(record1.id) shouldBe record1
+    result2.get.itemRecords(record2.id) shouldBe record2
   }
 
   it("only merges item records with matching bib IDs") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
@@ -30,7 +30,9 @@ class ItemUnlinkerTests extends AnyFunSpec with Matchers with SierraGenerators {
       itemRecords = Map.empty
     )
 
-    ItemUnlinker.unlinkItemRecord(sierraTransformable, unlinkedItemRecord).get shouldBe expectedSierraTransformable
+    ItemUnlinker
+      .unlinkItemRecord(sierraTransformable, unlinkedItemRecord)
+      .get shouldBe expectedSierraTransformable
   }
 
   it("returns None when merging an unlinked record which is already absent") {
@@ -54,7 +56,8 @@ class ItemUnlinkerTests extends AnyFunSpec with Matchers with SierraGenerators {
     ItemUnlinker.unlinkItemRecord(sierraTransformable, previouslyUnlinkedRecord) shouldBe None
   }
 
-  it("returns None when merging an unlinked record which has linked more recently") {
+  it(
+    "returns None when merging an unlinked record which has linked more recently") {
     val bibId = createSierraBibNumber
 
     val record = createSierraItemRecordWith(

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemUnlinkerTests.scala
@@ -30,11 +30,10 @@ class ItemUnlinkerTests extends AnyFunSpec with Matchers with SierraGenerators {
       itemRecords = Map.empty
     )
 
-    ItemUnlinker.unlinkItemRecord(sierraTransformable, unlinkedItemRecord) shouldBe expectedSierraTransformable
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, unlinkedItemRecord).get shouldBe expectedSierraTransformable
   }
 
-  it(
-    "returns the original record when merging an unlinked record which is already absent") {
+  it("returns None when merging an unlinked record which is already absent") {
     val bibId = createSierraBibNumber
 
     val record = createSierraItemRecordWith(
@@ -52,11 +51,10 @@ class ItemUnlinkerTests extends AnyFunSpec with Matchers with SierraGenerators {
       itemRecords = List(record)
     )
 
-    ItemUnlinker.unlinkItemRecord(sierraTransformable, previouslyUnlinkedRecord) shouldBe sierraTransformable
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, previouslyUnlinkedRecord) shouldBe None
   }
 
-  it(
-    "returns the original record when merging an unlinked record which has linked more recently") {
+  it("returns None when merging an unlinked record which has linked more recently") {
     val bibId = createSierraBibNumber
 
     val record = createSierraItemRecordWith(
@@ -76,7 +74,7 @@ class ItemUnlinkerTests extends AnyFunSpec with Matchers with SierraGenerators {
       itemRecords = List(record)
     )
 
-    ItemUnlinker.unlinkItemRecord(sierraTransformable, outOfDateUnlinkedRecord) shouldBe sierraTransformable
+    ItemUnlinker.unlinkItemRecord(sierraTransformable, outOfDateUnlinkedRecord) shouldBe None
   }
 
   it("only unlinks item records with matching bib IDs") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.sierra_item_merger.services
 
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.platform.sierra_item_merger.fixtures.SierraItemMergerFixtures
-import uk.ac.wellcome.sierra_adapter.model.{SierraGenerators, SierraTransformable}
+import uk.ac.wellcome.sierra_adapter.model.{
+  SierraGenerators,
+  SierraTransformable
+}
 import uk.ac.wellcome.storage.{StoreWriteError, UpdateWriteError, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
@@ -42,9 +45,9 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("only updates records that have changed") {
-    val bibId1 = createSierraBibNumber  // doesn't exist yet
-    val bibId2 = createSierraBibNumber  // exists, not linked to the item
-    val bibId3 = createSierraBibNumber  // exists, linked to the item
+    val bibId1 = createSierraBibNumber // doesn't exist yet
+    val bibId2 = createSierraBibNumber // exists, not linked to the item
+    val bibId3 = createSierraBibNumber // exists, linked to the item
 
     val bibIds = List(bibId1, bibId3, bibId2)
 
@@ -54,7 +57,9 @@ class SierraItemMergerUpdaterServiceTest
       createSierraTransformableWith(sierraId = bibId2, itemRecords = List.empty)
 
     val transformable3 =
-      createSierraTransformableWith(sierraId = bibId3, itemRecords = List(itemRecord))
+      createSierraTransformableWith(
+        sierraId = bibId3,
+        itemRecords = List(itemRecord))
 
     val sierraTransformableStore = createStore[SierraTransformable](
       Map(
@@ -267,8 +272,8 @@ class SierraItemMergerUpdaterServiceTest
   }
 
   it("does not unlink an item if it receives an outdated unlink update") {
-    val bibId1 = createSierraBibNumber  // linked to the item
-    val bibId2 = createSierraBibNumber  // not linked to the item
+    val bibId1 = createSierraBibNumber // linked to the item
+    val bibId2 = createSierraBibNumber // not linked to the item
 
     val itemRecord = createSierraItemRecordWith(
       bibIds = List(bibId1)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4915

This is a fairly simple change that should have a big impact, possibly as much as halving the work coming from the Sierra items pipeline.

**The problem:** we request items from Sierra in "windows". These windows overlap – this is a deliberate decision to make sure we get everything on the boundary of windows.

It has the unfortunate side effect that any item updated during the overlap will be fetched twice. The item merger can detect that's the Sierra source record has not changed, and not send an update to the rest of the pipeline. Indeed, we already had an `isNewerData` variable internally, we just didn't act upon it!

<img width="508" alt="Screenshot 2020-12-08 at 16 25 44" src="https://user-images.githubusercontent.com/301220/101510582-0782ce00-3972-11eb-945a-6478a7fe9817.png">

I spotted this when looking through the item records from the adapter, and seeing a lot of consecutive versions with no changes.

I'll apply this change to the other Sierra adapter services in separate PRs.

---

Back of the napkin calculations, based on the window generator config (https://github.com/wellcomecollection/catalogue/blob/master/sierra_adapter/terraform/window_generators.tf):

* The bib generator fires every 7 minutes, with a window length of 16 minutes. This means every record will be sent at least twice, and ~30% of records will be sent **three** times.
* The item generator fires every 15 minutes, with a window length of 31 minutes. This means every record will eb sent at least twice, and ~3% of records will be sent **three** times.

We should probably also reduce the window lengths; I'll do that when I deploy these services.