### PR TITLE
Better logging inside the METS transformer

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
@@ -4,5 +4,9 @@ case class RetrieverMultiResult[T](
   found: Map[String, T],
   notFound: Map[String, Throwable]
 ) {
-  require(found.keySet.intersect(notFound.keySet).isEmpty)
+  require(
+    found.keySet.intersect(notFound.keySet).isEmpty,
+    s"The Retriever both found and did not find the same key: ${found.keySet.intersect(notFound.keySet)}. " +
+      "This probably indicates a programming error."
+  )
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/RetrieverMultiResult.scala
@@ -6,7 +6,8 @@ case class RetrieverMultiResult[T](
 ) {
   require(
     found.keySet.intersect(notFound.keySet).isEmpty,
-    s"The Retriever both found and did not find the same key: ${found.keySet.intersect(notFound.keySet)}. " +
+    s"The Retriever both found and did not find the same key: ${found.keySet
+      .intersect(notFound.keySet)}. " +
       "This probably indicates a programming error."
   )
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -154,7 +154,8 @@ trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
             throw err
 
           case Right(None) =>
-            debug(s"$name: no transformed Work returned for $notification (this means the Work is already in the pipeline)")
+            debug(
+              s"$name: no transformed Work returned for $notification (this means the Work is already in the pipeline)")
             None
 
           case Right(Some((work, key))) =>

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -154,7 +154,7 @@ trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
             throw err
 
           case Right(None) =>
-            debug(s"$name: no transformed work returned for $notification")
+            debug(s"$name: no transformed Work returned for $notification (this means the Work is already in the pipeline)")
             None
 
           case Right(Some((work, key))) =>

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/TransformerWorker.scala
@@ -60,9 +60,14 @@ trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
       for {
         payload <- decodePayload(message)
         key = Version(payload.id, payload.version)
-        recordResult <- getRecord(payload)
-        (record, version) = recordResult
-        newWork <- work(record, version, key)
+
+        _ = debug(s"Decoded payload $payload and key $key")
+
+        getResult <- getSourceData(payload)
+        (sourceData, version) = getResult
+        _ = debug(s"Retrieved sourceData version $version for key $key")
+
+        newWork <- work(sourceData, version, key)
       } yield (newWork, key)
     }.flatMap { compareToStored }
 
@@ -81,7 +86,7 @@ trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
       case Failure(err)      => Left(DecodePayloadError(err, message))
     }
 
-  private def getRecord(p: Payload): Result[(SourceData, Int)] =
+  private def getSourceData(p: Payload): Result[(SourceData, Int)] =
     lookupSourceData(p)
       .map {
         case Identified(Version(storedId, storedVersion), sourceData) =>


### PR DESCRIPTION
I wrote the original log message, and still got confused when I saw it just now.

Plus logging when we hit an undocumented `require()` statement.