### PR TITLE
Use pipeline storage for images

### DIFF
--- a/.sbt_metadata/inference_manager.json
+++ b/.sbt_metadata/inference_manager.json
@@ -3,6 +3,6 @@
   "folder" : "pipeline/inferrer/inference_manager",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe"
+    "pipeline_storage_typesafe"
   ]
 }

--- a/.sbt_metadata/ingestor_common.json
+++ b/.sbt_metadata/ingestor_common.json
@@ -3,7 +3,6 @@
   "folder" : "pipeline/ingestor/ingestor_common",
   "dependencyIds" : [
     "elasticsearch_typesafe",
-    "big_messaging_typesafe",
     "pipeline_storage_typesafe"
   ]
 }

--- a/.sbt_metadata/ingestor_images.json
+++ b/.sbt_metadata/ingestor_images.json
@@ -2,8 +2,6 @@
   "id" : "ingestor_images",
   "folder" : "pipeline/ingestor/ingestor_images",
   "dependencyIds" : [
-    "elasticsearch_typesafe",
-    "big_messaging_typesafe",
     "ingestor_common"
   ]
 }

--- a/.sbt_metadata/ingestor_works.json
+++ b/.sbt_metadata/ingestor_works.json
@@ -2,8 +2,6 @@
   "id" : "ingestor_works",
   "folder" : "pipeline/ingestor/ingestor_works",
   "dependencyIds" : [
-    "elasticsearch_typesafe",
-    "big_messaging_typesafe",
     "ingestor_common"
   ]
 }

--- a/.sbt_metadata/merger.json
+++ b/.sbt_metadata/merger.json
@@ -3,7 +3,6 @@
   "folder" : "pipeline/merger",
   "dependencyIds" : [
     "internal_model",
-    "big_messaging_typesafe",
     "pipeline_storage_typesafe"
   ]
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFiltersTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.images
 
 import uk.ac.wellcome.models.work.internal.License
