### PR TITLE
Ensure MemoryIndexer changes are synchronised across threads

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -10,7 +10,7 @@ class MemoryIndexer[T: Indexable](
   def init(): Future[Unit] =
     Future.successful(())
 
-  def apply(documents: Seq[T]): Future[Either[Seq[T], Seq[T]]] = {
+  def apply(documents: Seq[T]): Future[Either[Seq[T], Seq[T]]] = synchronized {
     documents.foreach { doc =>
       index.get(indexable.id(doc)) match {
         case Some(storedDoc)


### PR DESCRIPTION
We've seen flaky transformer tests where it tries to store the same record twice in quick succession, and the second thread doesn't see the work stored by the first thread.  Synchronising the indexer should make this test stop misbehaving.