### PR TITLE
Default the contributorAgents on DerivedData to Nil

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.models.work.internal
 
 case class DerivedWorkData(
   availableOnline: Boolean,
-  contributorAgents: List[String],
+  contributorAgents: List[String] = Nil,
 )
 
 object DerivedWorkData {


### PR DESCRIPTION
For some reason, there are works in the index that don't have a value for this field (e.g. jpubbjnr).  Requesting them through the API returns a 500 error.

There's no harm in setting a reasonable default here, and hopefully it means these works will stop returning 500 errors.

This is hard to test without writing something to write deliberately bad data into a test index.