### PR TITLE
Reduce the number of objects fetched in a single Elasticsearch snapshot request

### DIFF
--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -40,7 +40,7 @@ def should_run_sbt_project(repo, project_name, changed_paths):
 
         if path.startswith("api/diff_tool"):
             continue
-           
+
         if os.path.basename(path) == ".terraform.lock.hcl":
             continue
 

--- a/snapshots/terraform/main.tf
+++ b/snapshots/terraform/main.tf
@@ -31,7 +31,7 @@ module "stack" {
   #      500 ~ too big in January 2021
   #
   # See https://github.com/wellcomecollection/platform/issues/4901
-  es_bulk_size = 250
+  es_bulk_size = 150
 
   shared_logging_secrets = local.shared_logging_secrets
 

--- a/snapshots/terraform/main.tf
+++ b/snapshots/terraform/main.tf
@@ -20,11 +20,18 @@ module "stack" {
   # generation fails.
   #
   # In general, the size of a work grows over time, so if we start hitting exceptions
-  # like 'ContentTooLongException', we should consider turning down this number.
-  # It used to be set to 1000, but that became too big in November 2020.
+  # of the following form:
+  #
+  #     Caused by: org.apache.http.ContentTooLongException:
+  #     entity content is too long [112524060] for the configured buffer limit [104857600]
+  #
+  # we should consider it down.  Previous values:
+  #
+  #     1000 ~ too big in November 2020
+  #      500 ~ too big in January 2021
   #
   # See https://github.com/wellcomecollection/platform/issues/4901
-  es_bulk_size = 500
+  es_bulk_size = 250
 
   shared_logging_secrets = local.shared_logging_secrets
 

--- a/snapshots/terraform/stack/snapshot_generator/messaging.tf
+++ b/snapshots/terraform/stack/snapshot_generator/messaging.tf
@@ -4,7 +4,7 @@ module "snapshot_generator_input_queue" {
   topic_arns = [var.snapshot_generator_input_topic_arn]
 
   # This should be longer than the time we expect a snapshot to take
-  visibility_timeout_seconds = 60 * 60
+  visibility_timeout_seconds = 60 * 60 * 2
 
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn


### PR DESCRIPTION
We're still seeing the same issues as https://github.com/wellcomecollection/platform/issues/4901