### PR TITLE
If the API diff tool changes, don't re-test all our sbt apps

### DIFF
--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -38,6 +38,9 @@ def should_run_sbt_project(repo, project_name, changed_paths):
         if path.endswith((".py", ".tf", ".md")):
             continue
 
+        if path.startswith("api/diff_tool"):
+            continue
+
         if path.endswith("Makefile"):
             if os.path.dirname(project.folder) == os.path.dirname(path):
                 print("*** %s is defined by %s" % (project.name, path))

--- a/.buildkite/scripts/test_run_job.py
+++ b/.buildkite/scripts/test_run_job.py
@@ -27,6 +27,7 @@ def repo():
         ("big_messaging_typesafe", ["common/big_messaging/file.scala"], True),
         ("merger", ["common/big_messaging/file.scala"], True),
         ("merger", ["common/big_messaging_typesafe/file.scala"], True),
+        ("merger", ["api/diff_tool/template.html"], False),
     ],
 )
 def test_should_run_sbt_project(repo, project_name, changed_paths, should_run_project):

--- a/.buildkite/scripts/test_run_job.py
+++ b/.buildkite/scripts/test_run_job.py
@@ -24,8 +24,8 @@ def repo():
         ("elasticsearch", ["common/Makefile"], True),
         ("elasticsearch", ["common/Makefile", "pipeline/Makefile"], True),
         ("elasticsearch", ["common/Makefile", "pipeline/Makefile"], True),
-        ("big_messaging_typesafe", ["common/big_messaging/file.scala"], False),
-        ("merger", ["common/big_messaging/file.scala"], False),
+        ("big_messaging_typesafe", ["common/big_messaging/file.scala"], True),
+        ("merger", ["common/big_messaging/file.scala"], True),
         ("merger", ["common/big_messaging_typesafe/file.scala"], True),
     ],
 )

--- a/.buildkite/scripts/test_run_job.py
+++ b/.buildkite/scripts/test_run_job.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8
+
+import os
 
 import pytest
 
+from commands import git
 from run_job import should_run_sbt_project
 from sbt_dependency_tree import Repository
 
 
 @pytest.fixture(scope="session")
 def repo():
-    yield Repository(".sbt_metadata")
+    root = git("rev-parse", "--show-toplevel")
+    yield Repository(os.path.join(root, ".sbt_metadata"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We've just burnt two full builds on the diff tool, even though it doesn't affect any of our Scala apps. We should not do that!

(I'm planning to make more changes to the diff tool, and I'd like it to be speedy through CI.)