### PR TITLE
Get URLs from MARC 520 subfield u as clickable links in the description

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -98,7 +98,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       title = SierraTitle(bibData),
       alternativeTitles = SierraAlternativeTitles(bibData),
       format = SierraFormat(bibData),
-      description = SierraDescription(bibData),
+      description = SierraDescription(bibId, bibData),
       physicalDescription = SierraPhysicalDescription(bibData),
       lettering = SierraLettering(bibData),
       subjects = SierraSubjects(bibId, bibData),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
@@ -3,12 +3,20 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import grizzled.slf4j.Logging
 
 import java.net.URL
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraBibData, SierraQueryOps, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraBibData,
+  SierraQueryOps,
+  VarField
+}
 import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 
 import scala.util.Try
 
-object SierraDescription extends SierraIdentifiedDataTransformer with SierraQueryOps with Logging {
+object SierraDescription
+    extends SierraIdentifiedDataTransformer
+    with SierraQueryOps
+    with Logging {
 
   type Output = Option[String]
 
@@ -39,7 +47,8 @@ object SierraDescription extends SierraIdentifiedDataTransformer with SierraQuer
     if (description.nonEmpty) Some(description) else None
   }
 
-  private def descriptionFromVarfield(bibId: SierraBibNumber, vf: VarField): String = {
+  private def descriptionFromVarfield(bibId: SierraBibNumber,
+                                      vf: VarField): String = {
     val subfields =
       Seq(
         vf.nonrepeatableSubfieldWithTag(tag = "a"),
@@ -59,7 +68,8 @@ object SierraDescription extends SierraIdentifiedDataTransformer with SierraQuer
           // For now, log the value and don't make it clickable -- we can decide how
           // best to handle it later.
           case MarcSubfield("u", contents) =>
-            warn(s"Bib $bibId has MARC 520 ǂu which doesn't look like a URL: $contents")
+            warn(
+              s"Bib $bibId has MARC 520 ǂu which doesn't look like a URL: $contents")
             contents
 
           case MarcSubfield(_, contents) => contents
@@ -70,5 +80,5 @@ object SierraDescription extends SierraIdentifiedDataTransformer with SierraQuer
   }
 
   private def isUrl(s: String): Boolean =
-    Try { new URL(s)}.isSuccess
+    Try { new URL(s) }.isSuccess
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
@@ -87,7 +87,8 @@ class SierraDescriptionTest
     it("wraps a single URL in <a> tags") {
       val url = "https://fruitpicking.org/"
 
-      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url">$url</a></p>"""
+      val expectedDescription =
+        s"""<p>$description $summaryDescription <a href="$url">$url</a></p>"""
 
       assertFindsCorrectDescription(
         varFields = List(
@@ -108,7 +109,8 @@ class SierraDescriptionTest
       val url1 = "https://fruitpicking.org/"
       val url2 = "https://fruitpicking.org/"
 
-      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url1">$url1</a> <a href="$url2">$url2</a></p>"""
+      val expectedDescription =
+        s"""<p>$description $summaryDescription <a href="$url1">$url1</a> <a href="$url2">$url2</a></p>"""
 
       assertFindsCorrectDescription(
         varFields = List(
@@ -126,11 +128,13 @@ class SierraDescriptionTest
       )
     }
 
-    it("does not wrap the contents of ǂu in <a> tags if it doesn't look like a URL") {
+    it(
+      "does not wrap the contents of ǂu in <a> tags if it doesn't look like a URL") {
       val url1 = "https://fruitpicking.org/"
       val uContents = "A website about fruitpicking"
 
-      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url1">$url1</a> $uContents</p>"""
+      val expectedDescription =
+        s"""<p>$description $summaryDescription <a href="$url1">$url1</a> $uContents</p>"""
 
       assertFindsCorrectDescription(
         varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
@@ -80,6 +80,75 @@ class SierraDescriptionTest
     )
   }
 
+  describe("getting URLs from MARC 520 ǂu") {
+    val description = "Picking particular pears in Poland."
+    val summaryDescription = "Selecting sumptious starfruit in Spain."
+
+    it("wraps a single URL in <a> tags") {
+      val url = "https://fruitpicking.org/"
+
+      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url">$url</a></p>"""
+
+      assertFindsCorrectDescription(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "520",
+            subfields = List(
+              MarcSubfield(tag = "a", content = description),
+              MarcSubfield(tag = "b", content = summaryDescription),
+              MarcSubfield(tag = "u", content = url)
+            )
+          )
+        ),
+        expectedDescription = Some(expectedDescription)
+      )
+    }
+
+    it("wraps multiple URLs in <a> tags") {
+      val url1 = "https://fruitpicking.org/"
+      val url2 = "https://fruitpicking.org/"
+
+      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url1">$url1</a> <a href="$url2">$url2</a></p>"""
+
+      assertFindsCorrectDescription(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "520",
+            subfields = List(
+              MarcSubfield(tag = "a", content = description),
+              MarcSubfield(tag = "b", content = summaryDescription),
+              MarcSubfield(tag = "u", content = url1),
+              MarcSubfield(tag = "u", content = url2)
+            )
+          )
+        ),
+        expectedDescription = Some(expectedDescription)
+      )
+    }
+
+    it("does not wrap the contents of ǂu in <a> tags if it doesn't look like a URL") {
+      val url1 = "https://fruitpicking.org/"
+      val uContents = "A website about fruitpicking"
+
+      val expectedDescription = s"""<p>$description $summaryDescription <a href="$url1">$url1</a> $uContents</p>"""
+
+      assertFindsCorrectDescription(
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "520",
+            subfields = List(
+              MarcSubfield(tag = "a", content = description),
+              MarcSubfield(tag = "b", content = summaryDescription),
+              MarcSubfield(tag = "u", content = url1),
+              MarcSubfield(tag = "u", content = uContents)
+            )
+          )
+        ),
+        expectedDescription = Some(expectedDescription)
+      )
+    }
+  }
+
   it("does not get a description if MARC field 520 is absent") {
     assertFindsCorrectDescription(
       varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescriptionTest.scala
@@ -163,7 +163,9 @@ class SierraDescriptionTest
     expectedDescription: Option[String]
   ): Assertion = {
     val actualDescription = SierraDescription(
-      createSierraBibDataWith(varFields = varFields))
+      bibId = createSierraBibNumber,
+      bibData = createSierraBibDataWith(varFields = varFields)
+    )
     actualDescription shouldBe expectedDescription
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4973

I took a cue from what we do on wellcomelibrary.org (e.g. https://search.wellcomelibrary.org/iii/encore/record/C__Rb3227624?lang=eng): anything in MARC 520 subfield u gets appended to the description inside the `<p>` tags. If the contents of the field looks like a URL, we wrap it in `<a>` tags with the URL as the link text.

Reviewers: @wellcomecollection/scala-devs for code, @jtweed for data modelling