### PR TITLE
Don't trigger an update from Sierra items_to_dynamo if nothing has changed

### DIFF
--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
@@ -4,34 +4,34 @@ import uk.ac.wellcome.sierra_adapter.model.SierraItemRecord
 
 object SierraItemRecordMerger {
   def mergeItems(existingRecord: SierraItemRecord,
-                 updatedRecord: SierraItemRecord): SierraItemRecord = {
-
+                 updatedRecord: SierraItemRecord): Option[SierraItemRecord] = {
     if (existingRecord.modifiedDate.isBefore(updatedRecord.modifiedDate)) {
-
-      updatedRecord.copy(
-        // Let's suppose we have
-        //
-        //    oldRecord = (linked = {1, 2, 3}, unlinked = {4, 5})
-        //    newRecord = (linked = {3, 4})
-        //
-        // First we get a list of all the bibIds the oldRecord knew about, in any capacity:
-        //
-        //    addList(oldRecord.unlinkedBibIds, oldRecord.bibIds) = {1, 2, 3, 4, 5}
-        //
-        // Any bibIds in this list which are _not_ on the new record should be unlinked.
-        //
-        //    unlinkedBibIds
-        //      = addList(oldRecord.unlinkedBibIds, oldRecord.bibIds) - newRecord.bibIds
-        //      = (all bibIds on old record) - (current bibIds on new record)
-        //      = {1, 2, 3, 4, 5} - {3, 4}
-        //      = {1, 2, 5}
-        //
-        unlinkedBibIds = subList(
-          addList(existingRecord.unlinkedBibIds, existingRecord.bibIds),
-          updatedRecord.bibIds)
+      Some(
+        updatedRecord.copy(
+          // Let's suppose we have
+          //
+          //    oldRecord = (linked = {1, 2, 3}, unlinked = {4, 5})
+          //    newRecord = (linked = {3, 4})
+          //
+          // First we get a list of all the bibIds the oldRecord knew about, in any capacity:
+          //
+          //    addList(oldRecord.unlinkedBibIds, oldRecord.bibIds) = {1, 2, 3, 4, 5}
+          //
+          // Any bibIds in this list which are _not_ on the new record should be unlinked.
+          //
+          //    unlinkedBibIds
+          //      = addList(oldRecord.unlinkedBibIds, oldRecord.bibIds) - newRecord.bibIds
+          //      = (all bibIds on old record) - (current bibIds on new record)
+          //      = {1, 2, 3, 4, 5} - {3, 4}
+          //      = {1, 2, 5}
+          //
+          unlinkedBibIds = subList(
+            addList(existingRecord.unlinkedBibIds, existingRecord.bibIds),
+            updatedRecord.bibIds)
+        )
       )
     } else {
-      existingRecord
+      None
     }
   }
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
@@ -7,14 +7,17 @@ import uk.ac.wellcome.storage.store.VersionedStore
 
 class DynamoInserter(
   versionedHybridStore: VersionedStore[String, Int, SierraItemRecord]) {
-  def insertIntoDynamo(
-    updatedRecord: SierraItemRecord): Either[Throwable, Option[Version[String, Int]]] = {
+  def insertIntoDynamo(updatedRecord: SierraItemRecord)
+    : Either[Throwable, Option[Version[String, Int]]] = {
     val upsertResult: versionedHybridStore.UpdateEither =
       versionedHybridStore
         .upsert(updatedRecord.id.withoutCheckDigit)(updatedRecord) {
           SierraItemRecordMerger.mergeItems(_, updatedRecord) match {
             case Some(mergedRecord) => Right(mergedRecord)
-            case None               => Left(UpdateNotApplied(new Throwable(s"Item ${updatedRecord.id} is already up-to-date")))
+            case None =>
+              Left(
+                UpdateNotApplied(new Throwable(
+                  s"Item ${updatedRecord.id} is already up-to-date")))
           }
         }
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserter.scala
@@ -2,23 +2,26 @@ package uk.ac.wellcome.platform.sierra_items_to_dynamo.services
 
 import uk.ac.wellcome.platform.sierra_items_to_dynamo.merger.SierraItemRecordMerger
 import uk.ac.wellcome.sierra_adapter.model.SierraItemRecord
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.{Identified, UpdateNotApplied, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 
 class DynamoInserter(
   versionedHybridStore: VersionedStore[String, Int, SierraItemRecord]) {
   def insertIntoDynamo(
-    record: SierraItemRecord): Either[Throwable, Version[String, Int]] =
-    versionedHybridStore
-      .upsert(record.id.withoutCheckDigit)(record) {
-        existingRecord: SierraItemRecord =>
-          Right(
-            SierraItemRecordMerger
-              .mergeItems(
-                existingRecord = existingRecord,
-                updatedRecord = record))
-      }
-      .map(id => id.id)
-      .left
-      .map(_.e)
+    updatedRecord: SierraItemRecord): Either[Throwable, Option[Version[String, Int]]] = {
+    val upsertResult: versionedHybridStore.UpdateEither =
+      versionedHybridStore
+        .upsert(updatedRecord.id.withoutCheckDigit)(updatedRecord) {
+          SierraItemRecordMerger.mergeItems(_, updatedRecord) match {
+            case Some(mergedRecord) => Right(mergedRecord)
+            case None               => Left(UpdateNotApplied(new Throwable(s"Item ${updatedRecord.id} is already up-to-date")))
+          }
+        }
+
+    upsertResult match {
+      case Right(Identified(id, _))  => Right(Some(id))
+      case Left(_: UpdateNotApplied) => Right(None)
+      case Left(err)                 => Left(err.e)
+    }
+  }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerService.scala
@@ -24,7 +24,7 @@ class SierraItemsToDynamoWorkerService[Destination](
         key <- dynamoInserter.insertIntoDynamo(itemRecord).toTry
         _ <- key match {
           case Some(k) => messageSender.sendT(k)
-          case None => Success(())
+          case None    => Success(())
         }
       } yield ()
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/WorkerServiceFixture.scala
@@ -24,8 +24,7 @@ trait WorkerServiceFixture
     queue: Queue,
     store: VersionedStore[String, Int, SierraItemRecord],
     metricsSender: Metrics[Future] = new MemoryMetrics()
-  )(
-    testWith: TestWith[(SierraItemsToDynamoWorkerService[String],
+  )(testWith: TestWith[(SierraItemsToDynamoWorkerService[String],
                         MemoryMessageSender),
                        R]): R =
     withActorSystem { implicit actorSystem =>

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/fixtures/WorkerServiceFixture.scala
@@ -23,29 +23,26 @@ trait WorkerServiceFixture
   def withWorkerService[R](
     queue: Queue,
     store: VersionedStore[String, Int, SierraItemRecord],
-    metricsSender: Metrics[Future] = new MemoryMetrics())(
+    metricsSender: Metrics[Future] = new MemoryMetrics()
+  )(
     testWith: TestWith[(SierraItemsToDynamoWorkerService[String],
                         MemoryMessageSender),
                        R]): R =
     withActorSystem { implicit actorSystem =>
       withSQSStream[NotificationMessage, R](queue, metricsSender) { sqsStream =>
         withDynamoInserter(store) { dynamoInserter =>
-          withSNSMessageSender { snsWriter =>
-            val workerService = new SierraItemsToDynamoWorkerService[String](
-              sqsStream = sqsStream,
-              dynamoInserter = dynamoInserter,
-              messageSender = snsWriter
-            )
+          val messageSender = new MemoryMessageSender
 
-            workerService.run()
+          val workerService = new SierraItemsToDynamoWorkerService[String](
+            sqsStream = sqsStream,
+            dynamoInserter = dynamoInserter,
+            messageSender = messageSender
+          )
 
-            testWith((workerService, snsWriter))
-          }
+          workerService.run()
+
+          testWith((workerService, messageSender))
         }
       }
     }
-
-  def withSNSMessageSender[R](testWith: TestWith[MemoryMessageSender, R]): R = {
-    testWith(new MemoryMessageSender)
-  }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -22,9 +22,11 @@ class SierraItemRecordMergerTest
     )
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingRecord = existingRecord,
-        updatedRecord = updatedRecord).get
+      SierraItemRecordMerger
+        .mergeItems(
+          existingRecord = existingRecord,
+          updatedRecord = updatedRecord)
+        .get
     mergedRecord.bibIds shouldBe bibIds
     mergedRecord.unlinkedBibIds shouldBe List()
   }
@@ -43,9 +45,11 @@ class SierraItemRecordMergerTest
     )
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingRecord = existingRecord,
-        updatedRecord = updatedRecord).get
+      SierraItemRecordMerger
+        .mergeItems(
+          existingRecord = existingRecord,
+          updatedRecord = updatedRecord)
+        .get
     mergedRecord.bibIds shouldBe bibIds.slice(2, 5)
     mergedRecord.unlinkedBibIds shouldBe bibIds.slice(0, 2)
   }
@@ -65,9 +69,11 @@ class SierraItemRecordMergerTest
     )
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingRecord = existingRecord,
-        updatedRecord = updatedRecord).get
+      SierraItemRecordMerger
+        .mergeItems(
+          existingRecord = existingRecord,
+          updatedRecord = updatedRecord)
+        .get
     mergedRecord.unlinkedBibIds should contain theSameElementsAs existingRecord.unlinkedBibIds
   }
 
