### PR TITLE
Provide more helpful logging messages when running a snapshot

### DIFF
--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -22,14 +22,12 @@ object ElasticsearchWorksSource extends Logging {
     implicit
     actorSystem: ActorSystem
   ): Source[Work[Indexed], NotUsed] = {
-    val loggingSink = Flow[Work[Indexed]]
-      .zipWithIndex
+    val loggingSink = Flow[Work[Indexed]].zipWithIndex
       .map { case (_, index) => index + 1 }
       .grouped(10000)
       .map(indices =>
-        info(
-          s"Received another ${intComma(indices.length)} works (${intComma(indices.max)} so far) from ${snapshotConfig.index}")
-      )
+        info(s"Received another ${intComma(indices.length)} works (${intComma(
+          indices.max)} so far) from ${snapshotConfig.index}"))
       .to(Sink.ignore)
 
     Source

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -14,6 +14,8 @@ import WorkState.Indexed
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.snapshot_generator.models.SnapshotGeneratorConfig
 
+import java.text.NumberFormat
+
 object ElasticsearchWorksSource extends Logging {
   def apply(elasticClient: ElasticClient,
             snapshotConfig: SnapshotGeneratorConfig)(
@@ -26,9 +28,10 @@ object ElasticsearchWorksSource extends Logging {
       .grouped(10000)
       .map(indices =>
         info(
-          s"Received another ${indices.length} works (${indices.max} so far) from ${snapshotConfig.index}")
+          s"Received another ${intComma(indices.length)} works (${intComma(indices.max)} so far) from ${snapshotConfig.index}")
       )
       .to(Sink.ignore)
+
     Source
       .fromPublisher(
         elasticClient.publisher(
@@ -42,4 +45,7 @@ object ElasticsearchWorksSource extends Logging {
       }
       .alsoTo(loggingSink)
   }
+
+  private def intComma(number: Long): String =
+    NumberFormat.getInstance().format(number)
 }

--- a/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
+++ b/snapshots/snapshot_generator/src/main/scala/uk/ac/wellcome/platform/snapshot_generator/akkastreams/source/ElasticsearchWorksSource.scala
@@ -21,12 +21,13 @@ object ElasticsearchWorksSource extends Logging {
     actorSystem: ActorSystem
   ): Source[Work[Indexed], NotUsed] = {
     val loggingSink = Flow[Work[Indexed]]
+      .zipWithIndex
+      .map { case (_, index) => index + 1 }
       .grouped(10000)
-      .map(works => {
-        logger.info(
-          s"Received ${works.length} works from ${snapshotConfig.index}")
-        works
-      })
+      .map(indices =>
+        info(
+          s"Received another ${indices.length} works (${indices.max} so far) from ${snapshotConfig.index}")
+      )
       .to(Sink.ignore)
     Source
       .fromPublisher(

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -153,7 +153,7 @@ class SnapshotServiceTest
 
           result.snapshotResult.startedAt shouldBe >(
             result.snapshotJob.requestedAt)
-          result.snapshotResult.finishedAt shouldBe >(
+          result.snapshotResult.finishedAt shouldBe >=(
             result.snapshotResult.startedAt)
 
           result.snapshotResult.s3Etag shouldBe s3Etag

--- a/snapshots/terraform/stack/snapshot_generator/service.tf
+++ b/snapshots/terraform/stack/snapshot_generator/service.tf
@@ -15,11 +15,11 @@ module "snapshot_generator" {
   memory = 8192
 
   secret_env_vars = {
-    es_host      = "catalogue/api/es_host"
-    es_port      = "catalogue/api/es_port"
-    es_protocol  = "catalogue/api/es_protocol"
-    es_username  = "catalogue/api/es_username"
-    es_password  = "catalogue/api/es_password"
+    es_host     = "catalogue/api/es_host"
+    es_port     = "catalogue/api/es_port"
+    es_protocol = "catalogue/api/es_protocol"
+    es_username = "catalogue/api/es_username"
+    es_password = "catalogue/api/es_password"
   }
 
   subnets = var.subnets


### PR DESCRIPTION
Currently, the snapshot generator is repeatedly logging:

```
Received 10000 works from Index(works-2021-01-12)
```

This isn't especially helpful, because I can't easily work out how through a snapshot I am. This patch updates the message to tell you how many works have been retrieved so far, e.g.:

```
Received another 10,000 works (350,000 so far) from Index(index-zdhdqo)
```

We could also fetch the total number of works by getting the `_count` of the index from Elasticsearch, but that would be a more involved patch with futures and stuff. This is just a small patch to make the logging a bit more useful.