### PR TITLE
make genre, subject and contributor filters keyword filters

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DocumentFilter.scala
@@ -27,9 +27,9 @@ case object VisibleWorkFilter extends WorkFilter
 
 case class LanguagesFilter(languageIds: Seq[String]) extends WorkFilter
 
-case class GenreFilter(genreQuery: String) extends WorkFilter
+case class GenreFilter(genreQuery: Seq[String]) extends WorkFilter
 
-case class SubjectFilter(subjectQuery: String) extends WorkFilter
+case class SubjectFilter(subjectQuery: Seq[String]) extends WorkFilter
 
 case class ContributorsFilter(contributorQueries: Seq[String])
     extends WorkFilter

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/QueryParams.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.api.rest
 
 import java.time.LocalDate
-
 import akka.http.scaladsl.server.{Directive, Directives, ValidationRejection}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import com.github.tototoshi.csv.CSVParser
 import io.circe.{Decoder, Json}
 import uk.ac.wellcome.platform.api.models.LicenseFilter
 import uk.ac.wellcome.platform.api.rest.MultipleWorksParams.decodeCommaSeparated
@@ -35,7 +35,17 @@ trait QueryParamsUtils extends Directives {
     Decoder.decodeInt.withErrorMessage("must be a valid Integer")
 
   def decodeCommaSeparated: Decoder[List[String]] =
-    Decoder.decodeString.emap(str => Right(str.split(",").toList))
+    Decoder.decodeString.emap(
+      str =>
+        Right(
+          CSVParser
+            .parse(
+              input = str,
+              escapeChar = '\\',
+              delimiter = ',',
+              quoteChar = '"'
+            )
+            .getOrElse(List(str))))
 
   def decodeOneOf[T](values: (String, T)*): Decoder[T] =
     Decoder.decodeString.emap { str =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -230,10 +230,10 @@ object MultipleWorksParams extends QueryParamsUtils {
     stringListFilter(LanguagesFilter)
 
   implicit val genreFilter: Decoder[GenreFilter] =
-    Decoder.decodeString.emap(str => Right(GenreFilter(str)))
+    decodeCommaSeparated.emap(strs => Right(GenreFilter(strs)))
 
   implicit val subjectFilter: Decoder[SubjectFilter] =
-    Decoder.decodeString.emap(str => Right(SubjectFilter(str)))
+    decodeCommaSeparated.emap(strs => Right(SubjectFilter(strs)))
 
   implicit val contributorsFilter: Decoder[ContributorsFilter] =
     decodeCommaSeparated.emap(strs => Right(ContributorsFilter(strs)))
@@ -242,7 +242,7 @@ object MultipleWorksParams extends QueryParamsUtils {
     stringListFilter(IdentifiersFilter)
 
   implicit val partOf: Decoder[PartOfFilter] =
-    Decoder.decodeString.map(PartOfFilter(_))
+    Decoder.decodeString.map(PartOfFilter)
 
   implicit val accessStatusFilter: Decoder[AccessStatusFilter] =
     decodeIncludesAndExcludes(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -145,16 +145,12 @@ object WorksRequestBuilder
         RangeQuery("data.production.dates.range.from", lte = lte, gte = gte)
       case LanguagesFilter(languageIds) =>
         termsQuery(field = "data.languages.id", values = languageIds)
-      case GenreFilter(genreQuery) =>
-        searchQueryFilter("data.genres.label", genreQuery)
-      case SubjectFilter(subjectQuery) =>
-        searchQueryFilter("data.subjects.label", subjectQuery)
+      case GenreFilter(genreQueries) =>
+        termsQuery("data.genres.label.keyword", genreQueries)
+      case SubjectFilter(subjectQueries) =>
+        termsQuery("data.subjects.label.keyword", subjectQueries)
       case ContributorsFilter(contributorQueries) =>
-        should(
-          contributorQueries.map { query =>
-            searchQueryFilter("data.contributors.agent.label", query)
-          }
-        )
+        termsQuery("data.contributors.agent.label.keyword", contributorQueries)
       case LicenseFilter(licenseIds) =>
         termsQuery(
           field = "data.items.locations.license.id",
@@ -185,9 +181,4 @@ object WorksRequestBuilder
       case PartOfFilter(id) =>
         termQuery(field = "state.relations.ancestors.id", value = id)
     }
-
-  private def searchQueryFilter(field: String, query: String) =
-    simpleStringQuery(query)
-      .field(field)
-      .defaultOperator("AND")
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -155,7 +155,7 @@ class AggregationsTest
             List(WorkAggregationRequest.Format, WorkAggregationRequest.Subject),
           filters = List(
             FormatFilter(List(Format.Books.id)),
-            SubjectFilter(subjectQuery)
+            SubjectFilter(Seq(subjectQuery))
           )
         )
         whenReady(aggregationQuery(index, searchOptions)) { aggs =>
@@ -179,7 +179,7 @@ class AggregationsTest
             List(WorkAggregationRequest.Format, WorkAggregationRequest.Subject),
           filters = List(
             FormatFilter(List(Format.Books.id)),
-            SubjectFilter(subjectQuery)
+            SubjectFilter(Seq(subjectQuery))
           )
         )
         whenReady(worksService.listOrSearchWorks(index, searchOptions)) { res =>

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -120,7 +120,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
     it("applies all other aggregation-dependent filters to the paired filter") {
       val formatFilter = FormatFilter(Seq("bananas"))
       val languagesFilter = LanguagesFilter(Seq("en"))
-      val genreFilter = GenreFilter("durian")
+      val genreFilter = GenreFilter(Seq("durian"))
       val builder = new WorkFiltersAndAggregationsBuilder(
         aggregationRequests = List(
           WorkAggregationRequest.Format,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFiltersTest.scala
@@ -13,11 +13,15 @@ import uk.ac.wellcome.models.work.generators.{
   ProductionEventGenerators
 }
 import WorkState.Indexed
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+import java.net.URLEncoder
 
 class WorksFiltersTest
     extends ApiWorksTestBase
     with ItemsGenerators
-    with ProductionEventGenerators {
+    with ProductionEventGenerators
+    with TableDrivenPropertyChecks {
 
   it("combines multiple filters") {
     val work1 = indexedWork()
@@ -456,131 +460,212 @@ class WorksFiltersTest
   }
 
   describe("filtering works by genre") {
-    val horror = createGenreWith("horrible stuff")
-    val romcom = createGenreWith("heartwarming stuff")
+    val annualReports = createGenreWith("Annual reports.")
+    val pamphlets = createGenreWith("Pamphlets.")
+    val psychology = createGenreWith("Psychology, Pathological")
+    val darwin = createGenreWith("Darwin \"Jones\", Charles")
 
-    val horrorWork = indexedWork().genres(List(horror))
-    val romcomWork = indexedWork().genres(List(romcom))
-    val romcomHorrorWork = indexedWork().genres(List(romcom, horror))
-    val noGenreWork = indexedWork()
+    val annualReportsWork = indexedWork().genres(List(annualReports))
+    val pamphletsWork = indexedWork().genres(List(pamphlets))
+    val psychologyWork = indexedWork().genres(List(psychology))
+    val darwinWork =
+      indexedWork().genres(List(darwin))
+    val mostThingsWork =
+      indexedWork().genres(List(pamphlets, psychology, darwin))
+    val nothingWork = indexedWork()
 
-    val works = List(horrorWork, romcomWork, romcomHorrorWork, noGenreWork)
+    val works =
+      List(
+        annualReportsWork,
+        pamphletsWork,
+        psychologyWork,
+        darwinWork,
+        mostThingsWork,
+        nothingWork)
 
-    it("filters by genre with partial match") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(routes, s"/$apiPrefix/works?genres.label=horrible") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(horrorWork, romcomHorrorWork).sortBy {
-                _.state.canonicalId
-              }
-            )
-          }
-      }
-    }
+    val testCases = Table(
+      ("query", "results", "clue"),
+      ("Annual reports.", Seq(annualReportsWork), "single match single genre"),
+      (
+        "Pamphlets.",
+        Seq(pamphletsWork, mostThingsWork),
+        "multi match single genre"),
+      (
+        "Annual reports.,Pamphlets.",
+        Seq(annualReportsWork, pamphletsWork, mostThingsWork),
+        "comma separated"),
+      (
+        """Annual reports.,"Psychology, Pathological"""",
+        Seq(annualReportsWork, psychologyWork, mostThingsWork),
+        "commas in quotes"),
+      (
+        """"Darwin \"Jones\", Charles","Psychology, Pathological",Pamphlets.""",
+        Seq(darwinWork, psychologyWork, mostThingsWork, pamphletsWork),
+        "escaped quotes in quotes")
+    )
 
-    it("filters by genre using multiple terms") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(
-            routes,
-            s"/$apiPrefix/works?genres.label=horrible%20heartwarming") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(romcomHorrorWork))
+    it("filters by genres as a comma separated list") {
+      forAll(testCases) {
+        (query: String,
+         results: Seq[Work.Visible[WorkState.Indexed]],
+         clue: String) =>
+          withClue(clue) {
+            withWorksApi {
+              case (worksIndex, routes) =>
+                insertIntoElasticsearch(worksIndex, works: _*)
+                assertJsonResponse(
+                  routes,
+                  s"/$apiPrefix/works?genres.label=${URLEncoder.encode(query, "UTF-8")}") {
+                  Status.OK -> worksListResponse(
+                    apiPrefix,
+                    works = results.sortBy {
+                      _.state.canonicalId
+                    }
+                  )
+                }
+            }
           }
       }
     }
   }
 
   describe("filtering works by subject") {
-    val nineteenthCentury = createSubjectWith("19th Century")
-    val paris = createSubjectWith("Paris")
+    val sanitation = createSubjectWith("Sanitation.")
+    val london = createSubjectWith("London (England)")
+    val psychology = createSubjectWith("Psychology, Pathological")
+    val darwin = createSubjectWith("Darwin \"Jones\", Charles")
 
-    val nineteenthCenturyWork =
-      indexedWork().subjects(List(nineteenthCentury))
-    val parisWork = indexedWork().subjects(List(paris))
-    val nineteenthCenturyParisWork =
-      indexedWork().subjects(List(nineteenthCentury, paris))
-    val noSubjectWork = indexedWork()
+    val sanitationWork = indexedWork().subjects(List(sanitation))
+    val londonWork = indexedWork().subjects(List(london))
+    val psychologyWork = indexedWork().subjects(List(psychology))
+    val darwinWork =
+      indexedWork().subjects(List(darwin))
+    val mostThingsWork =
+      indexedWork().subjects(List(london, psychology, darwin))
+    val nothingWork = indexedWork()
 
-    val works = List(
-      nineteenthCenturyWork,
-      parisWork,
-      nineteenthCenturyParisWork,
-      noSubjectWork)
+    val works =
+      List(
+        sanitationWork,
+        londonWork,
+        psychologyWork,
+        darwinWork,
+        mostThingsWork,
+        nothingWork)
 
-    it("filters by subjects") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(routes, s"/$apiPrefix/works?subjects.label=paris") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(parisWork, nineteenthCenturyParisWork).sortBy {
-                _.state.canonicalId
-              }
-            )
-          }
-      }
-    }
+    val testCases = Table(
+      ("query", "results", "clue"),
+      ("Sanitation.", Seq(sanitationWork), "single match single subject"),
+      (
+        "London (England)",
+        Seq(londonWork, mostThingsWork),
+        "multi match single subject"),
+      (
+        "Sanitation.,London (England)",
+        Seq(sanitationWork, londonWork, mostThingsWork),
+        "comma separated"),
+      (
+        """Sanitation.,"Psychology, Pathological"""",
+        Seq(sanitationWork, psychologyWork, mostThingsWork),
+        "commas in quotes"),
+      (
+        """"Darwin \"Jones\", Charles","Psychology, Pathological",London (England)""",
+        Seq(darwinWork, psychologyWork, londonWork, mostThingsWork),
+        "escaped quotes in quotes")
+    )
 
-    it("filters by subjects using multiple terms") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(
-            routes,
-            s"/$apiPrefix/works?subjects.label=19th%20century%20paris") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(nineteenthCenturyParisWork)
-            )
+    it("filters by subjects as a comma separated list") {
+      forAll(testCases) {
+        (query: String,
+         results: Seq[Work.Visible[WorkState.Indexed]],
+         clue: String) =>
+          withClue(clue) {
+            withWorksApi {
+              case (worksIndex, routes) =>
+                insertIntoElasticsearch(worksIndex, works: _*)
+                assertJsonResponse(
+                  routes,
+                  s"/$apiPrefix/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}") {
+                  Status.OK -> worksListResponse(
+                    apiPrefix,
+                    works = results.sortBy {
+                      _.state.canonicalId
+                    }
+                  )
+                }
+            }
           }
       }
     }
   }
 
   describe("filtering works by contributors") {
+    val patricia = Contributor(agent = Person("Bath, Patricia"), roles = Nil)
     val karlMarx = Contributor(agent = Person("Karl Marx"), roles = Nil)
     val jakePaul = Contributor(agent = Person("Jake Paul"), roles = Nil)
+    val darwin =
+      Contributor(agent = Person("Darwin \"Jones\", Charles"), roles = Nil)
 
-    val workA = indexedWork(canonicalId = "A").contributors(List(karlMarx))
-    val workB = indexedWork(canonicalId = "B").contributors(List(jakePaul))
-    val workC = indexedWork(canonicalId = "C")
-      .contributors(List(karlMarx, jakePaul))
-    val workD = indexedWork(canonicalId = "D").contributors(Nil)
-    val works = List(workA, workB, workC, workD)
+    val patriciaWork = indexedWork().contributors(List(patricia))
+    val karlMarxWork =
+      indexedWork().contributors(List(karlMarx))
+    val jakePaulWork =
+      indexedWork().contributors(List(jakePaul))
+    val darwinWork = indexedWork().contributors(List(darwin))
+    val patriciaDarwinWork = indexedWork()
+      .contributors(List(patricia, darwin))
+    val noContributorsWork = indexedWork().contributors(Nil)
 
-    it("filters by a single contributor") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(
-            routes,
-            s"/$apiPrefix/works?contributors.agent.label=marx") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(workA, workC)
-            )
-          }
-      }
-    }
+    val works = List(
+      patriciaWork,
+      karlMarxWork,
+      jakePaulWork,
+      darwinWork,
+      patriciaDarwinWork,
+      noContributorsWork)
 
