### PR TITLE
Store WorkData on deleted works

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -30,8 +30,8 @@ sealed trait Work[State <: WorkState] {
         Work.Visible(version, outData, outState)
       case Work.Invisible(version, _, _, invisibilityReasons) =>
         Work.Invisible(version, outData, outState, invisibilityReasons)
-      case Work.Deleted(version, _, deletedReasons) =>
-        Work.Deleted(version, outState, deletedReasons)
+      case Work.Deleted(version, _, _, deletedReasons) =>
+        Work.Deleted(version, outData, outState, deletedReasons)
       case Work.Redirected(version, redirect, _) =>
         Work.Redirected(version, transition.redirect(redirect), outState)
     }
@@ -63,11 +63,10 @@ object Work {
 
   case class Deleted[State <: WorkState](
     version: Int,
+    data: WorkData[State#WorkDataState],
     state: State,
     deletedReason: Option[DeletedReason] = None,
-  ) extends Work[State] {
-    val data = WorkData[State#WorkDataState]()
-  }
+  ) extends Work[State]
 }
 
 /** WorkData contains data common to all types of works that can exist at any

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -120,6 +120,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       deletedReason: Option[DeletedReason] = None): Work.Deleted[State] =
       Work.Deleted[State](
         state = work.state,
+        data = work.data,
         version = work.version,
         deletedReason = deletedReason
       )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -141,8 +141,8 @@ object Merger {
           Work.Invisible(version, f(data), state, reasons)
         case Work.Redirected(version, redirect, state) =>
           Work.Redirected(version, redirect, state)
-        case Work.Deleted(version, state, reason) =>
-          Work.Deleted(version, state, reason)
+        case Work.Deleted(version, data, state, reason) =>
+          Work.Deleted(version, f(data), state, reason)
       }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRuleTest.scala
@@ -28,9 +28,6 @@ class OtherIdentifiersRuleTest
       metsIdentifiedWork().invisible()
     }.toList
 
-  val metsDeletedWork: Work.Deleted[WorkState.Identified] =
-    metsIdentifiedWork().deleted()
-
   val physicalSierraWork: Work.Visible[WorkState.Identified] =
     sierraPhysicalIdentifiedWork().format(Format.Pictures)
 
@@ -72,7 +69,7 @@ class OtherIdentifiersRuleTest
       OtherIdentifiersRule
         .merge(
           calmWork,
-          physicalSierraWork :: nothingWork :: miroWork :: metsDeletedWork :: metsWorks)) {
+          physicalSierraWork :: nothingWork :: miroWork :: metsWorks)) {
       case FieldMergeResult(otherIdentifiers, mergedSources) =>
         otherIdentifiers should contain theSameElementsAs
           List(physicalSierraWork.sourceIdentifier, miroWork.sourceIdentifier) ++

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -41,6 +41,7 @@ object CalmTransformer
       Right(
         Work.Deleted[Source](
           state = Source(sourceIdentifier(record), record.retrievedAt),
+          data = workData(record).getOrElse(WorkData[DataState.Unidentified]()),
           version = version,
           deletedReason = Some(SuppressedFromSource("Calm"))
         )

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -515,6 +515,32 @@ class CalmTransformerTest
     )
     CalmTransformer(record, version) shouldBe Right(
       Work.Deleted[Source](
+          data = WorkData[DataState.Unidentified](
+          title = Some("Should suppress"),
+          format = Some(Format.ArchivesAndManuscripts),
+          collectionPath = Some(
+            CollectionPath(path = "AMSG/X/Y")
+          ),
+          otherIdentifiers = List(
+            SourceIdentifier(
+              value = "AMSG/X/Y",
+              identifierType = CalmIdentifierTypes.refNo,
+              ontologyType = "Work"),
+          ),
+          items = List(
+            Item(
+              title = None,
+              locations = List(
+                PhysicalLocationDeprecated(
+                  locationType = LocationType("scmac"),
+                  label = "Closed stores Arch. & MSS",
+                  accessConditions = Nil
+                )
+              )
+            )
+          ),
+          workType = WorkType.Section
+        ),
         state = Source(
           SourceIdentifier(
             value = record.id,

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -515,7 +515,7 @@ class CalmTransformerTest
     )
     CalmTransformer(record, version) shouldBe Right(
       Work.Deleted[Source](
-          data = WorkData[DataState.Unidentified](
+        data = WorkData[DataState.Unidentified](
           title = Some("Should suppress"),
           format = Some(Format.ArchivesAndManuscripts),
           collectionPath = Some(

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -26,6 +26,7 @@ case class MetsData(
         Right(
           Work.Deleted[Source](
             version = version,
+            data = WorkData[DataState.Unidentified](),
             state = Source(sourceIdentifier, modifiedTime),
             deletedReason = Some(DeletedFromSource("Mets"))))
       case false =>

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -70,6 +70,7 @@ class MetsDataTest
     metsData.toWork(version, createdDate).right.get shouldBe Work
       .Deleted[Source](
         version = version,
+        data = WorkData[DataState.Unidentified](),
         state = Source(expectedSourceIdentifier, createdDate),
         deletedReason = Some(DeletedFromSource("Mets"))
       )


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4952

## Description

This is required so deleted works get routed to the batcher, and thus related works correctly remove it from their relations.