### PR TITLE
Log the sourceIdentifiers we were matching if an ID minter lookup fails

### DIFF
--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDao.scala
@@ -73,7 +73,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       case None =>
                         // this should be impossible in practice
                         throw new RuntimeException(
-                          s"The row $row returned by the query could not be matched to a sourceIdentifier")
+                          s"The row returned by the query ($row) could not be matched to a sourceIdentifier in $sourceIdentifiers")
                     }
 
                   })


### PR DESCRIPTION
We're hitting this apparently impossible situation here in the METS adapter. The sourceIdentifiers are logged, but only at debug level – so in normal running, it's too late to go back and get it. (And debug logging is incredibly noisy.)

Given how useful it would be to use here, let's include it in this error message.

Part of https://github.com/wellcomecollection/platform/issues/4948