### PR TITLE
Lazy writing of work graphs in the matcher

### DIFF
--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStore.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.matcher.storage
 
-import scala.concurrent.{ExecutionContext, Future}
+import uk.ac.wellcome.models.matcher.WorkNode
 
+import scala.concurrent.{ExecutionContext, Future}
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
@@ -15,5 +16,8 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
     } yield WorkGraph(affectedWorks)
 
   def put(graph: WorkGraph): Future[Unit] =
-    workNodeDao.put(graph.nodes)
+    put(graph.nodes)
+
+  def put(nodes: Set[WorkNode]): Future[Unit] =
+    workNodeDao.put(nodes)
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.matcher.matcher
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{spy, times, verify, when}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
@@ -282,6 +282,41 @@ class WorkMatcherTest
 
       whenReady(workMatcher.matchWork(links).failed) { actualException =>
         actualException shouldBe MatcherException(expectedException)
+      }
+    }
+  }
+
+  it("skips writing to the store if there are no changes") {
+    withWorkGraphTable { graphTable =>
+      withWorkGraphStore(graphTable) { workGraphStore =>
+        val spyStore = spy(workGraphStore)
+
+        val links = createWorkLinks
+
+        withWorkMatcher(spyStore) { workMatcher =>
+          // Try to match the links more than once.  We have to match in sequence,
+          // not in parallel, or the locking will block all but one of them from
+          // doing anything non-trivial.
+          val futures =
+            workMatcher
+              .matchWork(links)
+              .flatMap { _ =>
+                workMatcher.matchWork(links)
+              }
+              .flatMap { _ =>
+                workMatcher.matchWork(links)
+              }
+              .flatMap { _ =>
+                workMatcher.matchWork(links)
+              }
+              .flatMap { _ =>
+                workMatcher.matchWork(links)
+              }
+
+          whenReady(futures) { _ =>
+            verify(spyStore, times(1)).put(any[Set[WorkNode]])
+          }
+        }
       }
     }
   }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -248,10 +248,12 @@ class WorkMatcherTest
         implicit val lockDao: MemoryLockDao[String, UUID] =
           new MemoryLockDao[String, UUID] {
             override def lock(id: String, contextId: UUID): LockResult =
-              if (id == componentId) {
-                Left(LockFailure(id, e = new Throwable("BOOM!")))
-              } else {
-                super.lock(id, contextId)
+              synchronized {
+                if (id == componentId) {
+                  Left(LockFailure(id, e = new Throwable("BOOM!")))
+                } else {
+                  super.lock(id, contextId)
+                }
               }
           }
 


### PR DESCRIPTION
Because we have the before/after state of the matcher graph, we can tell if anything has changed as a result of this update.  If it hasn't, we can skip writing anything to the graph store.

I'm not convinced this will make a dent in reindex cost (I considered only writing nodes that have changed, but I think that would introduce consistency bugs if two processes updated the matcher graph at the same time).

It will reduce the ongoing cost, and in particular, the cost of reindexing a source into an existing pipeline if you don't change the matcher relationships.

Part of wellcomecollection/platform#4969, follows #1277