### PR TITLE
Use relative redirects in the catalogue API

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -74,9 +74,19 @@ class WorksController(elasticsearchService: ElasticsearchService,
     }
 
   def workRedirect(work: Work.Redirected[Indexed]): Route =
-    extractPublicUri { uri =>
+    extractUri { uri =>
       val newPath = (work.redirect.canonicalId :: uri.path.reverse.tail).reverse
-      redirect(uri.withPath(newPath), Found)
+
+      // We use a relative URL here so that redirects keep you on the same host.
+      //
+      // e.g. on https://api-stage.wc.org, we tell the API that it's running at
+      // https://api.wc.org so URLs in responses look the same, but we don't want
+      // the stage API to send redirects to the prod API.
+      //
+      // Relative URLs are explicitly supported in HTTP 302 Redirects, see
+      // https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p2-semantics-17.html#rfc.section.9.5
+      // https://stackoverflow.com/q/8250259/1558022
+      redirect(uri.withPath(newPath).toRelative, Found)
     }
 
   def workFound(work: Work.Visible[Indexed], includes: WorksIncludes): Route =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
@@ -19,8 +19,7 @@ class WorksRedirectsTest extends ApiWorksTestBase {
         insertIntoElasticsearch(worksIndex, redirectedWork)
         val path = s"/$apiPrefix/works/${redirectedWork.state.canonicalId}"
         assertRedirectResponse(routes, path) {
-          Status.Found ->
-            s"$apiScheme://$apiHost/$apiPrefix/works/$redirectId"
+          Status.Found -> s"/$apiPrefix/works/$redirectId"
         }
     }
   }
@@ -32,8 +31,7 @@ class WorksRedirectsTest extends ApiWorksTestBase {
         val path =
           s"/$apiPrefix/works/${redirectedWork.state.canonicalId}?include=identifiers"
         assertRedirectResponse(routes, path) {
-          Status.Found ->
-            s"$apiScheme://$apiHost/$apiPrefix/works/$redirectId?include=identifiers"
+          Status.Found -> s"/$apiPrefix/works/$redirectId?include=identifiers"
         }
     }
   }


### PR DESCRIPTION
e.g. the current state of the API:

    GET https://api-stage.wellcomecollection.org/catalogue/v2/works/sqensfpm?_index=works-2021-01-12

    302 https://api.wellcomecollection.org/catalogue/v2/works/vhe8eqee?_index=works-2021-01-12

The staging API shouldn't be redirecting a work to the prod API.  It should redirect to the same work within the staging API.

Closes https://github.com/wellcomecollection/platform/issues/4967