### PR TITLE
Better handling of unexpected case/whitespace when parsing Sierra languages

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -105,7 +105,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       genres = SierraGenres(bibData),
       contributors = SierraContributors(bibData),
       production = SierraProduction(bibId, bibData),
-      languages = SierraLanguages(bibData),
+      languages = SierraLanguages(bibId, bibData),
       edition = SierraEdition(bibData),
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
@@ -53,6 +53,11 @@ object SierraLanguages
           // and can be safely discarded.  e.g. "ger " means the same as "ger"
           _.trim
         }
+        .map {
+          // Most of our records use a lowercase code, but if not we can safely lowercase
+          // the code.  e.g. "Lat" means the same as "lat"
+          _.toLowerCase()
+        }
         .map { code =>
           (code, MarcLanguageCodeList.lookupByCode(code))
         }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
@@ -7,9 +7,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraBibData,
   SierraQueryOps
 }
+import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 
 object SierraLanguages
-    extends SierraDataTransformer
+    extends SierraIdentifiedDataTransformer
     with SierraQueryOps
     with Logging {
   type Output = List[Language]
@@ -34,7 +35,7 @@ object SierraLanguages
   //    This is a repeatable field, as is the subfield.
   //    See https://www.loc.gov/marc/bibliographic/bd041.html
   //
-  override def apply(bibData: SierraBibData): List[Language] = {
+  override def apply(bibId: SierraBibNumber, bibData: SierraBibData): List[Language] = {
     val primaryLanguage =
       bibData.lang
         .map { lang =>
@@ -53,7 +54,7 @@ object SierraLanguages
         .map {
           case (_, Some(lang)) => Some(lang)
           case (code, None) =>
-            warn(s"Unrecognised code in MARC 041 ǂa: $code")
+            warn(s"$bibId: Unrecognised code in MARC 041 ǂa: $code")
             None
         }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
@@ -48,6 +48,11 @@ object SierraLanguages
       bibData
         .subfieldsWithTag("041" -> "a")
         .contents
+        .map {
+          // Some of our records include whitespace in this field, but it's irrelevant
+          // and can be safely discarded.  e.g. "ger " means the same as "ger"
+          _.trim
+        }
         .map { code =>
           (code, MarcLanguageCodeList.lookupByCode(code))
         }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -172,6 +172,25 @@ class SierraLanguagesTest
     )
   }
 
+  it("lowercases values in the 041 field") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "041",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "ENG"),
+            MarcSubfield(tag = "a", content = "Lat"),
+          )
+        )
+      )
+    )
+
+    getLanguages(bibData) shouldBe List(
+      Language(label = "English", id = "eng"),
+      Language(label = "Latin", id = "lat"),
+    )
+  }
+
   private def getLanguages(bibData: SierraBibData): List[Language] =
     SierraLanguages(bibId = createSierraBibNumber, bibData = bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -155,6 +155,23 @@ class SierraLanguagesTest
     )
   }
 
+  it("strips whitespace from values in the 041 field") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "041",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "eng "),
+          )
+        )
+      )
+    )
+
+    getLanguages(bibData) shouldBe List(
+      Language(label = "English", id = "eng"),
+    )
+  }
+
   private def getLanguages(bibData: SierraBibData): List[Language] =
     SierraLanguages(bibId = createSierraBibNumber, bibData = bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -33,8 +33,7 @@ class SierraLanguagesTest
       varFields = List.empty
     )
 
-    getLanguages(bibData) shouldBe List(
-      Language(label = "French", id = "fre"))
+    getLanguages(bibData) shouldBe List(Language(label = "French", id = "fre"))
   }
 
   it("combines the language from the 'lang' field and 041") {
@@ -100,8 +99,7 @@ class SierraLanguagesTest
       )
     )
 
-    getLanguages(bibData) shouldBe List(
-      Language(label = "Chinese", id = "chi"))
+    getLanguages(bibData) shouldBe List(Language(label = "Chinese", id = "chi"))
   }
 
   it("deduplicates, putting whatever's in 'lang' first") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraBibData
+}
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLanguage
 
 class SierraLanguagesTest
@@ -18,7 +21,7 @@ class SierraLanguagesTest
   it("ignores records without any languages") {
     val bibData = createSierraBibDataWith(lang = None, varFields = List.empty)
 
-    SierraLanguages(bibData) shouldBe empty
+    getLanguages(bibData) shouldBe empty
   }
 
   it("parses a single language from the 'lang' field") {
@@ -30,7 +33,7 @@ class SierraLanguagesTest
       varFields = List.empty
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "French", id = "fre"))
   }
 
@@ -51,7 +54,7 @@ class SierraLanguagesTest
       )
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "French", id = "fre"),
       Language(label = "German", id = "ger"),
       Language(label = "English", id = "eng")
@@ -75,7 +78,7 @@ class SierraLanguagesTest
       )
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "French", id = "fre"),
       Language(label = "German", id = "ger"),
       Language(label = "English", id = "eng")
@@ -97,7 +100,7 @@ class SierraLanguagesTest
       )
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "Chinese", id = "chi"))
   }
 
@@ -119,7 +122,7 @@ class SierraLanguagesTest
       )
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "German", id = "ger"),
       Language(label = "French", id = "fre"),
       Language(label = "English", id = "eng")
@@ -145,10 +148,13 @@ class SierraLanguagesTest
       )
     )
 
-    SierraLanguages(bibData) shouldBe List(
+    getLanguages(bibData) shouldBe List(
       Language(label = "Chinese", id = "chi"),
       Language(label = "English", id = "eng"),
       Language(label = "French", id = "fre")
     )
   }
+
+  private def getLanguages(bibData: SierraBibData): List[Language] =
+    SierraLanguages(bibId = createSierraBibNumber, bibData = bibData)
 }


### PR DESCRIPTION
We get the language of Sierra works from MARC 041. The logs from today’s reindex are showing that some records have values in MARC 041 that we can’t parse as a language. Some of these are mistakes that need to be corrected at source (e.g. when two languages have been smushed together); others we can handle in the transformer.

This patch adds support for two types of value which we were previously unable to parse:

* If the value contains whitespace, e.g. `fre `
* If the value isn't all-lowercase, e.g. `NOR` or `Lat`

Additionally, we now log the ID of bibs that we still can't parse, so we can get the data fixed at source if necessary.

For https://github.com/wellcomecollection/platform/issues/4988