### PR TITLE
Add support for license aggregations on images

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
@@ -14,7 +14,8 @@ case class DisplayAggregation[T](
 )
 
 case object DisplayAggregation {
-  def apply[T, DisplayT](agg: Aggregation[T], display: T => DisplayT): DisplayAggregation[DisplayT] =
+  def apply[T, DisplayT](agg: Aggregation[T],
+                         display: T => DisplayT): DisplayAggregation[DisplayT] =
     DisplayAggregation(
       buckets = agg.buckets.map { bucket =>
         DisplayAggregationBucket(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
@@ -13,6 +13,18 @@ case class DisplayAggregation[T](
   @JsonKey("type") @Schema(name = "type") ontologyType: String = "Aggregation"
 )
 
+case object DisplayAggregation {
+  def apply[T, D](agg: Aggregation[T], display: T => D): DisplayAggregation[D] =
+    DisplayAggregation(
+      buckets = agg.buckets.map { bucket =>
+        DisplayAggregationBucket(
+          data = display(bucket.data),
+          count = bucket.count
+        )
+      }
+    )
+}
+
 @Schema(
   name = "AggregationBucket",
   description = "An individual bucket within an aggregation."

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayAggregation.scala
@@ -14,7 +14,7 @@ case class DisplayAggregation[T](
 )
 
 case object DisplayAggregation {
-  def apply[T, D](agg: Aggregation[T], display: T => D): DisplayAggregation[D] =
+  def apply[T, DisplayT](agg: Aggregation[T], display: T => DisplayT): DisplayAggregation[DisplayT] =
     DisplayAggregation(
       buckets = agg.buckets.map { bucket =>
         DisplayAggregationBucket(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayImageAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayImageAggregations.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.api.models
+
+import io.circe.generic.extras.semiauto._
+import io.circe.Encoder
+import io.circe.generic.extras.JsonKey
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.ac.wellcome.display.models._
+import uk.ac.wellcome.display.json.DisplayJsonUtil._
+
+@Schema(
+  name = "Aggregations",
+  description = "A map containing the requested aggregations."
+)
+case class DisplayImageAggregations(
+  @Schema(
+    description = "License aggregation on a set of results."
+  ) license: Option[DisplayAggregation[DisplayLicense]],
+  @JsonKey("type") @Schema(name = "type") ontologyType: String = "Aggregations"
+)
+
+object DisplayImageAggregations {
+
+  implicit def encoder: Encoder[DisplayImageAggregations] = deriveConfiguredEncoder
+
+  def apply(aggs: ImageAggregations): DisplayImageAggregations =
+    DisplayImageAggregations(
+      license = displayAggregation(aggs.license, DisplayLicense.apply)
+    )
+
+  private def displayAggregation[T, D](
+    maybeAgg: Option[Aggregation[T]],
+    display: T => D): Option[DisplayAggregation[D]] =
+    maybeAgg.map {
+      DisplayAggregation(_, display)
+    }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayImageAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayImageAggregations.scala
@@ -20,7 +20,8 @@ case class DisplayImageAggregations(
 
 object DisplayImageAggregations {
 
-  implicit def encoder: Encoder[DisplayImageAggregations] = deriveConfiguredEncoder
+  implicit def encoder: Encoder[DisplayImageAggregations] =
+    deriveConfiguredEncoder
 
   def apply(aggs: ImageAggregations): DisplayImageAggregations =
     DisplayImageAggregations(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -74,14 +74,7 @@ object DisplayWorkAggregations {
   private def displayAggregation[T, D](
     maybeAgg: Option[Aggregation[T]],
     display: T => D): Option[DisplayAggregation[D]] =
-    maybeAgg.map { agg =>
-      DisplayAggregation(
-        buckets = agg.buckets.map { bucket =>
-          DisplayAggregationBucket(
-            data = display(bucket.data),
-            count = bucket.count
-          )
-        }
-      )
+    maybeAgg.map {
+      DisplayAggregation(_, display)
     }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ImageAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/ImageAggregations.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.sksamuel.elastic4s.requests.searches.SearchResponse
+import io.circe.Decoder
+import uk.ac.wellcome.models.work.internal._
+
+import scala.util.Try
+
+case class ImageAggregations(
+  license: Option[Aggregation[License]] = None,
+)
+
+object ImageAggregations extends ElasticAggregations {
+  def apply(searchResponse: SearchResponse): Option[ImageAggregations] = {
+    val e4sAggregations = searchResponse.aggregations
+    if (e4sAggregations.data.nonEmpty) {
+      Some(
+        ImageAggregations(
+          license = e4sAggregations.decodeAgg[License]("license")
+        ))
+    } else {
+      None
+    }
+  }
+
+  implicit val decodeLicense: Decoder[License] =
+    Decoder.decodeString.emap { str =>
+      Try(License.createLicense(str)).toEither.left
+        .map(err => err.getMessage)
+    }
+}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/ImagesParams.scala
@@ -35,6 +35,7 @@ case class MultipleImagesParams(
   license: Option[LicenseFilter],
   color: Option[ColorMustQuery],
   include: Option[MultipleImagesIncludes],
+  aggregations: Option[List[ImageAggregationRequest]],
   _index: Option[String]
 ) extends QueryParams
     with Paginated {
@@ -44,6 +45,7 @@ case class MultipleImagesParams(
       searchQuery = query.map(SearchQuery(_)),
       filters = filters,
       mustQueries = mustQueries,
+      aggregations = aggregations.getOrElse(Nil),
       pageSize = pageSize.getOrElse(apiConfig.defaultPageSize),
       pageNumber = page.getOrElse(1)
     )
@@ -67,6 +69,7 @@ object MultipleImagesParams extends QueryParamsUtils {
         "locations.license".as[LicenseFilter].?,
         "color".as[ColorMustQuery].?,
         "include".as[MultipleImagesIncludes].?,
+        "aggregations".as[List[ImageAggregationRequest]].?,
         "_index".as[String].?
       )
     ).tflatMap { args =>
@@ -82,4 +85,9 @@ object MultipleImagesParams extends QueryParamsUtils {
       "source.contributors" -> ImageInclude.SourceContributors,
       "source.languages" -> ImageInclude.SourceLanguages,
     ).emap(values => Right(MultipleImagesIncludes(values: _*)))
+
+  implicit val aggregationsDecoder: Decoder[List[ImageAggregationRequest]] =
+    decodeOneOfCommaSeparated(
+      "locations.license" -> ImageAggregationRequest.License
+    )
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -75,11 +75,13 @@ object DisplayResultList {
         )
     }
 
-  def apply(resultList: ResultList[Image[ImageState.Indexed], ImageAggregations],
-            searchOptions: SearchOptions[_, _, _],
-            includes: MultipleImagesIncludes,
-            requestUri: Uri,
-            contextUri: String): DisplayResultList[DisplayImage, DisplayImageAggregations] =
+  def apply(
+    resultList: ResultList[Image[ImageState.Indexed], ImageAggregations],
+    searchOptions: SearchOptions[_, _, _],
+    includes: MultipleImagesIncludes,
+    requestUri: Uri,
+    contextUri: String)
+    : DisplayResultList[DisplayImage, DisplayImageAggregations] =
     PaginationResponse(resultList, searchOptions, requestUri) match {
       case PaginationResponse(totalPages, prevPage, nextPage) =>
         DisplayResultList(
@@ -90,7 +92,8 @@ object DisplayResultList {
           results = resultList.results.map(DisplayImage(_, includes)),
           prevPage = prevPage,
           nextPage = nextPage,
-          aggregations = resultList.aggregations.map(DisplayImageAggregations.apply)
+          aggregations =
+            resultList.aggregations.map(DisplayImageAggregations.apply)
         )
     }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -75,11 +75,11 @@ object DisplayResultList {
         )
     }
 
-  def apply(resultList: ResultList[Image[ImageState.Indexed], Unit],
+  def apply(resultList: ResultList[Image[ImageState.Indexed], ImageAggregations],
             searchOptions: SearchOptions[_, _, _],
             includes: MultipleImagesIncludes,
             requestUri: Uri,
-            contextUri: String): DisplayResultList[DisplayImage, Unit] =
+            contextUri: String): DisplayResultList[DisplayImage, DisplayImageAggregations] =
     PaginationResponse(resultList, searchOptions, requestUri) match {
       case PaginationResponse(totalPages, prevPage, nextPage) =>
         DisplayResultList(
@@ -90,7 +90,7 @@ object DisplayResultList {
           results = resultList.results.map(DisplayImage(_, includes)),
           prevPage = prevPage,
           nextPage = nextPage,
-          aggregations = resultList.aggregations
+          aggregations = resultList.aggregations.map(DisplayImageAggregations.apply)
         )
     }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -7,8 +7,21 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{
   FilterAggregation
 }
 import com.sksamuel.elastic4s.requests.searches.queries.Query
-import uk.ac.wellcome.display.models.WorkAggregationRequest
-import uk.ac.wellcome.platform.api.models._
+import uk.ac.wellcome.display.models.{
+  ImageAggregationRequest,
+  WorkAggregationRequest
+}
+import uk.ac.wellcome.platform.api.models.{
+  ContributorsFilter,
+  FormatFilter,
+  GenreFilter,
+  ImageFilter,
+  ItemLocationTypeFilter,
+  LanguagesFilter,
+  LicenseFilter,
+  SubjectFilter,
+  WorkFilter
+}
 
 import scala.collection.immutable._
 
@@ -28,15 +41,17 @@ import scala.collection.immutable._
   * - `pairedFilters`: a list of all of the given filters which are paired to one
   *   of the given aggregations. These can be used as the ES post-query filters.
   */
-class FiltersAndAggregationsBuilder(
-  aggregationRequests: List[WorkAggregationRequest],
-  filters: List[WorkFilter],
-  requestToAggregation: WorkAggregationRequest => Aggregation,
-  filterToQuery: WorkFilter => Query) {
+trait FiltersAndAggregationsBuilder[Filter, AggregationRequest] {
+  val aggregationRequests: List[AggregationRequest]
+  val filters: List[Filter]
+  val requestToAggregation: AggregationRequest => Aggregation
+  val filterToQuery: Filter => Query
 
-  lazy val unpairedFilters: List[WorkFilter] =
+  def pairedAggregationRequest(filter: Filter): Option[AggregationRequest]
+
+  lazy val unpairedFilters: List[Filter] =
     filterSets.getOrElse(FilterCategory.Unpaired, List())
-  lazy val pairedFilters: List[WorkFilter] =
+  lazy val pairedFilters: List[Filter] =
     filterSets.getOrElse(FilterCategory.Paired, List())
 
   lazy val filteredAggregations: List[AbstractAggregation] =
@@ -55,7 +70,7 @@ class FiltersAndAggregationsBuilder(
       }
     }
 
-  private lazy val filterSets: Map[FilterCategory, List[WorkFilter]] =
+  private lazy val filterSets: Map[FilterCategory, List[Filter]] =
     filters.groupBy {
       pairedAggregationRequest(_) match {
         case Some(aggregationRequest)
@@ -66,7 +81,7 @@ class FiltersAndAggregationsBuilder(
     }
 
   private def pairedFilter(
-    aggregationRequest: WorkAggregationRequest): Option[WorkFilter] =
+    aggregationRequest: AggregationRequest): Option[Filter] =
     pairedFilters.find {
       pairedAggregationRequest(_) match {
         case Some(agg) => agg == aggregationRequest
@@ -74,9 +89,21 @@ class FiltersAndAggregationsBuilder(
       }
     }
 
-  // This pattern matching defines the pairings of filters <-> aggregations
-  private def pairedAggregationRequest(
-    filter: WorkFilter): Option[WorkAggregationRequest] =
+  private sealed trait FilterCategory
+  private object FilterCategory {
+    case object Unpaired extends FilterCategory
+    case object Paired extends FilterCategory
+  }
+}
+
+class WorkFiltersAndAggregationsBuilder(
+  val aggregationRequests: List[WorkAggregationRequest],
+  val filters: List[WorkFilter],
+  val requestToAggregation: WorkAggregationRequest => Aggregation,
+  val filterToQuery: WorkFilter => Query
+) extends FiltersAndAggregationsBuilder[WorkFilter, WorkAggregationRequest]{
+
+  override def pairedAggregationRequest(filter: WorkFilter): Option[WorkAggregationRequest] =
     filter match {
       case _: FormatFilter       => Some(WorkAggregationRequest.Format)
       case _: LanguagesFilter    => Some(WorkAggregationRequest.Languages)
@@ -88,10 +115,18 @@ class FiltersAndAggregationsBuilder(
         Some(WorkAggregationRequest.ItemLocationType)
       case _ => None
     }
+}
 
-  private sealed trait FilterCategory
-  private object FilterCategory {
-    case object Unpaired extends FilterCategory
-    case object Paired extends FilterCategory
-  }
+class ImageFiltersAndAggregationsBuilder(
+  val aggregationRequests: List[ImageAggregationRequest],
+  val filters: List[ImageFilter],
+  val requestToAggregation: ImageAggregationRequest => Aggregation,
+  val filterToQuery: ImageFilter => Query
+) extends FiltersAndAggregationsBuilder[ImageFilter, ImageAggregationRequest] {
+
+  override def pairedAggregationRequest(filter: ImageFilter): Option[ImageAggregationRequest] =
+    filter match {
+      case _: LicenseFilter => Some(ImageAggregationRequest.License)
+      case _ => None
+    }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -101,9 +101,10 @@ class WorkFiltersAndAggregationsBuilder(
   val filters: List[WorkFilter],
   val requestToAggregation: WorkAggregationRequest => Aggregation,
   val filterToQuery: WorkFilter => Query
-) extends FiltersAndAggregationsBuilder[WorkFilter, WorkAggregationRequest]{
+) extends FiltersAndAggregationsBuilder[WorkFilter, WorkAggregationRequest] {
 
-  override def pairedAggregationRequest(filter: WorkFilter): Option[WorkAggregationRequest] =
+  override def pairedAggregationRequest(
+    filter: WorkFilter): Option[WorkAggregationRequest] =
     filter match {
       case _: FormatFilter       => Some(WorkAggregationRequest.Format)
       case _: LanguagesFilter    => Some(WorkAggregationRequest.Languages)
@@ -124,9 +125,10 @@ class ImageFiltersAndAggregationsBuilder(
   val filterToQuery: ImageFilter => Query
 ) extends FiltersAndAggregationsBuilder[ImageFilter, ImageAggregationRequest] {
 
-  override def pairedAggregationRequest(filter: ImageFilter): Option[ImageAggregationRequest] =
+  override def pairedAggregationRequest(
+    filter: ImageFilter): Option[ImageAggregationRequest] =
     filter match {
       case _: LicenseFilter => Some(ImageAggregationRequest.License)
-      case _ => None
+      case _                => None
     }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -31,10 +31,9 @@ class ImagesService(searchService: ElasticsearchService,
         }
       }
 
-  def listOrSearchImages(
-    index: Index,
-    searchOptions: ImageSearchOptions): Future[
-    Either[ElasticError, ResultList[Image[ImageState.Indexed], ImageAggregations]]] =
+  def listOrSearchImages(index: Index, searchOptions: ImageSearchOptions)
+    : Future[Either[ElasticError,
+                    ResultList[Image[ImageState.Indexed], ImageAggregations]]] =
     searchService
       .executeSearch(
         searchOptions = searchOptions,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesService.scala
@@ -31,9 +31,10 @@ class ImagesService(searchService: ElasticsearchService,
         }
       }
 
-  def listOrSearchImages(index: Index,
-                         searchOptions: ImageSearchOptions): Future[
-    Either[ElasticError, ResultList[Image[ImageState.Indexed], Unit]]] =
+  def listOrSearchImages(
+    index: Index,
+    searchOptions: ImageSearchOptions): Future[
+    Either[ElasticError, ResultList[Image[ImageState.Indexed], ImageAggregations]]] =
     searchService
       .executeSearch(
         searchOptions = searchOptions,
@@ -70,13 +71,13 @@ class ImagesService(searchService: ElasticsearchService,
       }
 
   def createResultList(searchResponse: SearchResponse)
-    : ResultList[Image[ImageState.Indexed], Unit] =
+    : ResultList[Image[ImageState.Indexed], ImageAggregations] =
     ResultList(
       results = searchResponse.hits.hits
         .map(deserialize[Image[ImageState.Indexed]])
         .toList,
       totalResults = searchResponse.totalHits.toInt,
-      aggregations = None
+      aggregations = ImageAggregations(searchResponse)
     )
 
   private def deserialize[T](hit: Hit)(implicit decoder: Decoder[T]): T =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -31,7 +31,7 @@ object WorksRequestBuilder
 
   private def filteredAggregationBuilder(
     implicit searchOptions: WorkSearchOptions) =
-    new FiltersAndAggregationsBuilder(
+    new WorkFiltersAndAggregationsBuilder(
       aggregationRequests = searchOptions.aggregations,
       filters = searchOptions.filters,
       requestToAggregation = toAggregation,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -242,6 +242,17 @@ trait MultipleImagesSwagger {
         )
       ),
       new Parameter(
+        name = "aggregations",
+        in = ParameterIn.QUERY,
+        description =
+          "What aggregated data in correlation to the results should we return.",
+        schema = new Schema(
+          allowableValues = Array(
+            "locations.license")
+        ),
+        required = false
+      ),
+      new Parameter(
         name = "page",
         in = ParameterIn.QUERY,
         description = "The page to return from the result list",
@@ -608,11 +619,26 @@ trait MultipleWorksSwagger {
     description = "A paginated list of works."
   )
   class DisplayWorksResultList
-      extends DisplayResultList[DisplayWork, DisplayImageAggregations](
+      extends DisplayResultList[DisplayWork, DisplayWorkAggregations](
         context = "",
         pageSize = 0,
         totalPages = 0,
         totalResults = 0,
         results = Nil)
-  val _ = new DisplayWorksResultList
+
+  val w = new DisplayWorksResultList
+
+  @Schema(
+    name = "ImageResultList",
+    description = "A paginated list of works."
+  )
+  class DisplayImagesResultList
+    extends DisplayResultList[DisplayImage, DisplayImageAggregations](
+      context = "",
+      pageSize = 0,
+      totalPages = 0,
+      totalResults = 0,
+      results = Nil)
+
+  val i = new DisplayImagesResultList
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -247,8 +247,7 @@ trait MultipleImagesSwagger {
         description =
           "What aggregated data in correlation to the results should we return.",
         schema = new Schema(
-          allowableValues = Array(
-            "locations.license")
+          allowableValues = Array("locations.license")
         ),
         required = false
       ),
@@ -633,12 +632,12 @@ trait MultipleWorksSwagger {
     description = "A paginated list of works."
   )
   class DisplayImagesResultList
-    extends DisplayResultList[DisplayImage, DisplayImageAggregations](
-      context = "",
-      pageSize = 0,
-      totalPages = 0,
-      totalResults = 0,
-      results = Nil)
+      extends DisplayResultList[DisplayImage, DisplayImageAggregations](
+        context = "",
+        pageSize = 0,
+        totalPages = 0,
+        totalResults = 0,
+        results = Nil)
 
   val i = new DisplayImagesResultList
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -608,7 +608,7 @@ trait MultipleWorksSwagger {
     description = "A paginated list of works."
   )
   class DisplayWorksResultList
-      extends DisplayResultList[DisplayWork, DisplayWorkAggregations](
+      extends DisplayResultList[DisplayWork, DisplayImageAggregations](
         context = "",
         pageSize = 0,
         totalPages = 0,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -266,6 +266,7 @@ class ApiSwaggerTest
         "PeriodAggregationBucket",
         "SubjectAggregationBucket",
         "LanguageAggregationBucket",
+        "LicenseAggregationBucket",
       )
     }
   }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesAggregationsTest.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.api.images
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.Implicits._
+
+class ImagesAggregationsTest extends ApiImagesTestBase {
+  it("aggregates by license") {
+    val ccByImages = (1 to 5).map { _ =>
+      createLicensedImage(License.CCBY)
+    }
+
+    val pdmImages = (1 to 2).map { _ =>
+      createLicensedImage(License.PDM)
+    }
+
+    val images = ccByImages ++ pdmImages
+
+    withImagesApi {
+      case (imagesIndex, routes) =>
+        insertImagesIntoElasticsearch(imagesIndex, images: _*)
+
+        assertJsonResponse(routes, s"/$apiPrefix/images?aggregations=locations.license") {
+          Status.OK -> s"""
+            {
+              ${resultList(apiPrefix, totalResults = images.size)},
+              "aggregations": {
+                "type" : "Aggregations",
+                "license": {
+                  "type" : "Aggregation",
+                  "buckets": [
+                    {
+                      "data" : ${license(License.CCBY)},
+                      "count" : ${ccByImages.size},
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "data" : ${license(License.PDM)},
+                      "count" : ${pdmImages.size},
+                      "type" : "AggregationBucket"
+                    }
+                  ]
+                }
+              },
+              "results": [
+                ${images
+                    .sortBy { _.state.canonicalId }
+                    .map(imageResponse)
+                    .mkString(",")}
+              ]
+            }
+          """
+        }
+    }
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesAggregationsTest.scala
@@ -19,7 +19,9 @@ class ImagesAggregationsTest extends ApiImagesTestBase {
       case (imagesIndex, routes) =>
         insertImagesIntoElasticsearch(imagesIndex, images: _*)
 
-        assertJsonResponse(routes, s"/$apiPrefix/images?aggregations=locations.license") {
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/images?aggregations=locations.license") {
           Status.OK -> s"""
             {
               ${resultList(apiPrefix, totalResults = images.size)},
@@ -43,9 +45,9 @@ class ImagesAggregationsTest extends ApiImagesTestBase {
               },
               "results": [
                 ${images
-                    .sortBy { _.state.canonicalId }
-                    .map(imageResponse)
-                    .mkString(",")}
+            .sortBy { _.state.canonicalId }
+            .map(imageResponse)
+            .mkString(",")}
               ]
             }
           """

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
@@ -1,0 +1,66 @@
+package uk.ac.wellcome.platform.api.images
+
+import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.Implicits._
+
+class ImagesFilteredAggregationsTest extends ApiImagesTestBase {
+  it("filters and aggregates by license") {
+    val ccByImages = (1 to 5).map { _ =>
+      createLicensedImage(License.CCBY)
+    }
+
+    val pdmImages = (1 to 2).map { _ =>
+      createLicensedImage(License.PDM)
+    }
+
+    val oglImages = (1 to 3).map { _ =>
+      createLicensedImage(License.OGL)
+    }
+
+    val images = ccByImages ++ pdmImages ++ oglImages
+
+    withImagesApi {
+      case (imagesIndex, routes) =>
+        insertImagesIntoElasticsearch(imagesIndex, images: _*)
+        val expectedImages = ccByImages ++ pdmImages
+
+        assertJsonResponse(routes, s"/$apiPrefix/images?aggregations=locations.license&locations.license=cc-by,pdm") {
+          Status.OK -> s"""
+            {
+              ${resultList(apiPrefix, totalResults = expectedImages.size)},
+              "aggregations": {
+                "type" : "Aggregations",
+                "license": {
+                  "type" : "Aggregation",
+                  "buckets": [
+                    {
+                      "data" : ${license(License.CCBY)},
+                      "count" : ${ccByImages.size},
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "data" : ${license(License.PDM)},
+                      "count" : ${pdmImages.size},
+                      "type" : "AggregationBucket"
+                    }
+                    ,
+                    {
+                      "data" : ${license(License.OGL)},
+                      "count" : 0,
+                      "type" : "AggregationBucket"
+                    }
+                  ]
+                }
+              },
+              "results": [
+                ${expectedImages
+            .sortBy { _.state.canonicalId }
+            .map(imageResponse)
+            .mkString(",")}
+              ]
+            }
+          """
+        }
+    }
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
@@ -24,7 +24,9 @@ class ImagesFilteredAggregationsTest extends ApiImagesTestBase {
         insertImagesIntoElasticsearch(imagesIndex, images: _*)
         val expectedImages = ccByImages ++ pdmImages
 
-        assertJsonResponse(routes, s"/$apiPrefix/images?aggregations=locations.license&locations.license=cc-by,pdm") {
+        assertJsonResponse(
+          routes,
+          s"/$apiPrefix/images?aggregations=locations.license&locations.license=cc-by,pdm") {
           Status.OK -> s"""
             {
               ${resultList(apiPrefix, totalResults = expectedImages.size)},

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -17,7 +17,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
     it("separates paired and unpaired filters") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("eng"))
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests =
           List(WorkAggregationRequest.Format, WorkAggregationRequest.License),
         filters = List(formatFilter, languagesFilter, VisibleWorkFilter),
@@ -32,7 +32,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
     it("handles the case where all filters are unpaired") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("eng"))
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests = List(WorkAggregationRequest.License),
         filters = List(formatFilter, languagesFilter, VisibleWorkFilter),
         requestToAggregation = requestToAggregation,
@@ -46,7 +46,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
     it("handles the case where all filters are paired") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("en"))
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests =
           List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages),
         filters = List(formatFilter, languagesFilter),
@@ -63,7 +63,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
     it("applies to aggregations with a paired filter") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("en"))
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests =
           List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages),
         filters = List(formatFilter, languagesFilter),
@@ -80,11 +80,11 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
 
     it("does not apply to aggregations without a paired filter") {
       val languagesFilter = LanguagesFilter(Seq("en"))
-      val builder = new FiltersAndAggregationsBuilder(
-        List(WorkAggregationRequest.Format),
-        List(languagesFilter),
-        requestToAggregation,
-        filterToQuery
+      val builder = new WorkFiltersAndAggregationsBuilder(
+        aggregationRequests = List(WorkAggregationRequest.Format),
+        filters = List(languagesFilter),
+        requestToAggregation = requestToAggregation,
+        filterToQuery = filterToQuery
       )
 
       builder.filteredAggregations should have length 1
@@ -96,7 +96,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
 
     it("applies paired filters to non-paired aggregations") {
       val formatFilter = FormatFilter(Seq("bananas"))
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests =
           List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages),
         filters = List(formatFilter),
@@ -121,7 +121,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("en"))
       val genreFilter = GenreFilter("durian")
-      val builder = new FiltersAndAggregationsBuilder(
+      val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests = List(
           WorkAggregationRequest.Format,
           WorkAggregationRequest.Languages,

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/ImageAggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/ImageAggregationRequest.scala
@@ -1,3 +1,7 @@
 package uk.ac.wellcome.display.models
 
 sealed trait ImageAggregationRequest
+
+object ImageAggregationRequest {
+  case object License extends ImageAggregationRequest
+}


### PR DESCRIPTION
So now we can make the query

```
/images?locations.license=cc-by,pdm&aggregations=locations.license
```

and you get the result you expect.

For https://github.com/wellcomecollection/platform/issues/4994. Follows https://github.com/wellcomecollection/catalogue/pull/1322.