### PR TITLE
Refactoring and tidy-ups in the matcher

### DIFF
--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -40,7 +40,7 @@ def should_run_sbt_project(repo, project_name, changed_paths):
 
         if path.startswith("api/diff_tool"):
             continue
-           
+
         if os.path.basename(path) == ".terraform.lock.hcl":
             continue
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -6,8 +6,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
   MatcherResult,
-  WorkIdentifier,
-  WorkNode
+  WorkIdentifier
 }
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models._
@@ -49,7 +48,7 @@ class WorkMatcher(
           workGraphStore.put(afterGraph).map(_ => Set.empty)
         }
       } yield {
-        convertToIdentifiersList(afterGraph)
+        toMatchedIdentifiers(afterGraph)
       }
     }
 
@@ -76,14 +75,11 @@ class WorkMatcher(
       case _                     => new RuntimeException(failure.toString)
     }
 
-  private def convertToIdentifiersList(
-    graph: WorkGraph): Set[MatchedIdentifiers] =
-    groupBySetId(graph).map {
-      case (_, workNodes: Set[WorkNode]) =>
-        MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
-    }.toSet
-
-  private def groupBySetId(
-    updatedGraph: WorkGraph): Map[String, Set[WorkNode]] =
-    updatedGraph.nodes.groupBy(_.componentId)
+  private def toMatchedIdentifiers(g: WorkGraph): Set[MatchedIdentifiers] =
+    g.nodes
+      .groupBy { _.componentId }
+      .map {
+        case (_, workNodes) => MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
+      }
+      .toSet
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -54,14 +54,14 @@ class WorkMatcher(
                                    graphAfter: WorkGraph): Set[String] =
     graphBefore.nodes.map(_.componentId) ++ graphAfter.nodes.map(_.componentId)
 
