### PR TITLE
Lazy indexing in the works ingestor

### DIFF
--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -17,7 +17,14 @@ class ElasticIndexer[T: Indexable](
   client: ElasticClient,
   index: Index,
   config: IndexConfig,
-  skipReindexingIdenticalDocuments: Boolean = false)(implicit ec: ExecutionContext, encoder: Encoder[T], decoder: Decoder[T])
+  // This flag defaults to false because it adds extra work, and we should
+  // only enable it that if we think it's likely to save a lot of indexing.
+  skipReindexingIdenticalDocuments: Boolean = false
+)(
+  implicit
+  ec: ExecutionContext,
+  encoder: Encoder[T],
+  decoder: Decoder[T])
     extends Indexer[T]
     with Logging {
 

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
@@ -27,7 +27,7 @@ import uk.ac.wellcome.pipeline_storage.{
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait ElasticIndexerTestBase
-  extends IndexerTestCases[Index, SampleDocument]
+    extends IndexerTestCases[Index, SampleDocument]
     with ElasticsearchFixtures {
   val skipReindexingIdenticalDocuments: Boolean
 
@@ -98,7 +98,7 @@ trait ElasticIndexerTestBase
     }
 
     object StrictWithNoDataIndexConfig
-      extends IndexConfig
+        extends IndexConfig
         with IndexConfigFields {
 
       import com.sksamuel.elastic4s.ElasticDsl._
@@ -144,7 +144,7 @@ trait ElasticIndexerTestBase
     )
 
     object UnmappedDataMappingIndexConfig
-      extends IndexConfig
+        extends IndexConfig
         with IndexConfigFields {
 
       import com.sksamuel.elastic4s.ElasticDsl._

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
@@ -26,9 +26,10 @@ import uk.ac.wellcome.pipeline_storage.{
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ElasticIndexerTest
-    extends IndexerTestCases[Index, SampleDocument]
+trait ElasticIndexerTestBase
+  extends IndexerTestCases[Index, SampleDocument]
     with ElasticsearchFixtures {
+  val skipReindexingIdenticalDocuments: Boolean
 
   import SampleDocument._
 
@@ -97,7 +98,7 @@ class ElasticIndexerTest
     }
 
     object StrictWithNoDataIndexConfig
-        extends IndexConfig
+      extends IndexConfig
         with IndexConfigFields {
 
       import com.sksamuel.elastic4s.ElasticDsl._
@@ -143,7 +144,7 @@ class ElasticIndexerTest
     )
 
     object UnmappedDataMappingIndexConfig
-        extends IndexConfig
+      extends IndexConfig
         with IndexConfigFields {
 
       import com.sksamuel.elastic4s.ElasticDsl._
@@ -205,4 +206,12 @@ class ElasticIndexerTest
       }
     }
   }
+}
+
+class ElasticIndexerTest extends ElasticIndexerTestBase {
+  val skipReindexingIdenticalDocuments = true
+}
+
+class ElasticIndexerWithSkipReindexTest extends ElasticIndexerTestBase {
+  val skipReindexingIdenticalDocuments = false
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
@@ -46,6 +46,7 @@ trait ElasticIndexerFixtures extends ElasticsearchFixtures with Akka {
                                config: IndexConfig = NoStrictMapping)(
     testWith: TestWith[ElasticIndexer[T], R])(implicit
                                               ec: ExecutionContext,
+                                              decoder: Decoder[T],
                                               encoder: Encoder[T],
                                               indexable: Indexable[T]): R =
     testWith(new ElasticIndexer[T](esClient, idx, config))

--- a/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/ElasticIndexerBuilder.scala
+++ b/common/pipeline_storage_typesafe/src/main/scala/uk/ac/wellcome/pipeline_storage/typesafe/ElasticIndexerBuilder.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.pipeline_storage.typesafe
 
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import com.typesafe.config.Config
-import io.circe.Encoder
+import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.elasticsearch.IndexConfig
 import uk.ac.wellcome.pipeline_storage.{ElasticIndexer, Indexable}
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
@@ -14,15 +14,18 @@ object ElasticIndexerBuilder {
     config: Config,
     client: ElasticClient,
     namespace: String = "",
-    indexConfig: IndexConfig
+    indexConfig: IndexConfig,
+    skipReindexingIdenticalDocuments: Boolean = false
   )(
     implicit
     ec: ExecutionContext,
+    decoder: Decoder[T],
     encoder: Encoder[T]
   ): ElasticIndexer[T] =
     new ElasticIndexer[T](
       client = client,
       index = Index(config.requireString(s"es.$namespace.index")),
-      config = indexConfig
+      config = indexConfig,
+      skipReindexingIdenticalDocuments = skipReindexingIdenticalDocuments
     )
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/uk/ac/wellcome/platform/ingestor/works/Main.scala
@@ -40,7 +40,6 @@ object Main extends WellcomeTypesafeApp {
       ElasticBuilder.buildElasticClient(config, namespace = "catalogue"),
       namespace = "indexed-works",
       indexConfig = IndexedWorkIndexConfig,
-
       // The relation embedder will re-send an ID for a Work every time it adds
       // a new relation.  This is why we see way more IDs than there are Works on
       // the ingestor queue during a reindex.


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4999

Because the relation embedder runs so much faster than the ingestor, the final step of a reindex often ends with 2.5M+ messages on the ingestor queue while the relation embedder is finished.

Once the relation embedder is done, sending the same ID to the ingestor more than once won't change anything, but it will cause unnecessary index operations in Elasticsearch. This patch modifies the works ingestor to ask ES first _"hey, do you have any of the Works I'm about to index?"_, and to skip indexing anything which is **identical** to what's already in ES.

I've only enabled this in the works ingestor, because that's the only service where we expect to see a non-trivial saving here.