### PR TITLE
Better configurable secrets for pipeline storage Elasticsearch access

### DIFF
--- a/pipeline/create_pipeline_storage_es_credentials.py
+++ b/pipeline/create_pipeline_storage_es_credentials.py
@@ -136,7 +136,8 @@ def create_user(es, username, roles):
     "--password", hide_input=True, prompt="What is your Elasticsearch password?"
 )
 @click.option("--endpoint", prompt="What is your Elasticsearch endpoint?")
-def main(username, password, endpoint):
+@click.option("--deployment-id", default="pipeline_storage", prompt="What is your Elasticsearch deployment ID?")
+def main(username, password, endpoint, deployment_id):
     url = hyperlink.URL.from_text(endpoint)
     host = url.host
     protocol = url.scheme
@@ -150,12 +151,12 @@ def main(username, password, endpoint):
 
     print("")
 
-    store_secret(secret_id="catalogue/pipeline_storage/es_host", secret_value=host)
+    store_secret(secret_id=f"catalogue/{deployment_id}/es_host", secret_value=host)
 
-    store_secret(secret_id="catalogue/pipeline_storage/es_port", secret_value=port)
+    store_secret(secret_id=f"catalogue/{deployment_id}/es_port", secret_value=port)
 
     store_secret(
-        secret_id="catalogue/pipeline_storage/es_protocol", secret_value=protocol
+        secret_id=f"catalogue/{deployment_id}/es_protocol", secret_value=protocol
     )
 
     print("")
@@ -185,12 +186,12 @@ def main(username, password, endpoint):
 
     for username, password in newly_created_usernames:
         store_secret(
-            secret_id=f"catalogue/pipeline_storage/{username}/es_username",
+            secret_id=f"catalogue/{deployment_id}}/{username}/es_username",
             secret_value=username,
         )
 
         store_secret(
-            secret_id=f"catalogue/pipeline_storage/{username}/es_password",
+            secret_id=f"catalogue/{deployment_id}/{username}/es_password",
             secret_value=password,
         )
 

--- a/pipeline/create_pipeline_storage_es_credentials.py
+++ b/pipeline/create_pipeline_storage_es_credentials.py
@@ -136,7 +136,11 @@ def create_user(es, username, roles):
     "--password", hide_input=True, prompt="What is your Elasticsearch password?"
 )
 @click.option("--endpoint", prompt="What is your Elasticsearch endpoint?")
-@click.option("--deployment-id", default="pipeline_storage", prompt="What is your Elasticsearch deployment ID?")
+@click.option(
+    "--deployment-id",
+    default="pipeline_storage",
+    prompt="What is your Elasticsearch deployment ID?",
+)
 def main(username, password, endpoint, deployment_id):
     url = hyperlink.URL.from_text(endpoint)
     host = url.host

--- a/pipeline/create_pipeline_storage_es_credentials.py
+++ b/pipeline/create_pipeline_storage_es_credentials.py
@@ -186,7 +186,7 @@ def main(username, password, endpoint, deployment_id):
 
     for username, password in newly_created_usernames:
         store_secret(
-            secret_id=f"catalogue/{deployment_id}}/{username}/es_username",
+            secret_id=f"catalogue/{deployment_id}/{username}/es_username",
             secret_value=username,
         )
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -53,3 +53,61 @@ module "catalogue_pipeline_2021-01-12" {
 
   storage_bucket_name = local.storage_bucket
 }