-  private def withLocks(update: WorkLinks, ids: Set[String])(
+  private def withLocks(links: WorkLinks, ids: Set[String])(
     f: => Future[Out]): Future[Out] =
     lockingService
       .withLocks(ids)(f)
       .map {
         case Left(failure) => {
           debug(
-            s"Locking failed while matching work ${update.workId}: ${failure}")
+            s"Locking failed while matching work ${links.workId}: ${failure}")
           throw MatcherException(failureToException(failure))
         }
         case Right(out) => out

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -22,9 +22,10 @@ import uk.ac.wellcome.storage.locking.{
 
 import java.util.UUID
 
-class WorkMatcher(
-  workGraphStore: WorkGraphStore,
-  lockingService: LockingService[Set[MatchedIdentifiers], Future, LockDao[String, UUID]])(
+class WorkMatcher(workGraphStore: WorkGraphStore,
+                  lockingService: LockingService[Set[MatchedIdentifiers],
+                                                 Future,
+                                                 LockDao[String, UUID]])(
   implicit ec: ExecutionContext)
     extends Logging {
 
@@ -38,9 +39,7 @@ class WorkMatcher(
       for {
         beforeGraph <- workGraphStore.findAffectedWorks(links)
         afterGraph = WorkGraphUpdater.update(links, beforeGraph)
-        _ <- withLocks(
-          links,
-          getGraphComponentIds(beforeGraph, afterGraph)) {
+        _ <- withLocks(links, getGraphComponentIds(beforeGraph, afterGraph)) {
           // We are returning empty set here, as LockingService is tied to a
           // single `Out` type, here set to `Set[MatchedIdentifiers]`.
           // See issue here: https://github.com/wellcometrust/platform/issues/3873
@@ -62,8 +61,7 @@ class WorkMatcher(
       .withLocks(ids)(f)
       .map {
         case Left(failure) =>
-          debug(
-            s"Locking failed while matching work ${links.workId}: $failure")
+          debug(s"Locking failed while matching work ${links.workId}: $failure")
           throw MatcherException(failureToException(failure))
         case Right(out) => out
       }
@@ -79,7 +77,8 @@ class WorkMatcher(
     g.nodes
       .groupBy { _.componentId }
       .map {
-        case (_, workNodes) => MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
+        case (_, workNodes) =>
+          MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
       }
       .toSet
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -59,11 +59,10 @@ class WorkMatcher(
     lockingService
       .withLocks(ids)(f)
       .map {
-        case Left(failure) => {
+        case Left(failure) =>
           debug(
-            s"Locking failed while matching work ${links.workId}: ${failure}")
+            s"Locking failed while matching work ${links.workId}: $failure")
           throw MatcherException(failureToException(failure))
-        }
         case Right(out) => out
       }
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.matcher.matcher
 import scala.concurrent.{ExecutionContext, Future}
 import cats.implicits._
 import grizzled.slf4j.Logging
-
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
   MatcherResult,
@@ -14,16 +13,19 @@ import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.models._
 import uk.ac.wellcome.platform.matcher.storage.WorkGraphStore
 import uk.ac.wellcome.platform.matcher.workgraph.WorkGraphUpdater
-import uk.ac.wellcome.storage.locking.dynamo.DynamoLockingService
 import uk.ac.wellcome.storage.locking.{
   FailedLockingServiceOp,
   FailedProcess,
-  FailedUnlock
+  FailedUnlock,
+  LockDao,
+  LockingService
 }
+
+import java.util.UUID
 
 class WorkMatcher(
   workGraphStore: WorkGraphStore,
-  lockingService: DynamoLockingService[Set[MatchedIdentifiers], Future])(
+  lockingService: LockingService[Set[MatchedIdentifiers], Future, LockDao[String, UUID]])(
   implicit ec: ExecutionContext)
     extends Logging {
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -6,9 +6,9 @@ import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
 
-  def findAffectedWorks(workUpdate: WorkLinks): Future[WorkGraph] =
+  def findAffectedWorks(workLinks: WorkLinks): Future[WorkGraph] =
     for {
-      directlyAffectedWorks <- workNodeDao.get(workUpdate.ids)
+      directlyAffectedWorks <- workNodeDao.get(workLinks.ids)
       affectedComponentIds = directlyAffectedWorks.map(workNode =>
         workNode.componentId)
       affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.matcher.storage
 
 import grizzled.slf4j.Logging
 
-import javax.naming.ConfigurationException
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException
 import org.scanamo.{DynamoFormat, Scanamo, Table}
@@ -21,11 +20,7 @@ class WorkNodeDao(dynamoClient: AmazonDynamoDB, dynamoConfig: DynamoConfig)(
 
   private val scanamo = Scanamo(dynamoClient)
   private val nodes = Table[WorkNode](dynamoConfig.tableName)
-  private val index = nodes.index(
-    dynamoConfig.maybeIndexName.getOrElse {
-      throw new ConfigurationException("Index not specified")
-    }
-  )
+  private val index = nodes.index(dynamoConfig.indexName)
 
   private val batchWriter = new DynamoBatchWriter[WorkNode](
     dynamoConfig

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -134,6 +134,14 @@ object WorkGraphUpdater extends Logging {
     )
   }
 
+  /** Create the "component identifier".
+    *
+    * This is shared by all the Works in the same component -- i.e., all the
+    * Works that are matched together.
+    *
+    * Note that this is based on the *unversioned* identifiers.  This means the
+    * component identifier is stable across different versions of a Work.
+    */
   private def componentIdentifier(nodeIds: List[String]): String =
     DigestUtils.sha256Hex(nodeIds.sorted.mkString("+"))
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -141,6 +141,9 @@ object WorkGraphUpdater extends Logging {
     *
     * Note that this is based on the *unversioned* identifiers.  This means the
     * component identifier is stable across different versions of a Work.
+    *
+    * TODO: Does this need to be a SHA-256 value?
+    * Could we just concatenate all the IDs?
     */
   private def componentIdentifier(nodeIds: List[String]): String =
     DigestUtils.sha256Hex(nodeIds.sorted.mkString("+"))

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -134,7 +134,6 @@ object WorkGraphUpdater extends Logging {
     )
   }
 
-  private def componentIdentifier(nodeIds: List[String]) = {
+  private def componentIdentifier(nodeIds: List[String]): String =
     DigestUtils.sha256Hex(nodeIds.sorted.mkString("+"))
-  }
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -39,7 +39,7 @@ object WorkGraphUpdater extends Logging {
     }
   }
 
-  private def doUpdate(workUpdate: WorkLinks,
+  private def doUpdate(workLinks: WorkLinks,
                        existingGraph: WorkGraph): WorkGraph = {
 
     // Find everything that's in the existing graph, but which isn't
@@ -54,7 +54,7 @@ object WorkGraphUpdater extends Logging {
     // If we're updating work B, then this list will be (A C D E).
     //
     val linkedWorks =
-      existingGraph.nodes.filterNot(_.id == workUpdate.workId)
+      existingGraph.nodes.filterNot(_.id == workLinks.workId)
 
     // Create a map (work ID) -> (version) for every work in the graph.
     //
@@ -63,7 +63,7 @@ object WorkGraphUpdater extends Logging {
     val workVersions: Map[String, Int] =
       linkedWorks.collect {
         case WorkNode(id, Some(version), _, _) => (id, version)
-      }.toMap + (workUpdate.workId -> workUpdate.version)
+      }.toMap + (workLinks.workId -> workLinks.version)
 
     // Create a list of all the connections between works in the graph.
     //
@@ -77,8 +77,8 @@ object WorkGraphUpdater extends Logging {
     //    otherLinks  = (A → B, B → C, B → D)
     //
     val updateLinks =
-      workUpdate.referencedWorkIds.map {
-        workUpdate.workId ~> _
+      workLinks.referencedWorkIds.map {
+        workLinks.workId ~> _
       }
 
     val otherLinks =
@@ -94,7 +94,7 @@ object WorkGraphUpdater extends Logging {
       existingGraph.nodes
         .flatMap { node =>
           node.id +: node.linkedIds
-        } + workUpdate.workId
+        } + workLinks.workId
 
     val g = Graph.from(edges = links, nodes = workIds)
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/LocalWorkGraphDynamoDb.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/LocalWorkGraphDynamoDb.scala
@@ -10,47 +10,6 @@ import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 trait LocalWorkGraphDynamoDb extends DynamoFixtures with RandomGenerators {
   override def createTable(table: Table): Table = Table("table", "index")
 
-  def createLockTable(dynamoDbClient: AmazonDynamoDB): Table = {
-    val tableName = s"table-${randomAlphanumeric()}"
-    val indexName = s"index-${randomAlphanumeric()}"
-    val table = Table(tableName, indexName)
-
-    dynamoDbClient.createTable(
-      new CreateTableRequest()
-        .withTableName(table.name)
-        .withKeySchema(new KeySchemaElement()
-          .withAttributeName("id")
-          .withKeyType(KeyType.HASH))
-        .withAttributeDefinitions(
-          new AttributeDefinition()
-            .withAttributeName("id")
-            .withAttributeType("S"),
-          new AttributeDefinition()
-            .withAttributeName("contextId")
-            .withAttributeType("S")
-        )
-        .withProvisionedThroughput(new ProvisionedThroughput()
-          .withReadCapacityUnits(1L)
-          .withWriteCapacityUnits(1L))
-        .withGlobalSecondaryIndexes(
-          new GlobalSecondaryIndex()
-            .withIndexName(table.index)
-            .withProjection(
-              new Projection().withProjectionType(ProjectionType.ALL))
-            .withKeySchema(
-              new KeySchemaElement()
-                .withAttributeName("contextId")
-                .withKeyType(KeyType.HASH)
-            )
-            .withProvisionedThroughput(new ProvisionedThroughput()
-              .withReadCapacityUnits(1L)
-              .withWriteCapacityUnits(1L))))
-    eventually {
-      waitUntilActive(dynamoDbClient, table.name)
-    }
-    table
-  }
-
   def createWorkGraphTable(dynamoDbClient: AmazonDynamoDB): Table = {
     val tableName = s"table-${randomAlphanumeric()}"
     val indexName = s"index-${randomAlphanumeric()}"

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -19,7 +19,6 @@ import uk.ac.wellcome.platform.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.locking.dynamo.{
   DynamoLockDaoFixtures,
@@ -113,8 +112,8 @@ trait MatcherFixtures
   def withWorkNodeDao[R](table: Table)(
     testWith: TestWith[WorkNodeDao, R]): R = {
     val workNodeDao = new WorkNodeDao(
-      dynamoClient,
-      DynamoConfig(table.name, table.index)
+      dynamoClient = dynamoClient,
+      dynamoConfig = createDynamoConfigWith(table)
     )
     testWith(workNodeDao)
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -44,11 +44,6 @@ trait MatcherFixtures
   implicit val workNodeFormat: DynamoFormat[WorkNode] = deriveDynamoFormat
   implicit val lockFormat: DynamoFormat[ExpiringLock] = deriveDynamoFormat
 
-  def withLockTable[R](testWith: TestWith[Table, R]): R =
-    withSpecifiedLocalDynamoDbTable(createLockTable) { table =>
-      testWith(table)
-    }
-
   def withWorkGraphTable[R](testWith: TestWith[Table, R]): R =
     withSpecifiedLocalDynamoDbTable(createWorkGraphTable) { table =>
       testWith(table)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -83,8 +83,10 @@ trait MatcherFixtures
 
   def withWorkMatcher[R](workGraphStore: WorkGraphStore)(
     testWith: TestWith[WorkMatcher, R]): R = {
-    implicit val lockDao: MemoryLockDao[String, UUID] = new MemoryLockDao[String, UUID]
-    val lockingService = new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+    implicit val lockDao: MemoryLockDao[String, UUID] =
+      new MemoryLockDao[String, UUID]
+    val lockingService =
+      new MemoryLockingService[Set[MatchedIdentifiers], Future]()
 
     val workMatcher = new WorkMatcher(
       workGraphStore = workGraphStore,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -3,15 +3,16 @@ package uk.ac.wellcome.platform.matcher.matcher
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.matcher.MatcherResult
+import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.generators.WorkLinksGenerators
-import uk.ac.wellcome.storage.locking.dynamo.{
-  DynamoLockingService,
-  ExpiringLock
+import uk.ac.wellcome.storage.locking.memory.{
+  MemoryLockDao,
+  MemoryLockingService
 }
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -23,55 +24,51 @@ class WorkMatcherConcurrencyTest
     with WorkLinksGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {
-    withLockTable { lockTable =>
-      withWorkGraphTable { graphTable =>
-        withWorkGraphStore(graphTable) { workGraphStore =>
-          withLockDao(dynamoClient, lockTable) { implicit lockDao =>
-            withWorkMatcherAndLockingService(
-              workGraphStore,
-              new DynamoLockingService) { workMatcher =>
-              val identifierA = createIdentifier(id = "A")
-              val identifierB = createIdentifier(id = "B")
+    implicit val lockDao: MemoryLockDao[String, UUID] = new MemoryLockDao[String, UUID]
+    val lockingService = new MemoryLockingService[Set[MatchedIdentifiers], Future]()
 
-              val linksA = createWorkLinksWith(
-                id = identifierA,
-                referencedIds = Set(identifierB)
-              )
+    withWorkGraphTable { graphTable =>
+      withWorkGraphStore(graphTable) { workGraphStore =>
+        val workMatcher = new WorkMatcher(workGraphStore, lockingService)
+        val identifierA = createIdentifier(id = "A")
+        val identifierB = createIdentifier(id = "B")
 
-              val linksB = createWorkLinksWith(
-                id = identifierB
-              )
+        val linksA = createWorkLinksWith(
+          id = identifierA,
+          referencedIds = Set(identifierB)
+        )
 
-              val eventualResultA = workMatcher.matchWork(linksA)
-              val eventualResultB = workMatcher.matchWork(linksB)
+        val linksB = createWorkLinksWith(
+          id = identifierB
+        )
 
-              val eventualResults = for {
-                resultA <- eventualResultA recoverWith {
-                  case e: MatcherException =>
-                    Future.successful(e)
-                }
-                resultB <- eventualResultB recoverWith {
-                  case e: MatcherException =>
-                    Future.successful(e)
-                }
-              } yield (resultA, resultB)
+        val eventualResultA = workMatcher.matchWork(linksA)
+        val eventualResultB = workMatcher.matchWork(linksB)
 
-              whenReady(eventualResults) { results =>
-                val resultsList = results.productIterator.toList
-                val failure = resultsList.collect({
-                  case e: MatcherException => e
-                })
-                val result = resultsList.collect({
-                  case r: MatcherResult => r
-                })
-
-                failure.size shouldBe 1
-                result.size shouldBe 1
-
-                scan[ExpiringLock](dynamoClient, lockTable.name) shouldBe empty
-              }
-            }
+        val eventualResults = for {
+          resultA <- eventualResultA recoverWith {
+            case e: MatcherException =>
+              Future.successful(e)
           }
+          resultB <- eventualResultB recoverWith {
+            case e: MatcherException =>
+              Future.successful(e)
+          }
+        } yield (resultA, resultB)
+
+        whenReady(eventualResults) { results =>
+          val resultsList = results.productIterator.toList
+          val failure = resultsList.collect({
+            case e: MatcherException => e
+          })
+          val result = resultsList.collect({
+            case r: MatcherResult => r
+          })
+
+          failure.size shouldBe 1
+          result.size shouldBe 1
+
+          lockDao.locks shouldBe empty
         }
       }
     }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -24,8 +24,10 @@ class WorkMatcherConcurrencyTest
     with WorkLinksGenerators {
 
   it("processes one of two conflicting concurrent updates and locks the other") {
-    implicit val lockDao: MemoryLockDao[String, UUID] = new MemoryLockDao[String, UUID]
-    val lockingService = new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+    implicit val lockDao: MemoryLockDao[String, UUID] =
+      new MemoryLockDao[String, UUID]
+    val lockingService =
+      new MemoryLockingService[Set[MatchedIdentifiers], Future]()
 
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -56,16 +56,11 @@ class WorkMatcherTest
                 Set(WorkIdentifier(links.workId, links.version)))))
 
             val savedLinkedWork =
-              get[WorkNode](dynamoClient, graphTable.name)(
-                'id -> links.workId)
+              get[WorkNode](dynamoClient, graphTable.name)('id -> links.workId)
                 .map(_.value)
 
             savedLinkedWork shouldBe Some(
-              WorkNode(
-                links.workId,
-                links.version,
-                Nil,
-                ciHash(links.workId)))
+              WorkNode(links.workId, links.version, Nil, ciHash(links.workId)))
           }
         }
       }
@@ -88,9 +83,10 @@ class WorkMatcherTest
           whenReady(workMatcher.matchWork(links)) { identifiersList =>
             identifiersList shouldBe
               MatcherResult(
-                Set(MatchedIdentifiers(Set(
-                  WorkIdentifier(identifierA.canonicalId, links.version),
-                  WorkIdentifier(identifierB.canonicalId, None)))))
+                Set(
+                  MatchedIdentifiers(Set(
+                    WorkIdentifier(identifierA.canonicalId, links.version),
+                    WorkIdentifier(identifierB.canonicalId, None)))))
 
             val savedWorkNodes = scan[WorkNode](dynamoClient, graphTable.name)
               .map(_.right.get)
@@ -205,12 +201,14 @@ class WorkMatcherTest
   }
 
   it("throws MatcherException if it fails to lock primary works") {
-    implicit val lockDao: MemoryLockDao[String, UUID] = new MemoryLockDao[String, UUID] {
-      override def lock(id: String, contextId: UUID): LockResult =
-        Left(LockFailure(id, e = new Throwable("BOOM!")))
-    }
+    implicit val lockDao: MemoryLockDao[String, UUID] =
+      new MemoryLockDao[String, UUID] {
+        override def lock(id: String, contextId: UUID): LockResult =
+          Left(LockFailure(id, e = new Throwable("BOOM!")))
+      }
 
-    val lockingService = new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+    val lockingService =
+      new MemoryLockingService[Set[MatchedIdentifiers], Future]()
 
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
@@ -247,16 +245,18 @@ class WorkMatcherTest
           referencedIds = Set(identifierB)
         )
 
-        implicit val lockDao: MemoryLockDao[String, UUID] = new MemoryLockDao[String, UUID] {
-          override def lock(id: String, contextId: UUID): LockResult =
-            if (id == componentId) {
-              Left(LockFailure(id, e = new Throwable("BOOM!")))
-            } else {
-              super.lock(id, contextId)
-            }
-        }
+        implicit val lockDao: MemoryLockDao[String, UUID] =
+          new MemoryLockDao[String, UUID] {
+            override def lock(id: String, contextId: UUID): LockResult =
+              if (id == componentId) {
+                Left(LockFailure(id, e = new Throwable("BOOM!")))
+              } else {
+                super.lock(id, contextId)
+              }
+          }
 
-        val lockingService = new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+        val lockingService =
+          new MemoryLockingService[Set[MatchedIdentifiers], Future]()
 
         val workMatcher = new WorkMatcher(workGraphStore, lockingService)
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -40,30 +40,28 @@ class WorkMatcherTest
 
   it(
     "matches a work with no linked identifiers to itself only A and saves the updated graph A") {
-    withLockTable { lockTable =>
-      withWorkGraphTable { graphTable =>
-        withWorkGraphStore(graphTable) { workGraphStore =>
-          withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val id = createIdentifier("A")
-            val links = createWorkLinksWith(id = id)
+    withWorkGraphTable { graphTable =>
+      withWorkGraphStore(graphTable) { workGraphStore =>
+        withWorkMatcher(workGraphStore) { workMatcher =>
+          val id = createIdentifier("A")
+          val links = createWorkLinksWith(id = id)
 
-            whenReady(workMatcher.matchWork(links)) { matcherResult =>
-              matcherResult shouldBe
-                MatcherResult(Set(MatchedIdentifiers(
-                  Set(WorkIdentifier(links.workId, links.version)))))
+          whenReady(workMatcher.matchWork(links)) { matcherResult =>
+            matcherResult shouldBe
+              MatcherResult(Set(MatchedIdentifiers(
+                Set(WorkIdentifier(links.workId, links.version)))))
 
-              val savedLinkedWork =
-                get[WorkNode](dynamoClient, graphTable.name)(
-                  'id -> links.workId)
-                  .map(_.value)
+            val savedLinkedWork =
+              get[WorkNode](dynamoClient, graphTable.name)(
+                'id -> links.workId)
+                .map(_.value)
 
-              savedLinkedWork shouldBe Some(
-                WorkNode(
-                  links.workId,
-                  links.version,
-                  Nil,
-                  ciHash(links.workId)))
-            }
+            savedLinkedWork shouldBe Some(
+              WorkNode(
+                links.workId,
+                links.version,
+                Nil,
+                ciHash(links.workId)))
           }
         }
       }
@@ -72,46 +70,44 @@ class WorkMatcherTest
 
   it(
     "matches a work with a single linked identifier A->B and saves the graph A->B") {
-    withLockTable { lockTable =>
-      withWorkGraphTable { graphTable =>
-        withWorkGraphStore(graphTable) { workGraphStore =>
-          withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val identifierA = createIdentifier("A")
-            val identifierB = createIdentifier("B")
+    withWorkGraphTable { graphTable =>
+      withWorkGraphStore(graphTable) { workGraphStore =>
+        withWorkMatcher(workGraphStore) { workMatcher =>
+          val identifierA = createIdentifier("A")
+          val identifierB = createIdentifier("B")
 
-            val links = createWorkLinksWith(
-              id = identifierA,
-              referencedIds = Set(identifierB)
+          val links = createWorkLinksWith(
+            id = identifierA,
+            referencedIds = Set(identifierB)
+          )
+
+          whenReady(workMatcher.matchWork(links)) { identifiersList =>
+            identifiersList shouldBe
+              MatcherResult(
+                Set(MatchedIdentifiers(Set(
+                  WorkIdentifier(identifierA.canonicalId, links.version),
+                  WorkIdentifier(identifierB.canonicalId, None)))))
+
+            val savedWorkNodes = scan[WorkNode](dynamoClient, graphTable.name)
+              .map(_.right.get)
+
+            savedWorkNodes should contain theSameElementsAs List(
+              WorkNode(
+                identifierA.canonicalId,
+                links.version,
+                List(identifierB.canonicalId),
+                ciHash(
+                  List(identifierA.canonicalId, identifierB.canonicalId).sorted
+                    .mkString("+"))
+              ),
+              WorkNode(
+                identifierB.canonicalId,
+                None,
+                Nil,
+                ciHash(
+                  List(identifierA.canonicalId, identifierB.canonicalId).sorted
+                    .mkString("+")))
             )
-
-            whenReady(workMatcher.matchWork(links)) { identifiersList =>
-              identifiersList shouldBe
-                MatcherResult(
-                  Set(MatchedIdentifiers(Set(
-                    WorkIdentifier(identifierA.canonicalId, links.version),
-                    WorkIdentifier(identifierB.canonicalId, None)))))
-
-              val savedWorkNodes = scan[WorkNode](dynamoClient, graphTable.name)
-                .map(_.right.get)
-
-              savedWorkNodes should contain theSameElementsAs List(
-                WorkNode(
-                  identifierA.canonicalId,
-                  links.version,
-                  List(identifierB.canonicalId),
-                  ciHash(
-                    List(identifierA.canonicalId, identifierB.canonicalId).sorted
-                      .mkString("+"))
-                ),
-                WorkNode(
-                  identifierB.canonicalId,
-                  None,
-                  Nil,
-                  ciHash(
-                    List(identifierA.canonicalId, identifierB.canonicalId).sorted
-                      .mkString("+")))
-              )
-            }
           }
         }
       }
@@ -120,86 +116,84 @@ class WorkMatcherTest
 
   it(
     "matches a previously stored work A->B with an update B->C and saves the graph A->B->C") {
-    withLockTable { lockTable =>
-      withWorkGraphTable { graphTable =>
-        withWorkGraphStore(graphTable) { workGraphStore =>
-          withWorkMatcher(workGraphStore, lockTable) { workMatcher =>
-            val existingWorkA = WorkNode(
-              identifierA.canonicalId,
-              1,
-              List(identifierB.canonicalId),
+    withWorkGraphTable { graphTable =>
+      withWorkGraphStore(graphTable) { workGraphStore =>
+        withWorkMatcher(workGraphStore) { workMatcher =>
+          val existingWorkA = WorkNode(
+            identifierA.canonicalId,
+            1,
+            List(identifierB.canonicalId),
+            ciHash(
               ciHash(
-                ciHash(
-                  List(identifierA.canonicalId, identifierB.canonicalId).sorted
-                    .mkString("+"))))
-            val existingWorkB = WorkNode(
-              identifierB.canonicalId,
-              1,
-              Nil,
+                List(identifierA.canonicalId, identifierB.canonicalId).sorted
+                  .mkString("+"))))
+          val existingWorkB = WorkNode(
+            identifierB.canonicalId,
+            1,
+            Nil,
+            ciHash(
               ciHash(
-                ciHash(
-                  List(identifierA.canonicalId, identifierB.canonicalId).sorted
-                    .mkString("+"))))
-            val existingWorkC = WorkNode(
-              identifierC.canonicalId,
-              1,
-              Nil,
-              ciHash(identifierC.canonicalId))
-            put(dynamoClient, graphTable.name)(existingWorkA)
-            put(dynamoClient, graphTable.name)(existingWorkB)
-            put(dynamoClient, graphTable.name)(existingWorkC)
+                List(identifierA.canonicalId, identifierB.canonicalId).sorted
+                  .mkString("+"))))
+          val existingWorkC = WorkNode(
+            identifierC.canonicalId,
+            1,
+            Nil,
+            ciHash(identifierC.canonicalId))
+          put(dynamoClient, graphTable.name)(existingWorkA)
+          put(dynamoClient, graphTable.name)(existingWorkB)
+          put(dynamoClient, graphTable.name)(existingWorkC)
 
-            val links = createWorkLinksWith(
-              id = identifierB,
-              version = 2,
-              referencedIds = Set(identifierC)
+          val links = createWorkLinksWith(
+            id = identifierB,
+            version = 2,
+            referencedIds = Set(identifierC)
+          )
+
+          whenReady(workMatcher.matchWork(links)) { identifiersList =>
+            identifiersList shouldBe
+              MatcherResult(
+                Set(
+                  MatchedIdentifiers(
+                    Set(
+                      WorkIdentifier(identifierA.canonicalId, 1),
+                      WorkIdentifier(identifierB.canonicalId, 2),
+                      WorkIdentifier(identifierC.canonicalId, 1)))))
+
+            val savedNodes = scan[WorkNode](dynamoClient, graphTable.name)
+              .map(_.right.get)
+
+            savedNodes should contain theSameElementsAs List(
+              WorkNode(
+                identifierA.canonicalId,
+                1,
+                List(identifierB.canonicalId),
+                ciHash(
+                  List(
+                    identifierA.canonicalId,
+                    identifierB.canonicalId,
+                    identifierC.canonicalId).sorted.mkString("+"))
+              ),
+              WorkNode(
+                identifierB.canonicalId,
+                2,
+                List(identifierC.canonicalId),
+                ciHash(
+                  List(
+                    identifierA.canonicalId,
+                    identifierB.canonicalId,
+                    identifierC.canonicalId).sorted.mkString("+"))
+              ),
+              WorkNode(
+                identifierC.canonicalId,
+                1,
+                Nil,
+                ciHash(
+                  List(
+                    identifierA.canonicalId,
+                    identifierB.canonicalId,
+                    identifierC.canonicalId).sorted.mkString("+")))
             )
-
-            whenReady(workMatcher.matchWork(links)) { identifiersList =>
-              identifiersList shouldBe
-                MatcherResult(
-                  Set(
-                    MatchedIdentifiers(
-                      Set(
-                        WorkIdentifier(identifierA.canonicalId, 1),
-                        WorkIdentifier(identifierB.canonicalId, 2),
-                        WorkIdentifier(identifierC.canonicalId, 1)))))
-
-              val savedNodes = scan[WorkNode](dynamoClient, graphTable.name)
-                .map(_.right.get)
-
-              savedNodes should contain theSameElementsAs List(
-                WorkNode(
-                  identifierA.canonicalId,
-                  1,
-                  List(identifierB.canonicalId),
-                  ciHash(
-                    List(
-                      identifierA.canonicalId,
-                      identifierB.canonicalId,
-                      identifierC.canonicalId).sorted.mkString("+"))
-                ),
-                WorkNode(
-                  identifierB.canonicalId,
-                  2,
-                  List(identifierC.canonicalId),
-                  ciHash(
-                    List(
-                      identifierA.canonicalId,
-                      identifierB.canonicalId,
-                      identifierC.canonicalId).sorted.mkString("+"))
-                ),
-                WorkNode(
-                  identifierC.canonicalId,
-                  1,
-                  Nil,
-                  ciHash(
-                    List(
-                      identifierA.canonicalId,
-                      identifierB.canonicalId,
-                      identifierC.canonicalId).sorted.mkString("+")))
-              )
-            }
           }
         }
       }
@@ -273,20 +267,18 @@ class WorkMatcherTest
   }
 
   it("fails if saving the updated links fails") {
-    withLockTable { lockTable =>
-      val mockWorkGraphStore = mock[WorkGraphStore]
-      withWorkMatcher(mockWorkGraphStore, lockTable) { workMatcher =>
-        val expectedException = new RuntimeException("Failed to put")
-        when(mockWorkGraphStore.findAffectedWorks(any[WorkLinks]))
-          .thenReturn(Future.successful(WorkGraph(Set.empty)))
-        when(mockWorkGraphStore.put(any[WorkGraph]))
-          .thenThrow(expectedException)
+    val mockWorkGraphStore = mock[WorkGraphStore]
+    withWorkMatcher(mockWorkGraphStore) { workMatcher =>
+      val expectedException = new RuntimeException("Failed to put")
+      when(mockWorkGraphStore.findAffectedWorks(any[WorkLinks]))
+        .thenReturn(Future.successful(WorkGraph(Set.empty)))
+      when(mockWorkGraphStore.put(any[WorkGraph]))
+        .thenThrow(expectedException)
 
-        val links = createWorkLinks
+      val links = createWorkLinks
 
-        whenReady(workMatcher.matchWork(links).failed) { actualException =>
-          actualException shouldBe MatcherException(expectedException)
-        }
+      whenReady(workMatcher.matchWork(links).failed) { actualException =>
+        actualException shouldBe MatcherException(expectedException)
       }
     }
   }


### PR DESCRIPTION
I was reading the matcher code to see if I could spot any more ways to reduce the load it puts on DynamoDB.

I've got a couple of ideas; this PR just contains some refactoring that doesn't change the behaviour at all, but tidies up the code. In particular, I was able to clean up several fixtures by using an in-memory LockingService in the tests, rather than creating a DynamoDB table for locks. The DynamoLockingService is tested thoroughly in scala-libs.

Part of https://github.com/wellcomecollection/platform/issues/4969