### PR TITLE
Slightly improve the parsing of access conditions

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
@@ -53,7 +53,8 @@ object AccessStatus {
       case lowerCaseStatus
           if lowerCaseStatus.startsWith("requires registration") =>
         Right(AccessStatus.OpenWithAdvisory)
-      case lowerCaseStatus if lowerCaseStatus.startsWith("unrestricted / open") =>
+      case lowerCaseStatus
+          if lowerCaseStatus.startsWith("unrestricted / open") =>
         Right(AccessStatus.Open)
       case lowerCaseStatus if lowerCaseStatus.startsWith("open") =>
         Right(AccessStatus.Open)
@@ -84,7 +85,7 @@ object AccessStatus {
           if lowerCaseStatus.startsWith("permission required") =>
         Right(AccessStatus.PermissionRequired)
       case lowerCaseStatus
-        if lowerCaseStatus.startsWith("permission is required") =>
+          if lowerCaseStatus.startsWith("permission is required") =>
         Right(AccessStatus.PermissionRequired)
       case lowerCaseStatus if lowerCaseStatus.startsWith("donor permission") =>
         Right(AccessStatus.PermissionRequired)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
@@ -53,6 +53,8 @@ object AccessStatus {
       case lowerCaseStatus
           if lowerCaseStatus.startsWith("requires registration") =>
         Right(AccessStatus.OpenWithAdvisory)
+      case lowerCaseStatus if lowerCaseStatus.startsWith("unrestricted / open") =>
+        Right(AccessStatus.Open)
       case lowerCaseStatus if lowerCaseStatus.startsWith("open") =>
         Right(AccessStatus.Open)
       case lowerCaseStatus if lowerCaseStatus.startsWith("restricted") =>
@@ -80,6 +82,9 @@ object AccessStatus {
         Right(AccessStatus.LicensedResources)
       case lowerCaseStatus
           if lowerCaseStatus.startsWith("permission required") =>
+        Right(AccessStatus.PermissionRequired)
+      case lowerCaseStatus
+        if lowerCaseStatus.startsWith("permission is required") =>
         Right(AccessStatus.PermissionRequired)
       case lowerCaseStatus if lowerCaseStatus.startsWith("donor permission") =>
         Right(AccessStatus.PermissionRequired)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessConditionTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessConditionTest.scala
@@ -24,7 +24,10 @@ class AccessConditionTest extends AnyFunSpec with Matchers {
     }
   }
   it("creates PermissionRequired access condition") {
-    val restrictedValues = List("Permission Required.", "Donor Permission.", "Permission is required to view this item.")
+    val restrictedValues = List(
+      "Permission Required.",
+      "Donor Permission.",
+      "Permission is required to view this item.")
     restrictedValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.PermissionRequired)
     }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessConditionTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessConditionTest.scala
@@ -10,7 +10,9 @@ class AccessConditionTest extends AnyFunSpec with Matchers {
       "Restricted access (Data Protection Act)",
       "Cannot Be Produced - View Digitised Version",
       "Certain restrictions apply.",
-      "By Appointment.")
+      "By Appointment.",
+      "Restricted: currently undergoing conservation."
+    )
     restrictedValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.Restricted)
     }
@@ -22,10 +24,14 @@ class AccessConditionTest extends AnyFunSpec with Matchers {
     }
   }
   it("creates PermissionRequired access condition") {
-    val restrictedValues = List("Permission Required.", "Donor Permission.")
+    val restrictedValues = List("Permission Required.", "Donor Permission.", "Permission is required to view this item.")
     restrictedValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.PermissionRequired)
     }
