### PR TITLE
Add Catalogue pipeline storage Elastic Cloud cluster

### DIFF
--- a/infrastructure/critical/.terraform.lock.hcl
+++ b/infrastructure/critical/.terraform.lock.hcl
@@ -1,9 +1,40 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/elastic/ec" {
+  version     = "0.1.0-beta"
+  constraints = "0.1.0-beta"
+  hashes = [
+    "h1:FeIlgFFtDoVwNJ5sIBWCmuURRopyXXX9DqC7s0AwubQ=",
+    "zh:091d59c4ea25a8f9ea4046c7b1eee2fbe9fe107d715b060f2659cf7aebd6d437",
+    "zh:09efa6fecbc27039604a75be5e31ed886bcf67a0e031f40da40edf5875f6aa98",
+    "zh:32869c4bb353f9f9550689c56ea8d88d2d46f4e11ec7860261251680c38b9982",
+    "zh:4140e6121569620e9f8a20daa5bc1a2beec37459681ab001900979215043e7b4",
+    "zh:5f0ecf44cd5a385fd3081e9fa1e3e55b25e52cf1548b3a0bf2dc0af00edaff67",
+    "zh:9104902a070b3cf153051b3dfae88173a310165c1a2cbf5db80bc64f7dc5d950",
+    "zh:c7ed96bd9c5110d2ad5303ce530cc161d245d114e2eff03ee447be7ff3b8aafa",
+    "zh:d5ecb3b9710062c8fe8a7c5755666dac577fab95108023315e1297cd2660f4c9",
+    "zh:d84faf97b57e96c7c7518ad8c2eb7e04d75dd311a59f2c22b1ac7bb1f6dfe0f9",
+    "zh:eda7e297fdca4665a98320f58b62ca13b9ef58c849b701c9f3eeb0462528a22b",
+    "zh:eff814f45b195a40aa5cef658caccc2bc8ab7bc1028cf2582708d9efb7c34bc4",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "2.70.0"
   hashes = [
     "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+    "zh:01a5f351146434b418f9ff8d8cc956ddc801110f1cc8b139e01be2ff8c544605",
+    "zh:1ec08abbaf09e3e0547511d48f77a1e2c89face2d55886b23f643011c76cb247",
+    "zh:606d134fef7c1357c9d155aadbee6826bc22bc0115b6291d483bc1444291c3e1",
+    "zh:67e31a71a5ecbbc96a1a6708c9cc300bbfe921c322320cdbb95b9002026387e1",
+    "zh:75aa59ae6f0834ed7142c81569182a658e4c22724a34db5d10f7545857d8db0c",
+    "zh:76880f29fca7a0a3ff1caef31d245af2fb12a40709d67262e099bc22d039a51d",
+    "zh:aaeaf97ffc1f76714e68bc0242c7407484c783d604584c04ad0b267b6812b6dc",
+    "zh:ae1f88d19cc85b2e9b6ef71994134d55ef7830fd02f1f3c58c0b3f2b90e8b337",
+    "zh:b155bdda487461e7b3d6e3a8d5ce5c887a047e4d983512e81e2c8266009f2a1f",
+    "zh:ba394a7c391a26c4a91da63ad680e83bde0bc1ecc0a0856e26e9d62a4e77c408",
+    "zh:e243c9d91feb0979638f28eb26f89ebadc179c57a2bd299b5729fb52bd1902f2",
+    "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
   ]
 }

--- a/infrastructure/critical/README.md
+++ b/infrastructure/critical/README.md
@@ -1,0 +1,19 @@
+# Catalogue Critical Infrastructure
+
+Contains critical infrastructure for the catalogue services
+
+## Running terraform
+
+In order to run terraform the Elastic Cloud terraform provider requires that the EC_API_KEY environment variable be set.
+
+To retrieve the API key you can run 
+
+```
+aws secretsmanager get-secret-value \
+    --secret-id elastic_cloud/api_key \
+    --profile platform \
+    --output text \
+    --query 'SecretString'
+```
+
+Where the AWS profile used gives you read access to secrets in the platform account.

