### PR TITLE
Add contributorAgents to DerivedWorkData

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -151,7 +151,10 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
         )
         .dynamic("false"),
       objectField("derivedData")
-        .fields(booleanField("availableOnline"))
+        .fields(
+          booleanField("availableOnline"),
+          keywordField("contributorAgents")
+        )
         .dynamic("false")
     )
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
@@ -1,16 +1,31 @@
 package uk.ac.wellcome.models.work.internal
 
 case class DerivedWorkData(
-  availableOnline: Boolean
+  availableOnline: Boolean,
+  contributorAgents: List[String],
 )
 
 object DerivedWorkData {
-  def none: DerivedWorkData = DerivedWorkData(availableOnline = false)
 
-  def apply(workData: WorkData[_]): DerivedWorkData =
+  def none: DerivedWorkData =
     DerivedWorkData(
-      availableOnline = containsDigitalLocation(workData.items)
+      availableOnline = false,
+      contributorAgents = Nil
     )
+
+  def apply(data: WorkData[_]): DerivedWorkData =
+    DerivedWorkData(
+      availableOnline = containsDigitalLocation(data.items),
+      contributorAgents = contributorAgents(data.contributors)
+    )
+
+  private def contributorAgents(contributors: List[Contributor[_]]): List[String] =
+    contributors.map {
+      case Contributor(_, agent, _) =>
+        val ontologyType = agent.getClass.getSimpleName
+        val label = agent.label
+        s"$ontologyType:$label"
+    }
 
   private def containsDigitalLocation(items: List[Item[_]]): Boolean =
     items.exists { item =>

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
@@ -19,7 +19,8 @@ object DerivedWorkData {
       contributorAgents = contributorAgents(data.contributors)
     )
 
-  private def contributorAgents(contributors: List[Contributor[_]]): List[String] =
+  private def contributorAgents(
+    contributors: List[Contributor[_]]): List[String] =
     contributors.map {
       case Contributor(_, agent, _) =>
         val ontologyType = agent.getClass.getSimpleName

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -35,7 +35,6 @@ class DerivedDataTest
       derivedWorkData.availableOnline shouldBe false
     }
 
-
     it("derives contributorAgents from a heterogenous list of contributors") {
       val agents = List(
         Agent("0048146"),
@@ -43,7 +42,8 @@ class DerivedDataTest
         Person("Salt Bae"),
         Meeting("Brunch, 18th Jan 2021")
       )
-      val work = denormalisedWork().contributors(agents.map(Contributor(_, roles = Nil)))
+      val work =
+        denormalisedWork().contributors(agents.map(Contributor(_, roles = Nil)))
       val derivedWorkData = DerivedWorkData(work.data)
 
       derivedWorkData.contributorAgents shouldBe List(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -13,7 +13,7 @@ class DerivedDataTest
   describe("DerivedWorkData") {
 
     it("sets availableOnline = true if there is a digital location on an item") {
-      val work = mergedWork().items(
+      val work = denormalisedWork().items(
         List(createDigitalItem, createIdentifiedPhysicalItem))
       val derivedWorkData = DerivedWorkData(work.data)
 
@@ -22,19 +22,37 @@ class DerivedDataTest
 
     it(
       "sets availableOnline = false if there is no digital location on any items") {
-      val work = mergedWork().items(List(createIdentifiedPhysicalItem))
+      val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
       val derivedWorkData = DerivedWorkData(work.data)
 
       derivedWorkData.availableOnline shouldBe false
     }
 
     it("handles empty items list") {
-      val work = mergedWork().items(Nil)
+      val work = denormalisedWork().items(Nil)
       val derivedWorkData = DerivedWorkData(work.data)
 
       derivedWorkData.availableOnline shouldBe false
     }
 
+
+    it("derives contributorAgents from a heterogenous list of contributors") {
+      val agents = List(
+        Agent("0048146"),
+        Organisation("PKK"),
+        Person("Salt Bae"),
+        Meeting("Brunch, 18th Jan 2021")
+      )
+      val work = denormalisedWork().contributors(agents.map(Contributor(_, roles = Nil)))
+      val derivedWorkData = DerivedWorkData(work.data)
+
+      derivedWorkData.contributorAgents shouldBe List(
+        "Agent:0048146",
+        "Organisation:PKK",
+        "Person:Salt Bae",
+        "Meeting:Brunch, 18th Jan 2021"
+      )
+    }
   }
 
   describe("DerivedImageData") {


### PR DESCRIPTION
We cannot currently aggregate on contributors as we need to aggregate on both the agent label and its type. Here we derive a new string field which combines both of these fields (`"$type:$label"`). In the aggregations we will be able to decode this interpolated field to reconstruct the original `Contributor` object.