### PR TITLE
Show a breakdown of workTypes in the API diff tool

### DIFF
--- a/api/diff_tool/api_stats.py
+++ b/api/diff_tool/api_stats.py
@@ -1,0 +1,69 @@
+import boto3
+import httpx
+
+
+def get_session_with_role(role_arn):
+    """
+    Returns a boto3.Session that uses the given role ARN.
+    """
+    sts_client = boto3.client("sts")
+
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
+    )
+    credentials = assumed_role_object["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_secret_string(secrets_client, *, secret_id):
+    """
+    Look up the value of a SecretString in Secrets Manager.
+    """
+    return secrets_client.get_secret_value(SecretId=secret_id)["SecretString"]
+
+
+def get_api_es_url(session):
+    """
+    Returns the Elasticsearch URL for the catalogue cluster.
+    """
+    secrets = session.client("secretsmanager")
+
+    host = get_secret_string(secrets, secret_id="catalogue/api/es_host")
+    port = get_secret_string(secrets, secret_id="catalogue/api/es_port")
+    protocol = get_secret_string(secrets, secret_id="catalogue/api/es_protocol")
+    username = get_secret_string(secrets, secret_id="catalogue/api/es_username")
+    password = get_secret_string(secrets, secret_id="catalogue/api/es_password")
+
+    return f"{protocol}://{username}:{password}@{host}:{port}"
+
+
+def get_api_stats(session, *, api_url):
+    """
+    Returns some index stats about the API, including the index name and a breakdown
+    of work types in the index.
+    """
+    es_url = get_api_es_url(session)
+
+    search_templates_resp = httpx.get(
+        f"https://{api_url}/catalogue/v2/search-templates.json"
+    )
+    index_name = search_templates_resp.json()["templates"][0]["index"]
+
+    search_resp = httpx.request(
+        "GET",
+        es_url + f"/{index_name}/_search",
+        json={"size": 0, "aggs": {"work_type": {"terms": {"field": "type"}}}},
+    )
+
+    work_types = {
+        bucket["key"]: bucket["doc_count"]
+        for bucket in search_resp.json()["aggregations"]["work_type"]["buckets"]
+    }
+
+    work_types["TOTAL"] = sum(work_types.values())
+
+    return {"index_name": index_name, "work_types": work_types}

--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -13,13 +13,14 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 import requests
 
 
+PROD_URL = "api.wellcomecollection.org"
+STAGING_URL = "api-stage.wellcomecollection.org"
+
+
 class ApiDiffer:
     """Performs a diff against the same call to both prod and stage works API,
     printing the results to stdout.
     """
-
-    prod = "api.wellcomecollection.org"
-    stage = "api-stage.wellcomecollection.org"
 
     def __init__(self, work_id=None, params=None):
         suffix = f"/{work_id}" if work_id else ""
@@ -38,8 +39,8 @@ class ApiDiffer:
         """
         Fetches a URL from the prod/staging API, and returns a (status, HTML diff).
         """
-        (prod_status, prod_json) = self.call_api(self.prod)
-        (stage_status, stage_json) = self.call_api(self.stage)
+        (prod_status, prod_json) = self.call_api(PROD_URL)
+        (stage_status, stage_json) = self.call_api(STAGING_URL)
         if prod_status != stage_status:
             lines = [
                 f"* Received {prod_status} on prod and {stage_status} on stage",

--- a/api/diff_tool/template.html
+++ b/api/diff_tool/template.html
@@ -40,6 +40,27 @@
     .meta {
       color: brown;
     }
+
+    th, td {
+      padding-left:  10px;
+      padding-right: 10px;
+    }
+
+    th.row_header {
+      text-align: left;
+    }
+
+    td.stat {
+      text-align: right;
+    }
+
+    td.diff_increase {
+      color: green;
+    }
+
+    td.diff_decrease {
+      color: red;
+    }
   </style>
 
   <title>API diff for {{ now.strftime("%A %-d %B %Y @ %H:%M:%S") }}</title>
@@ -47,6 +68,34 @@
 
 <body>
   <h1>API diff for {{ now.strftime("%A %-d %B %Y @ %H:%M:%S") }}</h1>
+
+  <details open>
+    <summary><strong>ℹ️ Index statistics</strong></summary>
+    <table>
+      <tr>
+        <th></th>
+        <th>prod ({{ stats.prod.index_name }})</th>
+        <th>staging ({{ stats.staging.index_name }})</th>
+      </tr>
+
+      {% for work_type in ["Visible", "Redirected", "Invisible", "Deleted", "TOTAL"] %}
+      <tr>
+        <th class="row_header">{{ work_type }}</th>
+        <td class="stat">{{ stats.prod.work_types[work_type] | intcomma }}</td>
+        <td class="stat">{{ stats.staging.work_types[work_type] | intcomma }}</td>
+
+        {% set diff = stats.staging.work_types[work_type] - stats.prod.work_types[work_type] %}
+        <td class="stat {% if diff > 0 %}diff_increase{% else %}diff_decrease{% endif %}">
+          {% if diff > 0 %}
+            {{ diff | intcomma }} ▲
+          {% elif diff < 0 %}
+            {{ diff | intcomma }} ▼
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+  </details>
 
   {% for d in diffs %}
   <details {% if d.status == "match" %}class="match"{% else %}open{% endif %}>

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -10,7 +10,7 @@ variable "cluster_name" {
   type = string
 }
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }
 variable "cluster_arn" {
   type = string

--- a/infrastructure/shared/identity/cognito.tf
+++ b/infrastructure/shared/identity/cognito.tf
@@ -133,7 +133,7 @@ resource "aws_cognito_user_pool_client" "web_auth" {
   allowed_oauth_scopes                 = concat(["openid", "email"], aws_cognito_resource_server.stacks_api.scope_identifiers)
   explicit_auth_flows                  = ["USER_PASSWORD_AUTH"]
 
-  user_pool_id    = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id    = aws_cognito_user_pool.pool.id
   generate_secret = false
 
   callback_urls                = ["https://wellcomecollection.org/works/auth-code"]

--- a/pipeline/terraform/modules/service/variables.tf
+++ b/pipeline/terraform/modules/service/variables.tf
@@ -2,7 +2,7 @@ variable "service_name" {}
 variable "cluster_arn" {}
 variable "cluster_name" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }
 variable "subnets" {
   type = list(string)

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -12,7 +12,7 @@ variable "subnets" {
   type = list(string)
 }
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }
 
 variable "vpc_id" {}

--- a/reindexer/terraform/reindex_worker/variables.tf
+++ b/reindexer/terraform/reindex_worker/variables.tf
@@ -30,5 +30,5 @@ variable "private_subnets" {
 }
 variable "dlq_alarm_arn" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }

--- a/sierra_adapter/terraform/bib_merger/variables.tf
+++ b/sierra_adapter/terraform/bib_merger/variables.tf
@@ -31,5 +31,5 @@ variable "deployment_service_name" {
   type = string
 }
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }

