### PR TITLE
No-op refactoring and code tidies in the merger

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/MergeCandidate.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/MergeCandidate.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.models.work.internal.IdState.Identifiable
 
 /** Indicates that it might be possible to merge this Work with another Work.
   *
-  * @param identifier The SourceIdentifier of the other Work.
+  * @param id The SourceIdentifier of the other Work.
   * @param reason A statement of _why_ the we think it might be possible to
   *               to merge these two works.  For example, "MARC tag 776 points
   *               to electronic resource".

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/models/SourcesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/models/SourcesTest.scala
@@ -1,0 +1,89 @@
+package uk.ac.wellcome.platform.merger.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
+import uk.ac.wellcome.models.work.internal.{IdState, MergeCandidate}
+
+class SourcesTest extends AnyFunSpec with Matchers with SierraWorkGenerators {
+  describe("findFirstLinkedDigitisedSierraWorkFor") {
+    it("returns None if there are no source Works") {
+      val physicalWork = sierraPhysicalIdentifiedWork()
+
+      Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq.empty) shouldBe None
+    }
+
+    it("returns the first source work with a matching merge candidate") {
+      val digitisedWork1 = sierraDigitalIdentifiedWork()
+      val digitisedWork2 = sierraDigitalIdentifiedWork()
+
+      val physicalWork =
+        sierraPhysicalIdentifiedWork()
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = digitisedWork1.sourceIdentifier,
+                  canonicalId = digitisedWork1.state.canonicalId),
+                reason = Some("Physical/digitised Sierra work")
+              ),
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = digitisedWork2.sourceIdentifier,
+                  canonicalId = digitisedWork2.state.canonicalId),
+                reason = Some("Physical/digitised Sierra work")
+              )
+            )
+          )
+
+      val result =
+        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork1, digitisedWork2))
+
+      result shouldBe Some(digitisedWork1)
+    }
+
+    it("skips a MergeCandidate with the right ID but wrong reason") {
+      val digitisedWork = sierraDigitalIdentifiedWork()
+
+      val physicalWork =
+        sierraPhysicalIdentifiedWork()
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = digitisedWork.sourceIdentifier,
+                  canonicalId = digitisedWork.state.canonicalId),
+                reason = Some("Linked for a mystery reason")
+              )
+            )
+          )
+
+      val result =
+        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork))
+
+      result shouldBe None
+    }
+
+    it("skips a MergeCandidate with the right reason but the wrong ID") {
+      val digitisedWork = sierraDigitalIdentifiedWork()
+
+      val physicalWork =
+        sierraPhysicalIdentifiedWork()
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = createSierraIdentifierSourceIdentifier,
+                  canonicalId = createCanonicalId),
+                reason = Some("Physical/digitised Sierra work")
+              )
+            )
+          )
+
+      val result =
+        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork))
+
+      result shouldBe None
+    }
+  }
+}

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/models/SourcesTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/models/SourcesTest.scala
@@ -10,7 +10,9 @@ class SourcesTest extends AnyFunSpec with Matchers with SierraWorkGenerators {
     it("returns None if there are no source Works") {
       val physicalWork = sierraPhysicalIdentifiedWork()
 
-      Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq.empty) shouldBe None
+      Sources.findFirstLinkedDigitisedSierraWorkFor(
+        physicalWork,
+        sources = Seq.empty) shouldBe None
     }
 
     it("returns the first source work with a matching merge candidate") {
@@ -37,7 +39,9 @@ class SourcesTest extends AnyFunSpec with Matchers with SierraWorkGenerators {
           )
 
       val result =
-        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork1, digitisedWork2))
+        Sources.findFirstLinkedDigitisedSierraWorkFor(
+          physicalWork,
+          sources = Seq(digitisedWork1, digitisedWork2))
 
       result shouldBe Some(digitisedWork1)
     }
@@ -59,7 +63,9 @@ class SourcesTest extends AnyFunSpec with Matchers with SierraWorkGenerators {
           )
 
       val result =
-        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork))
+        Sources.findFirstLinkedDigitisedSierraWorkFor(
+          physicalWork,
+          sources = Seq(digitisedWork))
 
       result shouldBe None
     }
@@ -81,7 +87,9 @@ class SourcesTest extends AnyFunSpec with Matchers with SierraWorkGenerators {
           )
 
       val result =
-        Sources.findFirstLinkedDigitisedSierraWorkFor(physicalWork, sources = Seq(digitisedWork))
+        Sources.findFirstLinkedDigitisedSierraWorkFor(
+          physicalWork,
+          sources = Seq(digitisedWork))
 
       result shouldBe None
     }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -226,7 +226,7 @@ class PlatformMergerTest
   }
 
   it(
-    "merges a Sierra Sierra picture/digital image/3D object digital work with a Miro work") {
+    "merges a Sierra picture/digital image/3D object digital work with a Miro work") {
     val result = merger.merge(
       works = Seq(sierraDigitalWork, miroWork)
     )


### PR DESCRIPTION
Done as part of https://github.com/wellcomecollection/platform/issues/4876

This doesn't change the behaviour of the merger; it's just fixing two typos and adding some tests I wrote to help me understand some existing code.