### PR TITLE
Send a CalmSourcePayload from the Calm adapter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,8 @@ steps:
     label: "elasticsearch"
   - command: .buildkite/scripts/run_job.py big_messaging
     label: "big messaging"
+  - command: .buildkite/scripts/run_job.py source_model
+    label: "source model"
   - command: .buildkite/scripts/run_job.py pipeline_storage
     label: "pipeline storage"
   - command: .buildkite/scripts/run_job.py ingestor_common

--- a/.sbt_metadata/calm_adapter.json
+++ b/.sbt_metadata/calm_adapter.json
@@ -3,6 +3,7 @@
   "folder" : "calm_adapter/calm_adapter",
   "dependencyIds" : [
     "internal_model",
+    "source_model_typesafe",
     "big_messaging_typesafe"
   ]
 }

--- a/.sbt_metadata/source_model_typesafe.json
+++ b/.sbt_metadata/source_model_typesafe.json
@@ -1,0 +1,7 @@
+{
+  "id" : "source_model_typesafe",
+  "folder" : "common/source_model_typesafe",
+  "dependencyIds" : [
+    "source_model"
+  ]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,13 @@ lazy val source_model = setupProject(
   externalDependencies = CatalogueDependencies.sourceModelDependencies
 )
 
+lazy val source_model_typesafe = setupProject(
+  project,
+  folder = "common/source_model_typesafe",
+  localDependencies = Seq(source_model),
+  externalDependencies = CatalogueDependencies.sourceModelTypesafeDependencies
+)
+
 lazy val pipeline_storage = setupProject(
   project,
   "common/pipeline_storage",
@@ -257,7 +264,7 @@ lazy val mets_adapter = setupProject(
 lazy val calm_adapter = setupProject(
   project,
   folder = "calm_adapter/calm_adapter",
-  localDependencies = Seq(internal_model, big_messaging_typesafe),
+  localDependencies = Seq(internal_model, source_model_typesafe, big_messaging_typesafe),
   externalDependencies = CatalogueDependencies.calmAdapterDependencies
 )
 

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -5,16 +5,18 @@ import akka.stream.Materializer
 import akka.stream.scaladsl._
 import grizzled.slf4j.Logging
 import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
-
 import uk.ac.wellcome.bigmessaging.FlowOps
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.source_model.CalmSourcePayload
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /** Processes SQS messages consisting of a daily window, and publishes any CALM
   * records to the transformer that have been modified within this window.
@@ -87,21 +89,29 @@ class CalmAdapterWorkerService[Destination](
       .via(catchErrors)
 
   def publishKey =
-    Flow[Result[Option[(Key, CalmRecord)]]]
+    Flow[Result[Option[(Key, S3ObjectLocation, CalmRecord)]]]
       .map {
-        case Right(Some((key, record))) =>
-          messageSender.sendT(key).toEither.right.map(_ => Some(key -> record))
+        case Right(Some((key, location, record))) =>
+          val payload = CalmSourcePayload(
+            id = key.id,
+            location = location,
+            version = key.version
+          )
+
+          messageSender.sendT(payload) match {
+            case Success(_) => Right(Some((key, record)))
+            case Failure(err) => Left(err)
+          }
         case Right(None) => Right(None)
-        case err         => err
+        case Left(err)   => Left(err)
       }
 
   def updatePublished =
     Flow[Result[Option[(Key, CalmRecord)]]]
       .map {
-        case Right(Some((key, record))) =>
-          calmStore.setRecordPublished(key, record)
-        case Right(None) => Right(None)
-        case err         => err
+        case Right(Some((key, record))) => calmStore.setRecordPublished(key, record)
+        case Right(None)                => Right(None)
+        case Left(err)                  => Left(err)
       }
 
   def checkResultsForErrors(results: Seq[Result[_]],

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -99,7 +99,7 @@ class CalmAdapterWorkerService[Destination](
           )
 
           messageSender.sendT(payload) match {
-            case Success(_) => Right(Some((key, record)))
+            case Success(_)   => Right(Some((key, record)))
             case Failure(err) => Left(err)
           }
         case Right(None) => Right(None)
@@ -109,9 +109,10 @@ class CalmAdapterWorkerService[Destination](
   def updatePublished =
     Flow[Result[Option[(Key, CalmRecord)]]]
       .map {
-        case Right(Some((key, record))) => calmStore.setRecordPublished(key, record)
-        case Right(None)                => Right(None)
-        case Left(err)                  => Left(err)
+        case Right(Some((key, record))) =>
+          calmStore.setRecordPublished(key, record)
+        case Right(None) => Right(None)
+        case Left(err)   => Left(err)
       }
 
   def checkResultsForErrors(results: Seq[Result[_]],

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -10,14 +10,14 @@ import uk.ac.wellcome.storage.{
 }
 import weco.catalogue.source_model.store.SourceVHS
 
-class CalmStore(store: SourceVHS[CalmRecord])
-    extends Logging {
+class CalmStore(store: SourceVHS[CalmRecord]) extends Logging {
 
   type Key = Version[String, Int]
 
   type Result[T] = Either[Throwable, T]
 
-  def putRecord(record: CalmRecord): Result[Option[(Key, S3ObjectLocation, CalmRecord)]] = {
+  def putRecord(
+    record: CalmRecord): Result[Option[(Key, S3ObjectLocation, CalmRecord)]] = {
     val recordSummmary = s"ID=${record.id}, RefNo=${record.refNo.getOrElse(
       "NONE")}, Modified=${record.modified.getOrElse("NONE")}"
     shouldStoreRecord(record)
@@ -28,7 +28,8 @@ class CalmStore(store: SourceVHS[CalmRecord])
         case true =>
           info(s"Storing calm record: $recordSummmary")
           store.putLatest(record.id)(record) match {
-            case Right(Identified(key, (location, record))) => Right(Some((key, location, record)))
+            case Right(Identified(key, (location, record))) =>
+              Right(Some((key, location, record)))
             case Left(err) => Left(toReadableException(err))
           }
       }

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
@@ -8,8 +8,8 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import uk.ac.wellcome.bigmessaging.typesafe.VHSBuilder
 import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.source_model.config.SourceVHSBuilder
 
 object Main extends WellcomeTypesafeApp {
 
@@ -27,7 +27,9 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSStream(config),
       SNSBuilder.buildSNSMessageSender(config, subject = "CALM adapter"),
       calmRetriever(config),
-      calmStore(config),
+      calmStore = new CalmStore(
+        SourceVHSBuilder.build[CalmRecord](config)
+      ),
     )
   }
 
@@ -43,10 +45,5 @@ object Main extends WellcomeTypesafeApp {
         .requireString("calm.suppressedFields")
         .split(",")
         .toSet
-    )
-
-  def calmStore(config: Config) =
-    new CalmStore(
-      VHSBuilder.build[CalmRecord](config)
     )
 }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -60,9 +60,15 @@ class CalmAdapterWorkerServiceTest
           queue,
           CalmQuery.ModifiedDate(queryDate))
         eventually {
-          vhs.underlying.getLatest("A").value shouldBe Identified(Version("A", 1), recordA.copy(published = true))
-          vhs.underlying.getLatest("B").value shouldBe Identified(Version("B", 1), recordB.copy(published = true))
-          vhs.underlying.getLatest("C").value shouldBe Identified(Version("C", 1), recordC.copy(published = true))
+          vhs.underlying.getLatest("A").value shouldBe Identified(
+            Version("A", 1),
+            recordA.copy(published = true))
+          vhs.underlying.getLatest("B").value shouldBe Identified(
+            Version("B", 1),
+            recordB.copy(published = true))
+          vhs.underlying.getLatest("C").value shouldBe Identified(
+            Version("C", 1),
+            recordC.copy(published = true))
 
           retriever.previousQuery shouldBe Some(
             CalmQuery.ModifiedDate(queryDate))
@@ -75,10 +81,14 @@ class CalmAdapterWorkerServiceTest
             Version("C", 0)
           )
 
-          messageSender.getMessages[Version[String, Int]] shouldBe expectedVersions
+          messageSender
+            .getMessages[Version[String, Int]] shouldBe expectedVersions
 
-          messageSender.getMessages[CalmSourcePayload]
-            .map { payload => Version(payload.id, payload.version) } shouldBe expectedVersions
+          messageSender
+            .getMessages[CalmSourcePayload]
+            .map { payload =>
+              Version(payload.id, payload.version)
+            } shouldBe expectedVersions
         }
     }
   }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.calm_adapter
 
 import java.time.{Instant, LocalDate}
-
 import akka.NotUsed
 import akka.stream.scaladsl._
 import io.circe.Encoder
+import org.scalatest.EitherValues
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,10 +18,12 @@ import uk.ac.wellcome.messaging.memory.{
   MemoryMessageSender
 }
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.storage.Version
-import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
-import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.store.memory.MemoryStore
+import weco.catalogue.source_model.CalmSourcePayload
+import weco.catalogue.source_model.fixtures.SourceVHSFixture
+import weco.catalogue.source_model.store.SourceVHS
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.reflectiveCalls
@@ -30,10 +32,12 @@ import scala.util.{Failure, Try}
 class CalmAdapterWorkerServiceTest
     extends AnyFunSpec
     with Matchers
+    with EitherValues
     with Akka
     with SQS
     with Eventually
-    with IntegrationPatience {
+    with IntegrationPatience
+    with SourceVHSFixture {
 
   type Key = Version[String, Int]
 
@@ -45,51 +49,51 @@ class CalmAdapterWorkerServiceTest
   val recordC = CalmRecord("C", Map("RecordID" -> List("C")), instantC)
   val queryDate = LocalDate.of(2000, 1, 1)
 
-  it("should process an incoming window, storing records and publishing keys") {
-    val store = dataStore()
+  it("processes an incoming window, storing records and publishing keys") {
+    val vhs = createSourceVHS[CalmRecord]
     val retriever = calmRetriever(List(recordA, recordB, recordC))
     val messageSender = new MemoryMessageSender()
 
-    withCalmAdapterWorkerService(retriever, store, messageSender) {
+    withCalmAdapterWorkerService(retriever, vhs, messageSender) {
       case (_, QueuePair(queue, dlq)) =>
         sendNotificationToSQS[CalmQuery](
           queue,
           CalmQuery.ModifiedDate(queryDate))
         eventually {
-          store.entries shouldBe Map(
-            Version("A", 0) -> recordA,
-            Version("A", 1) -> recordA.copy(published = true),
-            Version("B", 0) -> recordB,
-            Version("B", 1) -> recordB.copy(published = true),
-            Version("C", 0) -> recordC,
-            Version("C", 1) -> recordC.copy(published = true)
-          )
+          vhs.underlying.getLatest("A").value shouldBe Identified(Version("A", 1), recordA.copy(published = true))
+          vhs.underlying.getLatest("B").value shouldBe Identified(Version("B", 1), recordB.copy(published = true))
+          vhs.underlying.getLatest("C").value shouldBe Identified(Version("C", 1), recordC.copy(published = true))
+
           retriever.previousQuery shouldBe Some(
             CalmQuery.ModifiedDate(queryDate))
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          messageSender.getMessages[Version[String, Int]] shouldBe List(
+          val expectedVersions = List(
             Version("A", 0),
             Version("B", 0),
             Version("C", 0)
           )
+
+          messageSender.getMessages[Version[String, Int]] shouldBe expectedVersions
+
+          messageSender.getMessages[CalmSourcePayload]
+            .map { payload => Version(payload.id, payload.version) } shouldBe expectedVersions
         }
     }
   }
 
-  it("should complete successfully when no records returned from the query") {
-    val store = dataStore()
+  it("completes successfully when no records returned from the query") {
     val retriever = calmRetriever(Nil)
     val messageSender = new MemoryMessageSender()
 
-    withCalmAdapterWorkerService(retriever, store, messageSender) {
+    withCalmAdapterWorkerService(retriever, messageSender = messageSender) {
       case (_, QueuePair(queue, dlq)) =>
         sendNotificationToSQS[CalmQuery](
           queue,
           CalmQuery.ModifiedDate(queryDate))
+
         Thread.sleep(1500)
-        store.entries shouldBe Map.empty
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
@@ -97,7 +101,7 @@ class CalmAdapterWorkerServiceTest
     }
   }
 
-  it("should send the message to the DLQ if publishing of any record fails") {
+  it("sends the message to the DLQ if publishing of any record fails") {
     val retriever = new CalmRetriever {
       def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
         val timestamp = Instant.now
@@ -134,9 +138,7 @@ class CalmAdapterWorkerServiceTest
 
   def withCalmAdapterWorkerService[R](
     retriever: CalmRetriever,
-    store: MemoryStore[Key, CalmRecord] with Maxima[String,
-                                                    Version[String, Int],
-                                                    CalmRecord] = dataStore(),
+    vhs: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord],
     messageSender: MemoryMessageSender = new MemoryMessageSender())(
     testWith: TestWith[(CalmAdapterWorkerService[String], QueuePair), R]): R =
     withActorSystem { implicit actorSystem =>
@@ -147,7 +149,7 @@ class CalmAdapterWorkerServiceTest
               stream,
               messageSender = messageSender,
               retriever,
-              new CalmStore(new MemoryVersionedStore(store))
+              calmStore = new CalmStore(vhs)
             )
             calmAdapter.run()
             testWith((calmAdapter, QueuePair(queue, dlq)))

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -11,7 +11,11 @@ import weco.catalogue.source_model.store.SourceVHS
 
 import java.time.Instant
 
-class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with SourceVHSFixture {
+class CalmStoreTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with SourceVHSFixture {
 
   type Key = Version[String, Int]
 
@@ -26,12 +30,14 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
 
   describe("putRecord") {
     it("stores new CALM records") {
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
 
-      val (storedId, storedLocation, storedRecord) = calmStore.putRecord(record).value.get
+      val (storedId, storedLocation, storedRecord) =
+        calmStore.putRecord(record).value.get
 
       storedId shouldBe Version("A", 0)
 
@@ -48,12 +54,14 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
       val newRecord = CalmRecord("A", newData, newTime)
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 1))(oldRecord)
 
-      val (storedId, storedLocation, storedRecord) = calmStore.putRecord(newRecord).value.get
+      val (storedId, storedLocation, storedRecord) =
+        calmStore.putRecord(newRecord).value.get
 
       storedId shouldBe Version("A", 2)
 
@@ -71,7 +79,8 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val oldRecord = CalmRecord("A", data, oldTime, published = true)
       val newRecord = CalmRecord("A", data, newTime)
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 1))(oldRecord)
@@ -86,12 +95,14 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val oldRecord = CalmRecord("A", oldData, oldTime, published = false)
       val newRecord = CalmRecord("A", oldData, newTime)
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 1))(oldRecord)
 
-      val (storedId, storedLocation, storedRecord) = calmStore.putRecord(newRecord).value.get
+      val (storedId, storedLocation, storedRecord) =
+        calmStore.putRecord(newRecord).value.get
 
       storedId shouldBe Version("A", 2)
 
@@ -109,7 +120,8 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val oldRecord = CalmRecord("A", oldData, oldTime)
       val newRecord = CalmRecord("A", newData, newTime)
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 4))(newRecord)
@@ -134,7 +146,8 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val x = CalmRecord("A", Map("key" -> List("x")), retrievedAt)
       val y = CalmRecord("A", Map("key" -> List("y")), retrievedAt)
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 2))(x)
@@ -150,21 +163,27 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
       val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
       record.published shouldBe false
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 5))(record)
 
-      calmStore.setRecordPublished(Version("A", 5), record) shouldBe a[Right[_, _]]
+      calmStore.setRecordPublished(Version("A", 5), record) shouldBe a[Right[_,
+                                                                             _]]
 
-      assertStored(id = "A", expectedVersion = 6, expectedRecord = record.copy(published = true))
+      assertStored(
+        id = "A",
+        expectedVersion = 6,
+        expectedRecord = record.copy(published = true))
     }
 
     it("fails setting Calm record as published if version already exists") {
       val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
       record.published shouldBe false
 
-      implicit val sourceVHS: SourceVHS[CalmRecord] = createSourceVHS[CalmRecord]
+      implicit val sourceVHS: SourceVHS[CalmRecord] =
+        createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
       sourceVHS.underlying.put(Version("A", 6))(record)
@@ -187,7 +206,10 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
   ): Assertion = {
     storedRecord shouldBe expectedRecord
 
-    sourceVHS.underlying.hybridStore.typedStore.get(storedLocation).value.identifiedT shouldBe expectedRecord
+    sourceVHS.underlying.hybridStore.typedStore
+      .get(storedLocation)
+      .value
+      .identifiedT shouldBe expectedRecord
 
     assertStored(id, expectedVersion, expectedRecord)
   }
@@ -199,5 +221,7 @@ class CalmStoreTest extends AnyFunSpec with Matchers with EitherValues with Sour
   )(
     implicit sourceVHS: SourceVHS[CalmRecord]
   ): Assertion =
-    sourceVHS.underlying.getLatest(id).value shouldBe Identified(Version(id, expectedVersion), expectedRecord)
+    sourceVHS.underlying.getLatest(id).value shouldBe Identified(
+      Version(id, expectedVersion),
+      expectedRecord)
 }

--- a/common/Makefile
+++ b/common/Makefile
@@ -7,7 +7,7 @@ SBT_APPS =
 SBT_NO_DOCKER_APPS =
 
 SBT_DOCKER_LIBRARIES    = elasticsearch big_messaging pipeline_storage
-SBT_NO_DOCKER_LIBRARIES = display elasticsearch_typesafe internal_model
+SBT_NO_DOCKER_LIBRARIES = display elasticsearch_typesafe internal_model source_model source_model_typesafe
 
 PYTHON_APPS =
 LAMBDAS     =

--- a/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
+++ b/common/big_messaging/src/main/scala/uk/ac/wellcome/bigmessaging/VHS.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.storage.store.{
   VersionedHybridStore
 }
 
-class VHS[T](val hybridStore: VHSInternalStore[T])
+class VHS[T](hybridStore: VHSInternalStore[T])
     extends VersionedHybridStore[
       String,
       Int,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/store/SourceVHS.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/store/SourceVHS.scala
@@ -1,0 +1,37 @@
+package weco.catalogue.source_model.store
+
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.store.VersionedHybridStore
+import uk.ac.wellcome.storage.{Identified, StorageError, Version}
+
+// A wrapper around a VHS that exposes the underlying S3 location
+// when you call certain methods.
+class SourceVHS[T](
+  val underlying: VersionedHybridStore[String, Int, S3ObjectLocation, T]
+) {
+  private val indexedStore = underlying.hybridStore.indexedStore
+
+  private def wrappedOp(
+    f: Either[StorageError, Identified[Version[String, Int], T]]
+  ): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+    f.flatMap { case Identified(id, record) =>
+      indexedStore.get(id).map { case Identified(_, location) =>
+        Identified(id, (location, record))
+      }
+    }
+
+  def putLatest(id: String)(t: T): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+    wrappedOp {
+      underlying.putLatest(id)(t)
+    }
+
+  def update(id: String)(f: underlying.UpdateFunction): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+    wrappedOp {
+      underlying.update(id)(f)
+    }
+
+  def upsert(id: String)(t: T)(f: underlying.UpdateFunction): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+    wrappedOp {
+      underlying.upsert(id)(t)(f)
+    }
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/store/SourceVHS.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/store/SourceVHS.scala
@@ -13,24 +13,33 @@ class SourceVHS[T](
 
   private def wrappedOp(
     f: Either[StorageError, Identified[Version[String, Int], T]]
-  ): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
-    f.flatMap { case Identified(id, record) =>
-      indexedStore.get(id).map { case Identified(_, location) =>
-        Identified(id, (location, record))
-      }
+  ): Either[StorageError,
+            Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+    f.flatMap {
+      case Identified(id, record) =>
+        indexedStore.get(id).map {
+          case Identified(_, location) =>
+            Identified(id, (location, record))
+        }
     }
 
-  def putLatest(id: String)(t: T): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+  def putLatest(id: String)(
+    t: T): Either[StorageError,
+                  Identified[Version[String, Int], (S3ObjectLocation, T)]] =
     wrappedOp {
       underlying.putLatest(id)(t)
     }
 
-  def update(id: String)(f: underlying.UpdateFunction): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+  def update(id: String)(f: underlying.UpdateFunction)
+    : Either[StorageError,
+             Identified[Version[String, Int], (S3ObjectLocation, T)]] =
     wrappedOp {
       underlying.update(id)(f)
     }
 
-  def upsert(id: String)(t: T)(f: underlying.UpdateFunction): Either[StorageError, Identified[Version[String, Int], (S3ObjectLocation, T)]] =
+  def upsert(id: String)(t: T)(f: underlying.UpdateFunction)
+    : Either[StorageError,
+             Identified[Version[String, Int], (S3ObjectLocation, T)]] =
     wrappedOp {
       underlying.upsert(id)(t)(f)
     }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/fixtures/SourceVHSFixture.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/fixtures/SourceVHSFixture.scala
@@ -16,18 +16,26 @@ import uk.ac.wellcome.storage.streaming.Codec
 import weco.catalogue.source_model.store.SourceVHS
 
 trait SourceVHSFixture extends S3ObjectLocationGenerators {
-  def createStore[T](implicit codec: Codec[T]): VersionedHybridStore[String, Int, S3ObjectLocation, T] = {
-    val hybridStore = new HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
-      implicit override val indexedStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Version[String, Int], S3ObjectLocation] =
-        new MemoryStore[Version[String, Int], S3ObjectLocation](initialEntries = Map.empty)
+  def createStore[T](implicit codec: Codec[T])
+    : VersionedHybridStore[String, Int, S3ObjectLocation, T] = {
+    val hybridStore =
+      new HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
+        implicit override val indexedStore
+          : Store[Version[String, Int], S3ObjectLocation] with Maxima[
+            String,
+            Version[String, Int],
+            S3ObjectLocation] =
+          new MemoryStore[Version[String, Int], S3ObjectLocation](
+            initialEntries = Map.empty)
           with MemoryMaxima[String, S3ObjectLocation]
 
-      override implicit val typedStore: TypedStore[S3ObjectLocation, T] =
-        MemoryTypedStore[S3ObjectLocation, T]()
+        override implicit val typedStore: TypedStore[S3ObjectLocation, T] =
+          MemoryTypedStore[S3ObjectLocation, T]()
 
-      override protected def createTypeStoreId(id: Version[String, Int]): S3ObjectLocation =
-        createS3ObjectLocation
-    }
+        override protected def createTypeStoreId(
+          id: Version[String, Int]): S3ObjectLocation =
+          createS3ObjectLocation
+      }
 
     new VersionedHybridStore(hybridStore)
   }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/fixtures/SourceVHSFixture.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/fixtures/SourceVHSFixture.scala
@@ -1,0 +1,37 @@
+package weco.catalogue.source_model.fixtures
+
+import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.store.{
+  HybridStoreWithMaxima,
+  Store,
+  TypedStore,
+  VersionedHybridStore
+}
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryTypedStore}
+import uk.ac.wellcome.storage.streaming.Codec
+import weco.catalogue.source_model.store.SourceVHS
+
+trait SourceVHSFixture extends S3ObjectLocationGenerators {
+  def createStore[T](implicit codec: Codec[T]): VersionedHybridStore[String, Int, S3ObjectLocation, T] = {
+    val hybridStore = new HybridStoreWithMaxima[String, Int, S3ObjectLocation, T] {
+      implicit override val indexedStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Version[String, Int], S3ObjectLocation] =
+        new MemoryStore[Version[String, Int], S3ObjectLocation](initialEntries = Map.empty)
+          with MemoryMaxima[String, S3ObjectLocation]
+
+      override implicit val typedStore: TypedStore[S3ObjectLocation, T] =
+        MemoryTypedStore[S3ObjectLocation, T]()
+
+      override protected def createTypeStoreId(id: Version[String, Int]): S3ObjectLocation =
+        createS3ObjectLocation
+    }
+
+    new VersionedHybridStore(hybridStore)
+  }
+
+  def createSourceVHS[T](implicit codec: Codec[T]): SourceVHS[T] =
+    new SourceVHS[T](createStore[T])
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/store/SourceVHSTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/store/SourceVHSTest.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.storage.{UpdateNoSourceError, Version}
 import weco.catalogue.source_model.fixtures.SourceVHSFixture
 
-class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with SourceVHSFixture {
+class SourceVHSTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with SourceVHSFixture {
   case class Shape(sides: Int, colour: String)
 
   it("adds the S3 location to the result of putLatest()") {
@@ -21,7 +25,10 @@ class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with Sour
     val (location, storedShape) = result.identifiedT
 
     storedShape shouldBe shape
-    store.underlying.hybridStore.typedStore.get(location).value.identifiedT shouldBe shape
+    store.underlying.hybridStore.typedStore
+      .get(location)
+      .value
+      .identifiedT shouldBe shape
   }
 
   it("adds the S3 location to the result of update()") {
@@ -30,23 +37,31 @@ class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with Sour
     val shape = Shape(sides = 4, colour = "blue")
     store.putLatest(id = "bluething")(shape) shouldBe a[Right[_, _]]
 
-    val result = store.update("bluething") { storedShape =>
-      Right(storedShape.copy(sides = storedShape.sides + 1))
-    }.value
+    val result = store
+      .update("bluething") { storedShape =>
+        Right(storedShape.copy(sides = storedShape.sides + 1))
+      }
+      .value
 
     result.id shouldBe Version("bluething", version = 1)
     val (location, storedShape) = result.identifiedT
 
     storedShape shouldBe Shape(sides = 5, colour = "blue")
-    store.underlying.hybridStore.typedStore.get(location).value.identifiedT shouldBe Shape(sides = 5, colour = "blue")
+    store.underlying.hybridStore.typedStore
+      .get(location)
+      .value
+      .identifiedT shouldBe Shape(sides = 5, colour = "blue")
   }
 
   it("wraps an error from an update()") {
     val store = createSourceVHS[Shape]
 
-    val err = store.update("doesNotExist") { storedShape =>
-      Right(storedShape.copy(sides = storedShape.sides + 1))
-    }.left.value
+    val err = store
+      .update("doesNotExist") { storedShape =>
+        Right(storedShape.copy(sides = storedShape.sides + 1))
+      }
+      .left
+      .value
 
     err shouldBe a[UpdateNoSourceError]
   }
@@ -57,23 +72,24 @@ class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with Sour
     // Call upsert() on an empty store, which should cause this item
     // to be initialised at v1.
     val result1 = store
-      .upsert("splodge")(
-        Shape(sides = 11, colour = "yellow")) { storedShape =>
-          Right(storedShape.copy(sides = storedShape.sides + 1))
-        }
+      .upsert("splodge")(Shape(sides = 11, colour = "yellow")) { storedShape =>
+        Right(storedShape.copy(sides = storedShape.sides + 1))
+      }
       .value
 
     result1.id shouldBe Version("splodge", version = 0)
     val (location1, storedShape1) = result1.identifiedT
 
     storedShape1 shouldBe Shape(sides = 11, colour = "yellow")
-    store.underlying.hybridStore.typedStore.get(location1).value.identifiedT shouldBe Shape(sides = 11, colour = "yellow")
+    store.underlying.hybridStore.typedStore
+      .get(location1)
+      .value
+      .identifiedT shouldBe Shape(sides = 11, colour = "yellow")
 
     // Now call upsert() a second time, which will update the entry
     // in the store.
     val result2 = store
-      .upsert("splodge")(
-        Shape(sides = 11, colour = "yellow")) { storedShape =>
+      .upsert("splodge")(Shape(sides = 11, colour = "yellow")) { storedShape =>
         Right(storedShape.copy(sides = storedShape.sides + 1))
       }
       .value
@@ -82,6 +98,9 @@ class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with Sour
     val (location2, storedShape2) = result2.identifiedT
 
     storedShape2 shouldBe Shape(sides = 12, colour = "yellow")
-    store.underlying.hybridStore.typedStore.get(location2).value.identifiedT shouldBe Shape(sides = 12, colour = "yellow")
+    store.underlying.hybridStore.typedStore
+      .get(location2)
+      .value
+      .identifiedT shouldBe Shape(sides = 12, colour = "yellow")
   }
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/store/SourceVHSTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/store/SourceVHSTest.scala
@@ -1,0 +1,108 @@
+package weco.catalogue.source_model.store
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.maxima.Maxima
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryTypedStore}
+import uk.ac.wellcome.storage.store.{HybridStoreWithMaxima, Store, TypedStore, VersionedHybridStore}
+import uk.ac.wellcome.storage.{UpdateNoSourceError, Version}
+
+class SourceVHSTest extends AnyFunSpec with Matchers with EitherValues with S3ObjectLocationGenerators {
+  case class Shape(sides: Int, colour: String)
+
+  it("adds the S3 location to the result of putLatest()") {
+    val store = new SourceVHS[Shape](createStore)
+
+    val shape = Shape(sides = 4, colour = "red")
+
+    val result = store.putLatest(id = "redsquare")(shape).value
+
+    result.id shouldBe Version("redsquare", version = 0)
+    val (location, storedShape) = result.identifiedT
+
+    storedShape shouldBe shape
+    store.underlying.hybridStore.typedStore.get(location).value.identifiedT shouldBe shape
+  }
+
+  it("adds the S3 location to the result of update()") {
+    val store = new SourceVHS[Shape](createStore)
+
+    val shape = Shape(sides = 4, colour = "blue")
+    store.putLatest(id = "bluething")(shape) shouldBe a[Right[_, _]]
+
+    val result = store.update("bluething") { storedShape =>
+      Right(storedShape.copy(sides = storedShape.sides + 1))
+    }.value
+
+    result.id shouldBe Version("bluething", version = 1)
+    val (location, storedShape) = result.identifiedT
+
+    storedShape shouldBe Shape(sides = 5, colour = "blue")
+    store.underlying.hybridStore.typedStore.get(location).value.identifiedT shouldBe Shape(sides = 5, colour = "blue")
+  }
+
+  it("wraps an error from an update()") {
+    val store = new SourceVHS[Shape](createStore)
+
+    val err = store.update("doesNotExist") { storedShape =>
+      Right(storedShape.copy(sides = storedShape.sides + 1))
+    }.left.value
+
+    err shouldBe a[UpdateNoSourceError]
+  }
+
+  it("adds the S3 location to the result of upsert()") {
+    val store = new SourceVHS[Shape](createStore)
+
+    // Call upsert() on an empty store, which should cause this item
+    // to be initialised at v1.
+    val result1 = store
+      .upsert("splodge")(
+        Shape(sides = 11, colour = "yellow")) { storedShape =>
+          Right(storedShape.copy(sides = storedShape.sides + 1))
+        }
+      .value
+
+    result1.id shouldBe Version("splodge", version = 0)
+    val (location1, storedShape1) = result1.identifiedT
+
+    storedShape1 shouldBe Shape(sides = 11, colour = "yellow")
+    store.underlying.hybridStore.typedStore.get(location1).value.identifiedT shouldBe Shape(sides = 11, colour = "yellow")
+
+    // Now call upsert() a second time, which will update the entry
+    // in the store.
+    val result2 = store
+      .upsert("splodge")(
+        Shape(sides = 11, colour = "yellow")) { storedShape =>
+        Right(storedShape.copy(sides = storedShape.sides + 1))
+      }
+      .value
+
+    result2.id shouldBe Version("splodge", version = 1)
+    val (location2, storedShape2) = result2.identifiedT
+
+    storedShape2 shouldBe Shape(sides = 12, colour = "yellow")
+    store.underlying.hybridStore.typedStore.get(location2).value.identifiedT shouldBe Shape(sides = 12, colour = "yellow")
+  }
+
+  def createStore: VersionedHybridStore[String, Int, S3ObjectLocation, Shape] = {
+    val hybridStore = new HybridStoreWithMaxima[String, Int, S3ObjectLocation, Shape] {
+      implicit override val indexedStore: Store[Version[String, Int], S3ObjectLocation] with Maxima[String, Version[String, Int], S3ObjectLocation] =
+        new MemoryStore[Version[String, Int], S3ObjectLocation](initialEntries = Map.empty)
+          with MemoryMaxima[String, S3ObjectLocation]
+
+      override implicit val typedStore: TypedStore[S3ObjectLocation, Shape] =
+        MemoryTypedStore[S3ObjectLocation, Shape]()
+
+      override protected def createTypeStoreId(id: Version[String, Int]): S3ObjectLocation =
+        createS3ObjectLocation
+    }
+
+    new VersionedHybridStore(hybridStore)
+  }
+}

--- a/common/source_model_typesafe/src/main/scala/weco/catalogue/source_model/config/SourceVHSBuilder.scala
+++ b/common/source_model_typesafe/src/main/scala/weco/catalogue/source_model/config/SourceVHSBuilder.scala
@@ -1,0 +1,60 @@
+package weco.catalogue.source_model.config
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.s3.AmazonS3
+import com.typesafe.config.Config
+import org.scanamo.auto._
+import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
+import uk.ac.wellcome.storage.store.{
+  HybridStoreWithMaxima,
+  VersionedHybridStore
+}
+import uk.ac.wellcome.storage.store.dynamo.{DynamoHashStore, DynamoHybridStore}
+import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import uk.ac.wellcome.storage.streaming.Codec
+import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import weco.catalogue.source_model.store.SourceVHS
+
+object SourceVHSBuilder {
+  def build[T](config: Config, namespace: String = "vhs")(
+    implicit codec: Codec[T]): SourceVHS[T] = {
+    implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
+    implicit val dynamoClient: AmazonDynamoDB =
+      DynamoBuilder.buildDynamoClient(config)
+
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = namespace)
+
+    implicit val indexedStore: DynamoHashStore[String, Int, S3ObjectLocation] =
+      new DynamoHashStore[String, Int, S3ObjectLocation](dynamoConfig)
+
+    implicit val typedStore: S3TypedStore[T] = S3TypedStore[T]
+
+    class VHSInternalStore(prefix: S3ObjectLocationPrefix)(
+      implicit
+      indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
+      typedStore: S3TypedStore[T]
+    ) extends DynamoHybridStore[T](prefix)(indexedStore, typedStore)
+      with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]
+
+
+    val vhs =
+      new VersionedHybridStore[String, Int, S3ObjectLocation, T](
+        new VHSInternalStore(
+          prefix = buildObjectLocationPrefix(config, namespace = namespace)
+        )
+      )
+
+    new SourceVHS[T](vhs)
+  }
+
+  private def buildObjectLocationPrefix(config: Config, namespace: String) =
+    S3ObjectLocationPrefix(
+      bucket = config
+        .requireString(s"aws.$namespace.s3.bucketName"),
+      keyPrefix = config
+        .getStringOption(s"aws.$namespace.s3.globalPrefix")
+        .getOrElse("")
+    )
+}

--- a/common/source_model_typesafe/src/main/scala/weco/catalogue/source_model/config/SourceVHSBuilder.scala
+++ b/common/source_model_typesafe/src/main/scala/weco/catalogue/source_model/config/SourceVHSBuilder.scala
@@ -36,8 +36,7 @@ object SourceVHSBuilder {
       indexedStore: DynamoHashStore[String, Int, S3ObjectLocation],
       typedStore: S3TypedStore[T]
     ) extends DynamoHybridStore[T](prefix)(indexedStore, typedStore)
-      with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]
-
+        with HybridStoreWithMaxima[String, Int, S3ObjectLocation, T]
 
     val vhs =
       new VersionedHybridStore[String, Int, S3ObjectLocation, T](

--- a/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/uk/ac/wellcome/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -82,6 +82,8 @@ class MetsAdapterWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
+          messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+            expectedVersion)
           messageSender.getMessages[MetsSourcePayload] shouldBe Seq(
             MetsSourcePayload(
               id = expectedVersion.id,
@@ -110,6 +112,8 @@ class MetsAdapterWorkerServiceTest
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+          expectedVersion)
         messageSender.getMessages[MetsSourcePayload]() shouldBe Seq(
           MetsSourcePayload(
             id = expectedVersion.id,
@@ -135,6 +139,8 @@ class MetsAdapterWorkerServiceTest
         assertQueueEmpty(queue)
         assertQueueEmpty(dlq)
 
+        messageSender.getMessages[Version[String, Int]]() shouldBe Seq(
+          expectedVersion)
         messageSender.getMessages[MetsSourcePayload] shouldBe Seq(
           MetsSourcePayload(
             id = expectedVersion.id,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "25.0.0"
+  val defaultVersion = "25.0.3"
 
   lazy val versions = new {
     val typesafe = defaultVersion
@@ -225,7 +225,8 @@ object CatalogueDependencies {
 
   val sourceModelDependencies: Seq[sbt.ModuleID] =
     WellcomeDependencies.storageLibrary ++
-      WellcomeDependencies.fixturesLibrary
+      WellcomeDependencies.fixturesLibrary ++
+      ExternalDependencies.scalatestDependencies
 
   val pipelineStorageDependencies: Seq[ModuleID] =
     WellcomeDependencies.messagingLibrary

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -228,6 +228,10 @@ object CatalogueDependencies {
       WellcomeDependencies.fixturesLibrary ++
       ExternalDependencies.scalatestDependencies
 
+  val sourceModelTypesafeDependencies: Seq[ModuleID] =
+    WellcomeDependencies.storageTypesafeLibrary ++
+      WellcomeDependencies.messagingTypesafeLibrary
+
   val pipelineStorageDependencies: Seq[ModuleID] =
     WellcomeDependencies.messagingLibrary
 


### PR DESCRIPTION
The next step towards wellcomecollection/platform#4918; follows #1186

This patch adds a `SourceVHS` class that exposes the underlying S3 location when it stores a record. It's a bit of a hack – it's re-queries DynamoDB for the location, but doing it properly requires fairly major surgery on the store classes and it's more work than I want to do right now.

The Calm adapter now uses these new locations, and sends a `CalmSourcePayload` that includes the location. It includes the id/version fields used by the existing Calm transformer, so it won't notice the difference.