### PR TITLE
Script to set EC_API_KEY var for terraform in infrastructure/critical

### DIFF
--- a/infrastructure/critical/README.md
+++ b/infrastructure/critical/README.md
@@ -6,14 +6,6 @@ Contains critical infrastructure for the catalogue services
 
 In order to run terraform the Elastic Cloud terraform provider requires that the EC_API_KEY environment variable be set.
 
-To retrieve the API key you can run 
+You can run `run_terraform.sh` to set the correct environment variable and run terraform. Any parameters you pass to that script will be passed to `terraform`.
 
-```
-aws secretsmanager get-secret-value \
-    --secret-id elastic_cloud/api_key \
-    --profile platform \
-    --output text \
-    --query 'SecretString'
-```
-
-Where the AWS profile used gives you read access to secrets in the platform account.
+The script will by default set AWS_PROFILE to "platform", but you can use a different value by setting AWS_PROFILE yourself.

--- a/infrastructure/critical/run_terraform.sh
+++ b/infrastructure/critical/run_terraform.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+AWS_CLI_PROFILE=${AWS_PROFILE:-platform}
+
+EC_API_KEY=$(aws secretsmanager get-secret-value --secret-id elastic_cloud/api_key --profile "$AWS_CLI_PROFILE" --output text --query 'SecretString')
+
+EC_API_KEY=$EC_API_KEY terraform "$@"


### PR DESCRIPTION
To make it a bit easier to run the infrastructure/critical stack this change adds a script that pulls the EC_API_KEY for the Elastic Cloud terraform provider from AWS SecretsManager and sets it in the environment for terraform.