### PR TITLE
Public access traffic filter for Elastic Cloud pipeline storage

### DIFF
--- a/infrastructure/critical/elastic.tf
+++ b/infrastructure/critical/elastic.tf
@@ -8,7 +8,8 @@ resource "ec_deployment" "pipeline_storage" {
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = [
-    ec_deployment_traffic_filter.allow_catalogue_pipeline_vpce.id
+    ec_deployment_traffic_filter.allow_catalogue_pipeline_vpce.id,
+    ec_deployment_traffic_filter.public_internet.id
   ]
 
   elasticsearch {
@@ -66,6 +67,16 @@ resource "ec_deployment_traffic_filter" "allow_catalogue_pipeline_vpce" {
 
   rule {
     source = aws_vpc_endpoint.catalogue_pipeline_elastic_cloud_vpce.id
+  }
+}
+
+resource "ec_deployment_traffic_filter" "public_internet" {
+  name   = "public_access"
+  region = "eu-west-1"
+  type   = "ip"
+
+  rule {
+    source = "0.0.0.0/0"
   }
 }
 

--- a/infrastructure/critical/elastic.tf
+++ b/infrastructure/critical/elastic.tf
@@ -70,6 +70,8 @@ resource "ec_deployment_traffic_filter" "allow_catalogue_pipeline_vpce" {
   }
 }
 
+# This enables public access to the ES cluster (with the usual x-pack auth proviso)
+# TODO: Restrict this to Wellcome internal IP addresses when physical office access is restored
 resource "ec_deployment_traffic_filter" "public_internet" {
   name   = "public_access"
   region = "eu-west-1"


### PR DESCRIPTION
There are some operations that are enabled by having direct access to the ES cluster, e.g.

- Setting up credentials
- Checking on reindexes

This change adds a traffic filter that restores public facing access to the ES cluster, this should eventually be restricted to office IP addresses, but does not represent a change in security from the current configuration.

Part of https://github.com/wellcomecollection/platform/issues/4949