### PR TITLE
Don't send an update from the bib merger if nothing has changed

### DIFF
--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
@@ -10,8 +10,9 @@ object BibMerger {
   /** Return the most up-to-date combination of the merged record and the
     * bib record we've just received.
     */
-  def mergeBibRecord(sierraTransformable: SierraTransformable,
-                     sierraBibRecord: SierraBibRecord): Option[SierraTransformable] = {
+  def mergeBibRecord(
+    sierraTransformable: SierraTransformable,
+    sierraBibRecord: SierraBibRecord): Option[SierraTransformable] = {
     if (sierraBibRecord.id != sierraTransformable.sierraId) {
       throw new RuntimeException(
         s"Non-matching bib ids ${sierraBibRecord.id} != ${sierraTransformable.sierraId}")

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
@@ -11,7 +11,7 @@ object BibMerger {
     * bib record we've just received.
     */
   def mergeBibRecord(sierraTransformable: SierraTransformable,
-                     sierraBibRecord: SierraBibRecord): SierraTransformable = {
+                     sierraBibRecord: SierraBibRecord): Option[SierraTransformable] = {
     if (sierraBibRecord.id != sierraTransformable.sierraId) {
       throw new RuntimeException(
         s"Non-matching bib ids ${sierraBibRecord.id} != ${sierraTransformable.sierraId}")
@@ -24,10 +24,9 @@ object BibMerger {
     }
 
     if (isNewerData) {
-      sierraTransformable.copy(maybeBibRecord = Some(sierraBibRecord))
+      Some(sierraTransformable.copy(maybeBibRecord = Some(sierraBibRecord)))
     } else {
-      sierraTransformable
+      None
     }
   }
-
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.sierra_adapter.model.{
   SierraBibRecord,
   SierraTransformable
 }
-import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.{Identified, UpdateNotApplied, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 
 class SierraBibMergerUpdaterService(
@@ -13,17 +13,20 @@ class SierraBibMergerUpdaterService(
 ) {
 
   def update(
-    bibRecord: SierraBibRecord): Either[Throwable, Version[String, Int]] =
-    versionedHybridStore
-      .upsert(bibRecord.id.withoutCheckDigit)(SierraTransformable(bibRecord)) {
-        existingSierraTransformable =>
-          Right(
-            BibMerger.mergeBibRecord(existingSierraTransformable, bibRecord))
-      }
-      .map { id =>
-        id.id
-      }
-      .left
-      .map(err => err.e)
+    bibRecord: SierraBibRecord): Either[Throwable, Option[Version[String, Int]]] = {
+    val upsertResult =
+      versionedHybridStore
+        .upsert(bibRecord.id.withoutCheckDigit)(SierraTransformable(bibRecord)) {
+          BibMerger.mergeBibRecord(_, bibRecord) match {
+            case Some(updatedTransformable) => Right(updatedTransformable)
+            case None => Left(UpdateNotApplied(new Throwable(s"${bibRecord.id} is already up-to-date")))
+          }
+        }
 
+    upsertResult match {
+      case Right(Identified(id, _)) => Right(Some(id))
+      case Left(_: UpdateNotApplied) => Right(None)
+      case Left(err) => Left(err.e)
+    }
+  }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerUpdaterService.scala
@@ -12,21 +12,24 @@ class SierraBibMergerUpdaterService(
   versionedHybridStore: VersionedStore[String, Int, SierraTransformable]
 ) {
 
-  def update(
-    bibRecord: SierraBibRecord): Either[Throwable, Option[Version[String, Int]]] = {
+  def update(bibRecord: SierraBibRecord)
+    : Either[Throwable, Option[Version[String, Int]]] = {
     val upsertResult =
       versionedHybridStore
         .upsert(bibRecord.id.withoutCheckDigit)(SierraTransformable(bibRecord)) {
           BibMerger.mergeBibRecord(_, bibRecord) match {
             case Some(updatedTransformable) => Right(updatedTransformable)
-            case None => Left(UpdateNotApplied(new Throwable(s"${bibRecord.id} is already up-to-date")))
+            case None =>
+              Left(
+                UpdateNotApplied(
+                  new Throwable(s"${bibRecord.id} is already up-to-date")))
           }
         }
 
     upsertResult match {
-      case Right(Identified(id, _)) => Right(Some(id))
+      case Right(Identified(id, _))  => Right(Some(id))
       case Left(_: UpdateNotApplied) => Right(None)
-      case Left(err) => Left(err.e)
+      case Left(err)                 => Left(err.e)
     }
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerService.scala
@@ -23,7 +23,7 @@ class SierraBibMergerWorkerService[Destination](
       key <- sierraBibMergerUpdaterService.update(bibRecord).toTry
       _ <- key match {
         case Some(k) => messageSender.sendT(k)
-        case _ => Success(())
+        case _       => Success(())
       }
     } yield ())
 

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/SierraBibMergerFeatureTest.scala
@@ -143,7 +143,6 @@ class SierraBibMergerFeatureTest
             sendNotificationToSQS(queue = queue, message = newBibRecord)
           }
 
-
           val expectedTransformable =
             SierraTransformable(bibRecord = newBibRecord)
 
@@ -171,23 +170,24 @@ class SierraBibMergerFeatureTest
     val key = Version(expectedTransformable.sierraId.withoutCheckDigit, 0)
     val store =
       createStore[SierraTransformable](Map(key -> expectedTransformable))
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      withWorkerService(store, queue) {
-        case (_, messageSender) =>
-          val oldBibRecord = createSierraBibRecordWith(
-            id = newBibRecord.id,
-            modifiedDate = olderDate
-          )
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorkerService(store, queue) {
+          case (_, messageSender) =>
+            val oldBibRecord = createSierraBibRecordWith(
+              id = newBibRecord.id,
+              modifiedDate = olderDate
+            )
 
-          sendNotificationToSQS(queue = queue, message = oldBibRecord)
+            sendNotificationToSQS(queue = queue, message = oldBibRecord)
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueEmpty(dlq)
 
-            messageSender.messages shouldBe empty
-          }
-      }
+              messageSender.messages shouldBe empty
+            }
+        }
     }
   }
 

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -18,7 +18,7 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       )
 
       val newTransformable = BibMerger.mergeBibRecord(transformable, bibRecord)
-      newTransformable.maybeBibRecord.get shouldEqual bibRecord
+      newTransformable.get.maybeBibRecord.get shouldEqual bibRecord
     }
 
     it("only merges bib records with matching ids") {
@@ -31,8 +31,7 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       caught.getMessage shouldEqual s"Non-matching bib ids ${bibRecord.id} != ${transformable.sierraId}"
     }
 
-    it(
-      "returns the unmerged transformable when merging bib records with stale data") {
+    it("returns None when merging a stale update") {
       val oldBibRecord = createSierraBibRecordWith(
         modifiedDate = olderDate
       )
@@ -47,7 +46,7 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       )
 
       val result = BibMerger.mergeBibRecord(transformable, oldBibRecord)
-      result shouldBe transformable
+      result shouldBe None
     }
 
     it("updates bibData when merging bib records with newer data") {
@@ -65,7 +64,7 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       )
 
       val result = BibMerger.mergeBibRecord(transformable, newBibRecord)
-      result.maybeBibRecord.get shouldBe newBibRecord
+      result.get.maybeBibRecord.get shouldBe newBibRecord
     }
   }
 }

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/services/SierraBibMergerWorkerServiceTest.scala
@@ -20,8 +20,7 @@ class SierraBibMergerWorkerServiceTest
     with Eventually
     with IntegrationPatience {
 
-  it(
-    "records a failure if the message on the queue does not represent a SierraRecord") {
+  it("records a failure if the message isn't a SierraRecord") {
     withWorkerServiceFixtures {
       case (metrics, QueuePair(queue, dlq)) =>
         sendNotificationToSQS(


### PR DESCRIPTION
For wellcomecollection/platform#4915; follows #1170

This completes the set – if the bib merger gets an update which isn't newer than the already stored record, it discards it without triggering any more work in the pipeline.