--- a/sierra_adapter/terraform/item_merger/variables.tf
+++ b/sierra_adapter/terraform/item_merger/variables.tf
@@ -28,5 +28,5 @@ variable "service_egress_security_group_id" {}
 variable "deployment_service_env" {}
 variable "deployment_service_name" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }

--- a/sierra_adapter/terraform/items_to_dynamo/variables.tf
+++ b/sierra_adapter/terraform/items_to_dynamo/variables.tf
@@ -24,5 +24,5 @@ variable "service_egress_security_group_id" {}
 variable "deployment_service_env" {}
 variable "deployment_service_name" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }

--- a/sierra_adapter/terraform/sierra_reader/variables.tf
+++ b/sierra_adapter/terraform/sierra_reader/variables.tf
@@ -34,5 +34,5 @@ variable "service_egress_security_group_id" {}
 variable "deployment_service_env" {}
 variable "deployment_service_name" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }

--- a/sierra_adapter/terraform/stack/variables.tf
+++ b/sierra_adapter/terraform/stack/variables.tf
@@ -11,7 +11,7 @@ variable "bibs_windows_topic_arns" {}
 variable "items_windows_topic_arns" {}
 variable "deployment_env" {}
 variable "shared_logging_secrets" {
-  type = map
+  type = map(any)
 }
 
 variable "sierra_reader_image" {


### PR DESCRIPTION
When you run the diff tool, you now get a table of index statistics. Here's what it looks like:

<img width="986" alt="Screenshot 2021-01-25 at 07 58 35" src="https://user-images.githubusercontent.com/301220/105677999-8614da00-5ee4-11eb-87f5-d01d5c204c87.png">

If the number of Works in the API has changed significantly, this helps you work out (1) why and (2) if that's something you expect.

In the example above, I know I've recently fixed a bug that was causing Works to be wrongly marked as Invisible. (https://github.com/wellcomecollection/catalogue/pull/1285)  These numbers seem plausible. But if I wasn't expecting that to happen, these numbers would give me a clue that there's something worth investigating in this index before I promote it to prod.