### PR TITLE
Use source works in idminter feature tests

### DIFF
--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.generators.WorkGenerators
-import uk.ac.wellcome.models.work.internal.WorkState.{Identified, Merged}
+import uk.ac.wellcome.models.work.internal.WorkState.Identified
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.id_minter.fixtures.WorkerServiceFixture
 
@@ -26,7 +26,7 @@ class IdMinterFeatureTest
 
     withLocalSqsQueue() { queue =>
       withIdentifiersTable { identifiersTableConfig =>
-        val work: Work[Merged] = mergedWork()
+        val work = sourceWork()
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
         withWorkerService(
@@ -62,7 +62,7 @@ class IdMinterFeatureTest
 
     withLocalSqsQueue() { queue =>
       withIdentifiersTable { identifiersTableConfig =>
-        val work: Work[Merged] = mergedWork().invisible()
+        val work = sourceWork().invisible()
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
         withWorkerService(
@@ -94,10 +94,9 @@ class IdMinterFeatureTest
 
     withLocalSqsQueue() { queue =>
       withIdentifiersTable { identifiersTableConfig =>
-        val work: Work[Merged] = mergedWork()
+        val work = sourceWork()
           .redirected(
-            redirect = IdState.Identified(
-              canonicalId = createCanonicalId,
+            redirect = IdState.Identifiable(
               sourceIdentifier = createSourceIdentifier))
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
@@ -134,7 +133,7 @@ class IdMinterFeatureTest
 
     withLocalSqsQueue() { queue =>
       withIdentifiersTable { identifiersTableConfig =>
-        val work: Work[Merged] = mergedWork()
+        val work = sourceWork()
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
         withWorkerService(

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
@@ -96,8 +96,8 @@ class IdMinterFeatureTest
       withIdentifiersTable { identifiersTableConfig =>
         val work = sourceWork()
           .redirected(
-            redirect = IdState.Identifiable(
-              sourceIdentifier = createSourceIdentifier))
+            redirect =
+              IdState.Identifiable(sourceIdentifier = createSourceIdentifier))
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
         withWorkerService(

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/WorkerServiceFixture.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.id_minter.services.IdMinterWorkerService
 import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, MemoryRetriever}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
-import WorkState.{Identified, Merged}
+import WorkState.{Identified, Source}
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 
 trait WorkerServiceFixture
@@ -83,6 +83,6 @@ trait WorkerServiceFixture
     }
   }
 
-  def createIndex(works: List[Work[Merged]]): Map[String, Json] =
+  def createIndex(works: List[Work[Source]]): Map[String, Json] =
     works.map(work => (work.id, work.asJson)).toMap
 }


### PR DESCRIPTION
Spotted trying to debug the failing works on the id minter. It has no effect on the id minter business logic, but it is wrong now that the id minter works on source works