@@ -87,9 +93,11 @@ class SierraItemRecordMergerTest
     )
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingRecord = existingRecord,
-        updatedRecord = updatedRecord).get
+      SierraItemRecordMerger
+        .mergeItems(
+          existingRecord = existingRecord,
+          updatedRecord = updatedRecord)
+        .get
     mergedRecord.bibIds shouldBe bibIds.slice(0, 2)
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }
@@ -109,9 +117,11 @@ class SierraItemRecordMergerTest
     )
 
     val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingRecord = existingRecord,
-        updatedRecord = updatedRecord).get
+      SierraItemRecordMerger
+        .mergeItems(
+          existingRecord = existingRecord,
+          updatedRecord = updatedRecord)
+        .get
     mergedRecord.bibIds shouldBe bibIds.slice(0, 2)
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -24,7 +24,7 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(
         existingRecord = existingRecord,
-        updatedRecord = updatedRecord)
+        updatedRecord = updatedRecord).get
     mergedRecord.bibIds shouldBe bibIds
     mergedRecord.unlinkedBibIds shouldBe List()
   }
@@ -45,7 +45,7 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(
         existingRecord = existingRecord,
-        updatedRecord = updatedRecord)
+        updatedRecord = updatedRecord).get
     mergedRecord.bibIds shouldBe bibIds.slice(2, 5)
     mergedRecord.unlinkedBibIds shouldBe bibIds.slice(0, 2)
   }
