### PR TITLE
Don't check the snapshot status on a weekend

### DIFF
--- a/snapshots/terraform/.terraform.lock.hcl
+++ b/snapshots/terraform/.terraform.lock.hcl
@@ -1,0 +1,9 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "2.70.0"
+  hashes = [
+    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+  ]
+}

--- a/snapshots/terraform/provider.tf
+++ b/snapshots/terraform/provider.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  region  = "eu-west-1"
-  version = "~> 2.0"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
@@ -10,8 +9,7 @@ provider "aws" {
 provider "aws" {
   alias = "platform"
 
-  region  = "eu-west-1"
-  version = "~> 2.0"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/snapshots/terraform/stack/snapshot_reporter/cloudwatch.tf
+++ b/snapshots/terraform/stack/snapshot_reporter/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "snapshot_reporter_rule" {
   name                = "snapshot_reporter_rule-${var.deployment_service_env}"
   description         = "Starts the snapshot_reporter (${var.deployment_service_env}) lambda"
-  schedule_expression = "cron(0 6 * * ? *)"
+  schedule_expression = "cron(0 6 ? * MON-FRI *)"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_trigger" {


### PR DESCRIPTION
Nobody should be looking at it on the weekend; this reduces noise on Slack.

If snapshot generation does fail over the weekend, we'll find out on the Monday.