### PR TITLE
Extract calm api client classes to a common project

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,8 @@ steps:
     label: "ingestor common"
   - command: .buildkite/scripts/run_job.py transformer_common
     label: "transformer common"
+  - command: .buildkite/scripts/run_job.py calm_api_client
+    label: "calm api client"
   - wait
   - command: .buildkite/scripts/run_job.py api
     label: "API"

--- a/.sbt_metadata/calm_adapter.json
+++ b/.sbt_metadata/calm_adapter.json
@@ -2,8 +2,8 @@
   "id" : "calm_adapter",
   "folder" : "calm_adapter/calm_adapter",
   "dependencyIds" : [
+    "calm_api_client",
     "internal_model",
-    "source_model_typesafe",
-    "flows"
+    "source_model_typesafe"
   ]
 }

--- a/.sbt_metadata/calm_api_client.json
+++ b/.sbt_metadata/calm_api_client.json
@@ -1,0 +1,7 @@
+{
+  "id" : "calm_api_client",
+  "folder" : "calm_adapter/calm_api_client",
+  "dependencyIds" : [
+    "flows"
+  ]
+}

--- a/.sbt_metadata/calm_deletion_checker.json
+++ b/.sbt_metadata/calm_deletion_checker.json
@@ -2,6 +2,7 @@
   "id" : "calm_deletion_checker",
   "folder" : "calm_adapter/calm_deletion_checker",
   "dependencyIds" : [
+    "calm_api_client",
     "source_model_typesafe"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -240,17 +240,24 @@ lazy val mets_adapter = setupProject(
 
 // CALM adapter
 
+lazy val calm_api_client = setupProject(
+  project,
+  folder = "calm_adapter/calm_api_client",
+  localDependencies = Seq(flows),
+  externalDependencies = CatalogueDependencies.calmApiClientDependencies
+)
+
 lazy val calm_adapter = setupProject(
   project,
   folder = "calm_adapter/calm_adapter",
-  localDependencies = Seq(internal_model, source_model_typesafe, flows),
-  externalDependencies = CatalogueDependencies.calmAdapterDependencies
+  localDependencies =
+    Seq(calm_api_client, internal_model, source_model_typesafe)
 )
 
 lazy val calm_deletion_checker = setupProject(
   project,
   folder = "calm_adapter/calm_deletion_checker",
-  localDependencies = Seq(source_model_typesafe)
+  localDependencies = Seq(calm_api_client, source_model_typesafe)
 )
 
 // Inference manager

--- a/calm_adapter/Makefile
+++ b/calm_adapter/Makefile
@@ -9,7 +9,7 @@ SBT_APPS = calm_adapter calm_deletion_checker
 SBT_NO_DOCKER_APPS =
 
 SBT_DOCKER_LIBRARIES =
-SBT_NO_DOCKER_LIBRARIES =
+SBT_NO_DOCKER_LIBRARIES = calm_api_client
 
 PYTHON_APPS =
 LAMBDAS = calm_window_generator calm_deletion_check_initiator

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerService.scala
@@ -9,6 +9,11 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.platform.calm_api_client.{
+  CalmQuery,
+  CalmRecord,
+  CalmRetriever
+}
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.typesafe.Runnable

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/CalmStore.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.calm_adapter
 
 import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.calm_api_client.CalmRecord
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.{
   Identified,

--- a/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Main.scala
@@ -9,6 +9,12 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.calm_api_client.{
+  CalmAkkaHttpClient,
+  CalmHttpClient,
+  CalmRecord,
+  HttpCalmRetriever
+}
 import weco.catalogue.source_model.config.SourceVHSBuilder
 
 object Main extends WellcomeTypesafeApp {

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.calm_adapter
 
 import java.time.{Instant, LocalDate}
+
 import akka.NotUsed
 import akka.stream.scaladsl._
 import io.circe.Encoder
@@ -18,6 +19,12 @@ import uk.ac.wellcome.messaging.memory.{
   MemoryMessageSender
 }
 import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.platform.calm_api_client
+import uk.ac.wellcome.platform.calm_api_client.{
+  CalmQuery,
+  CalmRecord,
+  CalmRetriever
+}
 import uk.ac.wellcome.storage.{Identified, Version}
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.MemoryStore
@@ -45,8 +52,10 @@ class CalmAdapterWorkerServiceTest
   val instantB = Instant.ofEpochSecond(instantA.getEpochSecond + 1)
   val instantC = Instant.ofEpochSecond(instantA.getEpochSecond + 2)
   val recordA = CalmRecord("A", Map("RecordID" -> List("A")), instantA)
-  val recordB = CalmRecord("B", Map("RecordID" -> List("B")), instantB)
-  val recordC = CalmRecord("C", Map("RecordID" -> List("C")), instantC)
+  val recordB =
+    calm_api_client.CalmRecord("B", Map("RecordID" -> List("B")), instantB)
+  val recordC =
+    calm_api_client.CalmRecord("C", Map("RecordID" -> List("C")), instantC)
   val queryDate = LocalDate.of(2000, 1, 1)
 
   it("processes an incoming window, storing records and publishing keys") {
@@ -116,9 +125,9 @@ class CalmAdapterWorkerServiceTest
       def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
         val timestamp = Instant.now
         val records = List(
-          CalmRecord("A", Map.empty, timestamp),
-          CalmRecord("B", Map.empty, timestamp),
-          CalmRecord("C", Map.empty, timestamp),
+          calm_api_client.CalmRecord("A", Map.empty, timestamp),
+          calm_api_client.CalmRecord("B", Map.empty, timestamp),
+          calm_api_client.CalmRecord("C", Map.empty, timestamp),
         )
         Source.fromIterator(() => records.toIterator)
       }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -19,7 +19,6 @@ import uk.ac.wellcome.messaging.memory.{
   MemoryMessageSender
 }
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.platform.calm_api_client
 import uk.ac.wellcome.platform.calm_api_client.{
   CalmQuery,
   CalmRecord,
@@ -53,9 +52,9 @@ class CalmAdapterWorkerServiceTest
   val instantC = Instant.ofEpochSecond(instantA.getEpochSecond + 2)
   val recordA = CalmRecord("A", Map("RecordID" -> List("A")), instantA)
   val recordB =
-    calm_api_client.CalmRecord("B", Map("RecordID" -> List("B")), instantB)
+    CalmRecord("B", Map("RecordID" -> List("B")), instantB)
   val recordC =
-    calm_api_client.CalmRecord("C", Map("RecordID" -> List("C")), instantC)
+    CalmRecord("C", Map("RecordID" -> List("C")), instantC)
   val queryDate = LocalDate.of(2000, 1, 1)
 
   it("processes an incoming window, storing records and publishing keys") {
@@ -125,9 +124,9 @@ class CalmAdapterWorkerServiceTest
       def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
         val timestamp = Instant.now
         val records = List(
-          calm_api_client.CalmRecord("A", Map.empty, timestamp),
-          calm_api_client.CalmRecord("B", Map.empty, timestamp),
-          calm_api_client.CalmRecord("C", Map.empty, timestamp),
+          CalmRecord("A", Map.empty, timestamp),
+          CalmRecord("B", Map.empty, timestamp),
+          CalmRecord("C", Map.empty, timestamp),
         )
         Source.fromIterator(() => records.toIterator)
       }

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -10,7 +10,6 @@ import weco.catalogue.source_model.fixtures.SourceVHSFixture
 import weco.catalogue.source_model.store.SourceVHS
 import java.time.Instant
 
-import uk.ac.wellcome.platform.calm_api_client
 import uk.ac.wellcome.platform.calm_api_client.CalmRecord
 
 class CalmStoreTest
@@ -36,10 +35,7 @@ class CalmStoreTest
         createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
-      val record = calm_api_client.CalmRecord(
-        "A",
-        Map("key" -> List("value")),
-        retrievedAt)
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
 
       val (storedId, storedLocation, storedRecord) =
         calmStore.putRecord(record).value.get
@@ -57,8 +53,8 @@ class CalmStoreTest
 
     it("replaces a stored record if the data is newer and different") {
       val oldRecord =
-        calm_api_client.CalmRecord("A", oldData, oldTime, published = true)
-      val newRecord = calm_api_client.CalmRecord("A", newData, newTime)
+        CalmRecord("A", oldData, oldTime, published = true)
+      val newRecord = CalmRecord("A", newData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -84,8 +80,8 @@ class CalmStoreTest
     it(
       "does not replace a stored CALM record if the retrieval date is newer and the data is the same") {
       val oldRecord =
-        calm_api_client.CalmRecord("A", data, oldTime, published = true)
-      val newRecord = calm_api_client.CalmRecord("A", data, newTime)
+        CalmRecord("A", data, oldTime, published = true)
+      val newRecord = CalmRecord("A", data, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -102,8 +98,8 @@ class CalmStoreTest
     it(
       "replaces a stored CALM record if the data is the same but it is not recorded as published") {
       val oldRecord =
-        calm_api_client.CalmRecord("A", oldData, oldTime, published = false)
-      val newRecord = calm_api_client.CalmRecord("A", oldData, newTime)
+        CalmRecord("A", oldData, oldTime, published = false)
+      val newRecord = CalmRecord("A", oldData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -128,8 +124,8 @@ class CalmStoreTest
 
     it(
       "does not replace a stored CALM record if the retrieval date on the new record is older") {
-      val oldRecord = calm_api_client.CalmRecord("A", oldData, oldTime)
-      val newRecord = calm_api_client.CalmRecord("A", newData, newTime)
+      val oldRecord = CalmRecord("A", oldData, oldTime)
+      val newRecord = CalmRecord("A", newData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -144,10 +140,7 @@ class CalmStoreTest
     }
 
     it("doesn't store CALM records when checking the stored data fails") {
-      val record = calm_api_client.CalmRecord(
-        "A",
-        Map("key" -> List("value")),
-        retrievedAt)
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
 
       val calmStore = new CalmStore(createSourceVHS[CalmRecord]) {
         override def shouldStoreRecord(record: CalmRecord): Result[Boolean] =
@@ -159,9 +152,9 @@ class CalmStoreTest
 
     it("errors if the data differs but timestamp is the same") {
       val x =
-        calm_api_client.CalmRecord("A", Map("key" -> List("x")), retrievedAt)
+        CalmRecord("A", Map("key" -> List("x")), retrievedAt)
       val y =
-        calm_api_client.CalmRecord("A", Map("key" -> List("y")), retrievedAt)
+        CalmRecord("A", Map("key" -> List("y")), retrievedAt)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -178,10 +171,7 @@ class CalmStoreTest
 
   describe("setRecordPublished") {
     it("sets Calm records as published") {
-      val record = calm_api_client.CalmRecord(
-        "A",
-        Map("key" -> List("value")),
-        retrievedAt)
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
       record.published shouldBe false
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
@@ -201,10 +191,7 @@ class CalmStoreTest
     }
 
     it("fails setting Calm record as published if version already exists") {
-      val record = calm_api_client.CalmRecord(
-        "A",
-        Map("key" -> List("value")),
-        retrievedAt)
+      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
       record.published shouldBe false
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =

--- a/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/CalmStoreTest.scala
@@ -8,8 +8,10 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.{Identified, Version}
 import weco.catalogue.source_model.fixtures.SourceVHSFixture
 import weco.catalogue.source_model.store.SourceVHS
-
 import java.time.Instant
+
+import uk.ac.wellcome.platform.calm_api_client
+import uk.ac.wellcome.platform.calm_api_client.CalmRecord
 
 class CalmStoreTest
     extends AnyFunSpec
@@ -34,7 +36,10 @@ class CalmStoreTest
         createSourceVHS[CalmRecord]
       val calmStore = new CalmStore(sourceVHS)
 
-      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val record = calm_api_client.CalmRecord(
+        "A",
+        Map("key" -> List("value")),
+        retrievedAt)
 
       val (storedId, storedLocation, storedRecord) =
         calmStore.putRecord(record).value.get
@@ -51,8 +56,9 @@ class CalmStoreTest
     }
 
     it("replaces a stored record if the data is newer and different") {
-      val oldRecord = CalmRecord("A", oldData, oldTime, published = true)
-      val newRecord = CalmRecord("A", newData, newTime)
+      val oldRecord =
+        calm_api_client.CalmRecord("A", oldData, oldTime, published = true)
+      val newRecord = calm_api_client.CalmRecord("A", newData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -77,8 +83,9 @@ class CalmStoreTest
 
     it(
       "does not replace a stored CALM record if the retrieval date is newer and the data is the same") {
-      val oldRecord = CalmRecord("A", data, oldTime, published = true)
-      val newRecord = CalmRecord("A", data, newTime)
+      val oldRecord =
+        calm_api_client.CalmRecord("A", data, oldTime, published = true)
+      val newRecord = calm_api_client.CalmRecord("A", data, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -94,8 +101,9 @@ class CalmStoreTest
 
     it(
       "replaces a stored CALM record if the data is the same but it is not recorded as published") {
-      val oldRecord = CalmRecord("A", oldData, oldTime, published = false)
-      val newRecord = CalmRecord("A", oldData, newTime)
+      val oldRecord =
+        calm_api_client.CalmRecord("A", oldData, oldTime, published = false)
+      val newRecord = calm_api_client.CalmRecord("A", oldData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -120,8 +128,8 @@ class CalmStoreTest
 
     it(
       "does not replace a stored CALM record if the retrieval date on the new record is older") {
-      val oldRecord = CalmRecord("A", oldData, oldTime)
-      val newRecord = CalmRecord("A", newData, newTime)
+      val oldRecord = calm_api_client.CalmRecord("A", oldData, oldTime)
+      val newRecord = calm_api_client.CalmRecord("A", newData, newTime)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -136,7 +144,10 @@ class CalmStoreTest
     }
 
     it("doesn't store CALM records when checking the stored data fails") {
-      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val record = calm_api_client.CalmRecord(
+        "A",
+        Map("key" -> List("value")),
+        retrievedAt)
 
       val calmStore = new CalmStore(createSourceVHS[CalmRecord]) {
         override def shouldStoreRecord(record: CalmRecord): Result[Boolean] =
@@ -147,8 +158,10 @@ class CalmStoreTest
     }
 
     it("errors if the data differs but timestamp is the same") {
-      val x = CalmRecord("A", Map("key" -> List("x")), retrievedAt)
-      val y = CalmRecord("A", Map("key" -> List("y")), retrievedAt)
+      val x =
+        calm_api_client.CalmRecord("A", Map("key" -> List("x")), retrievedAt)
+      val y =
+        calm_api_client.CalmRecord("A", Map("key" -> List("y")), retrievedAt)
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
         createSourceVHSWith(
@@ -165,7 +178,10 @@ class CalmStoreTest
 
   describe("setRecordPublished") {
     it("sets Calm records as published") {
-      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val record = calm_api_client.CalmRecord(
+        "A",
+        Map("key" -> List("value")),
+        retrievedAt)
       record.published shouldBe false
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =
@@ -185,7 +201,10 @@ class CalmStoreTest
     }
 
     it("fails setting Calm record as published if version already exists") {
-      val record = CalmRecord("A", Map("key" -> List("value")), retrievedAt)
+      val record = calm_api_client.CalmRecord(
+        "A",
+        Map("key" -> List("value")),
+        retrievedAt)
       record.published shouldBe false
 
       implicit val sourceVHS: SourceVHS[CalmRecord] =

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpClient.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpClient.scala
@@ -1,12 +1,13 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.stream.scaladsl._
 import akka.stream.{Materializer, RestartSettings}
 import akka.http.scaladsl._
 import akka.http.scaladsl.model._
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 trait CalmHttpClient {
 

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmQuery.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmQuery.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmRecord.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmRecord.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
 import java.time.Instant
 

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmRetriever.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmRetriever.scala
@@ -1,15 +1,16 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import scala.concurrent.{ExecutionContext, Future}
 import java.time.Instant
-import grizzled.slf4j.Logging
 
 import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import akka.stream.scaladsl._
+import grizzled.slf4j.Logging
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait CalmRetriever {
 

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmSession.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmSession.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
 import akka.http.scaladsl.model.headers.Cookie
 

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequest.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
 import scala.xml.Elem
 

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponse.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponse.scala
@@ -1,8 +1,9 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
 import scala.util.Try
 import scala.xml.{Elem, Node, NodeSeq, XML}
 import java.time.Instant
+
 import akka.http.scaladsl.model.headers.Cookie
 
 trait CalmXmlResponse[T] {
@@ -113,9 +114,10 @@ case class CalmSummaryResponse(root: Elem,
       .flatMap { nodes =>
         val data = toMapping(nodes)
         data.get("RecordID") match {
-          case Some(List(id)) => Right(CalmRecord(id, data, retrievedAt))
-          case Some(_)        => Left(new Exception("Multiple RecordIDs found"))
-          case None           => Left(new Exception("RecordID not found"))
+          case Some(List(id)) =>
+            Right(CalmRecord(id, data, retrievedAt))
+          case Some(_) => Left(new Exception("Multiple RecordIDs found"))
+          case None    => Left(new Exception("RecordID not found"))
         }
       }
 

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpClientTest.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpClientTest.scala
@@ -1,15 +1,16 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import akka.http.scaladsl.model._
+import akka.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
-import akka.stream.Materializer
-import akka.http.scaladsl.model._
-import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class CalmHttpClientTest
     extends AnyFunSpec

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmRetrieverTest.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmRetrieverTest.scala
@@ -1,20 +1,21 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.xml.XML
 import java.time.{Instant, LocalDate}
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.concurrent.ScalaFutures
-import akka.stream.Materializer
-import akka.stream.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
+import akka.stream.Materializer
+import akka.stream.scaladsl._
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.xml.XML
 
 class CalmRetrieverTest
     extends AnyFunSpec

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequestTest.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequestTest.scala
@@ -1,11 +1,12 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import scala.xml.Elem
-import scala.xml.Utility.trim
 import java.time.LocalDate
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.xml.Elem
+import scala.xml.Utility.trim
 
 class CalmXmlRequestTest extends AnyFunSpec with Matchers {
 

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponseTest.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponseTest.scala
@@ -1,10 +1,10 @@
-package uk.ac.wellcome.calm_adapter
+package uk.ac.wellcome.platform.calm_api_client
 
-import org.scalatest.matchers.should.Matchers
 import java.time.Instant
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair}
-import org.scalatest.funspec.AnyFunSpec
 
 class CalmXmlResponseTest extends AnyFunSpec with Matchers {
 
@@ -55,6 +55,7 @@ class CalmXmlResponseTest extends AnyFunSpec with Matchers {
             </UnexpectedResponse>
           </soap:Body>
         </soap:Envelope>
+
       CalmSearchResponse(xml, cookie).parse shouldBe a[Left[_, _]]
     }
   }
@@ -155,6 +156,7 @@ class CalmXmlResponseTest extends AnyFunSpec with Matchers {
             </SummaryHeaderResponse>
           </soap:Body>
         </soap:Envelope>
+
       CalmSummaryResponse(xml, retrievedAt).parse shouldBe Right(
         CalmRecord(
           "123",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -229,7 +229,7 @@ object CatalogueDependencies {
     WellcomeDependencies.typesafeLibrary
 
   val transformerCommonDependencies: Seq[ModuleID] =
-      WellcomeDependencies.storageLibrary
+    WellcomeDependencies.storageLibrary
 
   val apiDependencies: Seq[ModuleID] =
     ExternalDependencies.akkaHttpDependencies ++
@@ -253,7 +253,7 @@ object CatalogueDependencies {
       WellcomeDependencies.messagingTypesafeLibrary
 
   val routerDependencies: Seq[ModuleID] =
-      WellcomeDependencies.messagingTypesafeLibrary
+    WellcomeDependencies.messagingTypesafeLibrary
 
   val batcherDependencies: Seq[ModuleID] =
     ExternalDependencies.scalatestDependencies ++
@@ -296,8 +296,10 @@ object CatalogueDependencies {
 
   // CALM adapter
 
-  val calmAdapterDependencies: Seq[ModuleID] =
-    ExternalDependencies.akkaHttpDependencies
+  val calmApiClientDependencies: Seq[ModuleID] =
+    ExternalDependencies.akkaHttpDependencies ++
+      ExternalDependencies.scalaXmlDependencies ++
+      ExternalDependencies.scalatestDependencies
 
   // Sierra adapter stack
 


### PR DESCRIPTION
Getting this big diff out of the way now, it's possible/likely that some parts of it will make their way back into calm_adapter as I find out how best to abstract things but think it'll be easier this way round.

IntelliJ messed around with the imports a bit; there are no actual code changes here at all.