### PR TITLE
Create a shared set of TransformerWorker test cases

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -11,12 +11,11 @@ trait IdentifiersGenerators extends RandomGenerators {
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
   def createSourceIdentifierWith(
-    identifierType: IdentifierType =
-      chooseFrom(
-        IdentifierType("miro-image-number"),
-        IdentifierType("sierra-system-number"),
-        IdentifierType("calm-record-id")
-      ),
+    identifierType: IdentifierType = chooseFrom(
+      IdentifierType("miro-image-number"),
+      IdentifierType("sierra-system-number"),
+      IdentifierType("calm-record-id")
+    ),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/IdentifiersGenerators.scala
@@ -11,7 +11,12 @@ trait IdentifiersGenerators extends RandomGenerators {
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 
   def createSourceIdentifierWith(
-    identifierType: IdentifierType = IdentifierType("miro-image-number"),
+    identifierType: IdentifierType =
+      chooseFrom(
+        IdentifierType("miro-image-number"),
+        IdentifierType("sierra-system-number"),
+        IdentifierType("calm-record-id")
+      ),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"): SourceIdentifier =
     SourceIdentifier(

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.work.internal.result._
 import uk.ac.wellcome.platform.transformer.calm.models.CalmTransformerException
 import uk.ac.wellcome.platform.transformer.calm.models.CalmTransformerException._
-import uk.ac.wellcome.transformer.common.worker.Transformer
 import WorkState.Source
 import uk.ac.wellcome.models.work.internal.DeletedReason.SuppressedFromSource
 import uk.ac.wellcome.platform.transformer.calm.periods.PeriodParser
@@ -14,6 +13,7 @@ import uk.ac.wellcome.platform.transformer.calm.transformers.{
   CalmLanguages,
   CalmNotes
 }
+import weco.catalogue.transformer.Transformer
 
 object CalmTransformer
     extends Transformer[CalmRecord]

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerWorker.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.typesafe.Runnable
-import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
+import weco.catalogue.transformer.{Transformer, TransformerWorker}
 
 class CalmTransformerWorker(
   val pipelineStream: PipelineStorageStream[NotificationMessage,

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/Transformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/Transformer.scala
@@ -1,8 +1,8 @@
-package uk.ac.wellcome.transformer.common.worker
+package weco.catalogue.transformer
 
-import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal.result.Result
-import WorkState.Source
 
 trait Transformer[SourceData] {
   def apply(sourceData: SourceData, version: Int): Result[Work[Source]]

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -1,15 +1,16 @@
-package uk.ac.wellcome.transformer.common.worker
+package weco.catalogue.transformer
 
-import scala.concurrent.Future
 import akka.Done
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.storage.{Identified, ReadError, Version}
-import WorkState.Source
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
+import weco.catalogue
 
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 sealed abstract class TransformerWorkerError(msg: String) extends Exception(msg)
@@ -55,7 +56,7 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
                    version: Int,
                    key: StoreKey): Result[Work[Source]] =
     transformer(sourceData, version) match {
-      case Left(err)     => Left(TransformerError(err, sourceData, key))
+      case Left(err)     => Left(catalogue.transformer.TransformerError(err, sourceData, key))
       case Right(result) => Right(result)
     }
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -57,7 +57,8 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
                    key: StoreKey): Result[Work[Source]] =
     transformer(sourceData, version) match {
       case Right(result) => Right(result)
-      case Left(err)     => Left(catalogue.transformer.TransformerError(err, sourceData, key))
+      case Left(err) =>
+        Left(catalogue.transformer.TransformerError(err, sourceData, key))
     }
 
   private def decodeKey(message: NotificationMessage): Result[StoreKey] =

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -56,14 +56,14 @@ trait TransformerWorker[SourceData, SenderDest] extends Logging {
                    version: Int,
                    key: StoreKey): Result[Work[Source]] =
     transformer(sourceData, version) match {
-      case Left(err)     => Left(catalogue.transformer.TransformerError(err, sourceData, key))
       case Right(result) => Right(result)
+      case Left(err)     => Left(catalogue.transformer.TransformerError(err, sourceData, key))
     }
 
   private def decodeKey(message: NotificationMessage): Result[StoreKey] =
     fromJson[StoreKey](message.body) match {
-      case Failure(err)      => Left(DecodeKeyError(err, message))
       case Success(storeKey) => Right(storeKey)
+      case Failure(err)      => Left(DecodeKeyError(err, message))
     }
 
   private def getRecord(key: StoreKey): Result[(SourceData, Int)] =

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
@@ -1,108 +1,40 @@
 package weco.catalogue.transformer
 
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
-import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.pipeline_storage.MemoryIndexer
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
-import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, PipelineStorageStream}
-import uk.ac.wellcome.storage.store.VersionedStore
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import uk.ac.wellcome.storage.{Identified, ReadError, Version}
-
-import scala.concurrent.Future
-import scala.util.{Failure, Try}
-
-trait TestData
-case object ValidTestData extends TestData
-case object InvalidTestData extends TestData
-
-object TestTransformer extends Transformer[TestData] with WorkGenerators {
-  def apply(data: TestData,
-            version: Int): Either[Exception, Work.Visible[Source]] =
-    data match {
-      case ValidTestData   => Right(sourceWork().withVersion(version))
-      case InvalidTestData => Left(new Exception("No No No"))
-    }
-}
-
-class TestTransformerWorker(
-  val pipelineStream: PipelineStorageStream[NotificationMessage,
-                                            Work[Source],
-                                            String],
-  sourceStore: VersionedStore[String, Int, TestData]
-) extends TransformerWorker[TestData, String] {
-  val transformer: Transformer[TestData] = TestTransformer
-
-  override def lookupSourceData(
-    id: String): Either[ReadError, Identified[Version[String, Int], TestData]] =
-    sourceStore.getLatest(id)
-}
+import weco.catalogue.transformer.example.{ExampleData, ExampleTransformerWorker, ValidExampleData}
 
 class TransformerWorkerTest
     extends AnyFunSpec
-    with ScalaFutures
     with Matchers
     with Eventually
     with IntegrationPatience
-    with PipelineStorageStreamFixtures {
+    with PipelineStorageStreamFixtures
+    with IdentifiersGenerators {
 
-  describe("it sends a transformed work") {
-    def withTransformedWork[R](
-      testWith: TestWith[(QueuePair,
-                          MemoryIndexer[Work[Source]],
-                          MemoryMessageSender),
-                         R]): R = {
-      val records = Map(
-        Version("A", 1) -> ValidTestData,
-        Version("B", 2) -> ValidTestData,
-        Version("C", 3) -> ValidTestData
-      )
+  it("if it can't look up the source data, it fails") {
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorker(queue) { _ =>
+          sendNotificationToSQS(queue, Version("A", 1))
 
-      val workIndexer = new MemoryIndexer[Work[Source]]()
-      val workKeySender = new MemoryMessageSender()
-
-      withLocalSqsQueuePair() {
-        case queuePair @ QueuePair(queue, _) =>
-          withWorker(
-            queue,
-            workIndexer = workIndexer,
-            workKeySender = workKeySender,
-            records = records) { _ =>
-            sendNotificationToSQS(queue, Version("A", 1))
-            sendNotificationToSQS(queue, Version("B", 2))
-            sendNotificationToSQS(queue, Version("C", 3))
-
-            testWith((queuePair, workIndexer, workKeySender))
-          }
-      }
-    }
-
-    it("empties the queue") {
-      withTransformedWork {
-        case (QueuePair(queue, dlq), _, _) =>
           eventually {
-            assertQueueEmpty(dlq)
+            assertQueueHasSize(dlq, size = 1)
             assertQueueEmpty(queue)
           }
-      }
-    }
-
-    it("indexes the work and sends the index IDs") {
-      withTransformedWork {
-        case (_, workIndexer, workKeySender) =>
-          eventually {
-            workIndexer.index should have size 3
-            workKeySender.messages.map { _.body } should contain theSameElementsAs workIndexer.index.keys
-          }
-      }
+        }
     }
   }
 
@@ -110,14 +42,16 @@ class TransformerWorkerTest
     val storeVersion = 5
     val messageVersion = storeVersion - 1
 
-    val records = Map(
-      Version("A", storeVersion) -> ValidTestData,
+    val sourceStore = MemoryVersionedStore[String, ExampleData](
+      initialEntries = Map(
+        Version("A", storeVersion) -> ValidExampleData(createSourceIdentifier)
+      )
     )
 
     val workIndexer = new MemoryIndexer[Work[Source]]()
 
     withLocalSqsQueue() { queue =>
-      withWorker(queue, workIndexer = workIndexer, records = records) { _ =>
+      withWorker(queue, workIndexer = workIndexer, sourceStore = sourceStore) { _ =>
         sendNotificationToSQS(queue, Version("A", messageVersion))
 
         eventually {
@@ -128,129 +62,12 @@ class TransformerWorkerTest
     }
   }
 
-  describe("sends failures to the DLQ") {
-    it("if it can't parse the JSON on the queue") {
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(queue) { _ =>
-            sendInvalidJSONto(queue)
-
-            eventually {
-              assertQueueHasSize(dlq, size = 1)
-              assertQueueEmpty(queue)
-            }
-          }
-      }
-    }
-
-    it("if it can't parse the notification as a Version[String, Int]") {
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(queue) { _ =>
-            sendNotificationToSQS(queue, "not-a-version")
-
-            eventually {
-              assertQueueHasSize(dlq, size = 1)
-              assertQueueEmpty(queue)
-            }
-          }
-      }
-    }
-
-    it("if it can't find the source record in the store") {
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(queue) { _ =>
-            sendNotificationToSQS(queue, Version("A", 1))
-
-            eventually {
-              assertQueueHasSize(dlq, size = 1)
-              assertQueueEmpty(queue)
-            }
-          }
-      }
-    }
-
-    it("if the work can't be transformed") {
-      val records = Map(
-        Version("A", 1) -> ValidTestData,
-        Version("B", 2) -> ValidTestData,
-        Version("C", 3) -> InvalidTestData
-      )
-
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(queue, records = records) { _ =>
-            sendNotificationToSQS(queue, Version("A", 1))
-            sendNotificationToSQS(queue, Version("B", 2))
-            sendNotificationToSQS(queue, Version("C", 3))
-
-            eventually {
-              assertQueueHasSize(dlq, size = 1)
-              assertQueueEmpty(queue)
-            }
-          }
-      }
-    }
-
-    it("if it can't index the work") {
-      val brokenIndexer = new MemoryIndexer[Work[Source]]() {
-        override def index(documents: Seq[Work[Source]])
-          : Future[Either[Seq[Work[Source]], Seq[Work[Source]]]] =
-          Future.failed(new Throwable("BOOM!"))
-      }
-
-      val workKeySender = new MemoryMessageSender
-
-      val records = Map(Version("A", 1) -> ValidTestData)
-
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(
-            queue,
-            records = records,
-            workIndexer = brokenIndexer,
-            workKeySender = workKeySender) { _ =>
-            sendNotificationToSQS(queue, Version("A", 1))
-
-            eventually {
-              assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, size = 1)
-
-              workKeySender.messages shouldBe empty
-            }
-          }
-      }
-    }
-
-    it("if it can't send the key of the indexed work") {
-      val brokenSender = new MemoryMessageSender() {
-        override def send(body: String): Try[Unit] =
-          Failure(new Throwable("BOOM!"))
-      }
-
-      val records = Map(Version("A", 1) -> ValidTestData)
-
-      withLocalSqsQueuePair() {
-        case QueuePair(queue, dlq) =>
-          withWorker(queue, records = records, workKeySender = brokenSender) {
-            _ =>
-              sendNotificationToSQS(queue, Version("A", 1))
-
-              eventually {
-                assertQueueEmpty(queue)
-                assertQueueHasSize(dlq, size = 1)
-              }
-          }
-      }
-    }
-  }
-
   def withWorker[R](
     queue: Queue,
-    records: Map[Version[String, Int], TestData] = Map.empty,
     workIndexer: MemoryIndexer[Work[Source]] = new MemoryIndexer[Work[Source]](),
-    workKeySender: MemoryMessageSender = new MemoryMessageSender()
+    workKeySender: MemoryMessageSender = new MemoryMessageSender(),
+    sourceStore: MemoryVersionedStore[String, ExampleData] =
+      MemoryVersionedStore[String, ExampleData](initialEntries = Map.empty)
   )(
     testWith: TestWith[Unit, R]
   ): R =
@@ -258,14 +75,13 @@ class TransformerWorkerTest
       queue = queue,
       indexer = workIndexer,
       sender = workKeySender) { pipelineStream =>
-      val sourceStore = MemoryVersionedStore[String, TestData](records)
+        val worker = new ExampleTransformerWorker(
+          pipelineStream = pipelineStream,
+          sourceStore = sourceStore
+        )
 
-      val worker = new TestTransformerWorker(
-        pipelineStream = pipelineStream,
-        sourceStore = sourceStore
-      )
+        worker.run()
 
-      worker.run()
-      testWith(())
+        testWith(())
     }
 }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
@@ -14,7 +14,11 @@ import uk.ac.wellcome.pipeline_storage.MemoryIndexer
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import weco.catalogue.transformer.example.{ExampleData, ExampleTransformerWorker, ValidExampleData}
+import weco.catalogue.transformer.example.{
+  ExampleData,
+  ExampleTransformerWorker,
+  ValidExampleData
+}
 
 class TransformerWorkerTest
     extends AnyFunSpec
@@ -51,13 +55,14 @@ class TransformerWorkerTest
     val workIndexer = new MemoryIndexer[Work[Source]]()
 
     withLocalSqsQueue() { queue =>
-      withWorker(queue, workIndexer = workIndexer, sourceStore = sourceStore) { _ =>
-        sendNotificationToSQS(queue, Version("A", messageVersion))
+      withWorker(queue, workIndexer = workIndexer, sourceStore = sourceStore) {
+        _ =>
+          sendNotificationToSQS(queue, Version("A", messageVersion))
 
-        eventually {
-          workIndexer.index.values.map { _.version }.toSeq shouldBe Seq(
-            storeVersion)
-        }
+          eventually {
+            workIndexer.index.values.map { _.version }.toSeq shouldBe Seq(
+              storeVersion)
+          }
       }
     }
   }
@@ -75,13 +80,13 @@ class TransformerWorkerTest
       queue = queue,
       indexer = workIndexer,
       sender = workKeySender) { pipelineStream =>
-        val worker = new ExampleTransformerWorker(
-          pipelineStream = pipelineStream,
-          sourceStore = sourceStore
-        )
+      val worker = new ExampleTransformerWorker(
+        pipelineStream = pipelineStream,
+        sourceStore = sourceStore
+      )
 
-        worker.run()
+      worker.run()
 
-        testWith(())
+      testWith(())
     }
 }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.transformer.common.worker
+package weco.catalogue.transformer
 
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
@@ -13,9 +13,9 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, PipelineStorageStream}
-import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 
 import scala.concurrent.Future
 import scala.util.{Failure, Try}

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTestCases.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTestCases.scala
@@ -1,0 +1,90 @@
+package weco.catalogue.transformer
+
+import io.circe.Encoder
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.internal.Work
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
+import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, PipelineStorageStream}
+
+trait TransformerWorkerTestCases[Context, Payload, SourceData]
+  extends AnyFunSpec
+    with Eventually
+    with IntegrationPatience
+    with PipelineStorageStreamFixtures {
+
+  def withContext[R](testWith: TestWith[Context, R]): R
+
+  def createPayload(implicit context: Context): Payload
+
+  implicit val encoder: Encoder[Payload]
+
+  def id(p: Payload): String
+  def version(p: Payload): Int
+
+  def assertMatches(p: Payload, w: Work[Source])(implicit context: Context)
+
+  def withWorker[R](
+    pipelineStream: PipelineStorageStream[NotificationMessage, Work[Source], String])(
+    testWith: TestWith[TransformerWorker[SourceData, String], R]
+  )(
+    implicit context: Context
+  ): R
+
+  describe("behaves as a TransformerWorker") {
+    it("transforms works, indexes them, and removes them from the queue") {
+      withContext { implicit context =>
+        val payloads = (1 to 5).map { _ => createPayload }
+
+        val workIndexer = new MemoryIndexer[Work[Source]]()
+        val workKeySender = new MemoryMessageSender()
+
+        withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+          withWorkerImpl(queue, workIndexer, workKeySender) { _ =>
+            payloads.foreach { sendNotificationToSQS(queue, _) }
+
+            eventually {
+              assertQueueEmpty(dlq)
+              assertQueueEmpty(queue)
+
+              workIndexer.index should have size payloads.size
+
+              val sentKeys = workKeySender.messages.map { _.body }
+              val storedKeys = workIndexer.index.keys
+              sentKeys should contain theSameElementsAs storedKeys
+
+              payloads.foreach { p =>
+                assertMatches(p, workIndexer.index(id(p)))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def withWorkerImpl[R](
+    queue: Queue,
+    workIndexer: MemoryIndexer[Work[Source]] = new MemoryIndexer[Work[Source]](),
+    workKeySender: MemoryMessageSender = new MemoryMessageSender()
+  )(
+    testWith: TestWith[Unit, R]
+  )(
+    implicit context: Context
+ ): R =
+    withPipelineStream[Work[Source], R](
+      queue = queue,
+      indexer = workIndexer,
+      sender = workKeySender) { pipelineStream =>
+      withWorker(pipelineStream) { worker =>
+        worker.run()
+
+        testWith(())
+      }
+    }
+}

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformer.scala
@@ -31,6 +31,7 @@ class ExampleTransformerWorker(
 
   override val transformer: Transformer[ExampleData] = ExampleTransformer
 
-  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], ExampleData]] =
+  override def lookupSourceData(id: String)
+    : Either[ReadError, Identified[Version[String, Int], ExampleData]] =
     sourceStore.getLatest(id)
 }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformer.scala
@@ -1,0 +1,36 @@
+package weco.catalogue.transformer.example
+
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.models.work.internal.WorkState.Source
+import uk.ac.wellcome.models.work.internal.{SourceIdentifier, Work}
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
+import uk.ac.wellcome.storage.store.VersionedStore
+import uk.ac.wellcome.storage.{Identified, ReadError, Version}
+import weco.catalogue.transformer.{Transformer, TransformerWorker}
+
+sealed trait ExampleData
+case class ValidExampleData(id: SourceIdentifier) extends ExampleData
+case object InvalidExampleData extends ExampleData
+
+object ExampleTransformer extends Transformer[ExampleData] with WorkGenerators {
+  def apply(data: ExampleData,
+            version: Int): Either[Exception, Work.Visible[Source]] =
+    data match {
+      case ValidExampleData(id) => Right(sourceWork(id).withVersion(version))
+      case InvalidExampleData   => Left(new Exception("No No No"))
+    }
+}
+
+class ExampleTransformerWorker(
+  val pipelineStream: PipelineStorageStream[NotificationMessage,
+                                            Work[Source],
+                                            String],
+  sourceStore: VersionedStore[String, Int, ExampleData]
+) extends TransformerWorker[ExampleData, String] {
+
+  override val transformer: Transformer[ExampleData] = ExampleTransformer
+
+  override def lookupSourceData(id: String): Either[ReadError, Identified[Version[String, Int], ExampleData]] =
+    sourceStore.getLatest(id)
+}

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
@@ -38,6 +38,17 @@ class ExampleTransformerTest extends TransformerWorkerTestCases[
     id
   }
 
+  override def createBadPayload(implicit store: MemoryVersionedStore[String, ExampleData]): Version[String, Int] = {
+    val data = InvalidExampleData
+    val version = randomInt(from = 1, to = 10)
+
+    val id = Version(id = randomAlphanumeric(), version)
+
+    store.put(id)(data) shouldBe a[Right[_, _]]
+
+    id
+  }
+
   override def id(p: Version[String, Int]): String = p.id
   override def version(p: Version[String, Int]): Int = p.version
 

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
@@ -10,24 +10,31 @@ import uk.ac.wellcome.models.work.internal.{Work, WorkState}
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
-import weco.catalogue.transformer.{TransformerWorker, TransformerWorkerTestCases}
+import weco.catalogue.transformer.{
+  TransformerWorker,
+  TransformerWorkerTestCases
+}
 
-class ExampleTransformerTest extends TransformerWorkerTestCases[
-  MemoryVersionedStore[String, ExampleData],
-  Version[String, Int],
-  ExampleData
-]
+class ExampleTransformerTest
+    extends TransformerWorkerTestCases[
+      MemoryVersionedStore[String, ExampleData],
+      Version[String, Int],
+      ExampleData
+    ]
     with IdentifiersGenerators {
 
   implicit lazy val encoder: Encoder[Version[String, Int]] =
     deriveConfiguredEncoder[Version[String, Int]]
 
-  override def withContext[R](testWith: TestWith[MemoryVersionedStore[String, ExampleData], R]): R =
+  override def withContext[R](
+    testWith: TestWith[MemoryVersionedStore[String, ExampleData], R]): R =
     testWith(
       MemoryVersionedStore[String, ExampleData](initialEntries = Map.empty)
     )
 
-  override def createPayload(implicit store: MemoryVersionedStore[String, ExampleData]): Version[String, Int] = {
+  override def createPayload(
+    implicit store: MemoryVersionedStore[String, ExampleData])
+    : Version[String, Int] = {
     val data = ValidExampleData(id = createSourceIdentifier)
     val version = randomInt(from = 1, to = 10)
 
@@ -38,7 +45,9 @@ class ExampleTransformerTest extends TransformerWorkerTestCases[
     id
   }
 
-  override def createBadPayload(implicit store: MemoryVersionedStore[String, ExampleData]): Version[String, Int] = {
+  override def createBadPayload(
+    implicit store: MemoryVersionedStore[String, ExampleData])
+    : Version[String, Int] = {
     val data = InvalidExampleData
     val version = randomInt(from = 1, to = 10)
 
@@ -51,12 +60,19 @@ class ExampleTransformerTest extends TransformerWorkerTestCases[
 
   override def id(p: Version[String, Int]): String = p.id
 
-  override def assertMatches(p: Version[String, Int], w: Work[WorkState.Source])(implicit context: MemoryVersionedStore[String, ExampleData]): Unit = {
+  override def assertMatches(p: Version[String, Int],
+                             w: Work[WorkState.Source])(
+    implicit context: MemoryVersionedStore[String, ExampleData]): Unit = {
     w.sourceIdentifier.toString shouldBe p.id
     w.version shouldBe p.version
   }
 
-  override def withWorker[R](pipelineStream: PipelineStorageStream[NotificationMessage, Work[WorkState.Source], String])(testWith: TestWith[TransformerWorker[ExampleData, String], R])(implicit sourceStore: MemoryVersionedStore[String, ExampleData]): R =
+  override def withWorker[R](
+    pipelineStream: PipelineStorageStream[NotificationMessage,
+                                          Work[WorkState.Source],
+                                          String])(
+    testWith: TestWith[TransformerWorker[ExampleData, String], R])(
+    implicit sourceStore: MemoryVersionedStore[String, ExampleData]): R =
     testWith(
       new ExampleTransformerWorker(
         pipelineStream = pipelineStream,

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
@@ -1,0 +1,56 @@
+package weco.catalogue.transformer.example
+
+import io.circe.Encoder
+import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.internal.{Work, WorkState}
+import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
+import uk.ac.wellcome.storage.Version
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
+import weco.catalogue.transformer.{TransformerWorker, TransformerWorkerTestCases}
+
+class ExampleTransformerTest extends TransformerWorkerTestCases[
+  MemoryVersionedStore[String, ExampleData],
+  Version[String, Int],
+  ExampleData
+]
+    with IdentifiersGenerators {
+
+  implicit lazy val encoder: Encoder[Version[String, Int]] =
+    deriveConfiguredEncoder[Version[String, Int]]
+
+  override def withContext[R](testWith: TestWith[MemoryVersionedStore[String, ExampleData], R]): R =
+    testWith(
+      MemoryVersionedStore[String, ExampleData](initialEntries = Map.empty)
+    )
+
+  override def createPayload(implicit store: MemoryVersionedStore[String, ExampleData]): Version[String, Int] = {
+    val data = ValidExampleData(id = createSourceIdentifier)
+    val version = randomInt(from = 1, to = 10)
+
+    val id: Version[String, Int] = Version(data.id.toString, version)
+
+    store.put(id)(data) shouldBe a[Right[_, _]]
+
+    id
+  }
+
+  override def id(p: Version[String, Int]): String = p.id
+  override def version(p: Version[String, Int]): Int = p.version
+
+  override def assertMatches(p: Version[String, Int], w: Work[WorkState.Source])(implicit context: MemoryVersionedStore[String, ExampleData]): Unit = {
+    w.sourceIdentifier.toString shouldBe p.id
+    w.version shouldBe p.version
+  }
+
+  override def withWorker[R](pipelineStream: PipelineStorageStream[NotificationMessage, Work[WorkState.Source], String])(testWith: TestWith[TransformerWorker[ExampleData, String], R])(implicit sourceStore: MemoryVersionedStore[String, ExampleData]): R =
+    testWith(
+      new ExampleTransformerWorker(
+        pipelineStream = pipelineStream,
+        sourceStore = sourceStore
+      )
+    )
+}

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/example/ExampleTransformerTest.scala
@@ -50,7 +50,6 @@ class ExampleTransformerTest extends TransformerWorkerTestCases[
   }
 
   override def id(p: Version[String, Int]): String = p.id
-  override def version(p: Version[String, Int]): Int = p.version
 
   override def assertMatches(p: Version[String, Int], w: Work[WorkState.Source])(implicit context: MemoryVersionedStore[String, ExampleData]): Unit = {
     w.sourceIdentifier.toString shouldBe p.id

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/service/MetsTransformerWorkerService.scala
@@ -8,9 +8,9 @@ import uk.ac.wellcome.platform.transformer.mets.transformer.MetsXmlTransformer
 import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.{Readable, VersionedStore}
-import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
 import weco.catalogue.source_model.mets.MetsSourceData
+import weco.catalogue.transformer.{Transformer, TransformerWorker}
 
 class MetsTransformerWorkerService[MsgDestination](
   val pipelineStream: PipelineStorageStream[NotificationMessage,

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -5,8 +5,8 @@ import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.models.work.internal.{Work, WorkState}
 import uk.ac.wellcome.models.work.internal.result.Result
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
-import uk.ac.wellcome.transformer.common.worker.Transformer
 import weco.catalogue.source_model.mets.MetsSourceData
+import weco.catalogue.transformer.Transformer
 
 class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     extends Transformer[MetsSourceData] {

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.miro
 
 import java.time.Instant
-
 import scala.util.Try
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
@@ -12,7 +11,7 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.platform.transformer.miro.transformers._
 import WorkState.Source
 import uk.ac.wellcome.models.work.internal.result.Result
-import uk.ac.wellcome.transformer.common.worker.Transformer
+import weco.catalogue.transformer.Transformer
 
 class MiroRecordTransformer
     extends MiroContributors

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerService.scala
@@ -13,8 +13,8 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.{Identified, ReadError, Version}
-import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.transformer.{Transformer, TransformerWorker}
 
 class MiroTransformerWorkerService[MsgDestination](
   val pipelineStream: PipelineStorageStream[NotificationMessage,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorkerService.scala
@@ -8,8 +8,8 @@ import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
 import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
 import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.storage.store.VersionedStore
-import uk.ac.wellcome.transformer.common.worker.{Transformer, TransformerWorker}
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.transformer.{Transformer, TransformerWorker}
 
 class SierraTransformerWorkerService[MsgDestination](
   val pipelineStream: PipelineStorageStream[NotificationMessage,


### PR DESCRIPTION
Another piece for wellcomecollection/platform#4918

The transformers have been converging recently; now they're going to read SourcePayload, they're going to diverge again. It would be useful to have some shared test cases in each of the individual apps, so we can check that, say, the Sierra transformer knows how to read a SierraSourcePayload.

I've not implemented the tests yet because they'll change when I update the transformers, so I'll wait until I'm doing that.