### PR TITLE
Allow setting the global max_capacity on a pipeline

### DIFF
--- a/pipeline/terraform/.terraform.lock.hcl
+++ b/pipeline/terraform/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.70.0"
-  constraints = "~> 2.0"
+  version = "2.70.0"
   hashes = [
     "h1:6tf4jg37RrMHyVCql+fEgAFvX8JiqDognr+lk6rx7To=",
     "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
@@ -23,8 +22,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/template" {
-  version     = "2.2.0"
-  constraints = "~> 2.1"
+  version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
     "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -69,6 +69,9 @@ module "catalogue_pipeline_2021-01-04" {
   pipeline_date = "2021-01-04"
   release_label = "stage"
 
+  # This stack is paused while we work on fixing the ID minter database.
+  max_capacity = 0
+
   # Transformer config
   #
   # If this pipeline is meant to be reindexed, remember to uncomment the

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -53,10 +53,12 @@ module "id_minter" {
 
   // The total number of connections to RDS across all tasks from all ID minter
   // services must not exceed the maximum supported by the RDS instance.
-  max_capacity = floor(
-    local.id_minter_rds_max_connections / local.id_minter_task_max_connections
+  max_capacity = min(
+    floor(
+      local.id_minter_rds_max_connections / local.id_minter_task_max_connections
+    ),
+    var.max_capacity
   )
-
 
   subnets             = var.subnets
   messages_bucket_arn = aws_s3_bucket.messages.arn

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -119,7 +119,7 @@ module "image_inferrer" {
   subnets = var.subnets
 
   # Any higher than this currently causes latency spikes from Loris
-  max_capacity = 6
+  max_capacity = min(6, var.max_capacity)
 
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.image_inferrer_queue.read_policy

--- a/pipeline/terraform/stack/service_image_ingestor.tf
+++ b/pipeline/terraform/stack/service_image_ingestor.tf
@@ -41,7 +41,7 @@ module "ingestor_images" {
 
   subnets = var.subnets
 
-  max_capacity        = 5
+  max_capacity        = min(5, var.max_capacity)
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_images_queue.read_policy
 

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -58,7 +58,7 @@ module "matcher" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.matcher_input_queue.read_policy
 

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -40,7 +40,7 @@ module "merger" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.merger_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -41,7 +41,7 @@ module "calm_transformer" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
 
   queue_read_policy = module.calm_transformer_queue.read_policy

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -41,7 +41,7 @@ module "mets_transformer" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.mets_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -40,7 +40,7 @@ module "miro_transformer" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.miro_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -41,7 +41,7 @@ module "sierra_transformer" {
   }
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = var.max_capacity
   messages_bucket_arn = aws_s3_bucket.messages.arn
 
   queue_read_policy = module.sierra_transformer_queue.read_policy

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -36,7 +36,7 @@ module "batcher" {
   shared_logging_secrets = var.shared_logging_secrets
 
   subnets             = var.subnets
-  max_capacity        = 1
+  max_capacity        = min(1, var.max_capacity)
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.batcher_queue.read_policy
 

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -46,7 +46,7 @@ module "ingestor_works" {
 
   subnets = var.subnets
 
-  max_capacity        = 6
+  max_capacity        = min(6, var.max_capacity)
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.ingestor_works_queue.read_policy
 

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -44,8 +44,10 @@ module "relation_embedder" {
     es_password = "catalogue/pipeline_storage/relation_embedder/es_password"
   }
 
+  # NOTE: limit to avoid >500 concurrent scroll contexts
+  max_capacity        = min(10, var.max_capacity)
+
   subnets             = var.subnets
-  max_capacity        = 10 // NOTE: limit to avoid >500 concurrent scroll contexts
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.relation_embedder_queue.read_policy
 

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -45,7 +45,7 @@ module "relation_embedder" {
   }
 
   # NOTE: limit to avoid >500 concurrent scroll contexts
-  max_capacity        = min(10, var.max_capacity)
+  max_capacity = min(10, var.max_capacity)
 
   subnets             = var.subnets
   messages_bucket_arn = aws_s3_bucket.messages.arn

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -45,7 +45,7 @@ module "router" {
   shared_logging_secrets = var.shared_logging_secrets
 
   subnets             = var.subnets
-  max_capacity        = 10
+  max_capacity        = min(10, var.max_capacity)
   messages_bucket_arn = aws_s3_bucket.messages.arn
   queue_read_policy   = module.router_queue.read_policy
 

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -2,6 +2,12 @@ variable "pipeline_date" {
   type = string
 }
 
+variable "max_capacity" {
+  type        = number
+  default     = 10
+  description = "The max capacity of every ECS service will be less than or equal to this value"
+}
+
 variable "subnets" {
   type = list(string)
 }

--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -1,15 +1,12 @@
 provider "aws" {
-  region  = "eu-west-1"
-  version = "~> 2.0"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"
   }
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
+provider "template" {}
 
 terraform {
   backend "s3" {

--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -4,6 +4,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"
   }
+
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "template" {}


### PR DESCRIPTION
This patch fixes a few Terraform 0.14 warnings, plus:

There's a new `max_capacity` variable on the "stack" module. If you set this, the max capacity of every service will be at most whatever you set this variable to be. If you set this, the max capacity of every service will be *at most* whatever you set this variable to be.

It's not *exactly* this value -- some services can only run at a certain parallelism, and we don't want to exceed that.  e.g. the image inferrer can only go so fast before it overwhelms Loris.  For those services, we use the min of (service max, global max).

The primary use case for this is allowing us to set max_capacity = 0, allowing us to "pause" a pipeline. The pipeline will stop processing messages, but they'll still be on the queues, so when we unpause it will immediately work through the backlog. I want this today so that Nick and I can work on the ID minter database without it changing under our feet.

This PR is mergeable as-is; I'll do a separate PR to temporarily change this value to 0.