### PR TITLE
The Identified -> Merged argument can be an Instant, not an Option[Instant]

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -149,19 +149,6 @@ object WorkState {
     val relations = Relations.none
   }
 
-  case class Merged(
-    sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
-    modifiedTime: Instant,
-  ) extends WorkState {
-
-    type WorkDataState = DataState.Identified
-    type TransitionArgs = Option[Instant]
-
-    def id = canonicalId
-    val relations = Relations.none
-  }
-
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: String,
@@ -173,6 +160,19 @@ object WorkState {
 
     def id = canonicalId
     val relations = Relations.none
+  }
+
+  case class Merged(
+    sourceIdentifier: SourceIdentifier,
+    canonicalId: String,
+    modifiedTime: Instant,
+  ) extends WorkState {
+
+    type WorkDataState = DataState.Identified
+    type TransitionArgs = Option[Instant]
+
+    def id: String = canonicalId
+    val relations: Relations = Relations.none
   }
 
   case class Denormalised(

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -169,7 +169,7 @@ object WorkState {
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
-    type TransitionArgs = Option[Instant]
+    type TransitionArgs = Instant
 
     def id: String = canonicalId
     val relations: Relations = Relations.none
@@ -227,11 +227,11 @@ object WorkFsm {
   implicit val identifiedToMerged = new Transition[Identified, Merged] {
     def state(state: Identified,
               data: WorkData[DataState.Identified],
-              args: Option[Instant]): Merged =
+              modifiedTime: Instant): Merged =
       Merged(
-        state.sourceIdentifier,
-        state.id,
-        args.getOrElse(state.modifiedTime),
+        sourceIdentifier = state.sourceIdentifier,
+        canonicalId = state.id,
+        modifiedTime = modifiedTime
       )
 
     def data(data: WorkData[DataState.Identified]) = data

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -15,7 +15,7 @@ case class MergerOutcome(resultWorks: Seq[Work[Identified]],
                          imagesWithSources: Seq[ImageDataWithSource]) {
 
   def mergedWorksWithTime(modifiedTime: Instant): Seq[Work[Merged]] =
-    resultWorks.map(_.transition[Merged](Some(modifiedTime)))
+    resultWorks.map(_.transition[Merged](modifiedTime))
 
   def mergedImagesWithTime(
     modifiedTime: Instant): Seq[Image[ImageState.Initial]] =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -16,8 +16,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
 
     val result = mergerManager.applyMerge(maybeWorks = List(Some(work)))
 
-    result.mergedWorksWithTime(now) shouldBe List(
-      work.transition[Merged](now))
+    result.mergedWorksWithTime(now) shouldBe List(work.transition[Merged](now))
   }
 
   it("performs a merge with multiple works") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -17,7 +17,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
     val result = mergerManager.applyMerge(maybeWorks = List(Some(work)))
 
     result.mergedWorksWithTime(now) shouldBe List(
-      work.transition[Merged](Some(now)))
+      work.transition[Merged](now))
   }
 
   it("performs a merge with multiple works") {
@@ -29,7 +29,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
     val result = mergerManager.applyMerge(maybeWorks = works)
     val resultWorks = result.mergedWorksWithTime(now)
 
-    resultWorks.head shouldBe work.transition[Merged](Some(now))
+    resultWorks.head shouldBe work.transition[Merged](now)
 
     resultWorks.tail.zip(otherWorks).map {
       case (baseWork: Work[Merged], unmergedWork: Work.Visible[Identified]) =>
@@ -50,7 +50,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
     val result = mergerManager.applyMerge(maybeWorks = maybeWorks.toList)
 
     result.mergedWorksWithTime(now) should contain theSameElementsAs
-      expectedWorks.map(_.transition[Merged](Some(now)))
+      expectedWorks.map(_.transition[Merged](now))
   }
 
   val mergerRules = new Merger {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -88,7 +88,7 @@ class MergerTest
     mergedWorks.mergedWorksWithTime(now) should contain(
       inputWorks.head
         .asInstanceOf[Work.Visible[Identified]]
-        .transition[Merged](Some(now))
+        .transition[Merged](now)
         .mapData { data =>
           data.copy[DataState.Identified](
             items = mergedTargetItems,
@@ -108,7 +108,7 @@ class MergerTest
 
   it("returns all non-redirected and non-target works untouched") {
     mergedWorks.mergedWorksWithTime(now) should contain(
-      inputWorks.tail.head.transition[Merged](Some(now))
+      inputWorks.tail.head.transition[Merged](now)
     )
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -96,7 +96,8 @@ class MergerWorkerServiceTest
 
           getWorksSent(senders) should contain only work.id
 
-          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
+          index shouldBe Map(
+            work.id -> work.transition[Merged](work.state.modifiedTime))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")
@@ -150,7 +151,8 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
           getWorksSent(senders) should contain only work.id
-          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
+          index shouldBe Map(
+            work.id -> work.transition[Merged](work.state.modifiedTime))
         }
     }
   }
@@ -180,7 +182,8 @@ class MergerWorkerServiceTest
           assertQueueEmpty(dlq)
 
           getWorksSent(senders) should contain only work.id
-          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
+          index shouldBe Map(
+            work.id -> work.transition[Merged](work.state.modifiedTime))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -65,9 +65,9 @@ class MergerWorkerServiceTest
           )
 
           index shouldBe Map(
-            work1.id -> work1.transition[Merged](Some(latestUpdate)),
-            work2.id -> work2.transition[Merged](Some(latestUpdate)),
-            work3.id -> work3.transition[Merged](Some(latestUpdate))
+            work1.id -> work1.transition[Merged](latestUpdate),
+            work2.id -> work2.transition[Merged](latestUpdate),
+            work3.id -> work3.transition[Merged](latestUpdate)
           )
 
           metrics.incrementedCounts.length should be >= 1
@@ -96,7 +96,7 @@ class MergerWorkerServiceTest
 
           getWorksSent(senders) should contain only work.id
 
-          index shouldBe Map(work.id -> work.transition[Merged](None))
+          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")
@@ -150,7 +150,7 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
           getWorksSent(senders) should contain only work.id
-          index shouldBe Map(work.id -> work.transition[Merged](None))
+          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
         }
     }
   }
