### PR TITLE
Allow enabling of gzip compression for ES requests

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticClientBuilder.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticClientBuilder.scala
@@ -26,10 +26,12 @@ object ElasticClientBuilder {
              port: Int,
              protocol: String,
              username: String,
-             password: String): ElasticClient = {
+             password: String,
+             compressionEnabled: Boolean = false): ElasticClient = {
     val restClient = RestClient
       .builder(new HttpHost(hostname, port, protocol))
       .setHttpClientConfigCallback(new ElasticCredentials(username, password))
+      .setCompressionEnabled(compressionEnabled)
       .build()
 
     ElasticClient(JavaClient.fromRestClient(restClient))

--- a/common/elasticsearch/src/test/resources/logback-test.xml
+++ b/common/elasticsearch/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%logger{0}] %-5level %msg%n</pattern>
+      <!-- <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern> -->
+    </encoder>
+  </appender>
+
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
+  <root level="DEBUG">
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
+  </root>
+
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
+  <logger name="akka.actor" level="OFF"/>
+  <logger name="com.sksamuel.elastic4s" level="DEBUG"/>
+</configuration>

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfigTest.scala
@@ -152,4 +152,14 @@ class WorksIndexConfigTest
       }
     }
   }
+
+  it("puts a valid work using compression") {
+    forAll { sampleWork: Work[Identified] =>
+      withLocalWorksIndex { index =>
+        whenReady(indexObjectCompressed(index, sampleWork)) { resp =>
+          assertObjectIndexed(index, sampleWork)
+        }
+      }
+    }
+  }
 }

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -14,7 +14,7 @@ import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.indexes.IndexResponse
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
-import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
+import com.sksamuel.elastic4s.{Index, Response}
 import grizzled.slf4j.Logging
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.parser.parse
@@ -39,15 +39,22 @@ trait ElasticsearchFixtures
   private val esHost = "localhost"
   private val esPort = 9200
 
-  val compressionEnabled: Boolean = false
-
-  lazy val elasticClient: ElasticClient = ElasticClientBuilder.create(
+  lazy val elasticClient = ElasticClientBuilder.create(
     hostname = esHost,
     port = esPort,
     protocol = "http",
     username = "elastic",
     password = "changeme",
-    compressionEnabled = compressionEnabled,
+    compressionEnabled = false,
+  )
+
+  lazy val elasticClientWithCompression = ElasticClientBuilder.create(
+    hostname = esHost,
+    port = esPort,
+    protocol = "http",
+    username = "elastic",
+    password = "changeme",
+    compressionEnabled = true,
   )
 
   // Elasticsearch takes a while to start up so check that it actually started
@@ -244,7 +251,22 @@ trait ElasticsearchFixtures
         }
         r
       }
+  }
 
+  def indexObjectCompressed[T](index: Index, t: T)(
+    implicit encoder: Encoder[T]): Future[Response[IndexResponse]] = {
+    val doc = toJson(t).get
+    debug(s"ingesting: $doc")
+    elasticClientWithCompression
+      .execute {
+        indexInto(index.name).doc(doc)
+      }
+      .map { r =>
+        if (r.isError) {
+          error(s"Error from Elasticsearch: $r")
+        }
+        r
+      }
   }
 
   def insertIntoElasticsearch[State <: WorkState](

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -39,12 +39,15 @@ trait ElasticsearchFixtures
   private val esHost = "localhost"
   private val esPort = 9200
 
-  val elasticClient: ElasticClient = ElasticClientBuilder.create(
+  val compressionEnabled: Boolean = false
+
+  lazy val elasticClient: ElasticClient = ElasticClientBuilder.create(
     hostname = esHost,
     port = esPort,
     protocol = "http",
     username = "elastic",
-    password = "changeme"
+    password = "changeme",
+    compressionEnabled = compressionEnabled,
   )
 
   // Elasticsearch takes a while to start up so check that it actually started

--- a/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
+++ b/common/elasticsearch_typesafe/src/main/scala/uk/ac/wellcome/elasticsearch/typesafe/ElasticBuilder.scala
@@ -23,13 +23,17 @@ object ElasticBuilder {
     val password = config
       .getStringOption(s"es.$namespace.password")
       .getOrElse("password")
+    val compressionEnabled = config
+      .getBooleanOption(s"es.$namespace.compressionEnabled")
+      .getOrElse(false)
 
     ElasticClientBuilder.create(
       hostname = hostname,
       port = port,
       protocol = protocol,
       username = username,
-      password = password
+      password = password,
+      compressionEnabled = compressionEnabled
     )
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object ExternalDependencies {
     val apacheLogging = "2.8.2"
     val aws = "1.11.504"
     val circe = "0.13.0"
-    val elastic4s = "7.9.2"
+    val elastic4s = "7.10.1"
     val fastparse = "2.3.0"
     val swagger = "2.0.10"
     val mockito = "1.9.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -123,8 +123,6 @@ object ExternalDependencies {
   )
 
   val elasticsearchDependencies = Seq(
-    "org.apache.logging.log4j" % "log4j-core" % versions.apacheLogging,
-    "org.apache.logging.log4j" % "log4j-api" % versions.apacheLogging,
     "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
     "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % versions.elastic4s,
     "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % versions.elastic4s,
@@ -209,7 +207,8 @@ object CatalogueDependencies {
   val elasticsearchDependencies: Seq[ModuleID] =
     ExternalDependencies.elasticsearchDependencies ++
       ExternalDependencies.scalacheckDependencies ++
-      WellcomeDependencies.fixturesLibrary
+      WellcomeDependencies.fixturesLibrary ++
+      WellcomeDependencies.typesafeLibrary
 
   val bigMessagingDependencies: Seq[ModuleID] =
     ExternalDependencies.scalatestDependencies ++


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4929

## Description

This allows enabling compression of requests sent to Elasticsearch, on a per client basis.

This will potentially be useful for reducing NAT gateway costs for indexing works in the pipeline, although it will increase CPU load both on our containers and the ES cluster.

Before this can be merged:
- [x] Elastic4s needs a release >= `7.10.1`.
- [x] `EnrichConfig` in scala-libs should be updated to have a `getBooleanOption` method.
- [ ] Should check ES clusters that we are sending compressed data to are configured to have compression enabled.