### PR TITLE
Use the BatchWriteItem API to reduce DynamoDB traffic in the matcher

### DIFF
--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -5,6 +5,7 @@ import java.time.Duration
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import org.scanamo.auto._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -1,9 +1,7 @@
 package uk.ac.wellcome.platform.matcher.storage
 
-import org.scanamo.error.DynamoReadError
 import scala.concurrent.{ExecutionContext, Future}
 
-import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
@@ -16,10 +14,6 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
       affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
     } yield WorkGraph(affectedWorks)
 
-  def put(graph: WorkGraph)
-    : Future[Set[Option[Either[DynamoReadError, WorkNode]]]] = {
-    Future.sequence(
-      graph.nodes.map(workNodeDao.put)
-    )
-  }
+  def put(graph: WorkGraph): Future[Unit] =
+    workNodeDao.put(graph.nodes)
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -1,22 +1,21 @@
 package uk.ac.wellcome.platform.matcher.storage
 
 import grizzled.slf4j.Logging
+
 import javax.naming.ConfigurationException
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException
-import org.scanamo.{Scanamo, Table}
-import org.scanamo.error.DynamoReadError
+import org.scanamo.{DynamoFormat, Scanamo, Table}
 import org.scanamo.syntax._
-import org.scanamo.auto._
-
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
+import uk.ac.wellcome.platform.matcher.storage.dynamo.DynamoBatchWriter
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkNodeDao(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig)(
-  implicit ec: ExecutionContext)
+  implicit ec: ExecutionContext, format: DynamoFormat[WorkNode])
     extends Logging {
 
   private val scanamo = Scanamo(dynamoClient)
@@ -27,8 +26,12 @@ class WorkNodeDao(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig)(
     }
   )
 