+
+module "catalogue_pipeline_2021-01-18" {
+  source = "./stack"
+
+  pipeline_date = "2021-01-18"
+  release_label = "stage"
+
+  pipeline_storage_id = "pipeline_storage_delta"
+
+  # Transformer config
+  #
+  # If this pipeline is meant to be reindexed, remember to uncomment the
+  # reindexer topic names.
+
+  sierra_adapter_topic_arns = [
+    local.sierra_reindexer_topic_arn,
+    local.sierra_merged_bibs_topic_arn,
+    local.sierra_merged_items_topic_arn,
+  ]
+
+  miro_adapter_topic_arns = [
+    local.miro_reindexer_topic_arn,
+    local.miro_updates_topic_arn,
+  ]
+
+  mets_adapter_topic_arns = [
+    local.mets_reindexer_topic_arn,
+    local.mets_adapter_topic_arn,
+  ]
+
+  calm_adapter_topic_arns = [
+    local.calm_reindexer_topic_arn,
+    local.calm_adapter_topic_arn,
+  ]
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  aws_region = local.aws_region
+  vpc_id     = local.vpc_id
+  subnets    = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  # RDS
+  rds_ids_access_security_group_id = local.rds_access_security_group_id
+
+  # Adapter VHS
+  vhs_miro_read_policy   = local.vhs_miro_read_policy
+  vhs_sierra_read_policy = local.vhs_sierra_read_policy
+  vhs_calm_read_policy   = local.vhs_calm_read_policy
+
+  # Inferrer data
+  inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
+
+  shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+
+  storage_bucket_name = local.storage_bucket
+}

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -37,19 +37,13 @@ module "id_minter" {
     ingest_flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    cluster_url          = "rds/identifiers-delta-cluster/endpoint"
+  secret_env_vars = merge({
+    cluster_url = "rds/identifiers-delta-cluster/endpoint"
     cluster_url_readonly = "rds/identifiers-delta-cluster/reader_endpoint"
-    db_port              = "rds/identifiers-delta-cluster/port"
-    db_username          = "catalogue/id_minter/rds_user"
-    db_password          = "catalogue/id_minter/rds_password"
-
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/id_minter/es_username"
-    es_password = "catalogue/pipeline_storage/id_minter/es_password"
-  }
+    db_port = "rds/identifiers-delta-cluster/port"
+    db_username = "catalogue/id_minter/rds_user"
+    db_password = "catalogue/id_minter/rds_password"
+  }, local.pipeline_storage_es_service_secrets["id_minter"])
 
   // The total number of connections to RDS across all tasks from all ID minter
   // services must not exceed the maximum supported by the RDS instance.

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -38,11 +38,11 @@ module "id_minter" {
   }
 
   secret_env_vars = merge({
-    cluster_url = "rds/identifiers-delta-cluster/endpoint"
+    cluster_url          = "rds/identifiers-delta-cluster/endpoint"
     cluster_url_readonly = "rds/identifiers-delta-cluster/reader_endpoint"
-    db_port = "rds/identifiers-delta-cluster/port"
-    db_username = "catalogue/id_minter/rds_user"
-    db_password = "catalogue/id_minter/rds_password"
+    db_port              = "rds/identifiers-delta-cluster/port"
+    db_username          = "catalogue/id_minter/rds_user"
+    db_password          = "catalogue/id_minter/rds_password"
   }, local.pipeline_storage_es_service_secrets["id_minter"])
 
   // The total number of connections to RDS across all tasks from all ID minter

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -52,13 +52,7 @@ module "matcher" {
     es_index = local.es_works_identified_index
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/matcher/es_username"
-    es_password = "catalogue/pipeline_storage/matcher/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["matcher"]
 
   subnets             = var.subnets
   max_capacity        = var.max_capacity

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -37,13 +37,8 @@ module "merger" {
     flush_interval_seconds = 120
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/merger/es_username"
-    es_password = "catalogue/pipeline_storage/merger/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["merger"]
+
   cpu    = 2048
   memory = 4096
 

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -30,13 +30,7 @@ module "calm_transformer" {
     flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/transformer/es_username"
-    es_password = "catalogue/pipeline_storage/transformer/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
   subnets             = var.subnets
   max_capacity        = var.max_capacity

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -30,13 +30,7 @@ module "mets_transformer" {
     flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/transformer/es_username"
-    es_password = "catalogue/pipeline_storage/transformer/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
   subnets             = var.subnets
   max_capacity        = var.max_capacity

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -33,13 +33,7 @@ module "miro_transformer" {
     flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/transformer/es_username"
-    es_password = "catalogue/pipeline_storage/transformer/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
   subnets             = var.subnets
   max_capacity        = var.max_capacity

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -30,13 +30,7 @@ module "sierra_transformer" {
     flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/transformer/es_username"
-    es_password = "catalogue/pipeline_storage/transformer/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
   subnets             = var.subnets
   max_capacity        = var.max_capacity

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -39,11 +39,11 @@ module "ingestor_works" {
     es_password_catalogue = "catalogue/ingestor/es_password"
     es_protocol_catalogue = "catalogue/ingestor/es_protocol"
 
-    es_host_pipeline_storage     = var.pipeline_storage_es_host_secret_id
-    es_port_pipeline_storage     = "catalogue/pipeline_storage/es_port"
-    es_protocol_pipeline_storage = "catalogue/pipeline_storage/es_protocol"
-    es_username_pipeline_storage = "catalogue/pipeline_storage/work_ingestor/es_username"
-    es_password_pipeline_storage = "catalogue/pipeline_storage/work_ingestor/es_password"
+    es_host_pipeline_storage     = local.pipeline_storage_es_host
+    es_port_pipeline_storage     = local.pipeline_storage_es_port
+    es_protocol_pipeline_storage = local.pipeline_storage_es_protocol
+    es_username_pipeline_storage = "catalogue/${var.pipeline_storage_id}/ingestor/es_username"
+    es_password_pipeline_storage = "catalogue/${var.pipeline_storage_id}/ingestor/es_password"
   })
 
   subnets = var.subnets

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -32,7 +32,7 @@ module "ingestor_works" {
     ingest_flush_interval_seconds = 60
   }
 
-  secret_env_vars = {
+  secret_env_vars = merge({
     es_host_catalogue     = "catalogue/ingestor/es_host"
     es_port_catalogue     = "catalogue/ingestor/es_port"
     es_username_catalogue = "catalogue/ingestor/es_username"
@@ -44,7 +44,7 @@ module "ingestor_works" {
     es_protocol_pipeline_storage = "catalogue/pipeline_storage/es_protocol"
     es_username_pipeline_storage = "catalogue/pipeline_storage/work_ingestor/es_username"
     es_password_pipeline_storage = "catalogue/pipeline_storage/work_ingestor/es_password"
-  }
+  })
 
   subnets = var.subnets
 

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -36,13 +36,7 @@ module "relation_embedder" {
     index_flush_interval_seconds = 60
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/relation_embedder/es_username"
-    es_password = "catalogue/pipeline_storage/relation_embedder/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["relation_embedder"]
 
   # NOTE: limit to avoid >500 concurrent scroll contexts
   max_capacity = min(10, var.max_capacity)

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -34,13 +34,7 @@ module "router" {
     flush_interval_seconds = 30
   }
 
-  secret_env_vars = {
-    es_host     = var.pipeline_storage_es_host_secret_id
-    es_port     = "catalogue/pipeline_storage/es_port"
-    es_protocol = "catalogue/pipeline_storage/es_protocol"
-    es_username = "catalogue/pipeline_storage/router/es_username"
-    es_password = "catalogue/pipeline_storage/router/es_password"
-  }
+  secret_env_vars = local.pipeline_storage_es_service_secrets["router"]
 
   shared_logging_secrets = var.shared_logging_secrets
 

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -81,13 +81,13 @@ locals {
   ]
 
   pipeline_storage_es_service_secrets = zipmap(local.pipeline_storage_service_list, [
-    for service in local.pipeline_storage_service_list:
-      {
-        es_host     = local.pipeline_storage_es_host
-        es_port     = local.pipeline_storage_es_port
-        es_protocol = local.pipeline_storage_es_protocol
-        es_username = "catalogue/${var.pipeline_storage_id}/${service}/es_username"
-        es_password = "catalogue/${var.pipeline_storage_id}/${service}/es_password"
-      }
+    for service in local.pipeline_storage_service_list :
+    {
+      es_host     = local.pipeline_storage_es_host
+      es_port     = local.pipeline_storage_es_port
+      es_protocol = local.pipeline_storage_es_protocol
+      es_username = "catalogue/${var.pipeline_storage_id}/${service}/es_username"
+      es_password = "catalogue/${var.pipeline_storage_id}/${service}/es_password"
+    }
   ])
 }

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -62,7 +62,7 @@ variable "inferrer_model_data_bucket_name" {}
 
 variable "pipeline_storage_id" {
   default     = "pipeline_storage"
-  description = "The id of the secret where the es_host is stored"
+  description = "The ID of the pipeline_storage instance used for secrets"
 }
 
 locals {

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -60,7 +60,34 @@ variable "storage_bucket_name" {
 
 variable "inferrer_model_data_bucket_name" {}
 
-variable "pipeline_storage_es_host_secret_id" {
-  default     = "catalogue/pipeline_storage/es_host"
+variable "pipeline_storage_id" {
+  default     = "pipeline_storage"
   description = "The id of the secret where the es_host is stored"
+}
+
+locals {
+  pipeline_storage_es_host     = "catalogue/${var.pipeline_storage_id}/es_host"
+  pipeline_storage_es_port     = "catalogue/${var.pipeline_storage_id}/es_port"
+  pipeline_storage_es_protocol = "catalogue/${var.pipeline_storage_id}/es_protocol"
+
+  pipeline_storage_service_list = [
+    "id_minter",
+    "matcher",
+    "merger",
+    "transformer",
+    "ingestor",
+    "relation_embedder",
+    "router"
+  ]
+
+  pipeline_storage_es_service_secrets = zipmap(local.pipeline_storage_service_list, [
+    for service in local.pipeline_storage_service_list:
+      {
+        es_host     = local.pipeline_storage_es_host
+        es_port     = local.pipeline_storage_es_port
+        es_protocol = local.pipeline_storage_es_protocol
+        es_username = "catalogue/${var.pipeline_storage_id}/${service}/es_username"
+        es_password = "catalogue/${var.pipeline_storage_id}/${service}/es_password"
+      }
+  ])
 }

--- a/reindexer/get_reindex_status.py
+++ b/reindexer/get_reindex_status.py
@@ -3,8 +3,6 @@
 Reports some stats about the state of a reindex.
 """
 
-import sys
-
 import boto3
 import click
 from elasticsearch import Elasticsearch

--- a/reindexer/get_reindex_status.py
+++ b/reindexer/get_reindex_status.py
@@ -63,20 +63,20 @@ def get_secret_string(session, *, secret_id):
     return secrets.get_secret_value(SecretId=secret_id)["SecretString"]
 
 
-def get_pipeline_storage_es_client(session):
+def get_pipeline_storage_es_client(session, *, deployment_id):
     """
     Returns an Elasticsearch client for the pipeline-storage cluster.
     """
-    host = get_secret_string(session, secret_id="catalogue/pipeline_storage/es_host")
-    port = get_secret_string(session, secret_id="catalogue/pipeline_storage/es_port")
+    host = get_secret_string(session, secret_id=f"catalogue/{deployment_id}/es_host")
+    port = get_secret_string(session, secret_id=f"catalogue/{deployment_id}/es_port")
     protocol = get_secret_string(
-        session, secret_id="catalogue/pipeline_storage/es_protocol"
+        session, secret_id=f"catalogue/{deployment_id}/es_protocol"
     )
     username = get_secret_string(
-        session, secret_id="catalogue/pipeline_storage/dev/es_username"
+        session, secret_id=f"catalogue/{deployment_id}/dev/es_username"
     )
     password = get_secret_string(
-        session, secret_id="catalogue/pipeline_storage/dev/es_password"
+        session, secret_id=f"catalogue/{deployment_id}/dev/es_password"
     )
 
     return Elasticsearch(f"{protocol}://{username}:{password}@{host}:{port}")
@@ -104,11 +104,11 @@ def count_documents_in_index(es_client, *, index_name):
     return int(count_resp[0]["count"])
 
 
-def get_index_stats(session, *, reindex_date):
+def get_index_stats(session, *, deployment_id, reindex_date):
     """
     Returns a map (step) -> (ES documents count).
     """
-    pipeline_client = get_pipeline_storage_es_client(session)
+    pipeline_client = get_pipeline_storage_es_client(session, deployment_id=deployment_id)
 
     pipeline_steps = ["source", "identified", "merged", "denormalised"]
     result = {}
@@ -126,12 +126,10 @@ def get_index_stats(session, *, reindex_date):
     return result
 
 
-if __name__ == "__main__":
-    try:
-        reindex_date = sys.argv[1]
-    except IndexError:
-        sys.exit(f"Usage: {__file__} <REINDEX_DATE>")
-
+@click.command()
+@click.option("--deployment-id", default="pipeline_storage")
+@click.argument("reindex_date")
+def main(reindex_date, deployment_id):
     session_read_only = get_session_with_role(
         "arn:aws:iam::760097843905:role/platform-read_only"
     )
@@ -153,7 +151,7 @@ if __name__ == "__main__":
 
     print("")
 
-    index_stats = get_index_stats(session_dev, reindex_date=reindex_date)
+    index_stats = get_index_stats(session_dev, deployment_id=deployment_id, reindex_date=reindex_date)
 
     rows = [[step, count] for step, count in index_stats.items()]
     rows.insert(0, ["source records", source_counts["TOTAL"], ""])
@@ -191,3 +189,7 @@ if __name__ == "__main__":
                 "green",
             )
         )
+
+
+if __name__ == '__main__':
+    main()

--- a/reindexer/get_reindex_status.py
+++ b/reindexer/get_reindex_status.py
@@ -108,7 +108,9 @@ def get_index_stats(session, *, deployment_id, reindex_date):
     """
     Returns a map (step) -> (ES documents count).
     """
-    pipeline_client = get_pipeline_storage_es_client(session, deployment_id=deployment_id)
+    pipeline_client = get_pipeline_storage_es_client(
+        session, deployment_id=deployment_id
+    )
 
     pipeline_steps = ["source", "identified", "merged", "denormalised"]
     result = {}
@@ -151,7 +153,9 @@ def main(reindex_date, deployment_id):
 
     print("")
 
-    index_stats = get_index_stats(session_dev, deployment_id=deployment_id, reindex_date=reindex_date)
+    index_stats = get_index_stats(
+        session_dev, deployment_id=deployment_id, reindex_date=reindex_date
+    )
 
     rows = [[step, count] for step, count in index_stats.items()]
     rows.insert(0, ["source records", source_counts["TOTAL"], ""])
@@ -191,5 +195,5 @@ def main(reindex_date, deployment_id):
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
As we have a script that generates secrets and sets these in secrets managar on a per service basis we need to make our pipeline stack more flexible when taking ES config.

This change also updates the secret creation script to create secrets for multiple deployments of Elasticsearch pipeline storage.


Part of https://github.com/wellcomecollection/platform/issues/4949