### PR TITLE
Be less strict in our Sierra MARC parser

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.exceptions.ShouldNotTransformException
 
 trait SierraQueryOps extends Logging {
 
@@ -79,9 +78,12 @@ trait SierraQueryOps extends Logging {
       subfieldsWithTag(tag) match {
         case Seq(sf) => Some(sf)
         case Nil     => None
-        case fields =>
-          throw new ShouldNotTransformException(
-            s"Multiple instances of non-repeatable subfield with tag ǂ$tag: $fields"
+        case multiple =>
+          warn(
+            s"Multiple instances of non-repeatable subfield with tag ǂ$tag: $multiple"
+          )
+          Some(
+            MarcSubfield(tag = tag, content = multiple.map { _.content }.mkString(" "))
           )
       }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
@@ -83,7 +83,9 @@ trait SierraQueryOps extends Logging {
             s"Multiple instances of non-repeatable subfield with tag ǂ$tag: $multiple"
           )
           Some(
-            MarcSubfield(tag = tag, content = multiple.map { _.content }.mkString(" "))
+            MarcSubfield(
+              tag = tag,
+              content = multiple.map { _.content }.mkString(" "))
           )
       }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOps.scala
@@ -1,8 +1,9 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.ShouldNotTransformException
 
-trait SierraQueryOps {
+trait SierraQueryOps extends Logging {
 
   implicit class BibDataOps(bibData: SierraBibData) {
 
@@ -30,10 +31,11 @@ trait SierraQueryOps {
       varfieldsWithTag(tag) match {
         case Seq(vf) => Some(vf)
         case Nil     => None
-        case fields =>
-          throw new ShouldNotTransformException(
-            s"Multiple instances of non-repeatable varfield with tag $tag: $fields"
+        case multiple =>
+          warn(
+            s"Multiple instances of non-repeatable varfield with tag $tag: $multiple"
           )
+          Some(multiple.head)
       }
 
     def subfieldsWithTags(tags: (String, String)*): List[MarcSubfield] =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
@@ -46,4 +46,25 @@ class SierraQueryOpsTest
 
     bibData.nonrepeatableVarfieldWithTag(tag = "0") shouldBe Some(varFields(0))
   }
+
+  it("finds non-repeatable subfields") {
+    val varField = createVarFieldWith(
+      marcTag = "0",
+      subfields = List(
+        MarcSubfield(tag = "a", content = "Ablative armadillos"),
+        MarcSubfield(tag = "b", content = "Brave butterflies"),
+        MarcSubfield(tag = "b", content = "Billowing bison"),
+      )
+    )
+
+    varField.nonrepeatableSubfieldWithTag(tag = "a") shouldBe Some(
+      MarcSubfield(tag = "a", content = "Ablative armadillos")
+    )
+
+    varField.nonrepeatableSubfieldWithTag(tag = "b") shouldBe Some(
+      MarcSubfield(tag = "b", content = "Brave butterflies Billowing bison")
+    )
+
+    varField.nonrepeatableSubfieldWithTag(tag = "c") shouldBe None
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraQueryOpsTest.scala
@@ -31,4 +31,19 @@ class SierraQueryOpsTest
     bibData.varfieldsWithTags("0", "1") shouldBe varFields
     bibData.varfieldsWithTags("1", "0") shouldBe varFields
   }
+
+  it("finds instances of a non-repeatable varfield") {
+    val varFields = List(
+      createVarFieldWith(marcTag = "0", content = Some("Field 0A")),
+      createVarFieldWith(marcTag = "1", content = Some("Field 1")),
+      createVarFieldWith(marcTag = "0", content = Some("Field 0B")),
+    )
+
+    val bibData = createSierraBibDataWith(varFields = varFields)
+
+    bibData.nonrepeatableVarfieldWithTag(tag = "1") shouldBe Some(varFields(1))
+    bibData.nonrepeatableVarfieldWithTag(tag = "2") shouldBe None
+
+    bibData.nonrepeatableVarfieldWithTag(tag = "0") shouldBe Some(varFields(0))
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -73,6 +73,26 @@ class SierraTitleTest
     SierraTitle(bibData = bibData) shouldBe Some("A book with multiple covers")
   }
 
+  it("joins the subfields if one of them is repeated") {
+    // This is based on https://search.wellcomelibrary.org/iii/encore/record/C__Rb1057466?lang=eng&marcData=Y
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "245",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "The Book of common prayer:"),
+            MarcSubfield(tag = "b", content = "together with the Psalter or Psalms of David,"),
+            MarcSubfield(tag = "b", content = "and the form and manner of making bishops")
+          )
+        )
+      )
+    )
+
+    SierraTitle(bibData = bibData) shouldBe Some(
+      "The Book of common prayer: together with the Psalter or Psalms of David, and the form and manner of making bishops"
+    )
+  }
+
   describe("throws a ShouldNotTransformException if it can't create a title") {
     it("if there is no MARC field 245") {
       val bibData = createSierraBibDataWith(
@@ -82,27 +102,6 @@ class SierraTitleTest
         SierraTitle(bibData)
       }
       caught.getMessage should startWith("Could not find varField 245!")
-    }
-
-    it("if one of the subfields is repeated") {
-      val bibData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(
-            marcTag = "245",
-            subfields = List(
-              MarcSubfield(tag = "a", content = "The “winter mind” :"),
-              MarcSubfield(tag = "a", content = "The “spring mind” :"),
-              MarcSubfield(tag = "a", content = "The “autumn mind” :"),
-              MarcSubfield(tag = "a", content = "The “summer mind” :")
-            )
-          )
-        )
-      )
-      val caught = intercept[ShouldNotTransformException] {
-        SierraTitle(bibData)
-      }
-      caught.getMessage should startWith(
-        "Multiple instances of non-repeatable subfield with tag ǂa")
     }
 
     it("if there are no subfields a, b or c") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -57,21 +57,23 @@ class SierraTitleTest
     }
   }
 
-  describe("throws a ShouldNotTransformException if it can't create a title") {
-    it("if there are multiple instances of the MARC 245 field") {
-      val bibData = createSierraBibDataWith(
-        varFields = List(
-          createVarFieldWith(marcTag = "245"),
-          createVarFieldWith(marcTag = "245")
-        )
+  it("uses the first instance of MARC 245 if there are multiple instances") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "245",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "A book with multiple covers")
+          )
+        ),
+        createVarFieldWith(marcTag = "245")
       )
-      val caught = intercept[ShouldNotTransformException] {
-        SierraTitle(bibData)
-      }
-      caught.getMessage should startWith(
-        "Multiple instances of non-repeatable varfield with tag 245:")
-    }
+    )
 
+    SierraTitle(bibData = bibData) shouldBe Some("A book with multiple covers")
+  }
+
+  describe("throws a ShouldNotTransformException if it can't create a title") {
     it("if there is no MARC field 245") {
       val bibData = createSierraBibDataWith(
         varFields = List.empty

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -81,8 +81,12 @@ class SierraTitleTest
           marcTag = "245",
           subfields = List(
             MarcSubfield(tag = "a", content = "The Book of common prayer:"),
-            MarcSubfield(tag = "b", content = "together with the Psalter or Psalms of David,"),
-            MarcSubfield(tag = "b", content = "and the form and manner of making bishops")
+            MarcSubfield(
+              tag = "b",
+              content = "together with the Psalter or Psalms of David,"),
+            MarcSubfield(
+              tag = "b",
+              content = "and the form and manner of making bishops")
           )
         )
       )


### PR DESCRIPTION
A non-repeatable field being repeated should be a warning, not an error.

For https://github.com/wellcomecollection/platform/issues/4980