### PR TITLE
Use WorkUpdate/WorkLinks internally in the matcher

### DIFF
--- a/pipeline/matcher/docker-compose.yml
+++ b/pipeline/matcher/docker-compose.yml
@@ -6,3 +6,13 @@ dynamodb:
   image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/peopleperhour/dynamodb"
   ports:
     - "45678:8000"
+elasticsearch:
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.3"
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  environment:
+    - "http.host=0.0.0.0"
+    - "transport.host=0.0.0.0"
+    - "cluster.name=wellcome"
+    - "discovery.type=single-node"

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -57,7 +57,9 @@ object Main extends WellcomeTypesafeApp {
     val workMatcher = new WorkMatcher(workGraphStore, new DynamoLockingService)
 
     val workLinksRetriever =
-      new ElasticWorkLinksRetriever(esClient, index = Index(config.requireString("es.index")))
+      new ElasticWorkLinksRetriever(
+        esClient,
+        index = Index(config.requireString("es.index")))
 
     new MatcherWorkerService(
       workLinksRetriever = workLinksRetriever,

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/Main.scala
@@ -1,19 +1,16 @@
 package uk.ac.wellcome.platform.matcher
 
 import java.time.Duration
-
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.scanamo.auto._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.matcher.matcher.WorkMatcher
 import uk.ac.wellcome.platform.matcher.services.MatcherWorkerService
 import uk.ac.wellcome.platform.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
-import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.storage.locking.dynamo.{
@@ -23,8 +20,8 @@ import uk.ac.wellcome.storage.locking.dynamo.{
 }
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-import WorkState.Identified
-import uk.ac.wellcome.pipeline_storage.typesafe.ElasticRetrieverBuilder
+import com.sksamuel.elastic4s.Index
+import uk.ac.wellcome.platform.matcher.storage.elastic.ElasticWorkLinksRetriever
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -59,11 +56,11 @@ object Main extends WellcomeTypesafeApp {
 
     val workMatcher = new WorkMatcher(workGraphStore, new DynamoLockingService)
 
-    val workRetriever =
-      ElasticRetrieverBuilder.apply[Work[Identified]](config, esClient)
+    val workLinksRetriever =
+      new ElasticWorkLinksRetriever(esClient, index = Index(config.requireString("es.index")))
 
     new MatcherWorkerService(
-      workRetriever = workRetriever,
+      workLinksRetriever = workLinksRetriever,
       msgStream = SQSBuilder.buildSQSStream[NotificationMessage](config),
       msgSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "Sent from the matcher"),

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -35,7 +35,7 @@ class WorkMatcher(
     doMatch(work).map(MatcherResult)
 
   private def doMatch(work: Work[Identified]): Future[Out] = {
-    val update = WorkUpdate(work)
+    val update = WorkLinks(work)
     withLocks(update, update.ids) {
       for {
         graphBeforeUpdate <- workGraphStore.findAffectedWorks(update)
@@ -58,7 +58,7 @@ class WorkMatcher(
                                    graphAfter: WorkGraph): Set[String] =
     graphBefore.nodes.map(_.componentId) ++ graphAfter.nodes.map(_.componentId)
 
-  private def withLocks(update: WorkUpdate, ids: Set[String])(
+  private def withLocks(update: WorkLinks, ids: Set[String])(
     f: => Future[Out]): Future[Out] =
     lockingService
       .withLocks(ids)(f)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -74,12 +74,14 @@ class WorkMatcher(
       case _                     => new RuntimeException(failure.toString)
     }
 
-  private def convertToIdentifiersList(graph: WorkGraph): Set[MatchedIdentifiers] =
+  private def convertToIdentifiersList(
+    graph: WorkGraph): Set[MatchedIdentifiers] =
     groupBySetId(graph).map {
       case (_, workNodes: Set[WorkNode]) =>
         MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
     }.toSet
 
-  private def groupBySetId(updatedGraph: WorkGraph): Map[String, Set[WorkNode]] =
+  private def groupBySetId(
+    updatedGraph: WorkGraph): Map[String, Set[WorkNode]] =
     updatedGraph.nodes.groupBy(_.componentId)
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -78,13 +78,12 @@ class WorkMatcher(
       case _                     => new RuntimeException(failure.toString)
     }
 
-  private def convertToIdentifiersList(graph: WorkGraph) = {
+  private def convertToIdentifiersList(graph: WorkGraph): Set[MatchedIdentifiers] =
     groupBySetId(graph).map {
       case (_, workNodes: Set[WorkNode]) =>
         MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
     }.toSet
-  }
 
-  private def groupBySetId(updatedGraph: WorkGraph) =
+  private def groupBySetId(updatedGraph: WorkGraph): Map[String, Set[WorkNode]] =
     updatedGraph.nodes.groupBy(_.componentId)
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
@@ -3,14 +3,14 @@ package uk.ac.wellcome.platform.matcher.models
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Identified
 
-case class WorkUpdate(workId: String,
-                      version: Int,
-                      referencedWorkIds: Set[String]) {
+case class WorkLinks(workId: String,
+                     version: Int,
+                     referencedWorkIds: Set[String]) {
   lazy val ids: Set[String] = referencedWorkIds + workId
 }
 
-case object WorkUpdate {
-  def apply(work: Work[Identified]): WorkUpdate = {
+case object WorkLinks {
+  def apply(work: Work[Identified]): WorkLinks = {
     val id = work.id
     val referencedWorkIds = work.data.mergeCandidates
       .map { mergeCandidate =>
@@ -19,6 +19,6 @@ case object WorkUpdate {
       .filterNot { _ == id }
       .toSet
 
-    WorkUpdate(id, work.version, referencedWorkIds)
+    WorkLinks(id, work.version, referencedWorkIds)
   }
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -2,11 +2,11 @@ package uk.ac.wellcome.platform.matcher.storage
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
 
-  def findAffectedWorks(workUpdate: WorkUpdate): Future[WorkGraph] =
+  def findAffectedWorks(workUpdate: WorkLinks): Future[WorkGraph] =
     for {
       directlyAffectedWorks <- workNodeDao.get(workUpdate.ids)
       affectedComponentIds = directlyAffectedWorks.map(workNode =>

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.matcher.storage.elastic
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{Work, WorkState}
-import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, Retriever, RetrieverMultiResult}
+import uk.ac.wellcome.pipeline_storage.{
+  ElasticRetriever,
+  Retriever,
+  RetrieverMultiResult
+}
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -11,9 +15,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class ElasticWorkLinksRetriever(client: ElasticClient, index: Index)(
   implicit val ec: ExecutionContext
 ) extends Retriever[WorkLinks] {
-  private val underlying = new ElasticRetriever[Work[WorkState.Identified]](client, index)
+  private val underlying =
+    new ElasticRetriever[Work[WorkState.Identified]](client, index)
 
-  override def apply(ids: Seq[String]): Future[RetrieverMultiResult[WorkLinks]] =
+  override def apply(
+    ids: Seq[String]): Future[RetrieverMultiResult[WorkLinks]] =
     underlying.apply(ids).map { result =>
       RetrieverMultiResult(
         found = result.found.map { case (id, work) => id -> WorkLinks(work) },

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.matcher.storage.elastic
+
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.internal.{Work, WorkState}
+import uk.ac.wellcome.pipeline_storage.{ElasticRetriever, Retriever, RetrieverMultiResult}
+import uk.ac.wellcome.platform.matcher.models.WorkLinks
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ElasticWorkLinksRetriever(client: ElasticClient, index: Index)(
+  implicit val ec: ExecutionContext
+) extends Retriever[WorkLinks] {
+  private val underlying = new ElasticRetriever[Work[WorkState.Identified]](client, index)
+
+  override def apply(ids: Seq[String]): Future[RetrieverMultiResult[WorkLinks]] =
+    underlying.apply(ids).map { result =>
+      RetrieverMultiResult(
+        found = result.found.map { case (id, work) => id -> WorkLinks(work) },
+        notFound = result.notFound
+      )
+    }
+}

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -19,7 +19,7 @@ object WorkGraphUpdater extends Logging {
   }
 
   private def checkVersionConflicts(links: WorkLinks,
-                                    existingGraph: WorkGraph) = {
+                                    existingGraph: WorkGraph): Unit = {
     val maybeExistingNode = existingGraph.nodes.find(_.id == links.workId)
     maybeExistingNode match {
       case Some(WorkNode(_, Some(existingVersion), linkedIds, _)) =>
@@ -39,7 +39,7 @@ object WorkGraphUpdater extends Logging {
     }
   }
 
-  private def doUpdate(workUpdate: WorkLinks, existingGraph: WorkGraph) = {
+  private def doUpdate(workUpdate: WorkLinks, existingGraph: WorkGraph): WorkGraph = {
 
     // Find everything that's in the existing graph, but which isn't
     // the node we're updating.

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -9,29 +9,29 @@ import uk.ac.wellcome.platform.matcher.models.{
   VersionExpectedConflictException,
   VersionUnexpectedConflictException,
   WorkGraph,
-  WorkUpdate
+  WorkLinks
 }
 
 object WorkGraphUpdater extends Logging {
-  def update(workUpdate: WorkUpdate, existingGraph: WorkGraph): WorkGraph = {
-    checkVersionConflicts(workUpdate, existingGraph)
-    doUpdate(workUpdate, existingGraph)
+  def update(links: WorkLinks, existingGraph: WorkGraph): WorkGraph = {
+    checkVersionConflicts(links, existingGraph)
+    doUpdate(links, existingGraph)
   }
 
-  private def checkVersionConflicts(workUpdate: WorkUpdate,
+  private def checkVersionConflicts(links: WorkLinks,
                                     existingGraph: WorkGraph) = {
-    val maybeExistingNode = existingGraph.nodes.find(_.id == workUpdate.workId)
+    val maybeExistingNode = existingGraph.nodes.find(_.id == links.workId)
     maybeExistingNode match {
       case Some(WorkNode(_, Some(existingVersion), linkedIds, _)) =>
-        if (existingVersion > workUpdate.version) {
+        if (existingVersion > links.version) {
           val versionConflictMessage =
-            s"update failed, work:${workUpdate.workId} v${workUpdate.version} is not newer than existing work v$existingVersion"
+            s"update failed, work:${links.workId} v${links.version} is not newer than existing work v$existingVersion"
           debug(versionConflictMessage)
           throw VersionExpectedConflictException(versionConflictMessage)
         }
-        if (existingVersion == workUpdate.version && workUpdate.referencedWorkIds != linkedIds.toSet) {
+        if (existingVersion == links.version && links.referencedWorkIds != linkedIds.toSet) {
           val versionConflictMessage =
-            s"update failed, work:${workUpdate.workId} v${workUpdate.version} already exists with different content! update-ids:${workUpdate.referencedWorkIds} != existing-ids:${linkedIds.toSet}"
+            s"update failed, work:${links.workId} v${links.version} already exists with different content! update-ids:${links.referencedWorkIds} != existing-ids:${linkedIds.toSet}"
           debug(versionConflictMessage)
           throw VersionUnexpectedConflictException(versionConflictMessage)
         }
@@ -39,7 +39,7 @@ object WorkGraphUpdater extends Logging {
     }
   }
 
-  private def doUpdate(workUpdate: WorkUpdate, existingGraph: WorkGraph) = {
+  private def doUpdate(workUpdate: WorkLinks, existingGraph: WorkGraph) = {
 
     // Find everything that's in the existing graph, but which isn't
     // the node we're updating.

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -39,7 +39,8 @@ object WorkGraphUpdater extends Logging {
     }
   }
 
-  private def doUpdate(workUpdate: WorkLinks, existingGraph: WorkGraph): WorkGraph = {
+  private def doUpdate(workUpdate: WorkLinks,
+                       existingGraph: WorkGraph): WorkGraph = {
 
     // Find everything that's in the existing graph, but which isn't
     // the node we're updating.

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -12,11 +12,12 @@ import uk.ac.wellcome.models.matcher.{
   WorkIdentifier,
   WorkNode
 }
-import uk.ac.wellcome.models.work.generators.WorkGenerators
-import uk.ac.wellcome.models.work.internal.Work
-import uk.ac.wellcome.models.work.internal.WorkState.Identified
 import uk.ac.wellcome.pipeline_storage.MemoryRetriever
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
+import uk.ac.wellcome.platform.matcher.generators.WorkLinksGenerators
+import uk.ac.wellcome.platform.matcher.models.WorkLinks
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class MatcherFeatureTest
     extends AnyFunSpec
@@ -24,26 +25,26 @@ class MatcherFeatureTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with WorkGenerators {
+    with WorkLinksGenerators {
 
   it(
     "processes a message with a simple Work.Visible[Identified] with no linked works") {
-    implicit val retriever: MemoryRetriever[Work[Identified]] = createRetriever
+    implicit val retriever: MemoryRetriever[WorkLinks] = new MemoryRetriever[WorkLinks]()
     val messageSender = new MemoryMessageSender()
 
     withLocalSqsQueue() { queue =>
       withWorkerService(retriever, queue, messageSender) { _ =>
-        val work = identifiedWork()
+        val links = createWorkLinks
 
         val expectedResult = MatcherResult(
           Set(
             MatchedIdentifiers(
-              identifiers = Set(WorkIdentifier(work))
+              identifiers = Set(WorkIdentifier(links.workId, version = links.version))
             )
           )
         )
 
-        sendWork(work, retriever, queue)
+        sendWork(links, retriever, queue)
 
         eventually {
           messageSender.getMessages[MatcherResult].distinct shouldBe Seq(
@@ -54,7 +55,7 @@ class MatcherFeatureTest
   }
 
   it("skips a message if the graph store already has a newer version") {
-    implicit val retriever: MemoryRetriever[Work[Identified]] = createRetriever
+    implicit val retriever: MemoryRetriever[WorkLinks] = new MemoryRetriever[WorkLinks]()
     val messageSender = new MemoryMessageSender()
 
     withLocalSqsQueuePair() {
@@ -64,17 +65,17 @@ class MatcherFeatureTest
             val existingWorkVersion = 2
             val updatedWorkVersion = 1
 
-            val workAv1 = identifiedWork().withVersion(updatedWorkVersion)
+            val linksV1 = createWorkLinksWith(version = updatedWorkVersion)
 
-            val existingWorkAv2 = WorkNode(
-              id = workAv1.state.canonicalId,
+            val nodeV2 = WorkNode(
+              id = linksV1.workId,
               version = Some(existingWorkVersion),
               linkedIds = Nil,
-              componentId = workAv1.state.canonicalId
+              componentId = linksV1.workId
             )
-            put(dynamoClient, graphTable.name)(existingWorkAv2)
+            put(dynamoClient, graphTable.name)(nodeV2)
 
-            sendWork(workAv1, retriever, queue)
+            sendWork(linksV1, retriever, queue)
 
             eventually {
               noMessagesAreWaitingIn(queue)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -27,15 +27,14 @@ class MatcherFeatureTest
     with MatcherFixtures
     with WorkLinksGenerators {
 
-  it(
-    "processes a message with a simple Work.Visible[Identified] with no linked works") {
+  it("processes a message with a single WorkLinks with no linked works") {
     implicit val retriever: MemoryRetriever[WorkLinks] =
       new MemoryRetriever[WorkLinks]()
     val messageSender = new MemoryMessageSender()
 
     withLocalSqsQueue() { queue =>
       withWorkerService(retriever, queue, messageSender) { _ =>
-        val links = createWorkLinks
+        val links = createWorkLinksWith(referencedIds = Set.empty)
 
         val expectedResult = MatcherResult(
           Set(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -29,7 +29,8 @@ class MatcherFeatureTest
 
   it(
     "processes a message with a simple Work.Visible[Identified] with no linked works") {
-    implicit val retriever: MemoryRetriever[WorkLinks] = new MemoryRetriever[WorkLinks]()
+    implicit val retriever: MemoryRetriever[WorkLinks] =
+      new MemoryRetriever[WorkLinks]()
     val messageSender = new MemoryMessageSender()
 
     withLocalSqsQueue() { queue =>
@@ -39,7 +40,8 @@ class MatcherFeatureTest
         val expectedResult = MatcherResult(
           Set(
             MatchedIdentifiers(
-              identifiers = Set(WorkIdentifier(links.workId, version = links.version))
+              identifiers =
+                Set(WorkIdentifier(links.workId, version = links.version))
             )
           )
         )
@@ -55,7 +57,8 @@ class MatcherFeatureTest
   }
 
   it("skips a message if the graph store already has a newer version") {
-    implicit val retriever: MemoryRetriever[WorkLinks] = new MemoryRetriever[WorkLinks]()
+    implicit val retriever: MemoryRetriever[WorkLinks] =
+      new MemoryRetriever[WorkLinks]()
     val messageSender = new MemoryMessageSender()
 
     withLocalSqsQueuePair() {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -49,7 +49,7 @@ trait MatcherFixtures
     }
 
   def withWorkerService[R](
-                            workLinksRetriever: MemoryRetriever[WorkLinks],
+    workLinksRetriever: MemoryRetriever[WorkLinks],
     queue: SQS.Queue,
     messageSender: MemoryMessageSender,
     graphTable: Table)(testWith: TestWith[MatcherWorkerService[String], R]): R =

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -12,7 +12,7 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
     )
 
   def createWorkLinksWith(
-    id: IdState.Identified,
+    id: IdState.Identified = createIdentifier(randomAlphanumeric()),
     version: Int = randomInt(from = 1, to = 10),
     referencedIds: Set[IdState.Identified] = Set.empty
   ): WorkLinks =
@@ -24,7 +24,6 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
 
   def createWorkLinks: WorkLinks =
     createWorkLinksWith(
-      id = createIdentifier(randomAlphanumeric()),
       referencedIds = collectionOf(min = 0) { createIdentifier(randomAlphanumeric()) }.toSet
     )
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.matcher.generators
+
+import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.internal.IdState
+import uk.ac.wellcome.platform.matcher.models.WorkLinks
+
+trait WorkLinksGenerators extends IdentifiersGenerators {
+  def createIdentifier(id: String): IdState.Identified =
+    IdState.Identified(
+      canonicalId = id,
+      sourceIdentifier = createSourceIdentifierWith(value = id)
+    )
+
+  def createWorkLinksWith(
+    id: IdState.Identified,
+    version: Int = randomInt(from = 1, to = 10),
+    referencedIds: Set[IdState.Identified] = Set.empty
+  ): WorkLinks =
+    WorkLinks(
+      workId = id.canonicalId,
+      version = version,
+      referencedWorkIds = referencedIds.map { _.canonicalId }
+    )
+
+  def createWorkLinks: WorkLinks =
+    createWorkLinksWith(
+      id = createIdentifier(randomAlphanumeric()),
+      referencedIds = collectionOf(min = 0) { createIdentifier(randomAlphanumeric()) }.toSet
+    )
+}

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -24,6 +24,8 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
 
   def createWorkLinks: WorkLinks =
     createWorkLinksWith(
-      referencedIds = collectionOf(min = 0) { createIdentifier(randomAlphanumeric()) }.toSet
+      referencedIds = collectionOf(min = 0) {
+        createIdentifier(randomAlphanumeric())
+      }.toSet
     )
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -49,15 +49,20 @@ class WorkMatcherTest
 
             whenReady(workMatcher.matchWork(links)) { matcherResult =>
               matcherResult shouldBe
-                MatcherResult(Set(
-                  MatchedIdentifiers(Set(WorkIdentifier(links.workId, links.version)))))
+                MatcherResult(Set(MatchedIdentifiers(
+                  Set(WorkIdentifier(links.workId, links.version)))))
 
               val savedLinkedWork =
-                get[WorkNode](dynamoClient, graphTable.name)('id -> links.workId)
+                get[WorkNode](dynamoClient, graphTable.name)(
+                  'id -> links.workId)
                   .map(_.value)
 
               savedLinkedWork shouldBe Some(
-                WorkNode(links.workId, links.version, Nil, ciHash(links.workId)))
+                WorkNode(
+                  links.workId,
+                  links.version,
+                  Nil,
+                  ciHash(links.workId)))
             }
           }
         }
@@ -96,7 +101,8 @@ class WorkMatcherTest
                   List(identifierB.canonicalId),
                   ciHash(
                     List(identifierA.canonicalId, identifierB.canonicalId).sorted
-                      .mkString("+"))),
+                      .mkString("+"))
+                ),
                 WorkNode(
                   identifierB.canonicalId,
                   None,
@@ -211,7 +217,8 @@ class WorkMatcherTest
               workGraphStore,
               new DynamoLockingService) { workMatcher =>
               val failedLock = for {
-                _ <- Future.successful(lockDao.lock(links.workId, UUID.randomUUID))
+                _ <- Future.successful(
+                  lockDao.lock(links.workId, UUID.randomUUID))
                 result <- workMatcher.matchWork(links)
               } yield result
               whenReady(failedLock.failed) { failedMatch =>
@@ -277,9 +284,8 @@ class WorkMatcherTest
 
         val links = createWorkLinks
 
-        whenReady(workMatcher.matchWork(links).failed) {
-          actualException =>
-            actualException shouldBe MatcherException(expectedException)
+        whenReady(workMatcher.matchWork(links).failed) { actualException =>
+          actualException shouldBe MatcherException(expectedException)
         }
       }
     }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.models.work.internal.IdState.Identified
 import uk.ac.wellcome.models.work.internal.MergeCandidate
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.storage.locking.dynamo.DynamoLockingService
 
@@ -304,7 +304,7 @@ class WorkMatcherTest
       val mockWorkGraphStore = mock[WorkGraphStore]
       withWorkMatcher(mockWorkGraphStore, lockTable) { workMatcher =>
         val expectedException = new RuntimeException("Failed to put")
-        when(mockWorkGraphStore.findAffectedWorks(any[WorkUpdate]))
+        when(mockWorkGraphStore.findAffectedWorks(any[WorkLinks]))
           .thenReturn(Future.successful(WorkGraph(Set.empty)))
         when(mockWorkGraphStore.put(any[WorkGraph]))
           .thenThrow(expectedException)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -37,7 +37,8 @@ class MatcherWorkerServiceTest
     val expectedResult =
       MatcherResult(
         Set(
-          MatchedIdentifiers(identifiers = Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
+          MatchedIdentifiers(identifiers =
+            Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
         )
       )
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
-import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkUpdate}
+import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 
 class WorkGraphStoreTest
     extends AnyFunSpec
@@ -21,7 +21,7 @@ class WorkGraphStoreTest
         withWorkGraphStore(graphTable) { workGraphStore =>
           whenReady(
             workGraphStore.findAffectedWorks(
-              WorkUpdate("Not-there", 0, Set.empty))) { workGraph =>
+              WorkLinks("Not-there", 0, Set.empty))) { workGraph =>
             workGraph shouldBe WorkGraph(Set.empty)
           }
         }
@@ -37,7 +37,7 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(work)
 
           whenReady(
-            workGraphStore.findAffectedWorks(WorkUpdate("A", 0, Set.empty))) {
+            workGraphStore.findAffectedWorks(WorkLinks("A", 0, Set.empty))) {
             workGraph =>
               workGraph shouldBe WorkGraph(Set(work))
           }
@@ -56,7 +56,7 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workB)
 
           whenReady(
-            workGraphStore.findAffectedWorks(WorkUpdate("A", 0, Set("B")))) {
+            workGraphStore.findAffectedWorks(WorkLinks("A", 0, Set("B")))) {
             workGraph =>
               workGraph.nodes shouldBe Set(workA, workB)
           }
@@ -80,7 +80,7 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workB)
 
           whenReady(
-            workGraphStore.findAffectedWorks(WorkUpdate("A", 0, Set.empty))) {
+            workGraphStore.findAffectedWorks(WorkLinks("A", 0, Set.empty))) {
             workGraph =>
               workGraph.nodes shouldBe Set(workA, workB)
           }
@@ -115,7 +115,7 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workC)
 
           whenReady(
-            workGraphStore.findAffectedWorks(WorkUpdate("A", 0, Set.empty))) {
+            workGraphStore.findAffectedWorks(WorkLinks("A", 0, Set.empty))) {
             workGraph =>
               workGraph.nodes shouldBe Set(workA, workB, workC)
           }
@@ -143,7 +143,7 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workC)
 
           whenReady(
-            workGraphStore.findAffectedWorks(WorkUpdate("B", 0, Set("C")))) {
+            workGraphStore.findAffectedWorks(WorkLinks("B", 0, Set("C")))) {
             workGraph =>
               workGraph.nodes shouldBe Set(workA, workB, workC)
           }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
@@ -1,0 +1,67 @@
+package uk.ac.wellcome.platform.matcher.storage.elastic
+
+import com.sksamuel.elastic4s.Index
+import uk.ac.wellcome.elasticsearch.IdentifiedWorkIndexConfig
+import uk.ac.wellcome.elasticsearch.model.CanonicalId
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.models.work.internal.IdState.Identified
+import uk.ac.wellcome.models.work.internal.{MergeCandidate, Work, WorkState}
+import uk.ac.wellcome.pipeline_storage.fixtures.ElasticIndexerFixtures
+import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverTestCases}
+import uk.ac.wellcome.platform.matcher.generators.WorkLinksGenerators
+import uk.ac.wellcome.platform.matcher.models.WorkLinks
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ElasticWorkLinksRetrieverTest
+  extends RetrieverTestCases[Index, WorkLinks]
+    with ElasticsearchFixtures
+    with ElasticIndexerFixtures
+    with WorkGenerators
+    with WorkLinksGenerators {
+
+  override def withContext[R](links: Seq[WorkLinks])(
+    testWith: TestWith[Index, R]): R =
+    withLocalElasticsearchIndex(config = IdentifiedWorkIndexConfig) { index =>
+      withElasticIndexer[Work[WorkState.Identified], R](index) { indexer =>
+        val works: Seq[Work[WorkState.Identified]] = links.map { lk =>
+          identifiedWork(canonicalId = lk.workId)
+            .withVersion(lk.version)
+            .mergeCandidates(
+              lk.referencedWorkIds.map {
+                id => MergeCandidate(
+                  id = Identified(
+                    canonicalId = id,
+                    sourceIdentifier = createSourceIdentifier
+                  ),
+                  reason = None
+                ) }.toList
+            )
+        }
+
+        whenReady(indexer(works)) { _ =>
+          implicit val id: CanonicalId[Work[WorkState.Identified]] =
+            (w: Work[WorkState.Identified]) => w.id
+
+          assertElasticsearchEventuallyHas(index, works: _*)
+
+          testWith(index)
+        }
+      }
+    }
+
+  override def withRetriever[R](
+    testWith: TestWith[Retriever[WorkLinks], R])(
+    implicit index: Index): R =
+    testWith(
+      new ElasticWorkLinksRetriever(elasticClient, index)
+    )
+
+  override def createT: WorkLinks = createWorkLinks
+
+  override implicit val id: CanonicalId[WorkLinks] =
+    (links: WorkLinks) => links.workId
+}

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.matcher.models.WorkLinks
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ElasticWorkLinksRetrieverTest
-  extends RetrieverTestCases[Index, WorkLinks]
+    extends RetrieverTestCases[Index, WorkLinks]
     with ElasticsearchFixtures
     with ElasticIndexerFixtures
     with WorkGenerators
@@ -31,14 +31,15 @@ class ElasticWorkLinksRetrieverTest
           identifiedWork(canonicalId = lk.workId)
             .withVersion(lk.version)
             .mergeCandidates(
-              lk.referencedWorkIds.map {
-                id => MergeCandidate(
+              lk.referencedWorkIds.map { id =>
+                MergeCandidate(
                   id = Identified(
                     canonicalId = id,
                     sourceIdentifier = createSourceIdentifier
                   ),
                   reason = None
-                ) }.toList
+                )
+              }.toList
             )
         }
 
@@ -53,8 +54,7 @@ class ElasticWorkLinksRetrieverTest
       }
     }
 
-  override def withRetriever[R](
-    testWith: TestWith[Retriever[WorkLinks], R])(
+  override def withRetriever[R](testWith: TestWith[Retriever[WorkLinks], R])(
     implicit index: Index): R =
     testWith(
       new ElasticWorkLinksRetriever(elasticClient, index)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -34,7 +34,7 @@ class WorkGraphUpdaterTest
     it("updating nothing with A gives A:A") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 1, Set.empty),
+          links = WorkLinks("A", 1, Set.empty),
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(WorkNode("A", 1, List(), hashed_A))
@@ -43,7 +43,7 @@ class WorkGraphUpdaterTest
     it("updating nothing with A->B gives A+B:A->B") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 1, Set("B")),
+          links = WorkLinks("A", 1, Set("B")),
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
@@ -54,7 +54,7 @@ class WorkGraphUpdaterTest
     it("updating nothing with B->A gives A+B:B->A") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 1, Set("A")),
+          links = WorkLinks("B", 1, Set("A")),
           existingGraph = WorkGraph(Set.empty)
         )
         .nodes shouldBe Set(
@@ -67,7 +67,7 @@ class WorkGraphUpdaterTest
     it("updating A, B with A->B gives A+B:(A->B, B)") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 2, Set("B")),
+          links = WorkLinks("A", 2, Set("B")),
           existingGraph = WorkGraph(
             Set(WorkNode("A", 1, Nil, "A"), WorkNode("B", 1, Nil, "B")))
         )
@@ -80,7 +80,7 @@ class WorkGraphUpdaterTest
     it("updating A->B with A->B gives A+B:(A->B, B)") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 2, Set("B")),
+          links = WorkLinks("A", 2, Set("B")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 1, List("B"), "A+B"),
@@ -95,7 +95,7 @@ class WorkGraphUpdaterTest
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 2, Set("C")),
+          links = WorkLinks("B", 2, Set("C")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 2, List("B"), "A+B"),
@@ -112,7 +112,7 @@ class WorkGraphUpdaterTest
     it("updating A->B, C->D with B->C gives A+B+C+D:(A->B, B->C, C->D, D)") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 2, Set("C")),
+          links = WorkLinks("B", 2, Set("C")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 1, List("B"), "A+B"),
@@ -132,7 +132,7 @@ class WorkGraphUpdaterTest
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 2, Set("C", "D")),
+          links = WorkLinks("B", 2, Set("C", "D")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 2, List("B"), "A+B"),
@@ -153,7 +153,7 @@ class WorkGraphUpdaterTest
     it("updating A->B->C with A->C gives A+B+C:(A->B, B->C, C->A") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("C", 2, Set("A")),
+          links = WorkLinks("C", 2, Set("A")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 2, List("B"), "A+B+C"),
@@ -174,7 +174,7 @@ class WorkGraphUpdaterTest
       val updateVersion = 2
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+          links = WorkLinks("A", updateVersion, Set("B")),
           existingGraph =
             WorkGraph(Set(WorkNode("A", existingVersion, Nil, "A")))
         )
@@ -191,7 +191,7 @@ class WorkGraphUpdaterTest
       val thrown = intercept[VersionExpectedConflictException] {
         WorkGraphUpdater
           .update(
-            workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+            links = WorkLinks("A", updateVersion, Set("B")),
             existingGraph =
               WorkGraph(Set(WorkNode("A", existingVersion, Nil, "A")))
           )
@@ -206,7 +206,7 @@ class WorkGraphUpdaterTest
 
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", updateVersion, Set("B")),
+          links = WorkLinks("A", updateVersion, Set("B")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", existingVersion, List("B"), hashed_AB),
@@ -226,7 +226,7 @@ class WorkGraphUpdaterTest
       val thrown = intercept[VersionUnexpectedConflictException] {
         WorkGraphUpdater
           .update(
-            workUpdate = WorkUpdate("A", updateVersion, Set("A")),
+            links = WorkLinks("A", updateVersion, Set("A")),
             existingGraph = WorkGraph(
               Set(
                 WorkNode("A", existingVersion, List("B"), hashed_AB),
@@ -241,7 +241,7 @@ class WorkGraphUpdaterTest
     it("updating  A->B with A gives A:A and B:B") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 2, Set.empty),
+          links = WorkLinks("A", 2, Set.empty),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 1, List("B"), "A+B"),
@@ -256,7 +256,7 @@ class WorkGraphUpdaterTest
     it("updating A->B with A but NO B (*should* not occur) gives A:A and B:B") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("A", 2, Set.empty),
+          links = WorkLinks("A", 2, Set.empty),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 1, List("B"), "A+B")
@@ -271,7 +271,7 @@ class WorkGraphUpdaterTest
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 3, Set.empty),
+          links = WorkLinks("B", 3, Set.empty),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 2, List("B"), "A+B+C"),
@@ -288,7 +288,7 @@ class WorkGraphUpdaterTest
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
       WorkGraphUpdater
         .update(
-          workUpdate = WorkUpdate("B", 3, Set("C")),
+          links = WorkLinks("B", 3, Set("C")),
           existingGraph = WorkGraph(
             Set(
               WorkNode("A", 2, List("B"), "A+B+C"),


### PR DESCRIPTION
The matcher only cares about a small bit of information on a Work: the ID, version, and set of other works it's linked to.

The matcher holds this information internally in a case class called `WorkLinks`. (Previously `WorkUpdate`; I don't love the new name but it's a step in the right direction.) It retrieves a Work from pipeline_storage, then converts that into a WorkLinks.

This PR is a large refactor that changes the matcher to use WorkLinks pretty much everywhere, except when it actually fetches the data from pipeline_storage. This is one of two PRs that are part of https://github.com/wellcomecollection/platform/issues/4971 – the second will be to change the implementation of the Retriever so the matcher only retrieves the fields it needs to create a WorkLinks, not the whole Work.