### PR TITLE
Improve the error messages in the merger if you send in an invalid message

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -20,7 +20,8 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
     extends Retriever[T]
     with Logging {
 
-  override final def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
+  override final def apply(
+    ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
     assert(
       ids.nonEmpty,
       "You should never look up an empty list of IDs!"

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticRetriever.scala
@@ -20,7 +20,12 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
     extends Retriever[T]
     with Logging {
 
-  override final def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] =
+  override final def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
+    assert(
+      ids.nonEmpty,
+      "You should never look up an empty list of IDs!"
+    )
+
     client
       .execute {
         multiget(
@@ -59,4 +64,5 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
             notFound = documents.collect { case (id, Failure(e)) => id -> e }
           )
       }
+  }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
@@ -21,44 +21,33 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
         case WorkIdentifier(identifier, Some(_)) => identifier
       }
 
-    // A WorkIdentifier can have a version "None" if a Work in the pipeline points to
-    // it, but we haven't seen a Work with this identifier yet.
-    //
-    // e.g. Suppose a Work with identifier A says "I am matched to identifier B", but
-    // the pipeline hasn't seen a Work with identifier B yet.  Then the merger would
-    // receive something like:
-    //
-    //      WorkIdentifier("A", version = Some(1)), WorkIdentifier("B", version = None)
-    //
-    // Every message from the matcher should be triggered by a Work in the pipeline,
-    // so every set of identifiers it sends should include at least one WorkIdentifier
-    // with a non-empty version.
-    //
-    // If it doesn't, something has gone wrong and we should give up immediately.
-    assert(
-      workIds.nonEmpty,
-      s"At least one of the WorkIdentifiers should have a version ($workIdentifiers)"
-    )
-
-    retriever(workIds)
-      .map {
-        case RetrieverMultiResult(works, notFound) if notFound.isEmpty =>
-          workIdentifiers
-            .map {
-              case WorkIdentifier(_, None) => None
-              case WorkIdentifier(id, Some(version)) =>
-                val work = works(id)
-                // We only want to get the exact versions of the works specified
-                // by the matcher.
-                //
-                // e.g. if the matcher said "combine Av1 and Bv2", and we look
-                // in the retriever and find {Av2, Bv3}, we shouldn't merge
-                // these -- we should wait for the matcher to confirm we should
-                // still be merging these two works.
-                if (work.version == version) Some(work) else None
-            }
-        case RetrieverMultiResult(_, notFound) =>
-          throw new RuntimeException(s"Works not found: $notFound")
-      }
+    // If none of the work identifiers had a version, we'll discard anything
+    // we get from the retriever, so skip going out to it.
+    if (workIds.isEmpty) {
+      Future.successful(
+        workIdentifiers.map { _ => None }
+      )
+    } else {
+      retriever(workIds)
+        .map {
+          case RetrieverMultiResult(works, notFound) if notFound.isEmpty =>
+            workIdentifiers
+              .map {
+                case WorkIdentifier(_, None) => None
+                case WorkIdentifier(id, Some(version)) =>
+                  val work = works(id)
+                  // We only want to get the exact versions of the works specified
+                  // by the matcher.
+                  //
+                  // e.g. if the matcher said "combine Av1 and Bv2", and we look
+                  // in the retriever and find {Av2, Bv3}, we shouldn't merge
+                  // these -- we should wait for the matcher to confirm we should
+                  // still be merging these two works.
+                  if (work.version == version) Some(work) else None
+              }
+          case RetrieverMultiResult(_, notFound) =>
+            throw new RuntimeException(s"Works not found: $notFound")
+        }
+    }
   }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
@@ -25,7 +25,9 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
     // we get from the retriever, so skip going out to it.
     if (workIds.isEmpty) {
       Future.successful(
-        workIdentifiers.map { _ => None }
+        workIdentifiers.map { _ =>
+          None
+        }
       )
     } else {
       retriever(workIds)


### PR DESCRIPTION
I was sending some hand-rolled messages to the merger this evening, patching up a reindex. The merger takes a collection of `WorkIdentifier` instances, which is defined as:

```scala
case class WorkIdentifier(identifier: String, version: Option[Int])
```

In my naïveté, I sent the following WorkIdentifier to the merger: `WorkIdentifier(id = "qwkttzg2", version = None)`. I promptly saw a null pointer exception coming from the ElasticRetriever in the merger logs, which was both confusing and wrong. We pretty much never want to be throwing a null pointer error – it indicates a higher-level bug somewhere else, and we should catch it and explain what's actually gone wrong.

Digging in, I discovered that the ElasticRetriever throws a null pointer error if you ask it to retrieve an empty list of IDs. I've replaced that error with an assertion that throws a more explicable error message (*"You should never look up an empty list of IDs!"*). If it turns out there is some scenario when this is useful, it'll be easier to debug.

But why was the merger retrieving an empty list of IDs? Because it only asks the ElasticRetriever to find Works whose WorkIdentifier has a non-empty `version`.

I had to stare at the matcher code for quite a while to convince myself that yes, sometimes this field will be empty and that's okay, and also that the matcher should always include at least one non-empty version in the results it sends. I've added some comments to the matcher graph code so it's easier to follow, and an assertion/comment in the merger to catch this as well.