### PR TITLE
Build inference manager apps in docker-compose

### DIFF
--- a/pipeline/inferrer/inference_manager/docker-compose.yml
+++ b/pipeline/inferrer/inference_manager/docker-compose.yml
@@ -1,32 +1,32 @@
-sqs:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
-  ports:
-    - "9324:9324"
+services:
+  sqs:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
+    ports:
+      - "9324:9324"
 
-feature_inferrer:
-  image: feature_inferrer
-  ports:
-    - "3141:80"
-  environment:
-    MODEL_OBJECT_KEY: test-model.pkl
-  volumes:
-    - ../test_data:/app/data
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  feature_inferrer:
+    image: feature_inferrer
+    ports:
+      - "3141:80"
+    environment:
+      MODEL_OBJECT_KEY: test-model.pkl
+    volumes:
+      - ../test_data:/app/data
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-palette_inferrer:
-  image: palette_inferrer
-  ports:
-    - "3142:80"
-  volumes:
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  palette_inferrer:
+    ports:
+      - "3142:80"
+    volumes:
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-image_server:
-  image: nginx
-  ports:
-    - "2718:80"
-  volumes:
-    - ../test_data:/usr/share/nginx/html:ro
+  image_server:
+    image: nginx
+    ports:
+      - "2718:80"
+    volumes:
+      - ../test_data:/usr/share/nginx/html:ro

--- a/pipeline/inferrer/inference_manager/docker-compose.yml
+++ b/pipeline/inferrer/inference_manager/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       - "9324:9324"
 
   feature_inferrer:
+    build:
+      context: "../feature_inferrer"
+      dockerfile: "Dockerfile"
     image: feature_inferrer
     ports:
       - "3141:80"
@@ -17,6 +20,9 @@ services:
       - "image_server:image_server"
 
   palette_inferrer:
+    build:
+      context: "../palette_inferrer"
+      dockerfile: "Dockerfile"
     ports:
       - "3142:80"
     volumes:


### PR DESCRIPTION
Nick was having issues starting the docker-compose in the inference manager tests, because he doesn't run tests through Make, and the docker-compose relies on images that are built locally.

You can tell docker-compose "build this image from a local Dockerfile", so this patch does that – which slightly reduces our dependency on Make.

I'd like some eyes on this from @jamieparkinson when he's feeling better, as he wrote pretty much all this code and will know if I'm missing something.