-    it("filters by a multiple contributors") {
-      withWorksApi {
-        case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
-          assertJsonResponse(
-            routes,
-            s"/$apiPrefix/works?contributors.agent.label=marx,paul") {
-            Status.OK -> worksListResponse(
-              apiPrefix,
-              works = Seq(workA, workB, workC)
-            )
+    val testCases = Table(
+      ("query", "results", "clue"),
+      ("Karl Marx", Seq(karlMarxWork), "single match"),
+      (
+        """"Bath, Patricia"""",
+        Seq(patriciaWork, patriciaDarwinWork),
+        "multi match"),
+      (
+        "Karl Marx,Jake Paul",
+        Seq(karlMarxWork, jakePaulWork),
+        "comma separated"),
+      (
+        """"Bath, Patricia",Karl Marx""",
+        Seq(patriciaWork, patriciaDarwinWork, karlMarxWork),
+        "commas in quotes"),
+      (
+        """"Bath, Patricia",Karl Marx,"Darwin \"Jones\", Charles"""",
+        Seq(patriciaWork, karlMarxWork, darwinWork, patriciaDarwinWork),
+        "quotes in quotes"),
+    )
+
+    it("filters by contributors as a comma separated list") {
+      forAll(testCases) {
+        (query: String,
+         results: Seq[Work.Visible[WorkState.Indexed]],
+         clue: String) =>
+          withClue(clue) {
+            withWorksApi {
+              case (worksIndex, routes) =>
+                insertIntoElasticsearch(worksIndex, works: _*)
+                assertJsonResponse(
+                  routes,
+                  s"/$apiPrefix/works?contributors.agent.label=${URLEncoder
+                    .encode(query, "UTF-8")}") {
+                  Status.OK -> worksListResponse(
+                    apiPrefix,
+                    works = results.sortBy {
+                      _.state.canonicalId
+                    }
+                  )
+                }
+            }
           }
       }
     }


### PR DESCRIPTION
#1320 

After conversations with @jtweed we have decided to make these filters strict filters on the label of the genres, subjects and contributors (concepts).

This will be more inline with what we have for any other filters, i.e. `language`, `workType`, `...`, and how they interact with aggregations, which are used by the client to then link to these filters <sup>*</sup>.

We will leave more freestyle text search to the `query` parameter.

When we move into actual concept search, and how scoring works within that, we will probably have another endpoint, e.g. `/concepts?query=boom` and use the learning from other relevancy search we have applied elsewhere.

---
# Example (taken from tests)

* `contributors.agent.label="Bath, Patricia",Karl Marx,"Darwin \"Jones\", Charles"` searches for any works with any of the below contributors
  * `Bath, Patricia`
  * `Karl Marx`
  * `Darwin "Jones", Charles`
---

<sup>*</sup> this goes back to a conversation as well where I have suggested we create the aggregations with this use case rather than creating a pseudo version of the internal model, RFC to come)

![aggs_filters](https://user-images.githubusercontent.com/31692/106764827-144d3680-6630-11eb-9d1d-5434220fb9e6.png)