### PR TITLE
Make sure deleted Works don't get dropped by the merger

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -56,10 +56,7 @@ trait Merger extends MergerLogging {
                 .filterNot { _.isInstanceOf[Work.Deleted[Identified]]}
                 .filterNot { _.sourceIdentifier == target.sourceIdentifier },
             deleted =
-              matchedWorks
-                .filter { _.isInstanceOf[Work.Deleted[Identified]]}
-                .filterNot { _.sourceIdentifier == target.sourceIdentifier }
-                .map { _.asInstanceOf[Work.Deleted[Identified]] },
+              matchedWorks.collect { case w: Work.Deleted[Identified] => w},
           )
         }
     }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -43,7 +43,8 @@ trait Merger extends MergerLogging {
     require(deleted.intersect(sources).isEmpty)
   }
 
-  private def categoriseWorks(works: Seq[Work[Identified]]): Option[CategorisedWorks] =
+  private def categoriseWorks(
+    works: Seq[Work[Identified]]): Option[CategorisedWorks] =
     works match {
       case List(unmatchedWork: Work.Visible[Identified]) =>
         Some(CategorisedWorks(target = unmatchedWork))
@@ -51,12 +52,12 @@ trait Merger extends MergerLogging {
         findTarget(matchedWorks).map { target =>
           CategorisedWorks(
             target = target,
-            sources =
-              matchedWorks
-                .filterNot { _.isInstanceOf[Work.Deleted[Identified]]}
-                .filterNot { _.sourceIdentifier == target.sourceIdentifier },
-            deleted =
-              matchedWorks.collect { case w: Work.Deleted[Identified] => w},
+            sources = matchedWorks
+              .filterNot { _.isInstanceOf[Work.Deleted[Identified]] }
+              .filterNot { _.sourceIdentifier == target.sourceIdentifier },
+            deleted = matchedWorks.collect {
+              case w: Work.Deleted[Identified] => w
+            },
           )
         }
     }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
@@ -19,8 +19,7 @@ class MergerManager(mergerRules: Merger) {
       val result = mergerRules.merge(works)
       assert(result.resultWorks.size == works.size)
       result
-    }
-    else
+    } else
       MergerOutcome.passThrough(works)
   }
 }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerManager.scala
@@ -15,8 +15,11 @@ class MergerManager(mergerRules: Merger) {
   def applyMerge(maybeWorks: Seq[Option[Work[Identified]]]): MergerOutcome = {
     val works = maybeWorks.flatten
 
-    if (works.size == maybeWorks.size)
-      mergerRules.merge(works)
+    if (works.size == maybeWorks.size) {
+      val result = mergerRules.merge(works)
+      assert(result.resultWorks.size == works.size)
+      result
+    }
     else
       MergerOutcome.passThrough(works)
   }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -340,6 +340,53 @@ class MergerWorkerServiceTest
     }
   }
 
+  it("passes through a deleted work unmodified") {
+    val deletedWork = identifiedWork().deleted()
+    val visibleWork = sierraPhysicalIdentifiedWork()
+      .mergeCandidates(
+        List(
+          MergeCandidate(
+            id = IdState.Identified(
+              deletedWork.state.canonicalId,
+              deletedWork.sourceIdentifier),
+            reason = Some("Physical/digitised Sierra work")
+          )
+        )
+      )
+
+    withMergerWorkerServiceFixtures {
+      case (retriever, QueuePair(queue, dlq), senders, _, index) =>
+        retriever.index ++= Map(
+          visibleWork.id -> visibleWork,
+          deletedWork.id -> deletedWork
+        )
+
+        val matcherResult = MatcherResult(
+          Set(
+            MatchedIdentifiers(worksToWorkIdentifiers(List(visibleWork, deletedWork)))
+          ))
+
+        sendNotificationToSQS(queue = queue, message = matcherResult)
+
+        eventually {
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
+
+          getWorksSent(senders) should have size 2
+
+          val visibleWorks = index.collect {
+            case (_, Left(work: Work.Visible[Merged])) => work
+          }
+          val deletedWorks = index.collect {
+            case (_, Left(work: Work.Deleted[Merged])) => work
+          }
+
+          visibleWorks.map { _.id } shouldBe Seq(visibleWork.id)
+          deletedWorks.map { _.id } shouldBe Seq(deletedWork.id)
+        }
+    }
+  }
+
   it("fails if the message sent is not a matcher result") {
     withMergerWorkerServiceFixtures {
       case (_, QueuePair(queue, dlq), _, metrics, index) =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -363,7 +363,8 @@ class MergerWorkerServiceTest
 
         val matcherResult = MatcherResult(
           Set(
-            MatchedIdentifiers(worksToWorkIdentifiers(List(visibleWork, deletedWork)))
+            MatchedIdentifiers(
+              worksToWorkIdentifiers(List(visibleWork, deletedWork)))
           ))
 
         sendNotificationToSQS(queue = queue, message = matcherResult)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -310,13 +310,7 @@ class PlatformMergerTest
       expectedMergedWork)
   }
 
