### PR TITLE
Use HTML to display the results of the API diff tool

### DIFF
--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -1,8 +1,16 @@
 #!/bin/env python3
 
-import requests
-import click
+import datetime
+import difflib
 import json
+import os
+import tempfile
+import urllib.parse
+
+import click
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import requests
+import tqdm
 
 
 class ApiDiffer:
@@ -13,26 +21,24 @@ class ApiDiffer:
     prod = "api.wellcomecollection.org"
     stage = "api-stage.wellcomecollection.org"
 
-    def __init__(self, work_id=None, params=None, show_colour=True, verbose=False):
+    def __init__(self, work_id=None, params=None):
         suffix = f"/{work_id}" if work_id else ""
         self.path = f"/catalogue/v2/works{suffix}"
         self.params = params or {}
-        self.show_colour = show_colour
-        self.verbose = verbose
 
-    def display_diff(self):
-        click.echo(
-            "================================================================================"
-        )
-        click.echo(f"Performing diff on {self.path} with params:")
-        click.echo(self.params)
-        click.echo(
-            "================================================================================"
-        )
-        click.echo()
-        click.echo("* Calling prod API")
+    @property
+    def display_url(self):
+        display_params = urllib.parse.urlencode(list(self.params.items()))
+        if display_params:
+            return f"{self.path}?{display_params}"
+        else:
+            return self.path
+
+    def get_html_diff(self):
+        """
+        Fetches a URL from the prod/staging API, and returns a (status, HTML diff).
+        """
         (prod_status, prod_json) = self.call_api(self.prod)
-        click.echo("* Calling stage API")
         (stage_status, stage_json) = self.call_api(self.stage)
         if prod_status != stage_status:
             lines = [
@@ -44,17 +50,24 @@ class ApiDiffer:
                 "stage:",
                 f"{json.dumps(stage_json, indent=2)}",
             ]
-            msg = "\n".join(lines)
-            if self.show_colour:
-                msg = click.style(msg, fg="red")
-            click.echo(msg)
+            return ("different status", "\n".join(lines))
+        elif prod_json == stage_json:
+            return ("match", "")
         else:
-            click.echo(f"* Recived {prod_status} status from both APIs")
-            click.echo("* Generating diff")
-            click.echo()
-            differ = ObjDiffer(prod_json, stage_json, "prod", "stage", self.show_colour)
-            differ.display_diff()
-        click.echo()
+            prod_pretty = json.dumps(prod_json, indent=2, sort_keys=True)
+            stage_pretty = json.dumps(stage_json, indent=2, sort_keys=True)
+
+            return (
+                "different JSON",
+                list(
+                    difflib.unified_diff(
+                        prod_pretty.splitlines(),
+                        stage_pretty.splitlines(),
+                        fromfile="prod",
+                        tofile="stage",
+                    )
+                ),
+            )
 
     def call_api(self, api_base):
         url = f"https://{api_base}{self.path}"
@@ -62,105 +75,43 @@ class ApiDiffer:
         return (response.status_code, response.json())
 
 
-class ObjDiffer:
-    """Performs a diff between 2 json-like Python objects, and prints changes
-    between the two to stdout. It does this by flattening out any nesting within
-    the objects so each nested item is referenced by a single top level key
-    (represented as a variable length tuple containing string keys and array
-    indices).
-    """
-
-    def __init__(self, obj_a, obj_b, name_a, name_b, show_colour=True, verbose=False):
-        self.obj_a = dict(self.flatten(obj_a))
-        self.obj_b = dict(self.flatten(obj_b))
-        self.name_a = name_a
-        self.name_b = name_b
-        self.show_colour = show_colour
-        self.verbose = verbose
-
-    def display_diff(self):
-        results = list(self.diff_results)
-        if not self.verbose and not any(results):
-            msg = "Unchanged between stage and prod"
-            if self.show_colour:
-                msg = click.style(msg, fg="green")
-            click.echo(msg)
-        else:
-            self.display_results(results)
-
-    def display_results(self, results):
-        for (key, result) in zip(self.combined_keys, results):
-            if result:
-                a, b = map(self.format_value, result)
-                msg = f"changed from {a} on {self.name_a} to {b} on {self.name_b}"
-                col = "red"
-            else:
-                msg = f"unchanged between {self.name_a} and {self.name_b}"
-                col = "green"
-            if self.show_colour:
-                msg = click.style(msg, fg=col)
-            click.echo(f"{self.format_key(key)}: {msg}")
-
-    def format_key(self, key):
-        return ".".join(f"[{part}]" if isinstance(part, int) else part for part in key)
-
-    def format_value(self, value):
-        if isinstance(value, str):
-            return f'"{value}"'
-        if value is None:
-            return "null"
-        return str(value)
-
-    @property
-    def combined_keys(self):
-        return sorted(set(self.obj_a.keys()) | set(self.obj_b.keys()))
-
-    @property
-    def diff_results(self):
-        for key in self.combined_keys:
-            a, b = self.obj_a.get(key), self.obj_b.get(key)
-            yield None if a == b else (a, b)
-
-    def flatten(self, obj):
-        def flatten_tupled(obj):
-            nested = [join_subitems(key, self.flatten(value)) for key, value in obj]
-            return sum(nested, [])
-
-        def join_subitems(key, subitems):
-            return [((key, *subkey), value) for (subkey, value) in subitems]
-
-        if isinstance(obj, list):
-            return flatten_tupled(enumerate(obj))
-        if isinstance(obj, dict):
-            return flatten_tupled(obj.items())
-        return [((), obj)]
-
-
 @click.command()