--- a/infrastructure/critical/elastic.tf
+++ b/infrastructure/critical/elastic.tf
@@ -4,7 +4,7 @@ resource "ec_deployment" "pipeline_storage" {
   name = "catalogue-pipeline-storage-tf-managed"
 
   region                 = "eu-west-1"
-  version                = "7.10.1"
+  version                = "7.10.2"
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = [

--- a/infrastructure/critical/elastic.tf
+++ b/infrastructure/critical/elastic.tf
@@ -1,0 +1,86 @@
+resource "ec_deployment" "pipeline_storage" {
+  provider = ec
+
+  name = "catalogue-pipeline-storage-tf-managed"
+
+  region                 = "eu-west-1"
+  version                = "7.10.1"
+  deployment_template_id = "aws-io-optimized-v2"
+
+  traffic_filter = [
+    ec_deployment_traffic_filter.allow_catalogue_pipeline_vpce.id
+  ]
+
+  elasticsearch {
+    topology {
+      zone_count = 2
+      size       = "15g"
+    }
+  }
+
+  kibana {
+    topology {
+      zone_count = 1
+      size       = "1g"
+    }
+  }
+}
+
+resource "aws_security_group" "allow_catalogue_pipeline_elastic_cloud_vpce" {
+  provider = aws
+
+  name   = "allow_elastic_cloud_vpce"
+  vpc_id = local.vpc_id_new
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+}
+
+resource "aws_vpc_endpoint" "catalogue_pipeline_elastic_cloud_vpce" {
+  provider = aws
+
+  vpc_id            = local.vpc_id_new
+  service_name      = local.ec_eu_west_1_service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.allow_catalogue_pipeline_elastic_cloud_vpce.id,
+  ]
+
+  subnet_ids = local.private_subnets_new
+
+  private_dns_enabled = false
+}
+
+resource "ec_deployment_traffic_filter" "allow_catalogue_pipeline_vpce" {
+  provider = ec
+
+  name   = "ec_allow_vpc_endpoint"
+  region = "eu-west-1"
+  type   = "vpce"
+
+  rule {
+    source = aws_vpc_endpoint.catalogue_pipeline_elastic_cloud_vpce.id
+  }
+}
+
+resource "aws_route53_zone" "catalogue_pipeline_elastic_cloud_vpce" {
+  name = local.catalogue_pipeline_ec_vpce_domain
+
+  vpc {
+    vpc_id = local.vpc_id_new
+  }
+}
+
+resource "aws_route53_record" "cname_ec" {
+  zone_id = aws_route53_zone.catalogue_pipeline_elastic_cloud_vpce.zone_id
+  name    = "*.vpce.eu-west-1.aws.elastic-cloud.com"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [aws_vpc_endpoint.catalogue_pipeline_elastic_cloud_vpce.dns_entry[0]["dns_name"]]
+}

--- a/infrastructure/critical/locals.tf
+++ b/infrastructure/critical/locals.tf
@@ -7,6 +7,11 @@ locals {
   public_subnets_new  = local.catalogue_vpcs["catalogue_vpc_delta_public_subnets"]
   private_subnets_new = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
 
+  catalogue_pipeline_ec_vpce_domain = "vpce.eu-west-1.aws.elastic-cloud.com"
+  catalogue_pipeline_ec_privatelink_host = "${ec_deployment.pipeline_storage.id}.${local.catalogue_pipeline_ec_vpce_domain}"
+
+  ec_eu_west_1_service_name = "com.amazonaws.vpce.eu-west-1.vpce-svc-01f2afe87944eb12b"
+
   admin_cidr_ingress = data.aws_ssm_parameter.admin_cidr_ingress.value
 
   read_principles = [
@@ -15,4 +20,3 @@ locals {
     "arn:aws:iam::964279923020:root",
   ]
 }
-

--- a/infrastructure/critical/locals.tf
+++ b/infrastructure/critical/locals.tf
@@ -10,6 +10,8 @@ locals {
   catalogue_pipeline_ec_vpce_domain = "vpce.eu-west-1.aws.elastic-cloud.com"
   catalogue_pipeline_ec_privatelink_host = "${ec_deployment.pipeline_storage.id}.${local.catalogue_pipeline_ec_vpce_domain}"
 
+  # The correct endpoints are provided by Elastic Cloud
+  # https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-vpc.html
   ec_eu_west_1_service_name = "com.amazonaws.vpce.eu-west-1.vpce-svc-01f2afe87944eb12b"
 
   admin_cidr_ingress = data.aws_ssm_parameter.admin_cidr_ingress.value

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -30,3 +30,13 @@ output "vhs_miro_inventory_table_name" {
 output "vhs_miro_inventory_assumable_read_role" {
   value = module.vhs_miro_migration.assumable_read_role
 }
+
+# Catalogue Pipeline Elastic Cloud
+
+output "catalogue_pipeline_storage_elastic_cloud_sg_id" {
+  value = aws_security_group.allow_catalogue_pipeline_elastic_cloud_vpce.id
+}
+
+output "catalogue_pipeline_ec_privatelink_host" {
+  value = local.catalogue_pipeline_ec_privatelink_host
+}

--- a/infrastructure/critical/terraform.tf
+++ b/infrastructure/critical/terraform.tf
@@ -25,6 +25,8 @@ locals {
   catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
 }
 
+provider "ec" {}
+
 provider "aws" {
   region = "eu-west-1"
 

--- a/infrastructure/critical/terraform.tf
+++ b/infrastructure/critical/terraform.tf
@@ -1,4 +1,13 @@
 terraform {
+  required_version = ">= 0.12.29"
+
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
+    }
+  }
+
   backend "s3" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
 


### PR DESCRIPTION
This PR adds configuration for an Elastic Cloud cluster in terraform and AWS PrivateLink connection to the infrastructure critical stack.  

The intention is to reduce NAT Gateway costs and better manage infrastructure as code.

These changes add a new cluster, but do not attach it to a new pipeline, which should occur in an upcoming PR.

Part of: https://github.com/wellcomecollection/platform/issues/4949 