-  it("merges a non-picture Sierra work with a METS work") {
-    val result = merger.merge(
-      works = Seq(sierraPhysicalWork, metsWork)
-    )
-
-    result.mergedWorksWithTime(now).size shouldBe 2
-
+  describe("merges a non-picture Sierra work with a METS work") {
     val physicalItem = sierraPhysicalWork.data.items.head
     val digitalItem = metsWork.data.items.head
 
@@ -345,10 +339,34 @@ class PlatformMergerTest
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
 
-    result.mergedWorksWithTime(now) should contain theSameElementsAs List(
-      expectedMergedWork,
-      expectedRedirectedWork)
-    result.mergedImagesWithTime(now) shouldBe empty
+    it("merges the two Works") {
+      val result = merger.merge(
+        works = Seq(sierraPhysicalWork, metsWork)
+      )
+
+      result.mergedWorksWithTime(now).size shouldBe 2
+
+      result.mergedWorksWithTime(now) should contain(expectedMergedWork)
+      result.mergedWorksWithTime(now) should contain(expectedRedirectedWork)
+
+      result.mergedImagesWithTime(now) shouldBe empty
+    }
+
+    it("ignores a deleted Work when deciding how to merge the other Works") {
+      val deletedWork = identifiedWork().deleted()
+
+      val result = merger.merge(
+        works = Seq(sierraPhysicalWork, metsWork, deletedWork)
+      )
+
+      result.mergedWorksWithTime(now).size shouldBe 3
+
+      result.mergedWorksWithTime(now) should contain(expectedMergedWork)
+      result.mergedWorksWithTime(now) should contain(expectedRedirectedWork)
+      result.mergedWorksWithTime(now) should contain(deletedWork.transition[Merged](now))
+
+      result.mergedImagesWithTime(now) shouldBe empty
+    }
   }
 
   it("merges a picture Sierra work with a METS work") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -620,4 +620,15 @@ class PlatformMergerTest
       physicalVideo,
       digitisedVideo)
   }
+
+  it("returns both Works unmodified if one of the Works is deleted") {
+    val visibleWork = identifiedWork()
+    val deletedWork = identifiedWork().deleted()
+
+    val result = merger.merge(
+      works = Seq(visibleWork, deletedWork)
+    )
+
+    result.resultWorks should contain theSameElementsAs Seq(visibleWork, deletedWork)
+  }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -363,7 +363,8 @@ class PlatformMergerTest
 
       result.mergedWorksWithTime(now) should contain(expectedMergedWork)
       result.mergedWorksWithTime(now) should contain(expectedRedirectedWork)
-      result.mergedWorksWithTime(now) should contain(deletedWork.transition[Merged](now))
+      result.mergedWorksWithTime(now) should contain(
+        deletedWork.transition[Merged](now))
 
       result.mergedImagesWithTime(now) shouldBe empty
     }
@@ -647,6 +648,8 @@ class PlatformMergerTest
       works = Seq(visibleWork, deletedWork)
     )
 
-    result.resultWorks should contain theSameElementsAs Seq(visibleWork, deletedWork)
+    result.resultWorks should contain theSameElementsAs Seq(
+      visibleWork,
+      deletedWork)
   }
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5001

I believe this is why five Works keep disappearing from reindexes. If we can identify a target Work, we'd silently drop the deleted Works and they'd never get out of the merger. Now we pull them out separately, and add them to the MergerOutcome once all the merging logic has been applied.

I've also added some extra assertions that catch this issue, so it'll be easier to spot if something similar happens in future.