### PR TITLE
Revert "Revert "Update API to point to 2021-01-04 index""

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "2020-11-25"
+  val indexDate = "2021-01-04"
 
   def apply(): ElasticConfig =
     ElasticConfig(


### PR DESCRIPTION
Reverts wellcomecollection/catalogue#1219

Round and round the revert roundabout we go!

This index doesn't work with the current model.