### PR TITLE
Pause the 2021-01-04 pipeline

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -69,6 +69,9 @@ module "catalogue_pipeline_2021-01-04" {
   pipeline_date = "2021-01-04"
   release_label = "stage"
 
+  # This stack is paused while we work on fixing the ID minter database.
+  max_capacity = 0
+
   # Transformer config
   #
   # If this pipeline is meant to be reindexed, remember to uncomment the


### PR DESCRIPTION
Follows #1226. This change is applied; it means nothing should be writing new IDs to the ID minter right now.