### PR TITLE
Upgrade to terraform 0.14 in the Calm adapter; allow scaling to zero

### DIFF
--- a/calm_adapter/terraform/.terraform.lock.hcl
+++ b/calm_adapter/terraform/.terraform.lock.hcl
@@ -1,0 +1,9 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "2.70.0"
+  hashes = [
+    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+  ]
+}

--- a/calm_adapter/terraform/provider.tf
+++ b/calm_adapter/terraform/provider.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  region  = local.aws_region
-  version = "~> 2.0"
+  region = local.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/calm_adapter/terraform/worker.tf
+++ b/calm_adapter/terraform/worker.tf
@@ -3,16 +3,17 @@ module "worker" {
 
   name = local.namespace
 
-  image              = local.calm_adapter_image
-  env_vars           = local.env_vars
-  secret_env_vars    = local.secret_env_vars
-  min_capacity       = 1
-  max_capacity       = 2
-  desired_task_count = 1
-  cpu                = 512
-  memory             = 1024
+  image           = local.calm_adapter_image
+  env_vars        = local.env_vars
+  secret_env_vars = local.secret_env_vars
 
-  cluster_name           = local.namespace
+  min_capacity = 0
+  max_capacity = 2
+
+  cpu    = 512
+  memory = 1024
+
+  cluster_name           = aws_ecs_cluster.cluster.name
   cluster_arn            = aws_ecs_cluster.cluster.arn
   namespace_id           = aws_service_discovery_private_dns_namespace.namespace.id
   subnets                = local.private_subnets


### PR DESCRIPTION
I don't think there's a good reason the Calm adapter can't scale to zero when it's not in use; if there is, we should document it in the Terraform.