### PR TITLE
Use the same Docker image base and config model for all services

### DIFF
--- a/reindexer/reindex_worker/Dockerfile
+++ b/reindexer/reindex_worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:21
+FROM wellcome/typesafe_config_base:104
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_bib_merger/Dockerfile
+++ b/sierra_adapter/sierra_bib_merger/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:104
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_bib_merger/src/main/resources/application.conf
+++ b/sierra_adapter/sierra_bib_merger/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+aws.sqs.queue.url=${?windows_queue_url}
+aws.sns.topic.arn=${?topic_arn}
+aws.metrics.namespace=${?metrics_namespace}
+aws.vhs.s3.bucketName=${?bucket_name}
+aws.vhs.dynamo.tableName=${?dynamo_table_name}

--- a/sierra_adapter/sierra_bib_merger/src/universal/conf/application.conf.template
+++ b/sierra_adapter/sierra_bib_merger/src/universal/conf/application.conf.template
@@ -1,5 +1,0 @@
-aws.sqs.queue.url="${windows_queue_url}"
-aws.sns.topic.arn="${topic_arn}"
-aws.metrics.namespace="${metrics_namespace}"
-aws.vhs.s3.bucketName="${bucket_name}"
-aws.vhs.dynamo.tableName="${dynamo_table_name}"

--- a/sierra_adapter/sierra_item_merger/Dockerfile
+++ b/sierra_adapter/sierra_item_merger/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:21
+FROM wellcome/typesafe_config_base:104
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_items_to_dynamo/Dockerfile
+++ b/sierra_adapter/sierra_items_to_dynamo/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:2
+FROM wellcome/typesafe_config_base:104
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/resources/application.conf
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+aws.sns.topic.arn=${?topic_arn}
+aws.vhs.dynamo.tableName=${?vhs_table_name}
+aws.vhs.s3.bucketName=${?vhs_bucket_name}
+aws.sqs.queue.url=${?demultiplexer_queue_url}
+aws.metrics.namespace=${?metrics_namespace}

--- a/sierra_adapter/sierra_items_to_dynamo/src/universal/conf/application.conf.template
+++ b/sierra_adapter/sierra_items_to_dynamo/src/universal/conf/application.conf.template
@@ -1,5 +1,0 @@
-aws.sns.topic.arn="${topic_arn}"
-aws.vhs.dynamo.tableName="${vhs_table_name}"
-aws.vhs.s3.bucketName="${vhs_bucket_name}"
-aws.sqs.queue.url="${demultiplexer_queue_url}"
-aws.metrics.namespace="${metrics_namespace}"

--- a/snapshots/snapshot_generator/Dockerfile
+++ b/snapshots/snapshot_generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM wellcome/typesafe_config_base:21
+FROM wellcome/typesafe_config_base:104
 
 ADD target/universal/stage /opt/docker
 


### PR DESCRIPTION
While working in the Sierra adapter, I noticed it was using an old approach to config management.