+import uk.ac.wellcome.models.Implicits._
 
 class ImagesFiltersTest extends ApiImagesTestBase {
   describe("filtering images by license") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesIncludesTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.api.images
 
 import uk.ac.wellcome.models.work.generators.ContributorGenerators
 import uk.ac.wellcome.models.work.internal.Language
+import uk.ac.wellcome.models.Implicits._
 
 class ImagesIncludesTest extends ApiImagesTestBase with ContributorGenerators {
   describe("images includes") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesSimilarityTest.scala
@@ -1,4 +1,5 @@
 package uk.ac.wellcome.platform.api.images
+import uk.ac.wellcome.models.Implicits._
 
 class ImagesSimilarityTest extends ApiImagesTestBase {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.images
 
 import uk.ac.wellcome.models.work.generators.SierraWorkGenerators
+import uk.ac.wellcome.models.Implicits._
 
 class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/QueryConfigTest.scala
@@ -1,13 +1,14 @@
 package uk.ac.wellcome.platform.api.models
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import com.sksamuel.elastic4s.Index
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
 import uk.ac.wellcome.elasticsearch.ElasticClientBuilder
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.ImageGenerators
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.models.Implicits._
 
 class QueryConfigTest
     extends AnyFunSpec

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/ImagesServiceTest.scala
@@ -1,14 +1,15 @@
 package uk.ac.wellcome.platform.api.services
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import com.sksamuel.elastic4s.{ElasticError, Index}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{EitherValues, OptionValues}
+
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.platform.api.models.{QueryConfig, SimilarityMetric}
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.models.Implicits._
 
 class ImagesServiceTest
     extends AnyFunSpec

--- a/build.sbt
+++ b/build.sbt
@@ -110,22 +110,19 @@ lazy val id_minter = setupProject(
 lazy val ingestor_common = setupProject(
   project,
   "pipeline/ingestor/ingestor_common",
-  localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, pipeline_storage_typesafe)
+  localDependencies = Seq(elasticsearch_typesafe, pipeline_storage_typesafe)
 )
 
 lazy val ingestor_works = setupProject(
   project,
   "pipeline/ingestor/ingestor_works",
-  localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common)
+  localDependencies = Seq(ingestor_common)
 )
 
 lazy val ingestor_images = setupProject(
   project,
   "pipeline/ingestor/ingestor_images",
-  localDependencies =
-    Seq(elasticsearch_typesafe, big_messaging_typesafe, ingestor_common)
+  localDependencies = Seq(ingestor_common)
 )
 
 lazy val matcher = setupProject(

--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,7 @@ lazy val calm_adapter = setupProject(
 lazy val inference_manager = setupProject(
   project,
   folder = "pipeline/inferrer/inference_manager",
-  localDependencies = Seq(internal_model, big_messaging_typesafe),
+  localDependencies = Seq(internal_model, pipeline_storage_typesafe),
   externalDependencies = CatalogueDependencies.inferenceManagerDependencies
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,7 @@ lazy val merger = setupProject(
   project,
   "pipeline/merger",
   localDependencies =
-    Seq(internal_model, big_messaging_typesafe, pipeline_storage_typesafe),
+    Seq(internal_model, pipeline_storage_typesafe),
   externalDependencies = CatalogueDependencies.mergerDependencies
 )
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -5,6 +5,13 @@ import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 
+object InitialImageIndexConfig extends IndexConfig {
+
+  val analysis: Analysis = WorksAnalysis()
+
+  def mapping: MappingDefinition = properties(Seq())
+}
+
 object AugmentedImageIndexConfig extends IndexConfig {
 
   val analysis: Analysis = WorksAnalysis()
@@ -12,7 +19,7 @@ object AugmentedImageIndexConfig extends IndexConfig {
   def mapping: MappingDefinition = properties(Seq())
 }
 
-object ImagesIndexConfig extends IndexConfig with IndexConfigFields {
+object IndexedImageIndexConfig extends IndexConfig with IndexConfigFields {
 
   val analysis: Analysis = WorksAnalysis()
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ImagesIndexConfig.scala
@@ -5,6 +5,13 @@ import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 
+object AugmentedImageIndexConfig extends IndexConfig {
+
+  val analysis: Analysis = WorksAnalysis()
+
+  def mapping: MappingDefinition = properties(Seq())
+}
+
 object ImagesIndexConfig extends IndexConfig with IndexConfigFields {
 
   val analysis: Analysis = WorksAnalysis()

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -101,8 +101,19 @@ trait ElasticsearchFixtures
         testWith(index)
     }
 
+  def withLocalInitialImagesIndex[R](testWith: TestWith[Index, R]): R =
+    withLocalElasticsearchIndex[R](config = InitialImageIndexConfig) { index =>
+      testWith(index)
+    }
+
+  def withLocalAugmentedImageIndex[R](testWith: TestWith[Index, R]): R =
+    withLocalElasticsearchIndex[R](config = AugmentedImageIndexConfig) {
+      index =>
+        testWith(index)
+    }
+
   def withLocalImagesIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](config = ImagesIndexConfig) { index =>
+    withLocalElasticsearchIndex[R](config = IndexedImageIndexConfig) { index =>
       testWith(index)
     }
 

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -300,9 +300,9 @@ trait ElasticsearchFixtures
     }
   }
 
-  def insertImagesIntoElasticsearch[State <: ImageState](
-    index: Index,
-    images: Image[State]*)(implicit encoder: Encoder[Image[State]]): Assertion = {
+  def insertImagesIntoElasticsearch[State <: ImageState](index: Index,
+                                                         images: Image[State]*)(
+    implicit encoder: Encoder[Image[State]]): Assertion = {
     val result = elasticClient.execute(
       bulk(
         images.map { image =>

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -24,7 +24,6 @@ import uk.ac.wellcome.fixtures._
 import uk.ac.wellcome.json.JsonUtil.{fromJson, toJson}
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.models.Implicits._
 import WorkState.Identified
 
 trait ElasticsearchFixtures
@@ -164,7 +163,7 @@ trait ElasticsearchFixtures
     index: Index,
     works: Work[State]*)(implicit enc: Encoder[Work[State]]): Seq[Assertion] = {
     implicit val id: CanonicalId[Work[State]] =
-      (work: Work[State]) => work.state.id
+      (work: Work[State]) => work.id
     assertElasticsearchEventuallyHas(index, works: _*)
   }
 
@@ -173,7 +172,7 @@ trait ElasticsearchFixtures
     images: Image[State]*)(
     implicit enc: Encoder[Image[State]]): Seq[Assertion] = {
     implicit val id: CanonicalId[Image[State]] =
-      (image: Image[State]) => image.state.id
+      (image: Image[State]) => image.id
     assertElasticsearchEventuallyHas(index, images: _*)
   }
 
@@ -301,9 +300,9 @@ trait ElasticsearchFixtures
     }
   }
 
-  def insertImagesIntoElasticsearch(
+  def insertImagesIntoElasticsearch[State <: ImageState](
     index: Index,
-    images: Image[ImageState.Indexed]*): Assertion = {
+    images: Image[State]*)(implicit encoder: Encoder[Image[State]]): Assertion = {
     val result = elasticClient.execute(
       bulk(
         images.map { image =>

--- a/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
+++ b/common/elasticsearch/src/test/scala/uk/ac/wellcome/elasticsearch/test/fixtures/ElasticsearchFixtures.scala
@@ -18,6 +18,7 @@ import com.sksamuel.elastic4s.{Index, Response}
 import grizzled.slf4j.Logging
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.parser.parse
+
 import uk.ac.wellcome.elasticsearch._
 import uk.ac.wellcome.elasticsearch.model.CanonicalId
 import uk.ac.wellcome.fixtures._

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ImageGenerators.scala
@@ -12,6 +12,7 @@ trait ImageGenerators
     with InstantGenerators
     with VectorGenerators
     with SierraWorkGenerators {
+
   def createImageDataWith(
     locations: List[DigitalLocationDeprecated] = List(createImageLocation),
     version: Int = 1,
@@ -185,9 +186,9 @@ trait ImageGenerators
           locationType = createImageLocationType))
     ).toIndexedImage
 
-//   Create a set of images with intersecting LSH lists to ensure
-//   that similarity queries will return something. Returns them in order
-//   of similarity.
+  //   Create a set of images with intersecting LSH lists to ensure
+  //   that similarity queries will return something. Returns them in order
+  //   of similarity.
   def createSimilarImages(n: Int,
                           similarFeatures: Boolean,
                           similarPalette: Boolean): Seq[Image[Indexed]] = {

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
@@ -12,19 +12,21 @@ class EitherIndexer[L: Indexable, R: Indexable](
   def init(): Future[Unit] =
     leftIndexer.init().flatMap(_ => rightIndexer.init())
 
-  def apply(documents: Seq[Either[L, R]]): Future[Either[Seq[Either[L, R]], Seq[Either[L, R]]]] = {
-    val leftDocs = documents.collect { case Left(doc) => doc }
+  def apply(documents: Seq[Either[L, R]])
+    : Future[Either[Seq[Either[L, R]], Seq[Either[L, R]]]] = {
+    val leftDocs = documents.collect { case Left(doc)   => doc }
     val rightDocs = documents.collect { case Right(doc) => doc }
     for {
       leftResult <- leftIndexer(leftDocs)
       rightResult <- rightIndexer(rightDocs)
-    } yield (leftResult, rightResult) match {
-      case (Right(leftDocs), Right(rightDocs)) =>
-        Right(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
-      case (Left(leftDocs), Left(rightDocs)) =>
-        Left(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
-      case (Left(leftDocs), Right(_)) => Left(leftDocs.map(Left(_)))
-      case (Right(_), Left(rightDocs)) => Left(rightDocs.map(Right(_)))
-    }
+    } yield
+      (leftResult, rightResult) match {
+        case (Right(leftDocs), Right(rightDocs)) =>
+          Right(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
+        case (Left(leftDocs), Left(rightDocs)) =>
+          Left(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
+        case (Left(leftDocs), Right(_))  => Left(leftDocs.map(Left(_)))
+        case (Right(_), Left(rightDocs)) => Left(rightDocs.map(Right(_)))
+      }
   }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.pipeline_storage
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** An indexer for either values which defers to one of two internal indexers
+  *  dependning on whether a Left or Right is received. */
+class EitherIndexer[L: Indexable, R: Indexable](
+  leftIndexer: Indexer[L],
+  rightIndexer: Indexer[R])(implicit ec: ExecutionContext)
+    extends Indexer[Either[L, R]] {
+
+  def init(): Future[Unit] =
+    leftIndexer.init().flatMap(_ => rightIndexer.init())
+
+  def apply(documents: Seq[Either[L, R]]): Future[Either[Seq[Either[L, R]], Seq[Either[L, R]]]] = {
+    val leftDocs = documents.collect { case Left(doc) => doc }
+    val rightDocs = documents.collect { case Right(doc) => doc }
+    for {
+      leftResult <- leftIndexer(leftDocs)
+      rightResult <- rightIndexer(rightDocs)
+    } yield (leftResult, rightResult) match {
+      case (Right(leftDocs), Right(rightDocs)) =>
+        Right(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
+      case (Left(leftDocs), Left(rightDocs)) =>
+        Left(leftDocs.map(Left(_)) ++ rightDocs.map(Right(_)))
+      case (Left(leftDocs), Right(_)) => Left(leftDocs.map(Left(_)))
+      case (Right(_), Left(rightDocs)) => Left(rightDocs.map(Right(_)))
+    }
+  }
+}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/EitherIndexer.scala
@@ -32,7 +32,7 @@ class EitherIndexer[L: Indexable, R: Indexable](
 
   def index[T](indexer: Indexer[T], docs: Seq[T]): Future[Result[T]] =
     docs match {
-      case Nil => Future.successful(Right(Nil))
+      case Nil  => Future.successful(Right(Nil))
       case docs => indexer(docs)
     }
 
@@ -42,15 +42,16 @@ class EitherIndexer[L: Indexable, R: Indexable](
   def errors[T](result: Result[T]): Seq[T] =
     result match {
       case Left(errors) => errors
-      case Right(_) => Nil
+      case Right(_)     => Nil
     }
 
-  def successes(leftResult: Result[L], rightResult: Result[R]): Seq[Either[L, R]] =
+  def successes(leftResult: Result[L],
+                rightResult: Result[R]): Seq[Either[L, R]] =
     successes(leftResult).map(Left(_)) ++ successes(rightResult).map(Right(_))
 
   def successes[T](result: Result[T]): Seq[T] =
     result match {
-      case Left(_) => Nil
+      case Left(_)          => Nil
       case Right(successes) => successes
     }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -60,17 +60,18 @@ object Indexable extends Logging {
         )
     }
 
-  implicit def eitherIndexable[L: Indexable, R: Indexable]: Indexable[Either[L, R]] =
+  implicit def eitherIndexable[L: Indexable, R: Indexable]
+    : Indexable[Either[L, R]] =
     new Indexable[Either[L, R]] {
       def id(either: Either[L, R]): String =
         either match {
-          case Left(left) => implicitly[Indexable[L]].id(left)
+          case Left(left)   => implicitly[Indexable[L]].id(left)
           case Right(right) => implicitly[Indexable[R]].id(right)
         }
 
       def version(either: Either[L, R]) =
         either match {
-          case Left(left) => implicitly[Indexable[L]].version(left)
+          case Left(left)   => implicitly[Indexable[L]].version(left)
           case Right(right) => implicitly[Indexable[R]].version(right)
         }
     }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/Indexer.scala
@@ -59,4 +59,19 @@ object Indexable extends Logging {
           1.0 + (work.state.relations.size / 20.0)
         )
     }
+
+  implicit def eitherIndexable[L: Indexable, R: Indexable]: Indexable[Either[L, R]] =
+    new Indexable[Either[L, R]] {
+      def id(either: Either[L, R]): String =
+        either match {
+          case Left(left) => implicitly[Indexable[L]].id(left)
+          case Right(right) => implicitly[Indexable[R]].id(right)
+        }
+
+      def version(either: Either[L, R]) =
+        either match {
+          case Left(left) => implicitly[Indexable[L]].version(left)
+          case Right(right) => implicitly[Indexable[R]].version(right)
+        }
+    }
 }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.pipeline_storage
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -1,16 +1,16 @@
 package uk.ac.wellcome.pipeline_storage
 
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge}
 import akka.{Done, NotUsed}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
+
 import software.amazon.awssdk.services.sqs.model.Message
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sqs.SQSStream
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 
 case class PipelineStorageConfig(batchSize: Int,
                                  flushInterval: FiniteDuration,

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -47,7 +47,7 @@ class PipelineStorageStream[In, Out, MsgDestination](
             .via(
               broadcastAndMerge(
                 batchIndexAndSendFlow(
-                  config, 
+                  config,
                   (item: Out) => messageSender.send(indexable.id(item)),
                   indexer
                 ),
@@ -61,13 +61,13 @@ object PipelineStorageStream extends Logging {
 
   def processFlow[In, Out](
     config: PipelineStorageConfig,
-    process: In => Future[List[Out]])(
-    implicit ec: ExecutionContext): Flow[(Message, In), (Message, List[Out]), NotUsed] =
-      Flow[(Message, In)].mapAsyncUnordered(parallelism = config.parallelism) {
-        case (message, in) =>
-          debug(s"Processing message ${message.messageId()}")
-          process(in).map(w => (message, w))
-      }
+    process: In => Future[List[Out]])(implicit ec: ExecutionContext)
+    : Flow[(Message, In), (Message, List[Out]), NotUsed] =
+    Flow[(Message, In)].mapAsyncUnordered(parallelism = config.parallelism) {
+      case (message, in) =>
+        debug(s"Processing message ${message.messageId()}")
+        process(in).map(w => (message, w))
+    }
 
   def batchRetrieveFlow[T](config: PipelineStorageConfig,
                            retriever: Retriever[T])(
@@ -117,12 +117,12 @@ object PipelineStorageStream extends Logging {
       }
       .mapConcat(identity)
 
-  def batchIndexAndSendFlow[T, MsgDestination](
-    config: PipelineStorageConfig,
-    send: T => Try[Unit],
-    indexer: Indexer[T])(implicit
-                         ec: ExecutionContext,
-                         indexable: Indexable[T]) = {
+  def batchIndexAndSendFlow[T, MsgDestination](config: PipelineStorageConfig,
+                                               send: T => Try[Unit],
+                                               indexer: Indexer[T])(
+    implicit
+    ec: ExecutionContext,
+    indexable: Indexable[T]) = {
     val maxSubStreams = Integer.MAX_VALUE
     Flow[(Message, List[T])]
       .collect {
@@ -185,9 +185,8 @@ object PipelineStorageStream extends Logging {
     Flow[(Message, List[Out])]
       .collect { case (message, Nil) => message }
 
-  def broadcastAndMerge[I, O](
-    a: Flow[I, O, NotUsed],
-    b: Flow[I, O, NotUsed]): Flow[I, O, NotUsed] =
+  def broadcastAndMerge[I, O](a: Flow[I, O, NotUsed],
+                              b: Flow[I, O, NotUsed]): Flow[I, O, NotUsed] =
     Flow.fromGraph(
       GraphDSL.create() { implicit builder =>
         import GraphDSL.Implicits._

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/PipelineStorageStream.scala
@@ -53,7 +53,7 @@ class PipelineStorageStream[In, Out, MsgDestination](
             .via(processFlow)
             .via(
               broadcastAndMerge(
-                batchAndSendFlow(config, messageSender, indexer),
+                batchIndexAndSendFlow(config, messageSender, indexer),
                 identityFlow)
           )
       )
@@ -128,7 +128,7 @@ object PipelineStorageStream extends Logging {
       }
       .mapConcat(identity)
 
-  def batchAndSendFlow[T, MsgDestination](
+  def batchIndexAndSendFlow[T, MsgDestination](
     config: PipelineStorageConfig,
     msgSender: MessageSender[MsgDestination],
     indexer: Indexer[T])(implicit

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/EitherIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/EitherIndexerTest.scala
@@ -4,19 +4,29 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import uk.ac.wellcome.models.work.generators.{WorkGenerators, ImageGenerators}
+import uk.ac.wellcome.models.work.generators.{ImageGenerators, WorkGenerators}
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
-import uk.ac.wellcome.elasticsearch.{MergedWorkIndexConfig, InitialImageIndexConfig}
+import uk.ac.wellcome.elasticsearch.{
+  InitialImageIndexConfig,
+  MergedWorkIndexConfig
+}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.elasticsearch.model.CanonicalId
 import WorkState.Merged
-import ImageState.Initial 
+import ImageState.Initial
 
-class EitherIndexerTest extends AnyFunSpec with Matchers with ElasticsearchFixtures with WorkGenerators with ImageGenerators {
+class EitherIndexerTest
+    extends AnyFunSpec
+    with Matchers
+    with ElasticsearchFixtures
+    with WorkGenerators
+    with ImageGenerators {
 
-  implicit val workId: CanonicalId[Work.Visible[Merged]] = (work: Work[Merged]) => work.id
-  implicit val imageId: CanonicalId[Image[Initial]] = (image: Image[Initial]) => image.id
+  implicit val workId: CanonicalId[Work.Visible[Merged]] =
+    (work: Work[Merged]) => work.id
+  implicit val imageId: CanonicalId[Image[Initial]] = (image: Image[Initial]) =>
+    image.id
 
   val works = (1 to 3).map(_ => mergedWork()).toList
   val images = (1 to 3).map(_ => createImageData.toInitialImage).toList
@@ -24,7 +34,7 @@ class EitherIndexerTest extends AnyFunSpec with Matchers with ElasticsearchFixtu
   val worksAndImages = works.map(Left(_)) ++ images.map(Right(_))
 
   it("indexes a list of either works or images") {
-    
+
     withLocalInitialImagesIndex { imageIndex =>
       withLocalMergedWorksIndex { workIndex =>
         val indexer = new EitherIndexer(
@@ -43,8 +53,8 @@ class EitherIndexerTest extends AnyFunSpec with Matchers with ElasticsearchFixtu
         whenReady(indexer(worksAndImages)) { result =>
           result shouldBe a[Right[_, _]]
 
-          assertElasticsearchEventuallyHas(workIndex, works:_*)
-          assertElasticsearchEventuallyHas(imageIndex, images:_*)
+          assertElasticsearchEventuallyHas(workIndex, works: _*)
+          assertElasticsearchEventuallyHas(imageIndex, images: _*)
         }
       }
     }
@@ -68,7 +78,7 @@ class EitherIndexerTest extends AnyFunSpec with Matchers with ElasticsearchFixtu
 
         whenReady(indexer(works.map(Left(_)))) { result =>
           result shouldBe a[Right[_, _]]
-          assertElasticsearchEventuallyHas(workIndex, works:_*)
+          assertElasticsearchEventuallyHas(workIndex, works: _*)
         }
       }
     }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/EitherIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/EitherIndexerTest.scala
@@ -1,0 +1,76 @@
+package uk.ac.wellcome.pipeline_storage
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import uk.ac.wellcome.models.work.generators.{WorkGenerators, ImageGenerators}
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.elasticsearch.{MergedWorkIndexConfig, InitialImageIndexConfig}
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.elasticsearch.model.CanonicalId
+import WorkState.Merged
+import ImageState.Initial 
+
+class EitherIndexerTest extends AnyFunSpec with Matchers with ElasticsearchFixtures with WorkGenerators with ImageGenerators {
+
+  implicit val workId: CanonicalId[Work.Visible[Merged]] = (work: Work[Merged]) => work.id
+  implicit val imageId: CanonicalId[Image[Initial]] = (image: Image[Initial]) => image.id
+
+  val works = (1 to 3).map(_ => mergedWork()).toList
+  val images = (1 to 3).map(_ => createImageData.toInitialImage).toList
+
+  val worksAndImages = works.map(Left(_)) ++ images.map(Right(_))
+
+  it("indexes a list of either works or images") {
+    
+    withLocalInitialImagesIndex { imageIndex =>
+      withLocalMergedWorksIndex { workIndex =>
+        val indexer = new EitherIndexer(
+          leftIndexer = new ElasticIndexer[Work[Merged]](
+            client = elasticClient,
+            index = workIndex,
+            config = MergedWorkIndexConfig
+          ),
+          rightIndexer = new ElasticIndexer[Image[Initial]](
+            client = elasticClient,
+            index = imageIndex,
+            config = InitialImageIndexConfig
+          )
+        )
+
+        whenReady(indexer(worksAndImages)) { result =>
+          result shouldBe a[Right[_, _]]
+
+          assertElasticsearchEventuallyHas(workIndex, works:_*)
+          assertElasticsearchEventuallyHas(imageIndex, images:_*)
+        }
+      }
+    }
+  }
+
+  it("indexes a list of only works") {
+    withLocalInitialImagesIndex { imageIndex =>
+      withLocalMergedWorksIndex { workIndex =>
+        val indexer = new EitherIndexer(
+          leftIndexer = new ElasticIndexer[Work[Merged]](
+            client = elasticClient,
+            index = workIndex,
+            config = MergedWorkIndexConfig
+          ),
+          rightIndexer = new ElasticIndexer[Image[Initial]](
+            client = elasticClient,
+            index = imageIndex,
+            config = InitialImageIndexConfig
+          )
+        )
+
+        whenReady(indexer(works.map(Left(_)))) { result =>
+          result shouldBe a[Right[_, _]]
+          assertElasticsearchEventuallyHas(workIndex, works:_*)
+        }
+      }
+    }
+  }
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/ImageIndexableTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.Assertion
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
+import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.Implicits._
@@ -115,7 +115,7 @@ class ImageIndexableTest
       val indexer = new ElasticIndexer[Image[ImageState.Indexed]](
         elasticClient,
         index,
-        ImagesIndexConfig)
+        IndexedImageIndexConfig)
       testWith((index, indexer))
     }
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/PipelineStorageStreamFixtures.scala
@@ -17,8 +17,8 @@ import scala.concurrent.Future
 trait PipelineStorageStreamFixtures extends Akka with SQS {
   val pipelineStorageConfig = PipelineStorageConfig(
     batchSize = 1,
-    flushInterval = 1 seconds,
-    parallelism = 10
+    flushInterval = 1 milliseconds,
+    parallelism = 1
   )
 
   def withPipelineStream[T: Indexable, R](

--- a/pipeline/inferrer/inference_manager/docker-compose.yml
+++ b/pipeline/inferrer/inference_manager/docker-compose.yml
@@ -1,38 +1,32 @@
-services:
-  sqs:
-    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
-    ports:
-      - "9324:9324"
+sqs:
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
+  ports:
+    - "9324:9324"
 
-  feature_inferrer:
-    build:
-      context: "../feature_inferrer"
-      dockerfile: "Dockerfile"
-    image: feature_inferrer
-    ports:
-      - "3141:80"
-    environment:
-      MODEL_OBJECT_KEY: test-model.pkl
-    volumes:
-      - ../test_data:/app/data
-      - $ROOT:$ROOT
-    links:
-      - "image_server:image_server"
+feature_inferrer:
+  image: feature_inferrer
+  ports:
+    - "3141:80"
+  environment:
+    MODEL_OBJECT_KEY: test-model.pkl
+  volumes:
+    - ../test_data:/app/data
+    - $ROOT:$ROOT
+  links:
+    - "image_server:image_server"
 
-  palette_inferrer:
-    build:
-      context: "../palette_inferrer"
-      dockerfile: "Dockerfile"
-    ports:
-      - "3142:80"
-    volumes:
-      - $ROOT:$ROOT
-    links:
-      - "image_server:image_server"
+palette_inferrer:
+  image: palette_inferrer
+  ports:
+    - "3142:80"
+  volumes:
+    - $ROOT:$ROOT
+  links:
+    - "image_server:image_server"
 
-  image_server:
-    image: nginx
-    ports:
-      - "2718:80"
-    volumes:
-      - ../test_data:/usr/share/nginx/html:ro
+image_server:
+  image: nginx
+  ports:
+    - "2718:80"
+  volumes:
+    - ../test_data:/usr/share/nginx/html:ro

--- a/pipeline/inferrer/inference_manager/docker-compose.yml
+++ b/pipeline/inferrer/inference_manager/docker-compose.yml
@@ -1,32 +1,38 @@
-sqs:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
-  ports:
-    - "9324:9324"
+services:
+  sqs:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
+    ports:
+      - "9324:9324"
 
-feature_inferrer:
-  image: feature_inferrer
-  ports:
-    - "3141:80"
-  environment:
-    MODEL_OBJECT_KEY: test-model.pkl
-  volumes:
-    - ../test_data:/app/data
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  feature_inferrer:
+    build:
+      context: "../feature_inferrer"
+      dockerfile: "Dockerfile"
+    image: feature_inferrer
+    ports:
+      - "3141:80"
+    environment:
+      MODEL_OBJECT_KEY: test-model.pkl
+    volumes:
+      - ../test_data:/app/data
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-palette_inferrer:
-  image: palette_inferrer
-  ports:
-    - "3142:80"
-  volumes:
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  palette_inferrer:
+    build:
+      context: "../palette_inferrer"
+      dockerfile: "Dockerfile"
+    ports:
+      - "3142:80"
+    volumes:
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-image_server:
-  image: nginx
-  ports:
-    - "2718:80"
-  volumes:
-    - ../test_data:/usr/share/nginx/html:ro
+  image_server:
+    image: nginx
+    ports:
+      - "2718:80"
+    volumes:
+      - ../test_data:/usr/share/nginx/html:ro

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
@@ -75,7 +75,7 @@ class InferenceManagerWorkerService[Destination](
           .via(unmarshalResponse)
           .via(collectAndAugment)
           .asSource
-          .map { case (image, message) => (message, Some(image)) }
+          .map { case (image, message) => (message, List(image)) }
           .via(indexAndSend)
     )
 

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
@@ -22,12 +22,14 @@ import uk.ac.wellcome.platform.inference_manager.models.DownloadedImage
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.pipeline_storage.{
   Indexer,
+  Indexable,
   PipelineStorageConfig,
   PipelineStorageStream,
   Retriever
 }
 import uk.ac.wellcome.json.JsonUtil._
 import ImageState.{Augmented, Initial}
+import Indexable.imageIndexable
 
 case class AdapterResponseBundle[ImageType](
   image: ImageType,
@@ -56,7 +58,7 @@ class InferenceManagerWorkerService[Destination](
 
   val indexAndSend = PipelineStorageStream.batchIndexAndSendFlow(
     pipelineStorageConfig,
-    msgSender,
+    (image: Image[Augmented]) => msgSender.send(imageIndexable.id(image)),
     imageIndexer
   )
 

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
@@ -75,7 +75,7 @@ class InferenceManagerWorkerService[Destination](
           .via(unmarshalResponse)
           .via(collectAndAugment)
           .asSource
-          .map { case (image, message) => (message, List(image)) }
+          .map { case (image, message) => (message, Some(image)) }
           .via(indexAndSend)
     )
 

--- a/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerService.scala
@@ -21,8 +21,8 @@ import uk.ac.wellcome.platform.inference_manager.adapters.{
 import uk.ac.wellcome.platform.inference_manager.models.DownloadedImage
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.pipeline_storage.{
-  Indexer,
   Indexable,
+  Indexer,
   PipelineStorageConfig,
   PipelineStorageStream,
   Retriever

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -2,23 +2,16 @@ package uk.ac.wellcome.platform.inference_manager.fixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.mutable
-import scala.concurrent.duration._
 import software.amazon.awssdk.services.sqs.model.Message
 
-import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.inference_manager.adapters.InferrerAdapter
 import uk.ac.wellcome.platform.inference_manager.models.DownloadedImage
-import uk.ac.wellcome.pipeline_storage.{
-  MemoryIndexer,
-  MemoryRetriever,
-  PipelineStorageConfig
-}
+import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, MemoryRetriever}
 import uk.ac.wellcome.platform.inference_manager.services.{
   FileWriter,
   ImageDownloader,

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -29,7 +29,8 @@ import uk.ac.wellcome.platform.inference_manager.services.{
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import ImageState.{Augmented, Initial}
 
-trait InferenceManagerWorkerServiceFixture extends PipelineStorageStreamFixtures {
+trait InferenceManagerWorkerServiceFixture
+    extends PipelineStorageStreamFixtures {
 
   def withWorkerService[R](
     queue: Queue,

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/fixtures/InferenceManagerWorkerServiceFixture.scala
@@ -26,9 +26,10 @@ import uk.ac.wellcome.platform.inference_manager.services.{
   MergedIdentifiedImage,
   RequestPoolFlow
 }
+import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import ImageState.{Augmented, Initial}
 
-trait InferenceManagerWorkerServiceFixture extends SQS with Akka {
+trait InferenceManagerWorkerServiceFixture extends PipelineStorageStreamFixtures {
 
   def withWorkerService[R](
     queue: Queue,
@@ -53,11 +54,7 @@ trait InferenceManagerWorkerServiceFixture extends SQS with Akka {
             )
           ),
           imageIndexer = new MemoryIndexer(augmentedImages),
-          pipelineStorageConfig = PipelineStorageConfig(
-            batchSize = 1,
-            flushInterval = 1 milliseconds,
-            parallelism = 1
-          ),
+          pipelineStorageConfig = pipelineStorageConfig,
           inferrerAdapters = adapters,
           imageDownloader = new ImageDownloader(
             root = fileRoot,

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -104,7 +104,11 @@ class ManagerInferrerIntegrationTest
     }
 
   def withWorkerServiceFixtures[R](
-    testWith: TestWith[(QueuePair, MemoryMessageSender, mutable.Map[String, Image[Augmented]], File), R]): R =
+    testWith: TestWith[(QueuePair,
+                        MemoryMessageSender,
+                        mutable.Map[String, Image[Augmented]],
+                        File),
+                       R]): R =
     // We would like a timeout longer than 1s here because the inferrer
     // may need to warm up.
     withLocalSqsQueuePair(visibilityTimeout = 5) { queuePair =>

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -57,7 +57,7 @@ class ManagerInferrerIntegrationTest
               locationType = createImageLocationType,
               url = s"http://localhost:$localImageServerPort/test-image.jpg"
             ))).toInitialImage
-        sendMessage(queue, image)
+        sendNotificationToSQS(queue = queue, body = image.id)
         eventually {
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -1,8 +1,10 @@
 package uk.ac.wellcome.platform.inference_manager.integration
 
+import scala.concurrent.duration._
+import scala.io.Source
+import scala.collection.mutable
 import java.io.File
 import java.nio.file.Paths
-
 import akka.http.scaladsl.Http
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -10,10 +12,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inside, Inspectors, OptionValues}
 import software.amazon.awssdk.services.sqs.model.Message
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.models.work.internal.{Image, ImageState, InferredData}
 import uk.ac.wellcome.platform.inference_manager.adapters.{
@@ -27,9 +29,7 @@ import uk.ac.wellcome.platform.inference_manager.services.{
   DefaultFileWriter,
   MergedIdentifiedImage
 }
-
-import scala.concurrent.duration._
-import scala.io.Source
+import ImageState.Augmented
 
 class ManagerInferrerIntegrationTest
     extends AnyFunSpec
@@ -44,7 +44,7 @@ class ManagerInferrerIntegrationTest
 
   it("augments images with feature and palette vectors") {
     withWorkerServiceFixtures {
-      case (QueuePair(queue, dlq), messageSender, rootDir) =>
+      case (QueuePair(queue, dlq), messageSender, augmentedImages, rootDir) =>
         // This is (more than) enough time for the inferrer to have
         // done its prestart work and be ready to use
         eventually(Timeout(scaled(90 seconds))) {
@@ -65,10 +65,10 @@ class ManagerInferrerIntegrationTest
           rootDir.listFiles().length should be(0)
 
           val augmentedImage =
-            messageSender.getMessages[Image[ImageState.Augmented]].head
+            augmentedImages(messageSender.messages.head.body)
 
           inside(augmentedImage.state) {
-            case ImageState.Augmented(_, id, Some(inferredData)) =>
+            case Augmented(_, id, Some(inferredData)) =>
               id should be(image.id)
               inside(inferredData) {
                 case InferredData(
@@ -104,7 +104,7 @@ class ManagerInferrerIntegrationTest
     }
 
   def withWorkerServiceFixtures[R](
-    testWith: TestWith[(QueuePair, MemoryMessageSender, File), R]): R =
+    testWith: TestWith[(QueuePair, MemoryMessageSender, mutable.Map[String, Image[Augmented]], File), R]): R =
     // We would like a timeout longer than 1s here because the inferrer
     // may need to warm up.
     withLocalSqsQueuePair(visibilityTimeout = 5) { queuePair =>
@@ -112,9 +112,11 @@ class ManagerInferrerIntegrationTest
       val root = Paths.get("integration-tmp").toFile
       root.mkdir()
       withActorSystem { implicit actorSystem =>
+        val augmentedImages = mutable.Map.empty[String, Image[Augmented]]
         withWorkerService(
           queuePair.queue,
           messageSender,
+          augmentedImages = augmentedImages,
           adapters = Set(
             new FeatureVectorInferrerAdapter(
               "localhost",
@@ -132,7 +134,7 @@ class ManagerInferrerIntegrationTest
           fileRoot = root.getPath
         ) { _ =>
           try {
-            testWith((queuePair, messageSender, root))
+            testWith((queuePair, messageSender, augmentedImages, root))
           } finally {
             root.delete()
           }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -70,28 +70,27 @@ class InferenceManagerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          forAll(messageSender.messages.map(_.body)) {
-            id =>
-              val image = augmentedImages(id)
-              inside(image.state) {
-                case ImageState.Augmented(_, id, inferredData) =>
-                  images should contain key id
-                  val seed = id.hashCode
-                  inside(inferredData.value) {
-                    case InferredData(
-                        features1,
-                        features2,
-                        lshEncodedFeatures,
-                        palette) =>
-                      val featureVector =
-                        Responses.randomFeatureVector(seed)
-                      features1 should be(featureVector.slice(0, 2048))
-                      features2 should be(featureVector.slice(2048, 4096))
-                      lshEncodedFeatures should be(
-                        Responses.randomLshVector(seed))
-                      palette should be(Responses.randomPaletteVector(seed))
-                  }
-              }
+          forAll(messageSender.messages.map(_.body)) { id =>
+            val image = augmentedImages(id)
+            inside(image.state) {
+              case ImageState.Augmented(_, id, inferredData) =>
+                images should contain key id
+                val seed = id.hashCode
+                inside(inferredData.value) {
+                  case InferredData(
+                      features1,
+                      features2,
+                      lshEncodedFeatures,
+                      palette) =>
+                    val featureVector =
+                      Responses.randomFeatureVector(seed)
+                    features1 should be(featureVector.slice(0, 2048))
+                    features2 should be(featureVector.slice(2048, 4096))
+                    lshEncodedFeatures should be(
+                      Responses.randomLshVector(seed))
+                    palette should be(Responses.randomPaletteVector(seed))
+                }
+            }
           }
         }
     }
@@ -115,23 +114,22 @@ class InferenceManagerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          forAll(messageSender.messages.map(_.body)) {
-            id =>
-              val image = augmentedImages(id)
-              inside(image.state) {
-                case ImageState.Augmented(_, _, inferredData) =>
-                  inside(inferredData.value) {
-                    case InferredData(
-                        features1,
-                        features2,
-                        lshEncodedFeatures,
-                        palette) =>
-                      features1 should have length 2048
-                      features2 should have length 2048
-                      every(lshEncodedFeatures) should fullyMatch regex """(\d+)-(\d+)"""
-                      every(palette) should fullyMatch regex """\d+"""
-                  }
-              }
+          forAll(messageSender.messages.map(_.body)) { id =>
+            val image = augmentedImages(id)
+            inside(image.state) {
+              case ImageState.Augmented(_, _, inferredData) =>
+                inside(inferredData.value) {
+                  case InferredData(
+                      features1,
+                      features2,
+                      lshEncodedFeatures,
+                      palette) =>
+                    features1 should have length 2048
+                    features2 should have length 2048
+                    every(lshEncodedFeatures) should fullyMatch regex """(\d+)-(\d+)"""
+                    every(palette) should fullyMatch regex """\d+"""
+                }
+            }
           }
         }
     }
@@ -200,7 +198,8 @@ class InferenceManagerWorkerServiceTest
           imagesMock.pool,
           augmentedImages) {
           case (queuePair, sender) =>
-            testWith((queuePair, sender, augmentedImages, inferrerMock, imagesMock))
+            testWith(
+              (queuePair, sender, augmentedImages, inferrerMock, imagesMock))
         }
     }
 

--- a/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
@@ -22,10 +22,10 @@ class IngestorWorkerService[Destination, In, Out](
   def run(): Future[Done] =
     pipelineStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  private def processMessage(message: NotificationMessage): Future[Option[Out]] =
+  private def processMessage(message: NotificationMessage): Future[List[Out]] =
     workRetriever
       .apply(message.body)
       .map { item =>
-        Some(transform(item))
+        List(transform(item))
       }
 }

--- a/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
@@ -5,20 +5,27 @@ import akka.Done
 
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.pipeline_storage.{PipelineStorageStream, Retriever, Indexable}
+import uk.ac.wellcome.pipeline_storage.{
+  Indexable,
+  PipelineStorageStream,
+  Retriever
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 class IngestorWorkerService[Destination, In, Out](
   pipelineStream: PipelineStorageStream[NotificationMessage, Out, Destination],
   workRetriever: Retriever[In],
-  transform: In => Out)(
-  implicit ec: ExecutionContext, indexable: Indexable[Out])
+  transform: In => Out)(implicit ec: ExecutionContext,
+                        indexable: Indexable[Out])
     extends Runnable {
 
   def run(): Future[Done] =
     pipelineStream.foreach(this.getClass.getSimpleName, processMessage)
 
   private def processMessage(message: NotificationMessage): Future[List[Out]] =
-    workRetriever.apply(message.body)
-      .map { item => List(transform(item)) }
+    workRetriever
+      .apply(message.body)
+      .map { item =>
+        List(transform(item))
+      }
 }

--- a/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.ingestor.common
+
+import scala.concurrent.{ExecutionContext, Future}
+import akka.Done
+
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.pipeline_storage.{PipelineStorageStream, Retriever, Indexable}
+import uk.ac.wellcome.typesafe.Runnable
+
+class IngestorWorkerService[Destination, In, Out](
+  pipelineStream: PipelineStorageStream[NotificationMessage, Out, Destination],
+  workRetriever: Retriever[In],
+  transform: In => Out)(
+  implicit ec: ExecutionContext, indexable: Indexable[Out])
+    extends Runnable {
+
+  def run(): Future[Done] =
+    pipelineStream.foreach(this.getClass.getSimpleName, processMessage)
+
+  private def processMessage(message: NotificationMessage): Future[List[Out]] =
+    workRetriever.apply(message.body)
+      .map { item => List(transform(item)) }
+}

--- a/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/uk/ac/wellcome/platform/ingestor/common/IngestorWorkerService.scala
@@ -22,10 +22,10 @@ class IngestorWorkerService[Destination, In, Out](
   def run(): Future[Done] =
     pipelineStream.foreach(this.getClass.getSimpleName, processMessage)
 
-  private def processMessage(message: NotificationMessage): Future[List[Out]] =
+  private def processMessage(message: NotificationMessage): Future[Option[Out]] =
     workRetriever
       .apply(message.body)
       .map { item =>
-        List(transform(item))
+        Some(transform(item))
       }
 }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageIngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageIngestorWorkerService.scala
@@ -16,5 +16,7 @@ class ImageIngestorWorkerService[Destination](
   transform: Image[Augmented] => Image[Indexed] = ImageTransformer.deriveData,
 )(implicit
   ec: ExecutionContext)
-  extends IngestorWorkerService[Destination, Image[Augmented], Image[Indexed]](
-    pipelineStream, imageRetriever, transform)
+    extends IngestorWorkerService[
+      Destination,
+      Image[Augmented],
+      Image[Indexed]](pipelineStream, imageRetriever, transform)

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageIngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageIngestorWorkerService.scala
@@ -1,74 +1,20 @@
 package uk.ac.wellcome.platform.ingestor.images
 
-import akka.Done
-import software.amazon.awssdk.services.sqs.model.Message
-import grizzled.slf4j.Logging
-import uk.ac.wellcome.bigmessaging.message.BigMessageStream
-import uk.ac.wellcome.pipeline_storage.Indexer
-import uk.ac.wellcome.platform.ingestor.common.models.IngestorConfig
-import uk.ac.wellcome.typesafe.Runnable
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.pipeline_storage.{PipelineStorageStream, Retriever}
+import uk.ac.wellcome.platform.ingestor.common.IngestorWorkerService
+import ImageState.{Augmented, Indexed}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
-class ImageIngestorWorkerService[In, Out](
-  ingestorConfig: IngestorConfig,
-  documentIndexer: Indexer[Out],
-  messageStream: BigMessageStream[In],
-  transformBeforeIndex: In => Out
+class ImageIngestorWorkerService[Destination](
+  pipelineStream: PipelineStorageStream[NotificationMessage,
+                                        Image[Indexed],
+                                        Destination],
+  imageRetriever: Retriever[Image[Augmented]],
+  transform: Image[Augmented] => Image[Indexed] = ImageTransformer.deriveData,
 )(implicit
   ec: ExecutionContext)
-    extends Runnable
-    with Logging {
-
-  type FutureBundles = Future[List[Bundle]]
-  case class Bundle(message: Message, document: In)
-
-  private val className = this.getClass.getSimpleName
-
-  def run(): Future[Done] =
-    for {
-      _ <- documentIndexer.init()
-      result <- runStream()
-    } yield result
-
-  private def runStream(): Future[Done] = {
-    messageStream.runStream(
-      className,
-      _.map { case (msg, document) => Bundle(msg, document) }
-        .groupedWithin(
-          ingestorConfig.batchSize,
-          ingestorConfig.flushInterval
-        )
-        .mapAsyncUnordered(10) { msgs =>
-          for { bundles <- processMessages(msgs.toList) } yield
-            bundles.map(_.message)
-        }
-        .mapConcat(identity)
-    )
-  }
-
-  private def processMessages(bundles: List[Bundle]): FutureBundles =
-    for {
-      documents <- Future.successful(bundles.map(m => m.document))
-      transformedDocuments = documents.map(transformBeforeIndex)
-      either <- documentIndexer(documents = transformedDocuments)
-    } yield {
-      val failedWorks = either.left.getOrElse(Nil)
-      bundles.filterNot {
-        case Bundle(_, document) => failedWorks.contains(document)
-      }
-    }
-}
-
-object ImageIngestorWorkerService {
-  def apply[T](
-    ingestorConfig: IngestorConfig,
-    documentIndexer: Indexer[T],
-    messageStream: BigMessageStream[T])(implicit ec: ExecutionContext) =
-    new ImageIngestorWorkerService(
-      ingestorConfig,
-      documentIndexer,
-      messageStream,
-      identity[T]
-    )
-}
+  extends IngestorWorkerService[Destination, Image[Augmented], Image[Indexed]](
+    pipelineStream, imageRetriever, transform)

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageTransformer.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/ImageTransformer.scala
@@ -1,8 +1,9 @@
 package uk.ac.wellcome.platform.ingestor.images
 
 import uk.ac.wellcome.models.work.internal.{Image, ImageState}
+import ImageState.{Augmented, Indexed}
 
 object ImageTransformer {
-  val deriveData: Image[ImageState.Augmented] => Image[ImageState.Indexed] =
-    image => image.transition[ImageState.Indexed]()
+  val deriveData: Image[Augmented] => Image[Indexed] =
+    image => image.transition[Indexed]()
 }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
-import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
+import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.{Image, ImageState}
 import uk.ac.wellcome.pipeline_storage.Indexable.imageIndexable
@@ -29,7 +29,7 @@ object Main extends WellcomeTypesafeApp {
     val imageIndexer = ElasticIndexerBuilder[Image[ImageState.Indexed]](
       config,
       esClient,
-      indexConfig = ImagesIndexConfig
+      indexConfig = IndexedImageIndexConfig
     )
 
     val ingestorConfig = IngestorConfig(

--- a/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/uk/ac/wellcome/platform/ingestor/images/Main.scala
@@ -3,19 +3,20 @@ package uk.ac.wellcome.platform.ingestor.images
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import uk.ac.wellcome.bigmessaging.typesafe.BigMessagingBuilder
-import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
-import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.work.internal.{Image, ImageState}
-import uk.ac.wellcome.pipeline_storage.Indexable.imageIndexable
-import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
-import uk.ac.wellcome.pipeline_storage.typesafe.ElasticIndexerBuilder
-import uk.ac.wellcome.platform.ingestor.common.models.IngestorConfig
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
-import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-
-import scala.concurrent.duration._
+import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
+import uk.ac.wellcome.pipeline_storage.typesafe.{
+  ElasticIndexerBuilder,
+  ElasticRetrieverBuilder,
+  PipelineStorageStreamBuilder
+}
+import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.models.work.internal._
+import ImageState.{Augmented, Indexed}
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -24,26 +25,33 @@ object Main extends WellcomeTypesafeApp {
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
-    val esClient = ElasticBuilder.buildElasticClient(config)
+    val msgStream =
+      SQSBuilder.buildSQSStream[NotificationMessage](config)
 
-    val imageIndexer = ElasticIndexerBuilder[Image[ImageState.Indexed]](
+    val imageRetriever = ElasticRetrieverBuilder[Image[Augmented]](
       config,
-      esClient,
+      ElasticBuilder.buildElasticClient(config, namespace = "pipeline_storage"),
+      namespace = "augmented-images")
+
+    val imageIndexer = ElasticIndexerBuilder[Image[Indexed]](
+      config,
+      ElasticBuilder.buildElasticClient(config, namespace = "catalogue"),
+      namespace = "indexed-images",
       indexConfig = IndexedImageIndexConfig
     )
+    val msgSender = SNSBuilder
+      .buildSNSMessageSender(config, subject = "Sent from the ingestor-images")
 
-    val ingestorConfig = IngestorConfig(
-      batchSize = config.requireInt("es.ingest.batchSize"),
-      // TODO: Work out how to get a Duration from a Typesafe flag.
-      flushInterval = 1 minute
-    )
+    val pipelineStream =
+      PipelineStorageStreamBuilder.buildPipelineStorageStream(
+        msgStream,
+        imageIndexer,
+        msgSender)(config)
 
     new ImageIngestorWorkerService(
-      ingestorConfig = ingestorConfig,
-      documentIndexer = imageIndexer,
-      messageStream = BigMessagingBuilder
-        .buildMessageStream[Image[ImageState.Augmented]](config),
-      transformBeforeIndex = ImageTransformer.deriveData
+      pipelineStream = pipelineStream,
+      imageRetriever = imageRetriever,
+      transform = ImageTransformer.deriveData
     )
   }
 }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.time.{Seconds, Span}
 import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
+import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.Implicits._
@@ -32,7 +32,7 @@ class ImagesIngestorFeatureTest
           val indexer = new ElasticIndexer[Image[ImageState.Augmented]](
             elasticClient,
             index,
-            ImagesIndexConfig)
+            IndexedImageIndexConfig)
           withWorkerService(queue, indexer) { _ =>
             assertElasticsearchEventuallyHasImage[ImageState.Indexed](
               index,
@@ -55,7 +55,7 @@ class ImagesIngestorFeatureTest
           val indexer = new ElasticIndexer[Image[ImageState.Augmented]](
             elasticClient,
             index,
-            ImagesIndexConfig)
+            IndexedImageIndexConfig)
           withWorkerService(queue, indexer) { _ =>
             assertElasticsearchEmpty(index)
             eventually(Timeout(Span(5, Seconds))) {

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -1,25 +1,23 @@
 package uk.ac.wellcome.platform.ingestor.images
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.time.{Seconds, Span}
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
+
 import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.models.work.internal.{Image, ImageState}
-import uk.ac.wellcome.pipeline_storage.ElasticIndexer
+import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, ElasticIndexer}
 import uk.ac.wellcome.pipeline_storage.Indexable.imageIndexable
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import uk.ac.wellcome.json.JsonUtil._
+import ImageState.{Augmented, Indexed}
 
 class ImagesIngestorFeatureTest
     extends AnyFunSpec
     with ImageGenerators
-    with BigMessagingFixture
     with ElasticsearchFixtures
     with IngestorFixtures {
   it("reads an image from the queue, ingests it and deletes the message") {
@@ -27,40 +25,49 @@ class ImagesIngestorFeatureTest
 
     withLocalSqsQueuePair(visibilityTimeout = 10) {
       case QueuePair(queue, dlq) =>
-        sendMessage[Image[ImageState.Augmented]](queue = queue, obj = image)
+        sendNotificationToSQS(queue = queue, body = image.id)
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[Image[ImageState.Augmented]](
-            elasticClient,
-            index,
-            IndexedImageIndexConfig)
-          withWorkerService(queue, indexer) { _ =>
-            assertElasticsearchEventuallyHasImage[ImageState.Indexed](
+          withLocalAugmentedImageIndex { augmentedIndex =>
+            val indexer = new ElasticIndexer[Image[Indexed]](
+              elasticClient,
               index,
-              ImageTransformer.deriveData(image))
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
+              IndexedImageIndexConfig)
+            val retriever = new ElasticRetriever[Image[Augmented]](
+              elasticClient,
+              augmentedIndex
+            )
+            withWorkerService(queue, retriever, indexer) { _ =>
+              assertElasticsearchEventuallyHasImage[Indexed](
+                index,
+                ImageTransformer.deriveData(image))
+              assertQueueEmpty(queue)
+              assertQueueEmpty(dlq)
+            }
           }
         }
     }
   }
 
   it("does not delete a message from the queue if it fails processing it") {
-    case class Something(something: String, somethingElse: Int)
-    val wrongMessage = Something("abcd", 3)
-
     withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
-        sendMessage[Something](queue = queue, obj = wrongMessage)
+        sendNotificationToSQS(queue = queue, body = "nope")
         withLocalImagesIndex { index =>
-          val indexer = new ElasticIndexer[Image[ImageState.Augmented]](
-            elasticClient,
-            index,
-            IndexedImageIndexConfig)
-          withWorkerService(queue, indexer) { _ =>
-            assertElasticsearchEmpty(index)
-            eventually(Timeout(Span(5, Seconds))) {
-              assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, size = 1)
+          withLocalAugmentedImageIndex { augmentedIndex =>
+            val indexer = new ElasticIndexer[Image[Indexed]](
+              elasticClient,
+              index,
+              IndexedImageIndexConfig)
+            val retriever = new ElasticRetriever[Image[Augmented]](
+              elasticClient,
+              augmentedIndex
+            )
+            withWorkerService(queue, retriever, indexer) { _ =>
+              assertElasticsearchEmpty(index)
+              eventually(Timeout(Span(5, Seconds))) {
+                assertQueueEmpty(queue)
+                assertQueueHasSize(dlq, size = 1)
+              }
             }
           }
         }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.models.work.internal.{Image, ImageState}
-import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, ElasticIndexer}
+import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever}
 import uk.ac.wellcome.pipeline_storage.Indexable.imageIndexable
 import ImageState.{Augmented, Indexed}
 

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -28,14 +28,15 @@ class ImagesIngestorFeatureTest
         sendNotificationToSQS(queue = queue, body = image.id)
         withLocalImagesIndex { index =>
           withLocalAugmentedImageIndex { augmentedIndex =>
-            val indexer = new ElasticIndexer[Image[Indexed]](
-              elasticClient,
-              index,
-              IndexedImageIndexConfig)
+            insertImagesIntoElasticsearch(augmentedIndex, image)
             val retriever = new ElasticRetriever[Image[Augmented]](
               elasticClient,
               augmentedIndex
             )
+            val indexer = new ElasticIndexer[Image[Indexed]](
+              elasticClient,
+              index,
+              IndexedImageIndexConfig)
             withWorkerService(queue, retriever, indexer) { _ =>
               assertElasticsearchEventuallyHasImage[Indexed](
                 index,

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
@@ -1,51 +1,46 @@
 package uk.ac.wellcome.platform.ingestor.images
 
-import io.circe.Decoder
-import org.scalatest.Suite
-import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.bigmessaging.fixtures.BigMessagingFixture
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.pipeline_storage.Indexer
-import uk.ac.wellcome.platform.ingestor.common.models.IngestorConfig
-import uk.ac.wellcome.pipeline_storage.fixtures.ElasticIndexerFixtures
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.Suite
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.pipeline_storage.fixtures.{
+  ElasticIndexerFixtures,
+  PipelineStorageStreamFixtures
+}
+import uk.ac.wellcome.pipeline_storage.{
+  Indexer,
+  PipelineStorageConfig,
+  Retriever
+}
+import ImageState.{Augmented, Indexed}
 
 trait IngestorFixtures
     extends ElasticIndexerFixtures
-    with BigMessagingFixture
-    with Akka {
+    with PipelineStorageStreamFixtures {
   this: Suite =>
 
-  def withWorkerService[T: Decoder, R](queue: Queue, indexer: Indexer[T])(
-    testWith: TestWith[ImageIngestorWorkerService[T, T], R]): R =
-    withWorkerService(queue, indexer, identity[T])(testWith)
+  def withWorkerService[R](queue: Queue,
+                           retriever: Retriever[Image[Augmented]],
+                           indexer: Indexer[Image[Indexed]])(
+    testWith: TestWith[ImageIngestorWorkerService[String], R]): R = {
+    val config = PipelineStorageConfig(
+      batchSize = 100,
+      flushInterval = 1 second,
+      parallelism = 10)
+    withPipelineStream(queue, indexer, pipelineStorageConfig = config) {
+      msgStream =>
+        val workerService = new ImageIngestorWorkerService(
+          pipelineStream = msgStream,
+          imageRetriever = retriever
+        )
 
-  def withWorkerService[In: Decoder, Out, R](queue: Queue,
-                                             indexer: Indexer[Out],
-                                             transform: In => Out)(
-    testWith: TestWith[ImageIngestorWorkerService[In, Out], R]): R =
-    withActorSystem { implicit actorSystem =>
-      {
-        withBigMessageStream[In, R](queue) { messageStream =>
-          val ingestorConfig = IngestorConfig(
-            batchSize = 100,
-            flushInterval = 1 seconds
-          )
+        workerService.run()
 
-          val workerService = new ImageIngestorWorkerService(
-            documentIndexer = indexer,
-            ingestorConfig = ingestorConfig,
-            messageStream = messageStream,
-            transformBeforeIndex = transform
-          )
-
-          workerService.run()
-
-          testWith(workerService)
-        }
-      }
+        testWith(workerService)
     }
+  }
 }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
@@ -22,16 +22,18 @@ trait IngestorFixtures
                            retriever: Retriever[Image[Augmented]],
                            indexer: Indexer[Image[Indexed]])(
     testWith: TestWith[ImageIngestorWorkerService[String], R]): R = {
-    withPipelineStream(queue, indexer, pipelineStorageConfig = pipelineStorageConfig) {
-      msgStream =>
-        val workerService = new ImageIngestorWorkerService(
-          pipelineStream = msgStream,
-          imageRetriever = retriever
-        )
+    withPipelineStream(
+      queue,
+      indexer,
+      pipelineStorageConfig = pipelineStorageConfig) { msgStream =>
+      val workerService = new ImageIngestorWorkerService(
+        pipelineStream = msgStream,
+        imageRetriever = retriever
+      )
 
-        workerService.run()
+      workerService.run()
 
-        testWith(workerService)
+      testWith(workerService)
     }
   }
 }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/IngestorFixtures.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.ingestor.images
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 import org.scalatest.Suite
 
 import uk.ac.wellcome.fixtures.TestWith
@@ -11,11 +10,7 @@ import uk.ac.wellcome.pipeline_storage.fixtures.{
   ElasticIndexerFixtures,
   PipelineStorageStreamFixtures
 }
-import uk.ac.wellcome.pipeline_storage.{
-  Indexer,
-  PipelineStorageConfig,
-  Retriever
-}
+import uk.ac.wellcome.pipeline_storage.{Indexer, Retriever}
 import ImageState.{Augmented, Indexed}
 
 trait IngestorFixtures
@@ -27,11 +22,7 @@ trait IngestorFixtures
                            retriever: Retriever[Image[Augmented]],
                            indexer: Indexer[Image[Indexed]])(
     testWith: TestWith[ImageIngestorWorkerService[String], R]): R = {
-    val config = PipelineStorageConfig(
-      batchSize = 100,
-      flushInterval = 1 second,
-      parallelism = 10)
-    withPipelineStream(queue, indexer, pipelineStorageConfig = config) {
+    withPipelineStream(queue, indexer, pipelineStorageConfig = pipelineStorageConfig) {
       msgStream =>
         val workerService = new ImageIngestorWorkerService(
           pipelineStream = msgStream,

--- a/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/uk/ac/wellcome/platform/ingestor/images/services/ImagesIndexerTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.ingestor.images.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.elasticsearch.ImagesIndexConfig
+import uk.ac.wellcome.elasticsearch.IndexedImageIndexConfig
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.models.work.generators.ImageGenerators
 import uk.ac.wellcome.models.work.internal.{Image, ImageState}
@@ -29,7 +29,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig)
+          IndexedImageIndexConfig)
       val image = createImageData.toAugmentedImage
       whenReady(imagesIndexer(List(image))) { r =>
         r.isRight shouldBe true
@@ -45,7 +45,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig)
+          IndexedImageIndexConfig)
       val images = (1 to 5).map(_ => createImageData.toAugmentedImage)
       whenReady(imagesIndexer(images)) { r =>
         r.isRight shouldBe true
@@ -61,7 +61,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig)
+          IndexedImageIndexConfig)
       val image = createImageData.toAugmentedImage
       val newerImage =
         image.copy(
@@ -85,7 +85,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig)
+          IndexedImageIndexConfig)
       val image = createImageData.toAugmentedImage
       val olderImage =
         image.copy(

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -51,7 +51,7 @@ object Main extends WellcomeTypesafeApp {
     new WorkIngestorWorkerService(
       pipelineStream = pipelineStream,
       workRetriever = workRetriever,
-      transformBeforeIndex = WorkTransformer.deriveData
+      transform = WorkTransformer.deriveData
     )
   }
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/WorkIngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/WorkIngestorWorkerService.scala
@@ -1,39 +1,21 @@
 package uk.ac.wellcome.platform.ingestor.works
 
-import akka.Done
-import grizzled.slf4j.Logging
-import software.amazon.awssdk.services.sqs.model.Message
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.work.internal.WorkState.{Denormalised, Indexed}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.{PipelineStorageStream, Retriever}
-import uk.ac.wellcome.typesafe.Runnable
+import uk.ac.wellcome.platform.ingestor.common.IngestorWorkerService
+import WorkState.{Denormalised, Indexed}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class WorkIngestorWorkerService[Destination](
   pipelineStream: PipelineStorageStream[NotificationMessage,
                                         Work[Indexed],
                                         Destination],
   workRetriever: Retriever[Work[Denormalised]],
-  transformBeforeIndex: Work[Denormalised] => Work[Indexed] =
+  transform: Work[Denormalised] => Work[Indexed] =
     WorkTransformer.deriveData,
 )(implicit
   ec: ExecutionContext)
-    extends Runnable
-    with Logging {
-
-  case class Bundle(message: Message, key: String)
-
-  def run(): Future[Done] =
-    pipelineStream.foreach(this.getClass.getSimpleName, processMessage)
-
-  private def processMessage(
-    message: NotificationMessage): Future[List[Work[Indexed]]] = {
-    for {
-      denormalisedWork <- workRetriever.apply(message.body)
-      indexedWork = transformBeforeIndex(denormalisedWork)
-    } yield (List(indexedWork))
-  }
-}
+  extends IngestorWorkerService[Destination, Work[Denormalised], Work[Indexed]](
+    pipelineStream, workRetriever, transform)

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/WorkIngestorWorkerService.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/WorkIngestorWorkerService.scala
@@ -13,9 +13,10 @@ class WorkIngestorWorkerService[Destination](
                                         Work[Indexed],
                                         Destination],
   workRetriever: Retriever[Work[Denormalised]],
-  transform: Work[Denormalised] => Work[Indexed] =
-    WorkTransformer.deriveData,
+  transform: Work[Denormalised] => Work[Indexed] = WorkTransformer.deriveData,
 )(implicit
   ec: ExecutionContext)
-  extends IngestorWorkerService[Destination, Work[Denormalised], Work[Indexed]](
-    pipelineStream, workRetriever, transform)
+    extends IngestorWorkerService[
+      Destination,
+      Work[Denormalised],
+      Work[Indexed]](pipelineStream, workRetriever, transform)

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
@@ -22,16 +22,18 @@ trait IngestorFixtures
                            retriever: Retriever[Work[Denormalised]],
                            indexer: Indexer[Work[Indexed]])(
     testWith: TestWith[WorkIngestorWorkerService[String], R]): R = {
-    withPipelineStream(queue, indexer, pipelineStorageConfig = pipelineStorageConfig) {
-      msgStream =>
-        val workerService = new WorkIngestorWorkerService(
-          pipelineStream = msgStream,
-          workRetriever = retriever
-        )
+    withPipelineStream(
+      queue,
+      indexer,
+      pipelineStorageConfig = pipelineStorageConfig) { msgStream =>
+      val workerService = new WorkIngestorWorkerService(
+        pipelineStream = msgStream,
+        workRetriever = retriever
+      )
 
-        workerService.run()
+      workerService.run()
 
-        testWith(workerService)
+      testWith(workerService)
     }
   }
 }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
@@ -1,6 +1,8 @@
 package uk.ac.wellcome.platform.ingestor.works
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.Suite
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.models.work.internal.WorkState.{Denormalised, Indexed}
@@ -9,14 +11,7 @@ import uk.ac.wellcome.pipeline_storage.fixtures.{
   ElasticIndexerFixtures,
   PipelineStorageStreamFixtures
 }
-import uk.ac.wellcome.pipeline_storage.{
-  Indexer,
-  PipelineStorageConfig,
-  Retriever
-}
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import uk.ac.wellcome.pipeline_storage.{Indexer, Retriever}
 
 trait IngestorFixtures
     extends ElasticIndexerFixtures
@@ -27,11 +22,7 @@ trait IngestorFixtures
                            retriever: Retriever[Work[Denormalised]],
                            indexer: Indexer[Work[Indexed]])(
     testWith: TestWith[WorkIngestorWorkerService[String], R]): R = {
-    val config = PipelineStorageConfig(
-      batchSize = 100,
-      flushInterval = 1 second,
-      parallelism = 10)
-    withPipelineStream(queue, indexer, pipelineStorageConfig = config) {
+    withPipelineStream(queue, indexer, pipelineStorageConfig = pipelineStorageConfig) {
       msgStream =>
         val workerService = new WorkIngestorWorkerService(
           pipelineStream = msgStream,

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -4,7 +4,10 @@ import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 
-import uk.ac.wellcome.elasticsearch.{MergedWorkIndexConfig, InitialImageIndexConfig}
+import uk.ac.wellcome.elasticsearch.{
+  InitialImageIndexConfig,
+  MergedWorkIndexConfig
+}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.models.Implicits._
@@ -21,7 +24,6 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import WorkState.{Identified, Merged}
 import ImageState.Initial
-
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -72,7 +74,7 @@ object Main extends WellcomeTypesafeApp {
           namespace = "initial-images",
           indexConfig = InitialImageIndexConfig
         )
-    )
+      )
 
     new MergerWorkerService(
       msgStream = SQSBuilder.buildSQSStream[NotificationMessage](config),

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -60,15 +60,12 @@ object Main extends WellcomeTypesafeApp {
       indexConfig = MergedWorkIndexConfig
     )
 
-    val stream = PipelineStorageStreamBuilder.buildPipelineStorageStream(
-      sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
-      indexer = workIndexer,
-      messageSender = workSender
-    )(config)
-
     new MergerWorkerService(
-      pipelineStorageStream = stream,
       sourceWorkLookup = sourceWorkLookup,
+      msgStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
+      config = PipelineStorageStreamBuilder.buildPipelineStorageConfig(config),
+      workIndexer = workIndexer,
+      workMsgSender = workSender,
       mergerManager = mergerManager,
       imageSender = imageSender
     )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -15,14 +15,15 @@ import WorkFsm._
 case class MergerOutcome(resultWorks: Seq[Work[Identified]],
                          imagesWithSources: Seq[ImageDataWithSource]) {
 
-  def mergedWorksAndImagesWithTime(modifiedTime: Instant): Seq[Either[Work[Merged], Image[Initial]]] =
-    mergedWorksWithTime(modifiedTime).map(Left(_)) ++ mergedImagesWithTime(modifiedTime).map(Right(_))
+  def mergedWorksAndImagesWithTime(
+    modifiedTime: Instant): Seq[Either[Work[Merged], Image[Initial]]] =
+    mergedWorksWithTime(modifiedTime).map(Left(_)) ++ mergedImagesWithTime(
+      modifiedTime).map(Right(_))
 
   def mergedWorksWithTime(modifiedTime: Instant): Seq[Work[Merged]] =
     resultWorks.map(_.transition[Merged](modifiedTime))
 
-  def mergedImagesWithTime(
-    modifiedTime: Instant): Seq[Image[Initial]] =
+  def mergedImagesWithTime(modifiedTime: Instant): Seq[Image[Initial]] =
     imagesWithSources.map {
       case ImageDataWithSource(imageData, source) =>
         Image[Initial](

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergerOutcome.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.merger.models
 import java.time.Instant
 import uk.ac.wellcome.models.work.internal._
 import WorkState.{Identified, Merged}
+import ImageState.Initial
 import WorkFsm._
 
 /*
@@ -14,19 +15,22 @@ import WorkFsm._
 case class MergerOutcome(resultWorks: Seq[Work[Identified]],
                          imagesWithSources: Seq[ImageDataWithSource]) {
 
+  def mergedWorksAndImagesWithTime(modifiedTime: Instant): Seq[Either[Work[Merged], Image[Initial]]] =
+    mergedWorksWithTime(modifiedTime).map(Left(_)) ++ mergedImagesWithTime(modifiedTime).map(Right(_))
+
   def mergedWorksWithTime(modifiedTime: Instant): Seq[Work[Merged]] =
     resultWorks.map(_.transition[Merged](modifiedTime))
 
   def mergedImagesWithTime(
-    modifiedTime: Instant): Seq[Image[ImageState.Initial]] =
+    modifiedTime: Instant): Seq[Image[Initial]] =
     imagesWithSources.map {
       case ImageDataWithSource(imageData, source) =>
-        Image[ImageState.Initial](
+        Image[Initial](
           version = imageData.version,
           locations = imageData.locations,
           source = source,
           modifiedTime = modifiedTime,
-          state = ImageState.Initial(
+          state = Initial(
             sourceIdentifier = imageData.id.sourceIdentifier,
             canonicalId = imageData.id.canonicalId
           )

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -1,35 +1,43 @@
 package uk.ac.wellcome.platform.merger.services
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 import java.time.Instant
-import akka.Done
-import io.circe.Encoder
+import akka.{Done, NotUsed}
+import akka.stream.scaladsl.Flow
+import software.amazon.awssdk.services.sqs.model.Message
 
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
-import uk.ac.wellcome.models.work.internal.WorkState.{Identified, Merged}
+import uk.ac.wellcome.models.matcher.MatcherResult
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.pipeline_storage.{
   Indexer, Indexable, PipelineStorageStream, PipelineStorageConfig
 }
 import uk.ac.wellcome.typesafe.Runnable
+import WorkState.{Identified, Merged}
+import ImageState.Initial
 
 class MergerWorkerService[WorkDestination, ImageDestination](
   msgStream: SQSStream[NotificationMessage],
-  workMsgSender: MessageSender[WorkDestination],
-  config: PipelineStorageConfig,
-  workIndexer: Indexer[Work[Merged]],
   sourceWorkLookup: IdentifiedWorkLookup,
   mergerManager: MergerManager,
-  imageSender: MessageSender[ImageDestination]
+  workOrImageIndexer: Indexer[Either[Work[Merged], Image[Initial]]],
+  workMsgSender: MessageSender[WorkDestination],
+  imageMsgSender: MessageSender[ImageDestination],
+  config: PipelineStorageConfig
 )(implicit ec: ExecutionContext)
     extends Runnable {
 
   import PipelineStorageStream._
+  import Indexable._
+
+  type WorkOrImage = Either[Work[Merged], Image[Initial]]
+
+  type WorkSet = Seq[Option[Work[Identified]]]
 
   def run(): Future[Done] =
     msgStream.runStream(
@@ -37,58 +45,49 @@ class MergerWorkerService[WorkDestination, ImageDestination](
       source =>
         source
           .via(processFlow(config, processMessage))
-          .via(
-            broadcastAndMerge(
-              batchIndexAndSendFlow(
-                config,
-                (work: Work[Merged]) => workMsgSender.send(
-                  implicitly[Indexable[Work[Merged]]].id(work)
-                ),
-                workIndexer
-              ),
-              identityFlow)
-            )
+          .via(broadcastAndMerge(batchIndexAndSendWorksAndImages, identityFlow))
     )
+
+  val batchIndexAndSendWorksAndImages: Flow[(Message, List[WorkOrImage]), Message, NotUsed] =
+    batchIndexAndSendFlow(config, sendWorkOrImage, workOrImageIndexer)
 
   private def processMessage(
-    message: NotificationMessage): Future[List[Work[Merged]]] =
-    for {
-      matcherResult <- Future.fromTry(fromJson[MatcherResult](message.body))
-      workSets <- Future.sequence {
-        matcherResult.works.toList.map {
-          matchedIdentifiers: MatchedIdentifiers =>
-            sourceWorkLookup.fetchAllWorks(
-              matchedIdentifiers.identifiers.toList)
-        }
+    message: NotificationMessage): Future[List[WorkOrImage]] =
+    Future
+      .fromTry(fromJson[MatcherResult](message.body))
+      .flatMap { matcherResult =>
+        getWorkSets(matcherResult)
+          .map(workSets => workSets.filter(_.flatten.nonEmpty))
       }
-      nonEmptyWorkSets = workSets.filter(_.flatten.nonEmpty)
-      worksToSend <- nonEmptyWorkSets match {
-        case Nil => Future.successful(Nil)
-        case _ =>
-          val lastUpdated = nonEmptyWorkSets
-            .flatMap(_.flatten.map(work => work.state.modifiedTime))
-            .max
-          Future.sequence {
-            nonEmptyWorkSets.map(applyMerge(_, lastUpdated))
-          }
+      .map {
+        case Nil => Nil
+        case workSets =>
+          val lastUpdated = getLastUpdated(workSets)
+          workSets.flatMap(workSet => applyMerge(workSet, lastUpdated))
       }
-    } yield worksToSend.flatten
 
-  private def applyMerge(maybeWorks: Seq[Option[Work[Identified]]],
-                         lastUpdated: Instant): Future[Seq[Work[Merged]]] = {
-    val outcome = mergerManager.applyMerge(maybeWorks = maybeWorks)
-
-    for {
-      _ <- sendMessages(imageSender, outcome.mergedImagesWithTime(lastUpdated))
-    } yield outcome.mergedWorksWithTime(lastUpdated)
-  }
-
-  private def sendMessages[Destination, T](
-    sender: MessageSender[Destination],
-    items: Seq[T])(implicit encoder: Encoder[T]): Future[Seq[Unit]] =
-    Future.sequence(
-      items.map { item =>
-        Future.fromTry(sender.sendT(item))
+  private def getWorkSets(matcherResult: MatcherResult): Future[List[WorkSet]] =
+    Future.sequence {
+      matcherResult.works.toList.map {
+        matchedIdentifiers =>
+          sourceWorkLookup.fetchAllWorks(matchedIdentifiers.identifiers.toList)
       }
-    )
+    }
+
+  private def applyMerge(workSet: WorkSet,
+                         lastUpdated: Instant): Seq[WorkOrImage] =
+    mergerManager
+      .applyMerge(maybeWorks = workSet)
+      .mergedWorksAndImagesWithTime(lastUpdated)
+
+  private def sendWorkOrImage(workOrImage: WorkOrImage): Try[Unit] =
+    workOrImage match {
+      case Left(work) => workMsgSender.send(workIndexable.id(work))
+      case Right(image) => imageMsgSender.send(imageIndexable.id(image))
+    }
+
+  private def getLastUpdated(workSets: List[WorkSet]): Instant =
+    workSets
+      .flatMap(_.flatten.map(work => work.state.modifiedTime))
+      .max
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -12,21 +12,35 @@ import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.work.internal.WorkState.{Identified, Merged}
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
+import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.pipeline_storage.{Indexer, PipelineStorageStream, PipelineStorageConfig}
 import uk.ac.wellcome.typesafe.Runnable
 
 class MergerWorkerService[WorkDestination, ImageDestination](
-  pipelineStorageStream: PipelineStorageStream[NotificationMessage,
-                                               Work[Merged],
-                                               WorkDestination],
+  msgStream: SQSStream[NotificationMessage],
+  workMsgSender: MessageSender[WorkDestination],
+  config: PipelineStorageConfig,
+  workIndexer: Indexer[Work[Merged]],
   sourceWorkLookup: IdentifiedWorkLookup,
   mergerManager: MergerManager,
   imageSender: MessageSender[ImageDestination]
 )(implicit ec: ExecutionContext)
     extends Runnable {
 
+  import PipelineStorageStream._
+
   def run(): Future[Done] =
-    pipelineStorageStream.foreach(this.getClass.getSimpleName, processMessage)
+    msgStream.runStream(
+      this.getClass.getSimpleName,
+      source =>
+        source
+          .via(processFlow(config, processMessage))
+          .via(
+            broadcastAndMerge(
+              batchIndexAndSendFlow(config, workMsgSender, workIndexer),
+              identityFlow)
+            )
+    )
 
   private def processMessage(
     message: NotificationMessage): Future[List[Work[Merged]]] =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -15,7 +15,10 @@ import uk.ac.wellcome.models.matcher.MatcherResult
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.pipeline_storage.{
-  Indexer, Indexable, PipelineStorageStream, PipelineStorageConfig
+  Indexable,
+  Indexer,
+  PipelineStorageConfig,
+  PipelineStorageStream
 }
 import uk.ac.wellcome.typesafe.Runnable
 import WorkState.{Identified, Merged}
@@ -48,7 +51,8 @@ class MergerWorkerService[WorkDestination, ImageDestination](
           .via(broadcastAndMerge(batchIndexAndSendWorksAndImages, identityFlow))
     )
 
-  val batchIndexAndSendWorksAndImages: Flow[(Message, List[WorkOrImage]), Message, NotUsed] =
+  val batchIndexAndSendWorksAndImages
+    : Flow[(Message, List[WorkOrImage]), Message, NotUsed] =
     batchIndexAndSendFlow(config, sendWorkOrImage, workOrImageIndexer)
 
   private def processMessage(
@@ -68,9 +72,8 @@ class MergerWorkerService[WorkDestination, ImageDestination](
 
   private def getWorkSets(matcherResult: MatcherResult): Future[List[WorkSet]] =
     Future.sequence {
-      matcherResult.works.toList.map {
-        matchedIdentifiers =>
-          sourceWorkLookup.fetchAllWorks(matchedIdentifiers.identifiers.toList)
+      matcherResult.works.toList.map { matchedIdentifiers =>
+        sourceWorkLookup.fetchAllWorks(matchedIdentifiers.identifiers.toList)
       }
     }
 
@@ -82,7 +85,7 @@ class MergerWorkerService[WorkDestination, ImageDestination](
 
   private def sendWorkOrImage(workOrImage: WorkOrImage): Try[Unit] =
     workOrImage match {
-      case Left(work) => workMsgSender.send(workIndexable.id(work))
+      case Left(work)   => workMsgSender.send(workIndexable.id(work))
       case Right(image) => imageMsgSender.send(imageIndexable.id(image))
     }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.merger.services
 
+import scala.concurrent.{ExecutionContext, Future}
+import java.time.Instant
 import akka.Done
 import io.circe.Encoder
+
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
@@ -11,9 +14,6 @@ import uk.ac.wellcome.models.work.internal.WorkState.{Identified, Merged}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.PipelineStorageStream
 import uk.ac.wellcome.typesafe.Runnable
-
-import java.time.Instant
-import scala.concurrent.{ExecutionContext, Future}
 
 class MergerWorkerService[WorkDestination, ImageDestination](
   pipelineStorageStream: PipelineStorageStream[NotificationMessage,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -1,47 +1,52 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.models.work.internal.WorkState.{Identified, Merged}
+import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.monitoring.Metrics
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.pipeline_storage.{MemoryIndexer, MemoryRetriever}
 import uk.ac.wellcome.platform.merger.services._
-
-import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import WorkState.{Identified, Merged}
+import ImageState.Initial
 
 trait WorkerServiceFixture extends PipelineStorageStreamFixtures {
+
+  type WorkOrImage = Either[Work[Merged], Image[Initial]]
+
   def withWorkerService[R](retriever: MemoryRetriever[Work[Identified]],
                            queue: Queue,
                            workSender: MemoryMessageSender,
                            imageSender: MemoryMessageSender =
                              new MemoryMessageSender(),
                            metrics: Metrics[Future] = new MemoryMetrics,
-                           index: mutable.Map[String, Work[Merged]] =
-                             mutable.Map[String, Work[Merged]]())(
+                           index: mutable.Map[String, WorkOrImage] =
+                             mutable.Map.empty)(
     testWith: TestWith[MergerWorkerService[String, String], R]): R =
-    withPipelineStream(
-      queue = queue,
-      indexer = new MemoryIndexer(index),
-      sender = workSender,
-      metrics = metrics
-    ) { pipelineStream =>
-      val workerService = new MergerWorkerService(
-        pipelineStorageStream = pipelineStream,
-        sourceWorkLookup = new IdentifiedWorkLookup(retriever),
-        mergerManager = new MergerManager(PlatformMerger),
-        imageSender = imageSender
-      )
 
-      workerService.run()
+    withActorSystem { implicit actorSystem =>
+      withSQSStream[NotificationMessage, R](queue, metrics) { msgStream =>
+        val workerService = new MergerWorkerService(
+          msgStream = msgStream,
+          sourceWorkLookup = new IdentifiedWorkLookup(retriever),
+          mergerManager = new MergerManager(PlatformMerger),
+          workOrImageIndexer = new MemoryIndexer(index),
+          workMsgSender = workSender,
+          imageMsgSender = imageSender,
+          config = pipelineStorageConfig
+        )
 
-      testWith(workerService)
+        workerService.run()
+
+        testWith(workerService)
+      }
     }
 
   def withWorkerService[R](retriever: MemoryRetriever[Work[Identified]])(
@@ -59,7 +64,6 @@ trait WorkerServiceFixture extends PipelineStorageStreamFixtures {
   def getWorksSent(workSender: MemoryMessageSender): Seq[String] =
     workSender.messages.map { _.body }
 
-  def getImagesSent(
-    imageSender: MemoryMessageSender): Seq[Image[ImageState.Initial]] =
-    imageSender.getMessages[Image[ImageState.Initial]]
+  def getImagesSent(imageSender: MemoryMessageSender): Seq[String] =
+    imageSender.messages.map { _.body }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/WorkerServiceFixture.scala
@@ -21,16 +21,14 @@ trait WorkerServiceFixture extends PipelineStorageStreamFixtures {
 
   type WorkOrImage = Either[Work[Merged], Image[Initial]]
 
-  def withWorkerService[R](retriever: MemoryRetriever[Work[Identified]],
-                           queue: Queue,
-                           workSender: MemoryMessageSender,
-                           imageSender: MemoryMessageSender =
-                             new MemoryMessageSender(),
-                           metrics: Metrics[Future] = new MemoryMetrics,
-                           index: mutable.Map[String, WorkOrImage] =
-                             mutable.Map.empty)(
+  def withWorkerService[R](
+    retriever: MemoryRetriever[Work[Identified]],
+    queue: Queue,
+    workSender: MemoryMessageSender,
+    imageSender: MemoryMessageSender = new MemoryMessageSender(),
+    metrics: Metrics[Future] = new MemoryMetrics,
+    index: mutable.Map[String, WorkOrImage] = mutable.Map.empty)(
     testWith: TestWith[MergerWorkerService[String, String], R]): R =
-
     withActorSystem { implicit actorSystem =>
       withSQSStream[NotificationMessage, R](queue, metrics) { msgStream =>
         val workerService = new MergerWorkerService(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -4,6 +4,9 @@ import scala.collection.mutable
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
@@ -19,9 +22,6 @@ import WorkState.{Identified, Merged}
 import WorkFsm._
 import uk.ac.wellcome.models.work.generators.MiroWorkGenerators
 import uk.ac.wellcome.pipeline_storage.MemoryRetriever
-
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class MergerWorkerServiceTest
     extends AnyFunSpec

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/Main.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Denormalised
-import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.pipeline_storage.typesafe.ElasticIndexerBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder


### PR DESCRIPTION
## Issue

https://github.com/wellcomecollection/platform/issues/4965

## Description

Updates the image section of the pipeline to use `pipeline_storage` rather than `big_messaging`.

**NOTE: due to the size of this PR here I just update the code itself, a future PR will be needed for terraform and configuration of environment variables.**

- [x] Merger
- [x] Inference manager
- [x] Image ingestor