### PR TITLE
Strip whitespace from ISBN identifiers in Sierra records

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -51,7 +51,7 @@ object SierraIdentifiers
         SourceIdentifier(
           identifierType = IdentifierType("isbn"),
           ontologyType = "Work",
-          value = value
+          value = value.trim
         )
       }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -86,6 +86,26 @@ class SierraIdentifiersTest
       }
       isbnIdentifiers should have size 1
     }
+
+    it("strips whitespace") {
+      // Based on https://api.wellcomecollection.org/catalogue/v2/works/mhvnscj7?include=identifiers
+      val isbn = "978-1479144075"
+
+      val expectedIdentifier = SourceIdentifier(
+        identifierType = IdentifierType("isbn"),
+        ontologyType = "Work",
+        value = isbn
+      )
+
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          createVarFieldWith(marcTag = "020", subfieldA = s" $isbn")
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(expectedIdentifier)
+    }
   }
 
   describe("finds ISSN identifiers from MARC 022 ǂa") {


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4954

Although we somehow have some ID minter records for these IDs which are sometimes appearing in the logs (see https://github.com/wellcomecollection/platform/issues/4955), I'm pretty sure the canonical ID associated with an ISBN Work SourceIdentifier has never been surfaced publicly, so it's not a big issue if it changes.