@@ -67,7 +67,7 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(
         existingRecord = existingRecord,
-        updatedRecord = updatedRecord)
+        updatedRecord = updatedRecord).get
     mergedRecord.unlinkedBibIds should contain theSameElementsAs existingRecord.unlinkedBibIds
   }
 
@@ -89,7 +89,7 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(
         existingRecord = existingRecord,
-        updatedRecord = updatedRecord)
+        updatedRecord = updatedRecord).get
     mergedRecord.bibIds shouldBe bibIds.slice(0, 2)
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }
@@ -111,12 +111,12 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(
         existingRecord = existingRecord,
-        updatedRecord = updatedRecord)
+        updatedRecord = updatedRecord).get
     mergedRecord.bibIds shouldBe bibIds.slice(0, 2)
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }
 
-  it("returns the existing record unchanged if the update has an older date") {
+  it("returns None if it receives an outdated update") {
     val bibIds = createSierraBibNumbers(count = 5)
 
     val existingRecord = createSierraItemRecordWith(
@@ -132,6 +132,6 @@ class SierraItemRecordMergerTest
     val mergedRecord =
       SierraItemRecordMerger.mergeItems(existingRecord, updatedRecord)
 
-    mergedRecord shouldBe existingRecord
+    mergedRecord shouldBe None
   }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/DynamoInserterTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.sierra_adapter.model.{SierraGenerators, SierraItemRecord}
 import uk.ac.wellcome.sierra_adapter.utils.SierraAdapterHelpers
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
-import uk.ac.wellcome.storage.{UpdateNotApplied, Version}
+import uk.ac.wellcome.storage.{StoreWriteError, UpdateWriteError, Version}
 
 class DynamoInserterTest
     extends AnyFunSpec
@@ -171,7 +171,7 @@ class DynamoInserterTest
       with MemoryMaxima[String, SierraItemRecord]) {
       override def upsert(id: String)(t: SierraItemRecord)(
         f: UpdateFunction): UpdateEither = {
-        Left(UpdateNotApplied(exception))
+        Left(UpdateWriteError(StoreWriteError(exception)))
       }
     }
 


### PR DESCRIPTION
For wellcomecollection/platform#4915; follows #1170

Another fairly simple change which should reduce traffic in the pipeline.

See #1770 for an explanation of how the same item can be sent twice through the Sierra adapter. Every item record has a modified date; if the modified date on the receipt record is not newer than that of the stored record, then the update is a no-op. We don't change anything in our data stores.

This patch changes the Sierra items_to_dynamo so that it doesn't send a message if it gets a no-op update.