### PR TITLE
Warn if you're running a reindex that won't go anywhere

### DIFF
--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -154,7 +154,6 @@ def start_reindex(ctx, src, dst, mode):
         parameters = specific_reindex_parameters(specified_records)
 
     topic_arn = get_reindexer_topic_arn()
-    print
 
     publish_messages(
         job_config_id=f"{src}--{dst}", topic_arn=topic_arn, parameters=parameters

--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -170,7 +170,7 @@ def start_reindex(ctx, src, dst, mode):
     elif src == "all" and mode != "complete":
         sys.exit("All-source reindexes only support --mode=complete")
 
-    print(f"Starting a reindex {src!r} ~> {dst!r}")
+    print(f"Starting a reindex {src} ~> {dst}")
 
     if mode == "complete":
         total_segments = how_many_segments(table_name=SOURCES[src])

--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8
 
 import json
 import math

--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -115,13 +115,15 @@ def get_reindexer_job_config(session):
     # The container definition contains two containers: the reindexer app, and the
     # logstash router.
     container_definition = next(
-    cd for cd in resp["taskDefinition"]["containerDefinitions"] if cd["name"] == "reindexer"
+        cd
+        for cd in resp["taskDefinition"]["containerDefinitions"]
+        if cd["name"] == "reindexer"
     )
 
     job_config_str = next(
         ev["value"]
         for ev in container_definition["environment"]
-        if ev['name'] == 'reindexer_job_config_json'
+        if ev["name"] == "reindexer_job_config_json"
     )
 
     return json.loads(job_config_str)
@@ -132,10 +134,9 @@ def has_subscriptions(session, *, topic_arn):
     Returns True if a topic ARN has any subscriptions (e.g. an SQS queue), False otherwise.
     """
     sns_client = session.client("sns")
-    resp = sns_client.list_subscriptions_by_topic(
-    TopicArn=topic_arn)
+    resp = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)
 
-    return len(resp['Subscriptions']) > 0
+    return len(resp["Subscriptions"]) > 0
 
 
 @click.command()
@@ -188,7 +189,7 @@ def start_reindex(ctx, src, dst, mode):
             return sys.exit("You need to specify at least 1 record ID")
         parameters = specific_reindex_parameters(specified_records)
 
-    job_config_id=f"{src}--{dst}"
+    job_config_id = f"{src}--{dst}"
     reindexer_job_config = get_reindexer_job_config(session)
 
     # It's incredibly frustrating to run a reindex using this script, see nothing come
@@ -216,7 +217,9 @@ def start_reindex(ctx, src, dst, mode):
     reindexer_topic_arn = get_reindexer_topic_arn()
 
     publish_messages(
-        job_config_id=job_config_id, topic_arn=reindexer_topic_arn, parameters=parameters
+        job_config_id=job_config_id,
+        topic_arn=reindexer_topic_arn,
+        parameters=parameters,
     )
 
 


### PR DESCRIPTION
Several times recently, I've run the start_reindex script, and been confused about why I wasn't seeing anything come through the pipeline. Confusion quickly gives way to annoyance, as I realise the pipeline isn't subscribed to the transformer output topics, and I have to start again.

This patch adds a warning to the start_reindex script if it detects you're about to reindex into a topic that nobody is listening to. You can still do it if you really want to, but it'll double-check you meant to do that:

<img width="682" alt="Screenshot 2021-01-29 at 17 41 37" src="https://user-images.githubusercontent.com/301220/106308931-4ee25800-6259-11eb-96f4-9f879ba38b72.png">

Closes https://github.com/wellcomecollection/platform/issues/4974