### PR TITLE
Deploy a pipeline for 2021-02-01

### DIFF
--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -25,9 +25,8 @@ class ApiDiffer:
     printing the results to stdout.
     """
 
-    def __init__(self, work_id=None, params=None):
-        suffix = f"/{work_id}" if work_id else ""
-        self.path = f"/catalogue/v2/works{suffix}"
+    def __init__(self, path=None, params=None, **kwargs):
+        self.path = f"/catalogue/v2{path}"
         self.params = params or {}
 
     @property
@@ -94,8 +93,7 @@ def main(routes_file):
         routes = json.load(f)
 
     def get_diff(route):
-        work_id, params = route.get("workId"), route.get("params")
-        differ = ApiDiffer(work_id, params)
+        differ = ApiDiffer(**route)
         status, diff_lines = differ.get_html_diff()
 
         return {

--- a/api/diff_tool/diff_tool.py
+++ b/api/diff_tool/diff_tool.py
@@ -54,7 +54,7 @@ class ApiDiffer:
                 "stage:",
                 f"{json.dumps(stage_json, indent=2)}",
             ]
-            return ("different status", "\n".join(lines))
+            return ("different status", lines)
         elif prod_json == stage_json:
             return ("match", "")
         else:

--- a/api/diff_tool/routes.json
+++ b/api/diff_tool/routes.json
@@ -1,98 +1,110 @@
 [
   {
+    "path": "/works",
     "params": {
       "include": "notes"
     }
   },
   {
+    "path": "/works",
     "params": {
       "page": 4,
       "pageSize": 5
     }
   },
   {
+    "path": "/works",
     "params": {
       "query": "botany"
     }
   },
   {
+    "path": "/works",
     "params": {
       "dateFrom": "1890-12-03",
       "dateTo": "1896-03-03"
     }
   },
   {
+    "path": "/works",
     "params": {
       "sort": "production.dates",
       "sortOrder": "desc"
     }
   },
   {
+    "path": "/works",
     "params": {
       "sort": "INVALID"
     }
   },
   {
+    "path": "/works",
     "params": {
       "aggregations": "workType,genres"
     }
   },
   {
+    "path": "/works",
     "params": {
       "language": "ger"
     }
   },
   {
+    "path": "/works",
     "params": {
       "workType": "b"
     }
   },
   {
-    "workId": "a224tb56",
+    "path": "/works/a224tb56",
     "params": {
       "include": "notes"
     }
   },
   {
-    "workId": "a22au6yn",
+    "path": "/works/a22au6yn",
     "params": {
       "include": "items,genres,identifiers"
     }
   },
   {
-    "workId": "nonexistent",
+    "path": "/works/nonexistent",
     "params": {}
   },
   {
-    "workId": "sqensfpm",
+    "path": "/works/sqensfpm",
     "params": {}
   },
   {
-    "workId": "japtptkk",
+    "path": "/works/japtptkk",
     "params": {
       "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
     },
     "comment": "A Sierra <> Miro merged work"
   },
   {
-    "workId": "nbsqzbba",
+    "path": "/works/nbsqzbba",
     "params": {
       "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
     },
     "comment": "A Sierra <> METS merged work"
   },
   {
-    "workId": "tuzsytuh",
+    "path": "/works/tuzsytuh",
     "params": {
       "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
     },
     "comment": "A Sierra physical <> digital <> METS merged work"
   },
   {
-    "workId": "ugmmch83",
+    "path": "/works/ugmmch83",
     "params": {
       "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
     },
     "comment": "A Sierra work with lots of items"
+  },
+  {
+    "path": "/images"
   }
 ]

--- a/api/diff_tool/routes.json
+++ b/api/diff_tool/routes.json
@@ -106,5 +106,12 @@
   },
   {
     "path": "/images"
+  },
+  {
+    "path": "/works/qfkgyy9c",
+    "params": {
+      "include": "items,genres,identifiers"
+    },
+    "comment": "A redirected Work that had issues in the 2021-02-01 reindex"
   }
 ]

--- a/api/diff_tool/template.html
+++ b/api/diff_tool/template.html
@@ -102,8 +102,11 @@
     <summary>
       <strong>
         {% if d.status == "match" %}✅{% else %}❌{% endif %}
-        {{ d.display_url }}
-        {% if d.route.comment %}({{ d.route.comment }}){% endif %}
+        {% if d.route.comment %}
+          {{ d.route.comment }}
+        {% else %}
+          {{ d.display_url }}
+        {% endif %}
       </strong>
     </summary>
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "2021-01-22"
+  val indexDate = "2021-02-01"
 
   def apply(): ElasticConfig =
     ElasticConfig(

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -80,26 +80,26 @@ module "catalogue_pipeline_2021-02-01" {
   # If this pipeline is meant to be reindexed, remember to uncomment the
   # reindexer topic names.
 
-  is_reindexing = true
+  is_reindexing = false
 
   sierra_adapter_topic_arns = [
-    local.sierra_reindexer_topic_arn,
+    /*local.sierra_reindexer_topic_arn,*/
     local.sierra_merged_bibs_topic_arn,
     local.sierra_merged_items_topic_arn,
   ]
 
   miro_adapter_topic_arns = [
-    local.miro_reindexer_topic_arn,
+    /*local.miro_reindexer_topic_arn,*/
     local.miro_updates_topic_arn,
   ]
 
   mets_adapter_topic_arns = [
-    local.mets_reindexer_topic_arn,
+    /*local.mets_reindexer_topic_arn,*/
     local.mets_adapter_topic_arn,
   ]
 
   calm_adapter_topic_arns = [
-    local.calm_reindexer_topic_arn,
+    /*local.calm_reindexer_topic_arn,*/
     local.calm_adapter_topic_arn,
   ]
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -71,7 +71,7 @@ module "catalogue_pipeline_2021-02-01" {
   source = "./stack"
 
   pipeline_date = "2021-02-01"
-  release_label = "stage"
+  release_label = "prod"
 
   pipeline_storage_id = "pipeline_storage_delta"
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -66,3 +66,70 @@ module "catalogue_pipeline_2021-01-22" {
 
   storage_bucket_name = local.storage_bucket
 }
+
+module "catalogue_pipeline_2021-02-01" {
+  source = "./stack"
+
+  pipeline_date = "2021-02-01"
+  release_label = "stage"
+
+  pipeline_storage_id = "pipeline_storage_delta"
+
+  # Transformer config
+  #
+  # If this pipeline is meant to be reindexed, remember to uncomment the
+  # reindexer topic names.
+
+  is_reindexing = true
+
+  sierra_adapter_topic_arns = [
+    local.sierra_reindexer_topic_arn,
+    local.sierra_merged_bibs_topic_arn,
+    local.sierra_merged_items_topic_arn,
+  ]
+
+  miro_adapter_topic_arns = [
+    local.miro_reindexer_topic_arn,
+    local.miro_updates_topic_arn,
+  ]
+
+  mets_adapter_topic_arns = [
+    local.mets_reindexer_topic_arn,
+    local.mets_adapter_topic_arn,
+  ]
+
+  calm_adapter_topic_arns = [
+    local.calm_reindexer_topic_arn,
+    local.calm_adapter_topic_arn,
+  ]
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  aws_region = local.aws_region
+  vpc_id     = local.vpc_id
+  subnets    = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  rds_cluster_id        = local.rds_cluster_id
+  rds_subnet_group_name = local.rds_subnet_group_name
+
+  # Security groups
+  rds_ids_access_security_group_id   = local.rds_access_security_group_id
+  pipeline_storage_security_group_id = local.pipeline_storage_security_group_id
+
+  traffic_filter_platform_vpce_id   = local.traffic_filter_platform_vpce_id
+  traffic_filter_public_internet_id = local.traffic_filter_public_internet_id
+
+  # Adapter VHS
+  vhs_miro_read_policy   = local.vhs_miro_read_policy
+  vhs_sierra_read_policy = local.vhs_sierra_read_policy
+  vhs_calm_read_policy   = local.vhs_calm_read_policy
+
+  # Inferrer data
+  inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
+
+  shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+
+  storage_bucket_name = local.storage_bucket
+}

--- a/pipeline/terraform/stack/elastic_pipeline_storage.tf
+++ b/pipeline/terraform/stack/elastic_pipeline_storage.tf
@@ -53,6 +53,10 @@ resource "aws_secretsmanager_secret" "es_password" {
 #
 # Note: this must run *after* the cluster and secrets are created, or the script
 # won't work.
+#
+# TODO: Investigate why we can't attach the provisioner directly to the ec_deployment resource.
+# Some informal testing with a minimal TF configuration that just uses the EC provider
+# shows that this *should* work.
 resource "null_resource" "elasticsearch_users" {
   triggers = {
     pipeline_storage_elastic_id = local.pipeline_storage_elastic_id

--- a/pipeline/terraform/stack/locals.tf
+++ b/pipeline/terraform/stack/locals.tf
@@ -12,9 +12,10 @@ locals {
   es_images_augmented_index = "images-augmented-${var.pipeline_date}"
   es_images_index           = "images-${var.pipeline_date}"
 
-  # The max number of connections allowed by the instance
+  # The max number of connections allowed by the instance.
   # specified at /infrastructure/critical/rds_id_minter.tf
-  id_minter_rds_max_connections  = 2 * 45
+  base_rds_instances             = 1
+  id_minter_rds_max_connections  = (local.base_rds_instances + local.extra_rds_instances) * 45
   id_minter_task_max_connections = min(9, var.max_capacity)
 
   services = [

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -52,9 +52,9 @@ module "matcher" {
 
     dynamo_lock_timeout = local.lock_timeout
 
-    es_index                           = local.es_works_identified_index
-    read_ingest_batch_size             = 100
-    read_ingest_flush_interval_seconds = 30
+    es_index                    = local.es_works_identified_index
+    read_batch_size             = 100
+    read_flush_interval_seconds = 30
   }
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["matcher"]

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -4,7 +4,7 @@ variable "pipeline_date" {
 
 variable "max_capacity" {
   type        = number
-  default     = 10
+  default     = 15
   description = "The max capacity of every ECS service will be less than or equal to this value"
 }
 

--- a/reindexer/get_reindex_status.py
+++ b/reindexer/get_reindex_status.py
@@ -71,8 +71,12 @@ def get_pipeline_storage_es_client(session, *, reindex_date):
     host = get_secret_string(session, secret_id=f"{secret_prefix}/public_host")
     port = get_secret_string(session, secret_id=f"{secret_prefix}/port")
     protocol = get_secret_string(session, secret_id=f"{secret_prefix}/protocol")
-    username = get_secret_string(session, secret_id=f"{secret_prefix}/read_only/es_username")
-    password = get_secret_string(session, secret_id=f"{secret_prefix}/read_only/es_password")
+    username = get_secret_string(
+        session, secret_id=f"{secret_prefix}/read_only/es_username"
+    )
+    password = get_secret_string(
+        session, secret_id=f"{secret_prefix}/read_only/es_password"
+    )
 
     return Elasticsearch(f"{protocol}://{username}:{password}@{host}:{port}")
 


### PR DESCRIPTION
Infrastructure changes in this reindex:

* The ingestors should be using VPC endpoints to talk to the catalogue cluster, not going over the public Internet/NAT Gateway (#1311)
* Alice's improvements to use batch Elasticsearch reads in all our apps (#1313, #1325)
* A dedicated Elasticsearch cluster just for this pipeline (#1329)

Data transformation changes in this reindex:

* Better logging for unrecognised codes in Sierra languages (#1305)
* De-duplication of certain fields in the Sierra transformer (#1309)
* Nick's change to add contributorAgents to derivedWorkData (#1315), which opens the door to aggregating on contributors
* More parsing of access conditions in the Sierra transformer (#1324)