@@ -180,7 +180,7 @@ class MergerWorkerServiceTest
           assertQueueEmpty(dlq)
 
           getWorksSent(senders) should contain only work.id
-          index shouldBe Map(work.id -> work.transition[Merged](None))
+          index shouldBe Map(work.id -> work.transition[Merged](work.state.modifiedTime))
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -134,7 +134,7 @@ class PlatformMergerTest
     val miroItem = miroWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -185,7 +185,7 @@ class PlatformMergerTest
     result.mergedWorksWithTime(now).size shouldBe 2
 
     val expectedMergedWork = zeroItemSierraWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           otherIdentifiers = data.otherIdentifiers ++ miroWork.identifiers,
@@ -237,7 +237,7 @@ class PlatformMergerTest
     val miroItem = miroWork.data.items.head
 
     val expectedMergedWork = sierraDigitalWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -287,7 +287,7 @@ class PlatformMergerTest
     result.mergedWorksWithTime(now).size shouldBe 2
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           imageData = miroWork.data.imageData,
@@ -321,7 +321,7 @@ class PlatformMergerTest
     val digitalItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           items = List(
@@ -362,7 +362,7 @@ class PlatformMergerTest
     val digitalItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPictureWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           items = List(
@@ -416,7 +416,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
@@ -498,7 +498,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           thumbnail = metsWork.data.thumbnail,
@@ -536,7 +536,7 @@ class PlatformMergerTest
     val metsItem = metsWork.data.items.head
 
     val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](Some(now))
+      .transition[Merged](now)
       .mapData { data =>
         data.copy(
           otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitisedWork.identifiers,
@@ -581,8 +581,7 @@ class PlatformMergerTest
     val result = merger.merge(List(miroWork))
 
     result.mergedWorksWithTime(now) should have length 1
-    result.mergedWorksWithTime(now).head shouldBe miroWork.transition[Merged](
-      Some(now))
+    result.mergedWorksWithTime(now).head shouldBe miroWork.transition[Merged](now)
     result.mergedImagesWithTime(now) should have length 1
     result.mergedImagesWithTime(now).head shouldBe miroWork.data.imageData.head
       .toInitialImageWith(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -581,7 +581,8 @@ class PlatformMergerTest
     val result = merger.merge(List(miroWork))
 
     result.mergedWorksWithTime(now) should have length 1
-    result.mergedWorksWithTime(now).head shouldBe miroWork.transition[Merged](now)
+    result.mergedWorksWithTime(now).head shouldBe miroWork.transition[Merged](
+      now)
     result.mergedImagesWithTime(now) should have length 1
     result.mergedImagesWithTime(now).head shouldBe miroWork.data.imageData.head
       .toInitialImageWith(


### PR DESCRIPTION
Spotted on code read.

The only place we call `transition[Merged](None)` is in tests. Be explicit that this transition will always provide a modifiedTime.