### PR TITLE
Only retrieve specific fields from Elasticsearch in the matcher

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetriever.scala
@@ -25,7 +25,8 @@ trait ElasticRetriever[T] extends Retriever[T] with Logging {
   def createGetRequest(id: String): GetRequest
   def parseGetResponse(response: GetResponse): Try[T]
 
-  override final def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
+  override final def apply(
+    ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
     assert(
       ids.nonEmpty,
       "You should never look up an empty list of IDs!"

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticRetriever.scala
@@ -1,8 +1,9 @@
-package uk.ac.wellcome.pipeline_storage
+package uk.ac.wellcome.pipeline_storage.elastic
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
+import com.sksamuel.elastic4s.requests.get.{GetRequest, GetResponse}
 import com.sksamuel.elastic4s.{
   ElasticClient,
   Index,
@@ -10,18 +11,21 @@ import com.sksamuel.elastic4s.{
   RequestSuccess
 }
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.circe._
-import io.circe.Decoder
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.pipeline_storage.{
+  Retriever,
+  RetrieverMultiResult,
+  RetrieverNotFoundException
+}
 
-class ElasticRetriever[T](client: ElasticClient, index: Index)(
-  implicit val ec: ExecutionContext,
-  decoder: Decoder[T])
-    extends Retriever[T]
-    with Logging {
+trait ElasticRetriever[T] extends Retriever[T] with Logging {
+  val client: ElasticClient
+  val index: Index
 
-  override final def apply(
-    ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
+  def createGetRequest(id: String): GetRequest
+  def parseGetResponse(response: GetResponse): Try[T]
+
+  override final def apply(ids: Seq[String]): Future[RetrieverMultiResult[T]] = {
     assert(
       ids.nonEmpty,
       "You should never look up an empty list of IDs!"
@@ -30,9 +34,7 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
     client
       .execute {
         multiget(
-          ids.map { id =>
-            get(index, id)
-          }
+          ids.map { createGetRequest }
         )
       }
       .map {
@@ -50,7 +52,7 @@ class ElasticRetriever[T](client: ElasticClient, index: Index)(
             .map {
               case (getResponse, id) =>
                 if (getResponse.found) {
-                  id -> getResponse.safeTo[T]
+                  id -> parseGetResponse(getResponse)
                 } else {
                   id -> Failure(
                     new RetrieverNotFoundException(

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetriever.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.pipeline_storage.elastic
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.circe._
+import com.sksamuel.elastic4s.requests.get.{GetRequest, GetResponse}
+import io.circe.Decoder
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
+class ElasticSourceRetriever[T](
+  val client: ElasticClient,
+  val index: Index)(
+  implicit
+  val ec: ExecutionContext,
+  decoder: Decoder[T]
+) extends ElasticRetriever[T] {
+  override def createGetRequest(id: String): GetRequest =
+    get(index, id)
+
+  override def parseGetResponse(response: GetResponse): Try[T] =
+    response.safeTo[T]
+}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetriever.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetriever.scala
@@ -9,9 +9,7 @@ import io.circe.Decoder
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-class ElasticSourceRetriever[T](
-  val client: ElasticClient,
-  val index: Index)(
+class ElasticSourceRetriever[T](val client: ElasticClient, val index: Index)(
   implicit
   val ec: ExecutionContext,
   decoder: Decoder[T]

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetrieverTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticSourceRetrieverTest.scala
@@ -6,11 +6,7 @@ import uk.ac.wellcome.elasticsearch.model.CanonicalId
 import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
-import uk.ac.wellcome.pipeline_storage.{
-  ElasticRetriever,
-  Retriever,
-  RetrieverTestCases
-}
+import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverTestCases}
 import uk.ac.wellcome.pipeline_storage.fixtures.{
   ElasticIndexerFixtures,
   SampleDocument
@@ -18,7 +14,7 @@ import uk.ac.wellcome.pipeline_storage.fixtures.{
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ElasticRetrieverTest
+class ElasticSourceRetrieverTest
     extends RetrieverTestCases[Index, SampleDocument]
     with ElasticsearchFixtures
     with ElasticIndexerFixtures
@@ -42,7 +38,7 @@ class ElasticRetrieverTest
     testWith: TestWith[Retriever[SampleDocument], R])(
     implicit index: Index): R =
     testWith(
-      new ElasticRetriever(elasticClient, index = index)
+      new ElasticSourceRetriever(elasticClient, index)
     )
 
   override def createT: SampleDocument =

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/ElasticSourceRetrieverBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/ElasticSourceRetrieverBuilder.scala
@@ -3,13 +3,12 @@ package uk.ac.wellcome.pipeline_storage.typesafe
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import com.typesafe.config.Config
 import io.circe.Decoder
-
-import uk.ac.wellcome.pipeline_storage.ElasticRetriever
+import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 import scala.concurrent.ExecutionContext
 
-object ElasticRetrieverBuilder {
+object ElasticSourceRetrieverBuilder {
   def apply[T](
     config: Config,
     client: ElasticClient,
@@ -18,8 +17,8 @@ object ElasticRetrieverBuilder {
     implicit
     ec: ExecutionContext,
     decoder: Decoder[T]
-  ): ElasticRetriever[T] =
-    new ElasticRetriever[T](
+  ): ElasticSourceRetriever[T] =
+    new ElasticSourceRetriever[T](
       client = client,
       index = Index(config.requireString(s"es.$namespace.index"))
     )

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
@@ -66,9 +66,8 @@ object Main extends WellcomeTypesafeApp {
         messageSender)(config)
     new IdMinterWorkerService(
       identifierGenerator = identifierGenerator,
-      jsonRetriever = ElasticSourceRetrieverBuilder[Json](
-        config,
-        namespace = "source-works"),
+      jsonRetriever =
+        ElasticSourceRetrieverBuilder[Json](config, namespace = "source-works"),
       pipelineStream = pipelineStream,
       rdsClientConfig = RDSBuilder.buildRDSClientConfig(config),
       identifiersTableConfig = identifiersTableConfig

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
@@ -26,7 +26,6 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.elasticsearch.IdentifiedWorkIndexConfig
 import WorkState.Identified
-import com.sksamuel.elastic4s.ElasticClient
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -46,8 +45,7 @@ object Main extends WellcomeTypesafeApp {
       )
     )
 
-    implicit val esClient: ElasticClient =
-      ElasticBuilder.buildElasticClient(config)
+    val esClient = ElasticBuilder.buildElasticClient(config)
 
     val workIndexer = ElasticIndexerBuilder[Work[Identified]](
       config,
@@ -67,7 +65,7 @@ object Main extends WellcomeTypesafeApp {
     new IdMinterWorkerService(
       identifierGenerator = identifierGenerator,
       jsonRetriever =
-        ElasticSourceRetrieverBuilder[Json](config, namespace = "source-works"),
+        ElasticSourceRetrieverBuilder[Json](config, esClient, namespace = "source-works"),
       pipelineStream = pipelineStream,
       rdsClientConfig = RDSBuilder.buildRDSClientConfig(config),
       identifiersTableConfig = identifiersTableConfig

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/Main.scala
@@ -64,8 +64,10 @@ object Main extends WellcomeTypesafeApp {
         messageSender)(config)
     new IdMinterWorkerService(
       identifierGenerator = identifierGenerator,
-      jsonRetriever =
-        ElasticSourceRetrieverBuilder[Json](config, esClient, namespace = "source-works"),
+      jsonRetriever = ElasticSourceRetrieverBuilder[Json](
+        config,
+        esClient,
+        namespace = "source-works"),
       pipelineStream = pipelineStream,
       rdsClientConfig = RDSBuilder.buildRDSClientConfig(config),
       identifiersTableConfig = identifiersTableConfig

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -30,10 +30,11 @@ object Main extends WellcomeTypesafeApp {
     val denormalisedWorkStream =
       SQSBuilder.buildSQSStream[NotificationMessage](config)
 
-
     val workRetriever = {
       implicit val esClient: ElasticClient =
-        ElasticBuilder.buildElasticClient(config, namespace = "pipeline_storage")
+        ElasticBuilder.buildElasticClient(
+          config,
+          namespace = "pipeline_storage")
 
       ElasticSourceRetrieverBuilder[Work[Denormalised]](
         config,

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -31,9 +31,8 @@ object Main extends WellcomeTypesafeApp {
 
     val workRetriever = ElasticSourceRetrieverBuilder[Work[Denormalised]](
       config,
-      client = ElasticBuilder.buildElasticClient(
-        config,
-        namespace = "pipeline_storage"),
+      client = ElasticBuilder
+        .buildElasticClient(config, namespace = "pipeline_storage"),
       namespace = "denormalised-works")
 
     val workIndexer = ElasticIndexerBuilder[Work[Indexed]](

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -18,7 +18,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.internal._
 import WorkState.{Denormalised, Indexed}
-import com.sksamuel.elastic4s.ElasticClient
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -30,16 +29,12 @@ object Main extends WellcomeTypesafeApp {
     val denormalisedWorkStream =
       SQSBuilder.buildSQSStream[NotificationMessage](config)
 
-    val workRetriever = {
-      implicit val esClient: ElasticClient =
-        ElasticBuilder.buildElasticClient(
-          config,
-          namespace = "pipeline_storage")
-
-      ElasticSourceRetrieverBuilder[Work[Denormalised]](
+    val workRetriever = ElasticSourceRetrieverBuilder[Work[Denormalised]](
+      config,
+      client = ElasticBuilder.buildElasticClient(
         config,
-        namespace = "denormalised-works")
-    }
+        namespace = "pipeline_storage"),
+      namespace = "denormalised-works")
 
     val workIndexer = ElasticIndexerBuilder[Work[Indexed]](
       config,

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -76,7 +76,7 @@ class IngestorFeatureTest
         indexedIndex,
         IndexedWorkIndexConfig),
       retriever = new ElasticSourceRetriever[Work[Denormalised]](
-        denormalisedIndex
+        elasticClient, denormalisedIndex
       )
     )(testWith)
 }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -7,13 +7,14 @@ import uk.ac.wellcome.elasticsearch.IndexedWorkIndexConfig
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever}
+import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 import uk.ac.wellcome.pipeline_storage.Indexable.workIndexable
 import uk.ac.wellcome.models.Implicits._
 import WorkState.{Denormalised, Indexed}
 import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
 
 class IngestorFeatureTest
     extends AnyFunSpec
@@ -74,8 +75,7 @@ class IngestorFeatureTest
         elasticClient,
         indexedIndex,
         IndexedWorkIndexConfig),
-      retriever = new ElasticRetriever[Work[Denormalised]](
-        elasticClient,
+      retriever = new ElasticSourceRetriever[Work[Denormalised]](
         denormalisedIndex
       )
     )(testWith)

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -76,7 +76,8 @@ class IngestorFeatureTest
         indexedIndex,
         IndexedWorkIndexConfig),
       retriever = new ElasticSourceRetriever[Work[Denormalised]](
-        elasticClient, denormalisedIndex
+        elasticClient,
+        denormalisedIndex
       )
     )(testWith)
 }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
@@ -10,7 +10,8 @@ import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.models.work.internal.WorkState.{Denormalised, Indexed}
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.pipeline_storage.Indexable.workIndexable
-import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, ElasticRetriever}
+import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
+import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -131,8 +132,7 @@ class IngestorWorkerServiceTest
                 elasticClient,
                 indexedIndex,
                 IndexedWorkIndexConfig),
-              retriever = new ElasticRetriever[Work[Denormalised]](
-                elasticClient,
+              retriever = new ElasticSourceRetriever[Work[Denormalised]](
                 identifiedIndex
               )
             ) { _ =>

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
@@ -133,6 +133,7 @@ class IngestorWorkerServiceTest
                 indexedIndex,
                 IndexedWorkIndexConfig),
               retriever = new ElasticSourceRetriever[Work[Denormalised]](
+                elasticClient,
                 identifiedIndex
               )
             ) { _ =>

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -1,26 +1,54 @@
 package uk.ac.wellcome.platform.matcher.storage.elastic
 
+import com.sksamuel.elastic4s.ElasticDsl.get
+import com.sksamuel.elastic4s.requests.get.{GetRequest, GetResponse}
+import com.sksamuel.elastic4s.circe._
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.models.work.internal.{Work, WorkState}
-import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
-import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverMultiResult}
+import uk.ac.wellcome.models.work.internal.{IdState, MergeCandidate}
+import uk.ac.wellcome.pipeline_storage.elastic.ElasticRetriever
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
-class ElasticWorkLinksRetriever(client: ElasticClient, index: Index)(
+/** The matcher only needs to know about linking data on works; most of the fields
+ * it can completely ignore.
+ *
+ * This custom retriever fetches only the specific fields that the matcher needs, to
+ * reduce the amount of data we have to get out of Elasticsearch (and pay to send through
+ * the AWS NAT Gateway).
+ */
+class ElasticWorkLinksRetriever(val client: ElasticClient, val index: Index)(
   implicit val ec: ExecutionContext
-) extends Retriever[WorkLinks] {
-  private val underlying =
-    new ElasticSourceRetriever[Work[WorkState.Identified]](client, index)
+) extends ElasticRetriever[WorkLinks] {
 
-  override def apply(
-    ids: Seq[String]): Future[RetrieverMultiResult[WorkLinks]] =
-    underlying.apply(ids).map { result =>
-      RetrieverMultiResult(
-        found = result.found.map { case (id, work) => id -> WorkLinks(work) },
-        notFound = result.notFound
+  override def createGetRequest(id: String): GetRequest =
+    get(index, id)
+      .fetchSourceInclude("state.canonicalId", "data.mergeCandidates", "version")
+
+  override def parseGetResponse(response: GetResponse): Try[WorkLinks] =
+    response.safeTo[WorkStub].map { stub =>
+      val id = stub.state.canonicalId
+      val referencedWorkIds = stub.data.mergeCandidates
+        .map { mergeCandidate =>
+          mergeCandidate.id.canonicalId
+        }
+        .filterNot { _ == id }
+        .toSet
+
+      WorkLinks(
+        workId = id,
+        version = stub.version,
+        referencedWorkIds = referencedWorkIds
       )
     }
+
+  private case class StateStub(canonicalId: String)
+  private case class DataStub(mergeCandidates: List[MergeCandidate[IdState.Identified]])
+
+  private case class WorkStub(
+    state: StateStub,
+    version: Int,
+    data: DataStub)
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -13,19 +13,22 @@ import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 /** The matcher only needs to know about linking data on works; most of the fields
- * it can completely ignore.
- *
- * This custom retriever fetches only the specific fields that the matcher needs, to
- * reduce the amount of data we have to get out of Elasticsearch (and pay to send through
- * the AWS NAT Gateway).
- */
+  * it can completely ignore.
+  *
+  * This custom retriever fetches only the specific fields that the matcher needs, to
+  * reduce the amount of data we have to get out of Elasticsearch (and pay to send through
+  * the AWS NAT Gateway).
+  */
 class ElasticWorkLinksRetriever(val client: ElasticClient, val index: Index)(
   implicit val ec: ExecutionContext
 ) extends ElasticRetriever[WorkLinks] {
 
   override def createGetRequest(id: String): GetRequest =
     get(index, id)
-      .fetchSourceInclude("state.canonicalId", "data.mergeCandidates", "version")
+      .fetchSourceInclude(
+        "state.canonicalId",
+        "data.mergeCandidates",
+        "version")
 
   override def parseGetResponse(response: GetResponse): Try[WorkLinks] =
     response.safeTo[WorkStub].map { stub =>
@@ -45,10 +48,8 @@ class ElasticWorkLinksRetriever(val client: ElasticClient, val index: Index)(
     }
 
   private case class StateStub(canonicalId: String)
-  private case class DataStub(mergeCandidates: List[MergeCandidate[IdState.Identified]])
+  private case class DataStub(
+    mergeCandidates: List[MergeCandidate[IdState.Identified]])
 
-  private case class WorkStub(
-    state: StateStub,
-    version: Int,
-    data: DataStub)
+  private case class WorkStub(state: StateStub, version: Int, data: DataStub)
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -3,11 +3,8 @@ package uk.ac.wellcome.platform.matcher.storage.elastic
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal.{Work, WorkState}
-import uk.ac.wellcome.pipeline_storage.{
-  ElasticRetriever,
-  Retriever,
-  RetrieverMultiResult
-}
+import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
+import uk.ac.wellcome.pipeline_storage.{Retriever, RetrieverMultiResult}
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +13,7 @@ class ElasticWorkLinksRetriever(client: ElasticClient, index: Index)(
   implicit val ec: ExecutionContext
 ) extends Retriever[WorkLinks] {
   private val underlying =
-    new ElasticRetriever[Work[WorkState.Identified]](client, index)
+    new ElasticSourceRetriever[Work[WorkState.Identified]](client, index)
 
   override def apply(
     ids: Seq[String]): Future[RetrieverMultiResult[WorkLinks]] =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/Main.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.platform.merger.services._
@@ -31,7 +31,7 @@ object Main extends WellcomeTypesafeApp {
     val esClient = ElasticBuilder.buildElasticClient(config)
 
     val sourceWorkLookup = new IdentifiedWorkLookup(
-      retriever = ElasticRetrieverBuilder.apply[Work[Identified]](
+      retriever = ElasticSourceRetrieverBuilder.apply[Work[Identified]](
         config,
         esClient,
         namespace = "identified-works"

--- a/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/uk/ac/wellcome/platform/router/Main.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.{Denormalised, Merged}
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -35,7 +35,7 @@ object Main extends WellcomeTypesafeApp {
       indexConfig = DenormalisedWorkIndexConfig
     )
 
-    val workRetriever = ElasticRetrieverBuilder[Work[Merged]](
+    val workRetriever = ElasticSourceRetrieverBuilder[Work[Merged]](
       config,
       esClient,
       namespace = "merged-works"

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
@@ -54,7 +54,8 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     new CalmTransformerWorker(
       pipelineStream = pipelineStream,
       recordReadable = S3TypedStore[CalmRecord],
-      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+      retriever =
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.platform.transformer.calm.services.CalmTransformerWorker
@@ -33,7 +33,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     implicit val ec: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
-    val esClient = ElasticBuilder.buildElasticClient(config)
+    implicit val esClient = ElasticBuilder.buildElasticClient(config)
 
     val pipelineStream = PipelineStorageStreamBuilder
       .buildPipelineStorageStream(
@@ -54,7 +54,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     new CalmTransformerWorker(
       pipelineStream = pipelineStream,
       recordReadable = S3TypedStore[CalmRecord],
-      retriever = ElasticRetrieverBuilder.apply[Work[Source]](config, esClient)
+      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/Main.scala
@@ -33,7 +33,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     implicit val ec: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
-    implicit val esClient = ElasticBuilder.buildElasticClient(config)
+    val esClient = ElasticBuilder.buildElasticClient(config)
 
     val pipelineStream = PipelineStorageStreamBuilder
       .buildPipelineStorageStream(
@@ -55,7 +55,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
       pipelineStream = pipelineStream,
       recordReadable = S3TypedStore[CalmRecord],
       retriever =
-        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient)
     )
   }
 }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTestCases.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/catalogue/transformer/TransformerWorkerTestCases.scala
@@ -90,7 +90,7 @@ trait TransformerWorkerTestCases[Context, Payload <: SourcePayload, SourceData]
 
         // We need to wait for the pipeline storage stream to save the works.
         // If we're too quick in retrying, we'll retry before a work is in the index!
-        withLocalSqsQueuePair(visibilityTimeout = 2) {
+        withLocalSqsQueuePair(visibilityTimeout = 5) {
           case QueuePair(queue, dlq) =>
             withWorkerImpl(queue, workIndexer, workKeySender) { _ =>
               (1 to 5).foreach { _ =>

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -33,7 +33,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 
-    implicit val esClient = ElasticBuilder.buildElasticClient(config)
+    val esClient = ElasticBuilder.buildElasticClient(config)
 
     val pipelineStream = PipelineStorageStreamBuilder
       .buildPipelineStorageStream(
@@ -53,7 +53,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
       pipelineStream = pipelineStream,
       metsXmlStore = S3TypedStore[String],
       retriever =
-        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient)
     )
   }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
@@ -33,7 +33,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
 
-    val esClient = ElasticBuilder.buildElasticClient(config)
+    implicit val esClient = ElasticBuilder.buildElasticClient(config)
 
     val pipelineStream = PipelineStorageStreamBuilder
       .buildPipelineStorageStream(
@@ -52,7 +52,7 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     new MetsTransformerWorker(
       pipelineStream = pipelineStream,
       metsXmlStore = S3TypedStore[String],
-      retriever = ElasticRetrieverBuilder.apply[Work[Source]](config, esClient)
+      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/Main.scala
@@ -52,7 +52,8 @@ object Main extends WellcomeTypesafeApp with AWSClientConfigBuilder {
     new MetsTransformerWorker(
       pipelineStream = pipelineStream,
       metsXmlStore = S3TypedStore[String],
-      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+      retriever =
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -55,7 +55,8 @@ object Main extends WellcomeTypesafeApp {
     new MiroTransformerWorker(
       pipelineStream = pipelineStream,
       miroReadable = S3TypedStore[MiroRecord],
-      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+      retriever =
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -56,7 +56,7 @@ object Main extends WellcomeTypesafeApp {
       pipelineStream = pipelineStream,
       miroReadable = S3TypedStore[MiroRecord],
       retriever =
-        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient)
     )
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.platform.transformer.miro.Implicits._
@@ -55,7 +55,7 @@ object Main extends WellcomeTypesafeApp {
     new MiroTransformerWorker(
       pipelineStream = pipelineStream,
       miroReadable = S3TypedStore[MiroRecord],
-      retriever = ElasticRetrieverBuilder.apply[Work[Source]](config, esClient)
+      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.models.work.internal.Work
 import uk.ac.wellcome.models.work.internal.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.typesafe.{
   ElasticIndexerBuilder,
-  ElasticRetrieverBuilder,
+  ElasticSourceRetrieverBuilder,
   PipelineStorageStreamBuilder
 }
 import uk.ac.wellcome.platform.transformer.sierra.services.SierraTransformerWorker
@@ -55,7 +55,7 @@ object Main extends WellcomeTypesafeApp {
     new SierraTransformerWorker(
       pipelineStream = pipelineStream,
       sierraReadable = S3TypedStore[SierraTransformable],
-      retriever = ElasticRetrieverBuilder.apply[Work[Source]](config, esClient)
+      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -56,7 +56,7 @@ object Main extends WellcomeTypesafeApp {
       pipelineStream = pipelineStream,
       sierraReadable = S3TypedStore[SierraTransformable],
       retriever =
-        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient)
     )
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/Main.scala
@@ -55,7 +55,8 @@ object Main extends WellcomeTypesafeApp {
     new SierraTransformerWorker(
       pipelineStream = pipelineStream,
       sierraReadable = S3TypedStore[SierraTransformable],
-      retriever = ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
+      retriever =
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](esClient, config)
     )
   }
 }


### PR DESCRIPTION
Follows #1263; this is the second part of and closes https://github.com/wellcomecollection/platform/issues/4971

This follows a similar pattern we use in the relation embedder – rather than fetching and decoding the whole Work, we fetch specific fields. This reduces traffic over the NAT Gateway – not a huge amount, but it's low-handing fruit we can easily pick.