### PR TITLE
Bump scala-libs to v26.0.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.0.0"
+  val defaultVersion = "26.0.2"
 
   lazy val versions = new {
     val typesafe = defaultVersion


### PR DESCRIPTION
This should get us better logging if we have errors sending SNS notifications.