### PR TITLE
[WIP] Migrate Calm works to have the correct ontology type

### DIFF
--- a/pipeline/id_minter/src/main/resources/db/migration/V7__use_correct_ontology_type_for_calm_works.sql
+++ b/pipeline/id_minter/src/main/resources/db/migration/V7__use_correct_ontology_type_for_calm_works.sql
@@ -1,0 +1,3 @@
+USE ${database};
+
+UPDATE ${tableName} SET OntologyType="Work" WHERE SourceSystem="calm-record-id";

--- a/pipeline/id_minter/src/main/resources/db/migration/V7__use_correct_ontology_type_for_calm_works.sql
+++ b/pipeline/id_minter/src/main/resources/db/migration/V7__use_correct_ontology_type_for_calm_works.sql
@@ -1,3 +1,4 @@
 USE ${database};
 
+DELETE FROM ${tableName} WHERE OntologyType="Work" AND SourceSystem="calm-record-id";
 UPDATE ${tableName} SET OntologyType="Work" WHERE SourceSystem="calm-record-id";


### PR DESCRIPTION
- [x] Add a migration for updating the Calm works to have the `Work` ontology type.
- [ ] Test this against a dump of the data (will this query catch anything which shouldn't be a work?)
- [ ] Work out how migrations are run, and do anything else required to run it