### PR TITLE
Make pipeline storage es host configurable

### DIFF
--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -44,7 +44,7 @@ module "id_minter" {
     db_username          = "catalogue/id_minter/rds_user"
     db_password          = "catalogue/id_minter/rds_password"
 
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/id_minter/es_username"

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -53,7 +53,7 @@ module "matcher" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/matcher/es_username"

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -38,7 +38,7 @@ module "merger" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/merger/es_username"

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -31,7 +31,7 @@ module "calm_transformer" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/transformer/es_username"

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -31,7 +31,7 @@ module "mets_transformer" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/transformer/es_username"

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -34,7 +34,7 @@ module "miro_transformer" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/transformer/es_username"

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -31,7 +31,7 @@ module "sierra_transformer" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/transformer/es_username"

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -39,7 +39,7 @@ module "ingestor_works" {
     es_password_catalogue = "catalogue/ingestor/es_password"
     es_protocol_catalogue = "catalogue/ingestor/es_protocol"
 
-    es_host_pipeline_storage     = "catalogue/pipeline_storage/es_host"
+    es_host_pipeline_storage     = var.pipeline_storage_es_host_secret_id
     es_port_pipeline_storage     = "catalogue/pipeline_storage/es_port"
     es_protocol_pipeline_storage = "catalogue/pipeline_storage/es_protocol"
     es_username_pipeline_storage = "catalogue/pipeline_storage/ingestor/es_username"

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -37,7 +37,7 @@ module "relation_embedder" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/relation_embedder/es_username"

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -35,7 +35,7 @@ module "router" {
   }
 
   secret_env_vars = {
-    es_host     = "catalogue/pipeline_storage/es_host"
+    es_host     = var.pipeline_storage_es_host_secret_id
     es_port     = "catalogue/pipeline_storage/es_port"
     es_protocol = "catalogue/pipeline_storage/es_protocol"
     es_username = "catalogue/pipeline_storage/router/es_username"

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -59,3 +59,8 @@ variable "storage_bucket_name" {
 }
 
 variable "inferrer_model_data_bucket_name" {}
+
+variable "pipeline_storage_es_host_secret_id" {
+  default = "catalogue/pipeline_storage/es_host"
+  description = "The id of the secret where the es_host is stored"
+}

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -61,6 +61,6 @@ variable "storage_bucket_name" {
 variable "inferrer_model_data_bucket_name" {}
 
 variable "pipeline_storage_es_host_secret_id" {
-  default = "catalogue/pipeline_storage/es_host"
+  default     = "catalogue/pipeline_storage/es_host"
   description = "The id of the secret where the es_host is stored"
 }


### PR DESCRIPTION
In order to use the new pipeline storage ES cluster accessible via a VPC endpoint we need to make the ES host used by the pipeline stack configurable. Using this mechanism we should be able to spin up a new pipeline that uses the VPC endpoint ES host exported from the infrastructure/critical stack, while keeping the existing pipeline working.

Part of https://github.com/wellcomecollection/platform/issues/4949
Depends on https://github.com/wellcomecollection/catalogue/pull/1261