### PR TITLE
Fetch the API diffs concurrently, not one-by-one

### DIFF
--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -1,5 +1,6 @@
 #!/bin/env python3
 
+import concurrent.futures
 import datetime
 import difflib
 import json
@@ -10,7 +11,6 @@ import urllib.parse
 import click
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 import requests
-import tqdm
 
 
 class ApiDiffer:
@@ -85,8 +85,6 @@ def main(routes_file):
     with open(routes_file) as f:
         routes = json.load(f)
 
-    diffs = []
-
     def get_diff(route):
         work_id, params = route.get("workId"), route.get("params")
         differ = ApiDiffer(work_id, params)
@@ -98,8 +96,11 @@ def main(routes_file):
             "diff_lines": diff_lines,
         }
 
-    for route in tqdm.tqdm(routes):
-        diffs.append(get_diff(route))
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [executor.submit(get_diff, r) for r in routes]
+        concurrent.futures.wait(futures, return_when=concurrent.futures.ALL_COMPLETED)
+
+        diffs = [fut.result() for fut in futures]
 
     env = Environment(
         loader=FileSystemLoader("."), autoescape=select_autoescape(["html", "xml"])

--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -87,18 +87,19 @@ def main(routes_file):
 
     diffs = []
 
-    for route in tqdm.tqdm(routes):
+    def get_diff(route):
         work_id, params = route.get("workId"), route.get("params")
         differ = ApiDiffer(work_id, params)
         status, diff_lines = differ.get_html_diff()
 
-        diffs.append(
-            {
-                "display_url": differ.display_url,
-                "status": status,
-                "diff_lines": diff_lines,
-            }
-        )
+        return {
+            "display_url": differ.display_url,
+            "status": status,
+            "diff_lines": diff_lines,
+        }
+
+    for route in tqdm.tqdm(routes):
+        diffs.append(get_diff(route))
 
     env = Environment(
         loader=FileSystemLoader("."), autoescape=select_autoescape(["html", "xml"])


### PR DESCRIPTION
This makes the diff tool dramatically faster – running locally, it went from ~8s to run to ~1s.