### PR TITLE
Expose the source of a reindex to the reindexer

### DIFF
--- a/reindexer/terraform/.terraform.lock.hcl
+++ b/reindexer/terraform/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "2.70.0"
+  hashes = [
+    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.0.0"
+  hashes = [
+    "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+  ]
+}

--- a/reindexer/terraform/ecr.tf
+++ b/reindexer/terraform/ecr.tf
@@ -1,4 +1,3 @@
-module "ecr_repository_reindex_worker" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v1.0.0"
-  name   = "reindex_worker"
+resource "aws_ecr_repository" "reindexer" {
+  name = "uk.ac.wellcome/reindex_worker"
 }

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -31,39 +31,46 @@ locals {
   #
   reindexer_jobs = [
     {
-      id    = "sierra--reporting"
-      table = local.vhs_sierra_table_name
-      topic = local.reporting_sierra_hybrid_records_topic_arn
+      source      = "sierra"
+      destination = "reporting"
+      table       = local.vhs_sierra_table_name
+      topic       = local.reporting_sierra_hybrid_records_topic_arn
     },
     {
-      id    = "sierra--catalogue"
-      table = local.vhs_sierra_table_name
-      topic = local.catalogue_sierra_hybrid_records_topic_arn
+      source      = "sierra"
+      destination = "catalogue"
+      table       = local.vhs_sierra_table_name
+      topic       = local.catalogue_sierra_hybrid_records_topic_arn
     },
     {
-      id    = "miro--reporting"
-      table = local.vhs_miro_table_name
-      topic = local.reporting_miro_hybrid_records_topic_arn
+      source      = "miro"
+      destination = "reporting"
+      table       = local.vhs_miro_table_name
+      topic       = local.reporting_miro_hybrid_records_topic_arn
     },
     {
-      id    = "miro--catalogue"
-      table = local.vhs_miro_table_name
-      topic = local.catalogue_miro_hybrid_records_topic_arn
+      source      = "miro"
+      destination = "catalogue"
+      table       = local.vhs_miro_table_name
+      topic       = local.catalogue_miro_hybrid_records_topic_arn
     },
     {
-      id    = "miro_inventory--reporting"
-      table = local.vhs_miro_inventory_table_name
-      topic = local.reporting_miro_inventory_hybrid_records_topic_arn
+      source      = "miro_inventory"
+      destination = "reporting"
+      table       = local.vhs_miro_inventory_table_name
+      topic       = local.reporting_miro_inventory_hybrid_records_topic_arn
     },
     {
-      id    = "mets--catalogue"
-      table = local.mets_dynamo_table_name
-      topic = local.mets_reindexer_topic_arn
+      source      = "mets"
+      destination = "catalogue"
+      table       = local.mets_dynamo_table_name
+      topic       = local.mets_reindexer_topic_arn
     },
     {
-      id    = "calm--catalogue"
-      table = local.vhs_calm_table_name
-      topic = local.calm_reindexer_topic_arn
+      source      = "calm"
+      destination = "catalogue"
+      table       = local.vhs_calm_table_name
+      topic       = local.calm_reindexer_topic_arn
     },
   ]
 }

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -21,7 +21,7 @@ locals {
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
   dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
 
-  reindex_worker_image = "${module.ecr_repository_reindex_worker.repository_url}:env.${local.environment}"
+  reindex_worker_image = "${aws_ecr_repository.reindexer.repository_url}:env.${local.environment}"
 
   # This map defines the possible reindexer configurations.
   #

--- a/reindexer/terraform/provider.tf
+++ b/reindexer/terraform/provider.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.7"
+  region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/reindexer/terraform/reindexer_job_config.tf
+++ b/reindexer/terraform/reindexer_job_config.tf
@@ -24,7 +24,8 @@
 
 data "template_file" "single_reindex_job_config" {
   template = <<EOF
-  "$${id}": {
+  "$${source}--$${destination}": {
+    "source": "$${source}",
     "dynamoConfig": {
       "tableName": "$${table}"
     },
@@ -37,9 +38,10 @@ EOF
   count = length(local.reindexer_jobs)
 
   vars = {
-    id       = lookup(local.reindexer_jobs[count.index], "id")
-    table    = lookup(local.reindexer_jobs[count.index], "table")
-    topicArn = lookup(local.reindexer_jobs[count.index], "topic")
+    source      = lookup(local.reindexer_jobs[count.index], "source")
+    destination = lookup(local.reindexer_jobs[count.index], "destination")
+    table       = lookup(local.reindexer_jobs[count.index], "table")
+    topicArn    = lookup(local.reindexer_jobs[count.index], "topic")
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4918

The reindexer config now includes a field "source" that contains a string calm/miro/mets/sierra, so the reindexer knows what it's reindexing from. It doesn't read this yet – that will be a separate patch.

Plus making the terraform work with 0.14.