-@click.option(
-    "--colour/--no-colour",
-    default=True,
-    help="Whether to display in terminal with colours or not",
-)
 @click.option(
     "--routes-file",
     default="routes.json",
     help="What routes file to use (default=routes.json)",
 )
-@click.option(
-    "--verbose",
-    default=False,
-    help="Displays full diffs even when there are no changes.",
-)
-@click.option("--repeats", default=1, help="How many times to call each route")
-def main(colour, routes_file, repeats, verbose):
+def main(routes_file):
     with open(routes_file) as f:
         routes = json.load(f)
-    for route in routes:
+
+    diffs = []
+
+    for route in tqdm.tqdm(routes):
         work_id, params = route.get("workId"), route.get("params")
-        for _ in range(repeats):
-            differ = ApiDiffer(work_id, params, show_colour=colour, verbose=verbose)
-            differ.display_diff()
+        differ = ApiDiffer(work_id, params)
+        status, diff_lines = differ.get_html_diff()
+
+        diffs.append(
+            {
+                "display_url": differ.display_url,
+                "status": status,
+                "diff_lines": diff_lines,
+            }
+        )
+
+    env = Environment(
+        loader=FileSystemLoader("."), autoescape=select_autoescape(["html", "xml"])
+    )
+
+    template = env.get_template("template.html")
+    html = template.render(now=datetime.datetime.now(), diffs=diffs)
+
+    _, tmp_path = tempfile.mkstemp(suffix=".html")
+    with open(tmp_path, "w") as outfile:
+        outfile.write(html)
+
+    os.system(f"open {tmp_path}")
 
 
 if __name__ == "__main__":

--- a/api/diff_tool/template.html
+++ b/api/diff_tool/template.html
@@ -1,0 +1,75 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style>
+    body {
+      max-width: 950px;
+      margin-right: auto;
+      margin-left:  auto;
+      font: 13pt sans-serif;
+      padding: 1em;
+    }
+
+    details {
+      border: 1px solid #999;
+      margin-bottom: 1em;
+      border-radius: 5px;
+      padding: 0.5em 1em;
+      background: #f3f3f3;
+    }
+
+    details.match {
+      background: #eeffef;
+    }
+
+    pre {
+      overflow: scroll;
+    }
+
+    .addition {
+      color: green;
+    }
+
+    .removal {
+      color: red;
+    }
+
+    .meta {
+      color: brown;
+    }
+  </style>
+
+  <title>API diff for {{ now.strftime("%A %-d %B %Y @ %H:%M:%S") }}</title>
+</head>
+
+<body>
+  <h1>API diff for {{ now.strftime("%A %-d %B %Y @ %H:%M:%S") }}</h1>
+
+  {% for d in diffs %}
+  <details {% if d.status == "match" %}class="match"{% else %}open{% endif %}>
+    <summary>
+      <strong>
+        {% if d.status == "match" %}✅{% else %}❌{% endif %}
+        {{ d.display_url }}
+      </strong>
+    </summary>
+
+    <p>
+      <a href="https://api.wellcomecollection.org{{ d.display_url }}">prod API</a> /
+      <a href="https://api-stage.wellcomecollection.org{{ d.display_url }}">staging API</a>
+    </p>
+
+    {% if d.diff_lines %}
+<pre>{% for line in d.diff_lines -%}
+<code
+  {% if line.startswith("+") %}class="addition"{% endif %}
+  {% if line.startswith("-") %}class="removal"{% endif %}
+  {% if line.startswith("@") %}class="meta"{% endif %}
+>{{ line.rstrip() }}</code><br/>{% endfor %}</pre>
+    {% endif %}
+  </details>
+  {% endfor %}
+</body>


### PR DESCRIPTION
Now running the diff tool takes you to an HTML page like this:

<img width="1391" alt="Screenshot 2021-01-12 at 12 20 43" src="https://user-images.githubusercontent.com/301220/104313987-b3b75780-54d0-11eb-806d-f27848036cb1.png">

By default all the diffs are open `<details>` elements, but you can collapse/expand them as appropriate. The hope is that this is a bit easier to process/make decisions about than a pile of text in the console.