### PR TITLE
Add a SourcePayload model for the adapters to send

### DIFF
--- a/.sbt_metadata/reindex_worker.json
+++ b/.sbt_metadata/reindex_worker.json
@@ -2,6 +2,7 @@
   "id" : "reindex_worker",
   "folder" : "reindexer/reindex_worker",
   "dependencyIds" : [
+    "internal_model",
     "big_messaging_typesafe"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val batcher = setupProject(
 lazy val reindex_worker = setupProject(
   project,
   "reindexer/reindex_worker",
-  localDependencies = Seq(big_messaging_typesafe),
+  localDependencies = Seq(internal_model, big_messaging_typesafe),
   externalDependencies = CatalogueDependencies.reindexWorkerDependencies)
 
 lazy val transformer_common = setupProject(

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/MetsSourceData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/MetsSourceData.scala
@@ -5,7 +5,7 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import java.time.Instant
 
 /** METS location data to send onwards to the transformer.
- */
+  */
 case class MetsSourceData(bucket: String,
                           path: String,
                           version: Int,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/MetsSourceData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/MetsSourceData.scala
@@ -1,11 +1,11 @@
-package uk.ac.wellcome.mets_adapter.models
-
-import java.time.Instant
+package uk.ac.wellcome.models.pipeline
 
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 
+import java.time.Instant
+
 /** METS location data to send onwards to the transformer.
-  */
+ */
 case class MetsSourceData(bucket: String,
                           path: String,
                           version: Int,
@@ -14,9 +14,9 @@ case class MetsSourceData(bucket: String,
                           deleted: Boolean,
                           manifestations: List[String] = Nil) {
 
-  def xmlLocation =
-    S3ObjectLocation(bucket, s"${path}/${file}")
+  def xmlLocation: S3ObjectLocation =
+    S3ObjectLocation(bucket, key = s"$path/$file")
 
-  def manifestationLocations =
-    manifestations.map(file => S3ObjectLocation(bucket, s"${path}/${file}"))
+  def manifestationLocations: List[S3ObjectLocation] =
+    manifestations.map(file => S3ObjectLocation(bucket, key = s"$path/$file"))
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/SourcePayload.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/pipeline/SourcePayload.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.models.pipeline
+
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+
+sealed trait SourcePayload {
+  val id: String
+  val version: Int
+}
+
+case class CalmSourcePayload(
+  id: String,
+  version: Int,
+  location: S3ObjectLocation
+) extends SourcePayload
+
+case class MetsSourcePayload(
+  id: String,
+  version: Int,
+  payload: MetsSourceData
+) extends SourcePayload {
+  val sourceData: MetsSourceData = payload
+}
+
+case class MiroSourcePayload(
+  id: String,
+  version: Int,
+  location: S3ObjectLocation,
+  isClearedForCatalogueAPI: Boolean
+) extends SourcePayload
+
+case class SierraSourcePayload(
+  id: String,
+  version: Int,
+  payload: S3ObjectLocation
+) extends SourcePayload {
+  val location: S3ObjectLocation = payload
+}

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/models/Bag.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.mets_adapter.models
 
+import uk.ac.wellcome.models.pipeline.MetsSourceData
+
 import java.time.Instant
 
 /** The response receiveved from the storage-service bag API.

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerService.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.mets_adapter.models._
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.bigmessaging.FlowOps
 import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 
 import scala.concurrent.Future
 

--- a/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/uk/ac/wellcome/mets_adapter/services/MetsStore.scala
@@ -4,7 +4,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.VersionAlreadyExistsError
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 
 class MetsStore(store: VersionedStore[String, Int, MetsSourceData])
     extends Logging {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/generators/MetsSourceDataGenerators.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/generators/MetsSourceDataGenerators.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.mets_adapter.generators
 import java.time.Instant
 
 import uk.ac.wellcome.fixtures.RandomGenerators
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 
 trait MetsSourceDataGenerators extends RandomGenerators {
   val olderDate: Instant = Instant.parse("1999-09-09T09:09:09Z")

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/models/BagTest.scala
@@ -2,6 +2,8 @@ package uk.ac.wellcome.mets_adapter.models
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.pipeline.MetsSourceData
+
 import java.time.Instant
 
 class BagTest extends AnyFunSpec with Matchers {

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -21,6 +21,7 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import java.time.Instant
 
 import uk.ac.wellcome.mets_adapter.generators.MetsSourceDataGenerators
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 
 class MetsAdapterWorkerServiceTest
     extends AnyFunSpec

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsStoreTest.scala
@@ -4,9 +4,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
-
 import uk.ac.wellcome.mets_adapter.generators.MetsSourceDataGenerators
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 
 class MetsStoreTest
     extends AnyFunSpec

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -7,7 +7,6 @@ import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
 import uk.ac.wellcome.platform.transformer.mets.service.MetsTransformerWorkerService
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
@@ -18,6 +17,7 @@ import scala.concurrent.ExecutionContext
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
 import uk.ac.wellcome.elasticsearch.SourceWorkIndexConfig
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.typesafe.{

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.mets.service
 
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.mets.transformer
 
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.Identified
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
 import uk.ac.wellcome.models.work.internal.{Work, WorkState}
 import uk.ac.wellcome.models.work.internal.result.Result
 import uk.ac.wellcome.storage.s3.S3ObjectLocation

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import org.scalatest.matchers.should.Matchers
 import org.apache.commons.io.IOUtils
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.mets_adapter.models.MetsSourceData
+import uk.ac.wellcome.models.pipeline.MetsSourceData
 import uk.ac.wellcome.models.work.internal.License
 import uk.ac.wellcome.platform.transformer.mets.fixtures.MetsGenerators
 import uk.ac.wellcome.storage.s3.S3ObjectLocation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -197,6 +197,7 @@ object CatalogueDependencies {
     ExternalDependencies.scalacsvDependencies ++
       WellcomeDependencies.fixturesLibrary ++
       WellcomeDependencies.jsonLibrary ++
+      WellcomeDependencies.storageLibrary ++
       ExternalDependencies.parseDependencies ++
       ExternalDependencies.scalacheckDependencies ++
       ExternalDependencies.enumeratumDependencies ++


### PR DESCRIPTION
Part of wellcomecollection/platform#4918

These models reflect the rows in our DynamoDB tables.

My thinking on what’s next:

* Have the reindexer parse and send records as these typed models (using the new source info provided in #1176)
* Have the adapters start to send these models, where appropriate

This means we'll know we're getting a consistent model in the transformers.

The transformers won't notice the difference yet – these models all have the same fields as `Version[String, Int]`, which is what the transformers expect right now.