### PR TITLE
Lowercase b numbers in the METS transformer

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -58,7 +58,12 @@ case class MetsData(
     identifier = SourceIdentifier(
       identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
-      value = recordIdentifier
+
+      // We lowercase the b number in the METS file so it matches the
+      // case used by Sierra.
+      // e.g. b20442233 has the identifier "B20442233" in the METS file,
+      //
+      value = recordIdentifier.toLowerCase
     ),
     reason = "METS work"
   )
@@ -115,9 +120,15 @@ case class MetsData(
 
   private def sourceIdentifier =
     SourceIdentifier(
-      IdentifierType("mets"),
+      identifierType = IdentifierType("mets"),
       ontologyType = "Work",
-      value = recordIdentifier)
+
+      // We lowercase the b number in the METS file so it matches the
+      // case used by Sierra.
+      // e.g. b20442233 has the identifier "B20442233" in the METS file,
+      //
+      value = recordIdentifier.toLowerCase
+    )
 
   private def titlePageFileReference: Option[FileReference] =
     titlePageId

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -58,7 +58,6 @@ case class MetsData(
     identifier = SourceIdentifier(
       identifierType = IdentifierType("sierra-system-number"),
       ontologyType = "Work",
-
       // We lowercase the b number in the METS file so it matches the
       // case used by Sierra.
       // e.g. b20442233 has the identifier "B20442233" in the METS file,
@@ -122,7 +121,6 @@ case class MetsData(
     SourceIdentifier(
       identifierType = IdentifierType("mets"),
       ontologyType = "Work",
-
       // We lowercase the b number in the METS file so it matches the
       // case used by Sierra.
       // e.g. b20442233 has the identifier "B20442233" in the METS file,

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/fixtures/MetsGenerators.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/fixtures/MetsGenerators.scala
@@ -1,10 +1,14 @@
 package uk.ac.wellcome.platform.transformer.mets.fixtures
 
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.models.work.internal.License
 
 import scala.xml.NodeSeq
 
-trait MetsGenerators {
+trait MetsGenerators extends RandomGenerators {
+  def createBibNumber: String =
+    s"b%08d.test".format(randomInt(from = 1, to = 99999999))
+
   def metsXmlWith(recordIdentifier: String,
                   license: Option[License] = None,
                   accessConditionStatus: Option[String] = None,

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/services/MetsTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/services/MetsTransformerWorkerTest.scala
@@ -42,7 +42,7 @@ class MetsTransformerWorkerTest
   override def createPayload(
     implicit store: MemoryTypedStore[S3ObjectLocation, String])
     : MetsSourcePayload = {
-    val bibId = randomAlphanumeric()
+    val bibId = createBibNumber
 
     val metsXML = metsXmlWith(
       recordIdentifier = bibId,

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -473,7 +473,7 @@ class MetsDataTest
       value = "b1234"
     )
 
-    val mergeCandidates = work.asInstanceOf[Work[Source]].data.mergeCandidates
+    val mergeCandidates = work.data.mergeCandidates
     mergeCandidates should have size 1
 
     mergeCandidates.head.id.sourceIdentifier shouldBe

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -19,7 +19,9 @@ class MetsDataTest
   it("creates a invisible work with an item and a license") {
     val bibNumber = createBibNumber
     val metsData =
-      MetsData(recordIdentifier = bibNumber, accessConditionDz = Some("CC-BY-NC"))
+      MetsData(
+        recordIdentifier = bibNumber,
+        accessConditionDz = Some("CC-BY-NC"))
     val version = 1
     val expectedSourceIdentifier = SourceIdentifier(
       IdentifierType("mets", "METS"),


### PR DESCRIPTION
The Sierra source exclusively returns lowercase identifiers (e.g. b1234). The METS source currently returns identifiers as mixed case (e.g. B1234).

This causes an issue for matching and ID minting, because pipeline identifiers are case sensitive:

*   These two works won't be recognised as the same and matched/merged
*   When the ID minter tries to find existing ID for "B1234", it does a case insensitive database search.  It finds the existing ID for "b1234", and gets confused because that's not what it asked for.

Because we know METS identifiers are always b numbers, let's lowercase them to match Sierra.

This is affecting three METS works. All three of them are invisible in the current prod API. The canonical ID of these works will change, but because the old ID was never publicly visible I don't think that's an issue.

* B20442178 / xsfkn7tk
* B20442506 / q9u4bnvx
* B20442233 / r5uw7g74

Part of https://github.com/wellcomecollection/platform/issues/4948