### PR TITLE
Deduplicate library reference identifiers in the Miro transformer

### DIFF
--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
@@ -67,8 +67,7 @@ trait MiroIdentifiers extends MiroTransformableUtils {
     val libraryRefsList: List[SourceIdentifier] =
       zipMiroFields(
         keys = miroRecord.libraryRefDepartment,
-        values = miroRecord.libraryRefId)
-        .distinct
+        values = miroRecord.libraryRefId).distinct
         .collect {
           case (Some(label), Some(value)) =>
             SourceIdentifier(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
@@ -68,6 +68,7 @@ trait MiroIdentifiers extends MiroTransformableUtils {
       zipMiroFields(
         keys = miroRecord.libraryRefDepartment,
         values = miroRecord.libraryRefId)
+        .distinct
         .collect {
           case (Some(label), Some(value)) =>
             SourceIdentifier(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.internal.{IdentifierType, SourceIdentifier}
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 
 class MiroIdentifiersTest
@@ -23,6 +24,25 @@ class MiroIdentifiersTest
     otherIdentifiers shouldBe List(
       createSierraSystemSourceIdentifierWith(
         value = "b15551040"
+      )
+    )
+  }
+
+  it("deduplicates the library references") {
+    // This is based on Miro record L0032098
+    val miroRecord = createMiroRecordWith(
+      libraryRefDepartment = List(Some("EPB"), Some("EPB")),
+      libraryRefId = List(Some("20057/B/1"), Some("20057/B/1"))
+    )
+
+    val otherIdentifiers =
+      transformer.getOtherIdentifiers(miroRecord = miroRecord)
+
+    otherIdentifiers shouldBe List(
+      SourceIdentifier(
+        identifierType = IdentifierType("miro-library-reference"),
+        ontologyType = "Work",
+        value = "EPB 20057/B/1"
       )
     )
   }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4964