+  }
+
+  it("creates the Open access condition") {
+    AccessStatus("Unrestricted / Open.") shouldBe Right(AccessStatus.Open)
   }
 
   it("strips punctuation from access condition if present") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -109,7 +109,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       edition = SierraEdition(bibData),
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),
-      items = SierraItems(itemDataMap)(bibData)
+      items = SierraItems(itemDataMap)(bibId, bibData)
     )
 
   lazy val bibId = sierraTransformable.sierraId

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -78,7 +78,9 @@ trait SierraLocation extends SierraQueryOps with Logging {
   //  - look in subfield ǂf for the standardised terminology
   //
   // See https://www.loc.gov/marc/bibliographic/bd506.html
-  private def getAccessStatus(bibId: SierraBibNumber, varfield: VarField, terms: Option[String]): Option[AccessStatus] = {
+  private def getAccessStatus(bibId: SierraBibNumber,
+                              varfield: VarField,
+                              terms: Option[String]): Option[AccessStatus] = {
 
     // If the first indicator is 0, then there are no restrictions
     val indicator0 =
@@ -89,18 +91,23 @@ trait SierraLocation extends SierraQueryOps with Logging {
 
     // Look in subfield ǂf for the standardised terminology
     val subfieldF =
-      varfield.subfieldsWithTag("f").contents.headOption
+      varfield
+        .subfieldsWithTag("f")
+        .contents
+        .headOption
         .flatMap { contents =>
           AccessStatus(contents) match {
             case Right(status) => Some(status)
             case Left(err) =>
-              warn(s"$bibId: Unable to parse access status from subfield ǂf: $contents ($err)")
+              warn(
+                s"$bibId: Unable to parse access status from subfield ǂf: $contents ($err)")
               None
           }
         }
 
     // Look at the terms for the standardised terminology
-    val termsStatus = terms.map { AccessStatus(_) }.collect { case Right(status) => status }
+    val termsStatus =
+      terms.map { AccessStatus(_) }.collect { case Right(status) => status }
 
     // Finally, we look at all three fields together.  If the data is inconsistent
     // we should drop a warning and not set an access status, rather than set one that's
@@ -111,7 +118,7 @@ trait SierraLocation extends SierraQueryOps with Logging {
     //     (e.g. claiming an Item is open when it's actually restricted)
     //
     Seq(indicator0, subfieldF, termsStatus).flatten.distinct match {
-      case Nil => None
+      case Nil         => None
       case Seq(status) => Some(status)
       case multiple =>
         warn(s"$bibId: Multiple, conflicting access statuses: $multiple")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -61,6 +61,13 @@ trait SierraLocation extends SierraQueryOps {
         case _                                 => true
       }
 
+  // Get an AccessStatus that draws from our list of types.
+  //
+  // Rules:
+  //  - if the first indicator is 0, then there are no restrictions
+  //  - look in subfield ǂf for the standardised terminology
+  //
+  // See https://www.loc.gov/marc/bibliographic/bd506.html
   private def getAccessStatus(varfield: VarField): Option[AccessStatus] =
     if (varfield.indicator1.contains("0"))
       Some(AccessStatus.Open)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -50,9 +50,15 @@ trait SierraLocation extends SierraQueryOps {
     bibData
       .varfieldsWithTag("506")
       .map { varfield =>
+        // MARC 506 subfield ǂa contains "terms governing access".  This is a
+        // non-repeatable field.  See https://www.loc.gov/marc/bibliographic/bd506.html
+        val terms = varfield
+          .nonrepeatableSubfieldWithTag("a")
+          .map { _.content.trim }
+
         AccessCondition(
           status = getAccessStatus(varfield),
-          terms = varfield.nonrepeatableSubfieldWithTag("a").map { _.content },
+          terms = terms,
           to = varfield.subfieldsWithTag("g").contents.headOption
         )
       }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -164,5 +164,5 @@ class SierraItemsTest
     bibData: SierraBibData = createSierraBibData,
     itemDataMap: Map[SierraItemNumber, SierraItemData] = Map())
     : List[Item[IdState.Unminted]] =
-    SierraItems(itemDataMap)(bibData)
+    SierraItems(itemDataMap)(createSierraBibNumber, bibData)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
@@ -146,13 +146,16 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
-      location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
+      location.accessConditions.head.status shouldBe Some(
+        AccessStatus.Restricted)
     }
 
-    it("sets an access status based on the contents of subfield ǂa if ǂf is missing") {
+    it(
+      "sets an access status based on the contents of subfield ǂa if ǂf is missing") {
       val bibData = createSierraBibDataWith(
         varFields = List(
           VarField(
@@ -164,10 +167,12 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
-      location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
+      location.accessConditions.head.status shouldBe Some(
+        AccessStatus.Restricted)
       location.accessConditions.head.terms shouldBe Some("Restricted")
     }
 
@@ -184,14 +189,16 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
       location.accessConditions.head.terms shouldBe Some("Restricted")
     }
 
-    it("does not set an AccessStatus if the indicator 0 and the contents of subfield ǂf disagree") {
+    it(
+      "does not set an AccessStatus if the indicator 0 and the contents of subfield ǂf disagree") {
       val bibData = createSierraBibDataWith(
         varFields = List(
           VarField(
@@ -205,14 +212,17 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
-      location.accessConditions.head.terms shouldBe Some("This item is inconsistent and weird")
+      location.accessConditions.head.terms shouldBe Some(
+        "This item is inconsistent and weird")
     }
 
-    it("does not set an AccessStatus if the contents of subfield ǂf can't be parsed") {
+    it(
+      "does not set an AccessStatus if the contents of subfield ǂf can't be parsed") {
       val bibData = createSierraBibDataWith(
         varFields = List(
           VarField(
@@ -225,11 +235,13 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
-      location.accessConditions.head.terms shouldBe Some("This item is inconsistent and weird")
+      location.accessConditions.head.terms shouldBe Some(
+        "This item is inconsistent and weird")
     }
 
     it(
@@ -265,10 +277,12 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
+      val location =
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
-      location.accessConditions.head.terms shouldBe Some("Permission is required to view this item.")
+      location.accessConditions.head.terms shouldBe Some(
+        "Permission is required to view this item.")
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
@@ -25,7 +25,7 @@ class SierraLocationDeprecatedTest
   private val transformer = new SierraLocation {}
 
   describe("Physical locations") {
-
+    val bibId = createSierraBibNumber
     val bibData = createSierraBibData
 
     val locationType = LocationType("sgmed")
@@ -36,7 +36,7 @@ class SierraLocationDeprecatedTest
 
     it("extracts location from item data") {
       val expectedLocation = PhysicalLocationDeprecated(locationType, label)
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -45,14 +45,14 @@ class SierraLocationDeprecatedTest
         location = Some(SierraSourceLocation("", ""))
       )
 
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("returns None if the location field only contains the string 'none'") {
       val itemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("none", "none"))
       )
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("returns None if there is no location in the item data") {
@@ -60,7 +60,7 @@ class SierraLocationDeprecatedTest
         location = None
       )
 
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("adds access condition to the location if present") {
@@ -76,7 +76,7 @@ class SierraLocationDeprecatedTest
           )
         )
       )
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         PhysicalLocationDeprecated(
           locationType = locationType,
           label = label,
@@ -97,7 +97,7 @@ class SierraLocationDeprecatedTest
           VarField(marcTag = Some("506"), indicator1 = Some("0"))
         )
       )
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         PhysicalLocationDeprecated(
           locationType = locationType,
           label = label,
@@ -118,7 +118,7 @@ class SierraLocationDeprecatedTest
           )
         )
       )
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         PhysicalLocationDeprecated(
           locationType = locationType,
           label = label,
@@ -146,7 +146,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
@@ -164,7 +164,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
@@ -184,7 +184,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -205,7 +205,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -225,7 +225,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -244,7 +244,7 @@ class SierraLocationDeprecatedTest
           )
         )
       )
-      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         PhysicalLocationDeprecated(
           locationType = locationType,
           label = label,
@@ -265,7 +265,7 @@ class SierraLocationDeprecatedTest
         )
       )
 
-      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      val location = transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.terms shouldBe Some("Permission is required to view this item.")

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
@@ -154,6 +154,23 @@ class SierraLocationDeprecatedTest
       )
     }
 
+    it("strips whitespace from the access conditions") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield("a", "Permission is required to view this item. "),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.terms shouldBe Some("Permission is required to view this item.")
+    }
   }
 
   describe("Digital locations") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationDeprecatedTest.scala
@@ -133,6 +133,105 @@ class SierraLocationDeprecatedTest
       )
     }
 
+    it("sets an access status based on the contents of subfield ǂf") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield("a", "You're not allowed yet"),
+              MarcSubfield("f", "Restricted"),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
+    }
+
+    it("sets an access status based on the contents of subfield ǂa if ǂf is missing") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield("a", "Restricted"),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.status shouldBe Some(AccessStatus.Restricted)
+      location.accessConditions.head.terms shouldBe Some("Restricted")
+    }
+
+    it("does not set an AccessStatus if the contents of ǂa and ǂf disagree") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield("a", "Restricted"),
+              MarcSubfield("f", "Open"),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.status shouldBe None
+      location.accessConditions.head.terms shouldBe Some("Restricted")
+    }
+
+    it("does not set an AccessStatus if the indicator 0 and the contents of subfield ǂf disagree") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            indicator1 = Some("0"),
+            subfields = List(
+              MarcSubfield("a", "This item is inconsistent and weird"),
+              MarcSubfield("f", "Restricted"),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.status shouldBe None
+      location.accessConditions.head.terms shouldBe Some("This item is inconsistent and weird")
+    }
+
+    it("does not set an AccessStatus if the contents of subfield ǂf can't be parsed") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield("a", "This item is inconsistent and weird"),
+              MarcSubfield("f", "fffffff my cat sat on the keyboard"),
+            )
+          )
+        )
+      )
+
+      val location = transformer.getPhysicalLocation(itemData, bibData).get
+      location.accessConditions should have size 1
+
+      location.accessConditions.head.status shouldBe None
+      location.accessConditions.head.terms shouldBe Some("This item is inconsistent and weird")
+    }
+
     it(
       "does not add an access condition if none of the relevant subfields are present") {
       val bibData = createSierraBibDataWith(


### PR DESCRIPTION
As part of https://github.com/wellcomecollection/platform/issues/4996, I ended up looking at every access condition we currently have in the catalogue, and I spotted some low-hanging fruit for data quality improvements. These are primarily aimed at Sierra:

* Strip whitespace from the free-text description of access terms. We have some trailing spaces in the existing data.
* We look at MARC 520 subfield $f for the controlled terminology to choose our AccessStatus type, but that isn't populated. If it isn't, look at the free-text description (from subfield $a) and see if we can parse it from there.
* There are three indicators of AccessStatus on a Sierra bib, and they may not agree – if that's the case, drop a warning and don't set a status. This means we won't accidentally set an "open" status on a restricted item, and instead it'll get flagged and we can fix it in the catalogue.