### PR TITLE
Trim trailing spaces from mergeCandidates bnumber

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
@@ -6,5 +6,7 @@ case class SourceIdentifier(
   ontologyType: String,
   value: String
 ) {
+  assert(!value.endsWith(" "))
+
   override def toString = s"${identifierType.id}/$value"
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
@@ -6,7 +6,7 @@ case class SourceIdentifier(
   ontologyType: String,
   value: String
 ) {
-  assert(!value.endsWith(" "))
+  require(value == value.trim, s"SourceIdentifier value contains trailing whitespace: <$value>")
 
   override def toString = s"${identifierType.id}/$value"
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
@@ -6,7 +6,9 @@ case class SourceIdentifier(
   ontologyType: String,
   value: String
 ) {
-  require(value == value.trim, s"SourceIdentifier value contains whitespaces: <$value>")
+  require(
+    value == value.trim,
+    s"SourceIdentifier value contains whitespaces: <$value>")
 
   override def toString = s"${identifierType.id}/$value"
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/SourceIdentifier.scala
@@ -6,7 +6,7 @@ case class SourceIdentifier(
   ontologyType: String,
   value: String
 ) {
-  require(value == value.trim, s"SourceIdentifier value contains trailing whitespace: <$value>")
+  require(value == value.trim, s"SourceIdentifier value contains whitespaces: <$value>")
 
   override def toString = s"${identifierType.id}/$value"
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
@@ -15,7 +15,7 @@ class SourceIdentifierTest extends AnyFunSpec with Matchers {
   }
 
   it("fails creating a sourceIdentifier with a trailing space in the value"){
-    intercept[AssertionError]{
+    intercept[IllegalArgumentException]{
       SourceIdentifier(identifierType = IdentifierType("sierra-system-number"), value = "b1234567  ", ontologyType = "Work")
     }
   }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
@@ -14,9 +14,12 @@ class SourceIdentifierTest extends AnyFunSpec with Matchers {
     sourceIdentifier.toString shouldBe "miro-image-number/A0001234"
   }
 
-  it("fails creating a sourceIdentifier with extra spaces in the value"){
-    intercept[IllegalArgumentException]{
-      SourceIdentifier(identifierType = IdentifierType("sierra-system-number"), value = "b1234567  ", ontologyType = "Work")
+  it("fails creating a sourceIdentifier with extra spaces in the value") {
+    intercept[IllegalArgumentException] {
+      SourceIdentifier(
+        identifierType = IdentifierType("sierra-system-number"),
+        value = "b1234567  ",
+        ontologyType = "Work")
     }
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
@@ -13,4 +13,10 @@ class SourceIdentifierTest extends AnyFunSpec with Matchers {
 
     sourceIdentifier.toString shouldBe "miro-image-number/A0001234"
   }
+
+  it("fails creating a sourceIdentifier with a trailing space in the value"){
+    intercept[AssertionError]{
+      SourceIdentifier(identifierType = IdentifierType("sierra-system-number"), value = "b1234567  ", ontologyType = "Work")
+    }
+  }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/SourceIdentifierTest.scala
@@ -14,7 +14,7 @@ class SourceIdentifierTest extends AnyFunSpec with Matchers {
     sourceIdentifier.toString shouldBe "miro-image-number/A0001234"
   }
 
-  it("fails creating a sourceIdentifier with a trailing space in the value"){
+  it("fails creating a sourceIdentifier with extra spaces in the value"){
     intercept[IllegalArgumentException]{
       SourceIdentifier(identifierType = IdentifierType("sierra-system-number"), value = "b1234567  ", ontologyType = "Work")
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -54,7 +54,7 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
             identifier = SourceIdentifier(
               identifierType = IdentifierType("sierra-system-number"),
               ontologyType = "Work",
-              value = bibNumber
+              value = bibNumber.trim
             ),
             reason = "Physical/digitised Sierra work"
           )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -3,9 +3,21 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.internal.IdState.Identifiable
-import uk.ac.wellcome.models.work.internal.{IdentifierType, MergeCandidate, SourceIdentifier}
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraBibData, SierraMaterialType, VarField}
+import uk.ac.wellcome.models.work.internal.{
+  IdentifierType,
+  MergeCandidate,
+  SourceIdentifier
+}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraBibData,
+  SierraMaterialType,
+  VarField
+}
 
 class SierraMergeCandidatesTest
     extends AnyFunSpec
@@ -261,33 +273,38 @@ class SierraMergeCandidatesTest
 
   describe("Calm/Sierra harvest") {
 
-    it("adds a single Calm ID as a mergeCandidate"){
+    it("adds a single Calm ID as a mergeCandidate") {
       val calmId = randomUUID.toString
       val bibData = bibDataWith035(List(calmId))
 
-      SierraMergeCandidates(bibData) shouldBe List(createCalmMergeCandidate(calmId))
+      SierraMergeCandidates(bibData) shouldBe List(
+        createCalmMergeCandidate(calmId))
     }
-    it("adds multiple Calm IDs as mergeCandidates"){
+    it("adds multiple Calm IDs as mergeCandidates") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val bibData = bibDataWith035(calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
+      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+        createCalmMergeCandidate)
     }
-    it("dedupes Calm IDs and adds as mergeCandidates"){
+    it("dedupes Calm IDs and adds as mergeCandidates") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
 
       val bibData = bibDataWith035(calmIds ++ calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
+      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+        createCalmMergeCandidate)
     }
-    it("creates calm merge candidates if it has a mix of calm and non calm identifiers"){
+    it(
+      "creates calm merge candidates if it has a mix of calm and non calm identifiers") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds ++ calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
+      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+        createCalmMergeCandidate)
     }
-    it("doesn't create merge candidates if there are no calm ids"){
+    it("doesn't create merge candidates if there are no calm ids") {
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds)
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -280,7 +280,7 @@ class SierraMergeCandidatesTest
 
       SierraMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
     }
-    it("creates clam merge candidates if it has a mix of calm and non calm identifiers"){
+    it("creates calm merge candidates if it has a mix of calm and non calm identifiers"){
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds ++ calmIds)


### PR DESCRIPTION
Some record with a sierra digital merge candidate have a trailing space. This causes the "impossible" id minter bug where the id minter is able to retrieve the canonical id for that sourceIdentifier, but not match back to that sourceIdentifier and add it to the json