-  def put(work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] =
-    Future { scanamo.exec { nodes.put(work) } }
+  private val batchWriter = new DynamoBatchWriter[WorkNode](
+    dynamoConfig
+  )(ec, dynamoClient, format)
+
+  def put(workNodes: Set[WorkNode]): Future[Unit] =
+    batchWriter.batchWrite(workNodes.toSeq)
       .recover {
         case exception: ProvisionedThroughputExceededException =>
           throw MatcherException(exception)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -15,7 +15,8 @@ import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkNodeDao(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig)(
-  implicit ec: ExecutionContext, format: DynamoFormat[WorkNode])
+  implicit ec: ExecutionContext,
+  format: DynamoFormat[WorkNode])
     extends Logging {
 
   private val scanamo = Scanamo(dynamoClient)
@@ -31,7 +32,8 @@ class WorkNodeDao(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig)(
   )(ec, dynamoClient, format)
 
   def put(workNodes: Set[WorkNode]): Future[Unit] =
-    batchWriter.batchWrite(workNodes.toSeq)
+    batchWriter
+      .batchWrite(workNodes.toSeq)
       .recover {
         case exception: ProvisionedThroughputExceededException =>
           throw MatcherException(exception)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.platform.matcher.storage.dynamo
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import org.scanamo.{DynamoFormat, Scanamo, Table}
+import uk.ac.wellcome.storage.dynamo.DynamoConfig
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DynamoBatchWriter[T](config: DynamoConfig)(
+  implicit ec: ExecutionContext,
+  client: AmazonDynamoDB,
+  format: DynamoFormat[T]
+) {
+  private val scanamo = Scanamo(client)
+  private val table = Table[T](config.tableName)
+
+  def batchWrite(items: Seq[T]): Future[Unit] =
+    Future {
+      // We can write up to 25 nodes at once as part of a DynamoDB BatchWriteItem
+      // operation.  Since nodes are small, we expect this not to exceed the
+      // 16MB total limit / 400KB limit for a single node.
+      items.grouped(25)
+        .flatMap { batch =>
+          val ops = table.putAll(batch.toSet)
+          scanamo.exec(ops)
+        }
+        .foreach { result =>
+
+          // Note: this is based on a description of how BatchWriteItems works, and
+          // isn't tested.  Unfortunately, the local DynamoDB instance we use ignores
+          // provisioned throughput settings, so we can't test what happens if we
+          // write too quickly.
+          // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html#DynamoDBLocal.Differences
+          if (result.getUnprocessedItems.isEmpty) {
+            ()
+          } else {
+            throw new Throwable(s"Not all items were written correctly: ${result.getUnprocessedItems}")
+          }
+        }
+    }
+}

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
@@ -30,6 +30,10 @@ class DynamoBatchWriter[T](config: DynamoConfig)(
           // isn't tested.  Unfortunately, the local DynamoDB instance we use ignores
           // provisioned throughput settings, so we can't test what happens if we
           // write too quickly.
+          //
+          // We could be more intelligent about this, but I'm hoping we never actually
+          // hit this branch in practice.  If we do, we'll think about how to handle it then.
+          //
           // See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html#DynamoDBLocal.Differences
           if (result.getUnprocessedItems.isEmpty) {
             ()

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriter.scala
@@ -31,7 +31,8 @@ class DynamoBatchWriter[T](config: DynamoConfig)(
         if (result.getUnprocessedItems.isEmpty) {
           ()
         } else {
-          throw new Throwable(s"Not all items were written correctly: ${result.getUnprocessedItems}")
+          throw new Throwable(
+            s"Not all items were written correctly: ${result.getUnprocessedItems}")
         }
       }
     }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -5,7 +5,6 @@ import scala.concurrent.Future
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
-import org.scanamo.error.DynamoReadError
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
@@ -180,8 +179,7 @@ class WorkGraphStoreTest
       dynamoClient,
       dynamoConfig = createDynamoConfigWith(nonExistentTable)
     ) {
-      override def put(
-        work: WorkNode): Future[Option[Either[DynamoReadError, WorkNode]]] =
+      override def put(nodes: Set[WorkNode]): Future[Unit] =
         Future.failed(expectedException)
     }
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -211,7 +211,8 @@ class WorkNodeDaoTest
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
+        whenReady(
+          workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
           failedException =>
             failedException shouldBe expectedException
         }
@@ -229,7 +230,8 @@ class WorkNodeDaoTest
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
+        whenReady(
+          workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
           failedException =>
             failedException shouldBe a[MatcherException]
         }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -177,7 +177,7 @@ class WorkNodeDaoTest
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
           val work = WorkNode("A", 1, List("B"), "A+B")
-          whenReady(workNodeDao.put(work)) { _ =>
+          whenReady(workNodeDao.put(Set(work))) { _ =>
             val savedLinkedWork =
               get[WorkNode](dynamoClient, table.name)('id -> "A")
             savedLinkedWork shouldBe Some(Right(work))
@@ -204,14 +204,14 @@ class WorkNodeDaoTest
       withWorkGraphTable { table =>
         val dynamoClient = mock[AmazonDynamoDB]
         val expectedException = new RuntimeException("FAILED")
-        when(dynamoClient.putItem(any[PutItemRequest]))
+        when(dynamoClient.batchWriteItem(any[BatchWriteItemRequest]))
           .thenThrow(expectedException)
         val workNodeDao = new WorkNodeDao(
           dynamoClient,
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.put(WorkNode("A", 1, List("B"), "A+B")).failed) {
+        whenReady(workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
           failedException =>
             failedException shouldBe expectedException
         }
@@ -222,14 +222,14 @@ class WorkNodeDaoTest
       "returns a GracefulFailure if ProvisionedThroughputExceededException occurs during put to dynamo") {
       withWorkGraphTable { table =>
         val dynamoClient = mock[AmazonDynamoDB]
-        when(dynamoClient.putItem(any[PutItemRequest]))
+        when(dynamoClient.batchWriteItem(any[BatchWriteItemRequest]))
           .thenThrow(new ProvisionedThroughputExceededException("test"))
         val workNodeDao = new WorkNodeDao(
           dynamoClient,
           DynamoConfig(table.name, table.index)
         )
 
-        whenReady(workNodeDao.put(WorkNode("A", 1, List("B"), "A+B")).failed) {
+        whenReady(workNodeDao.put(Set(WorkNode("A", 1, List("B"), "A+B"))).failed) {
           failedException =>
             failedException shouldBe a[MatcherException]
         }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriterTest.scala
@@ -1,0 +1,66 @@
+package uk.ac.wellcome.platform.matcher.storage.dynamo
+
+import com.amazonaws.services.dynamodbv2.model.{ResourceNotFoundException, ScalarAttributeType}
+import org.scalatest.EitherValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.auto._
+import org.scanamo.syntax._
+import org.scanamo.{Table => ScanamoTable}
+import uk.ac.wellcome.storage.fixtures.DynamoFixtures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DynamoBatchWriterTest extends AnyFunSpec with Matchers with EitherValues with DynamoFixtures with ScalaFutures {
+  override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table =
+    createTableWithHashKey(table, keyName = "sides", keyType = ScalarAttributeType.N)
+
+  case class Shape(sides: Int, description: String)
+
+  it("writes some items to DynamoDB") {
+    withLocalDynamoDbTable { table =>
+      val writer = new DynamoBatchWriter[Shape](createDynamoConfigWith(table))
+
+      val shapes = Seq(
+        Shape(sides = 3, description = "yellow triangle"),
+        Shape(sides = 4, description = "red square"),
+        Shape(sides = 5, description = "blue pentagon")
+      )
+
+      whenReady(writer.batchWrite(shapes)) { _ =>
+        shapes.foreach { s =>
+          scanamo.exec(ScanamoTable[Shape](table.name).get('sides -> s.sides)).get.value shouldBe s
+        }
+      }
+    }
+  }
+
+  it("writes lots of items (>25) to DynamoDB") {
+    withLocalDynamoDbTable { table =>
+      val writer = new DynamoBatchWriter[Shape](createDynamoConfigWith(table))
+
+      val shapes = (1 to 100).map { sides =>
+        Shape(sides = sides, description = "a mysterious shape")
+      }
+
+      whenReady(writer.batchWrite(shapes)) { _ =>
+        shapes.foreach { s =>
+          scanamo.exec(ScanamoTable[Shape](table.name).get('sides -> s.sides)).get.value shouldBe s
+        }
+      }
+    }
+  }
+
+  it("fails if we try to write to a non-existent table") {
+    val writer = new DynamoBatchWriter[Shape](createDynamoConfigWith(nonExistentTable))
+
+    val shapes = (1 to 100).map { sides =>
+      Shape(sides = sides, description = "an invisible shape")
+    }
+
+    whenReady(writer.batchWrite(shapes).failed) {
+      _ shouldBe a[ResourceNotFoundException]
+    }
+  }
+}

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/dynamo/DynamoBatchWriterTest.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.platform.matcher.storage.dynamo
 
-import com.amazonaws.services.dynamodbv2.model.{ResourceNotFoundException, ScalarAttributeType}
+import com.amazonaws.services.dynamodbv2.model.{
+  ResourceNotFoundException,
+  ScalarAttributeType
+}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
@@ -12,9 +15,17 @@ import uk.ac.wellcome.storage.fixtures.DynamoFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DynamoBatchWriterTest extends AnyFunSpec with Matchers with EitherValues with DynamoFixtures with ScalaFutures {
+class DynamoBatchWriterTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with DynamoFixtures
+    with ScalaFutures {
   override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table =
-    createTableWithHashKey(table, keyName = "sides", keyType = ScalarAttributeType.N)
+    createTableWithHashKey(
+      table,
+      keyName = "sides",
+      keyType = ScalarAttributeType.N)
 
   case class Shape(sides: Int, description: String)
 
@@ -30,7 +41,10 @@ class DynamoBatchWriterTest extends AnyFunSpec with Matchers with EitherValues w
 
       whenReady(writer.batchWrite(shapes)) { _ =>
         shapes.foreach { s =>
-          scanamo.exec(ScanamoTable[Shape](table.name).get('sides -> s.sides)).get.value shouldBe s
+          scanamo
+            .exec(ScanamoTable[Shape](table.name).get('sides -> s.sides))
+            .get
+            .value shouldBe s
         }
       }
     }
@@ -46,14 +60,18 @@ class DynamoBatchWriterTest extends AnyFunSpec with Matchers with EitherValues w
 
       whenReady(writer.batchWrite(shapes)) { _ =>
         shapes.foreach { s =>
-          scanamo.exec(ScanamoTable[Shape](table.name).get('sides -> s.sides)).get.value shouldBe s
+          scanamo
+            .exec(ScanamoTable[Shape](table.name).get('sides -> s.sides))
+            .get
+            .value shouldBe s
         }
       }
     }
   }
 
   it("fails if we try to write to a non-existent table") {
-    val writer = new DynamoBatchWriter[Shape](createDynamoConfigWith(nonExistentTable))
+    val writer =
+      new DynamoBatchWriter[Shape](createDynamoConfigWith(nonExistentTable))
 
     val shapes = (1 to 100).map { sides =>
       Shape(sides = sides, description = "an invisible shape")


### PR DESCRIPTION
Right now, we write works to the graph database with an individual PutItem call per node. Whenever a single node in a component gets updated, we re-write *every node in the component*.

DynamoDB [pricing for on-demand capacity](https://aws.amazon.com/dynamodb/pricing/on-demand/) is based on the notion of "write request units" – every request is rounded up to the nearest kilobyte, and you pay per kilobyte of data written. Given the matcher entries are small, this means we're probably overpaying for writes.

Using the BatchWriteItem API means we waste way less capacity – we round up once for all the items in a component, rather than once per item. I would hope this reduces the amount of money we spend on DynamoDB in the matcher.

Part of https://github.com/wellcomecollection/platform/issues/4969