### PR TITLE
Add worker service and deletion marker for calm deletions

### DIFF
--- a/calm_adapter/calm_deletion_checker/docker-compose.yml
+++ b/calm_adapter/calm_deletion_checker/docker-compose.yml
@@ -2,3 +2,8 @@ sqs:
   image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
   ports:
     - "9324:9324"
+
+dynamodb:
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/peopleperhour/dynamodb"
+  ports:
+    - "45678:8000"

--- a/calm_adapter/calm_deletion_checker/src/main/resources/application.conf
+++ b/calm_adapter/calm_deletion_checker/src/main/resources/application.conf
@@ -5,3 +5,4 @@ aws.vhs.s3.bucketName=${?vhs_bucket_name}
 calm.api.url=${?calm_api_url}
 calm.api.username=${?calm_api_username}
 calm.api.password=${?calm_api_password}
+calm.deletion_checker.batch_size=${?batch_size}

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionChecker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionChecker.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.calm_deletion_checker
+
+import uk.ac.wellcome.platform.calm_api_client.CalmRetriever
+import weco.catalogue.source_model.CalmSourcePayload
+
+import scala.concurrent.Future
+
+class DeletionChecker(calmRetriever: CalmRetriever) {
+
+  def deletedRecords(
+    batch: Seq[CalmSourcePayload]): Future[Set[CalmSourcePayload]] =
+    ???
+
+}

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
@@ -65,7 +65,7 @@ class DeletionCheckerWorkerService[Destination](
         case (msg, record, Deleted) =>
           Future
             .fromTry(markDeleted(record))
-            .map(messageSender.sendT)
+            .map(messageSender.sendT[CalmSourcePayload])
             .map(_ => msg)
         case (msg, _, Extant) => Future.successful(msg)
       }

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
@@ -1,20 +1,57 @@
 package uk.ac.wellcome.platform.calm_deletion_checker
 
-import akka.Done
+import akka.{Done, NotUsed}
+import akka.stream.scaladsl.{Flow}
+import software.amazon.awssdk.services.sqs.model.Message
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.calm_api_client.CalmRetriever
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.source_model.CalmSourcePayload
 
-import scala.concurrent.Future
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 class DeletionCheckerWorkerService[Destination](
   msgStream: SQSStream[NotificationMessage],
   messageSender: MessageSender[Destination],
-  calmRetriever: CalmRetriever)
+  calmRetriever: CalmRetriever,
+  batchSize: Int)(implicit ec: ExecutionContext)
     extends Runnable {
 
-  def run(): Future[Done] = Future.successful(Done)
+  private val className = this.getClass.getSimpleName
+  private val batchDuration = 3 minutes
+  private val parallelism = 5
+
+  def run(): Future[Done] = msgStream.runStream(
+    className,
+    source =>
+      source
+        .via(parseBody)
+        .groupedWithin(batchSize, batchDuration)
+        .via(checkDeletions)
+        .mapConcat(identity)
+        .via(updateSourceData)
+  )
+
+  private def parseBody =
+    Flow[(Message, NotificationMessage)]
+      .mapAsyncUnordered(parallelism) {
+        case (msg, NotificationMessage(body)) =>
+          Future
+            .fromTry(fromJson[CalmSourcePayload](body))
+            .map(payload => (msg, payload))
+      }
+
+  private def checkDeletions
+    : Flow[immutable.Seq[(Message, CalmSourcePayload)],
+           immutable.Seq[(Message, CalmSourcePayload, DeletionStatus)],
+           NotUsed] = ???
+
+  private def updateSourceData
+    : Flow[(Message, CalmSourcePayload, DeletionStatus), Message, NotUsed] = ???
 
 }

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.platform.calm_deletion_checker
+
+import akka.Done
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+import uk.ac.wellcome.messaging.sqs.SQSStream
+import uk.ac.wellcome.platform.calm_api_client.CalmRetriever
+import uk.ac.wellcome.typesafe.Runnable
+
+import scala.concurrent.Future
+
+class DeletionCheckerWorkerService[Destination](
+  msgStream: SQSStream[NotificationMessage],
+  messageSender: MessageSender[Destination],
+  calmRetriever: CalmRetriever)
+    extends Runnable {
+
+  def run(): Future[Done] = Future.successful(Done)
+
+}

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerService.scala
@@ -1,23 +1,26 @@
 package uk.ac.wellcome.platform.calm_deletion_checker
 
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.{Flow}
+import akka.Done
+import akka.stream.scaladsl.Flow
 import software.amazon.awssdk.services.sqs.model.Message
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.sqs.SQSStream
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.calm_api_client.CalmRetriever
+import uk.ac.wellcome.platform.calm_api_client.{CalmRecord, CalmRetriever}
 import uk.ac.wellcome.typesafe.Runnable
 import weco.catalogue.source_model.CalmSourcePayload
+import weco.catalogue.source_model.store.SourceVHS
 
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.util.Try
 
 class DeletionCheckerWorkerService[Destination](
   msgStream: SQSStream[NotificationMessage],
   messageSender: MessageSender[Destination],
+  calmVHS: SourceVHS[CalmRecord],
   calmRetriever: CalmRetriever,
   batchSize: Int)(implicit ec: ExecutionContext)
     extends Runnable {
@@ -46,12 +49,36 @@ class DeletionCheckerWorkerService[Destination](
             .map(payload => (msg, payload))
       }
 
-  private def checkDeletions
-    : Flow[immutable.Seq[(Message, CalmSourcePayload)],
-           immutable.Seq[(Message, CalmSourcePayload, DeletionStatus)],
-           NotUsed] = ???
+  private def checkDeletions =
+    Flow[immutable.Seq[(Message, CalmSourcePayload)]]
+      .mapAsyncUnordered(parallelism) { messages =>
+        val (_, batch) = messages.unzip
+        deletionChecker.deletedRecords(batch).map { deleted =>
+          messages.map {
+            case (m, record) if deleted.contains(record) => (m, record, Deleted)
+            case (m, record)                             => (m, record, Extant)
+          }
+        }
+      }
 
-  private def updateSourceData
-    : Flow[(Message, CalmSourcePayload, DeletionStatus), Message, NotUsed] = ???
+  private def updateSourceData =
+    Flow[(Message, CalmSourcePayload, DeletionStatus)]
+      .mapAsyncUnordered(parallelism) {
+        case (msg, record, Deleted) =>
+          Future
+            .fromTry(markRecordDeleted(record))
+            .map(messageSender.sendT)
+            .map(_ => msg)
+        case (msg, _, Extant) => Future.successful(msg)
+      }
+
+  private def markRecordDeleted(
+    record: CalmSourcePayload): Try[CalmSourcePayload] = ???
+
+  private lazy val deletionChecker = new DeletionChecker(calmRetriever)
+
+  sealed trait DeletionStatus extends Product with Serializable
+  case object Deleted extends DeletionStatus
+  case object Extant extends DeletionStatus
 
 }

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionMarker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionMarker.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.platform.calm_deletion_checker
+
+import cats.implicits.toShow
+import org.scanamo.syntax._
+import org.scanamo.{
+  ConditionNotMet,
+  DynamoReadError,
+  Scanamo,
+  ScanamoError,
+  Table
+}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import weco.catalogue.source_model.CalmSourcePayload
+
+import scala.util.{Failure, Success, Try}
+
+class DeletionMarker(sourceTable: Table[CalmSourcePayload])(
+  implicit client: DynamoDbClient) {
+
+  def apply(record: CalmSourcePayload): Try[CalmSourcePayload] =
+    toTry(
+      scanamo.exec(
+        sourceTable
+          .when(attributeNotExists("isDeleted") or "isDeleted" === false)
+          .update(
+            "id" === record.id and "version" === record.version,
+            set("isDeleted", true)
+          )
+      )
+    )
+
+  private def toTry(result: Either[ScanamoError, CalmSourcePayload]) =
+    result match {
+      case Right(record)                    => Success(record)
+      case Left(ConditionNotMet(exception)) => Failure(exception)
+      case Left(error: DynamoReadError) =>
+        Failure(new RuntimeException("Dynamo read error: " + error.show))
+    }
+
+  private lazy val scanamo = Scanamo(client)
+}

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
@@ -26,10 +26,12 @@ object Main extends WellcomeTypesafeApp {
       new CalmAkkaHttpClient()
 
     new DeletionCheckerWorkerService(
-      SQSBuilder.buildSQSStream(config),
-      SNSBuilder
+      msgStream = SQSBuilder.buildSQSStream(config),
+      messageSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "CALM deletion checker"),
-      calmRetriever(config)
+      calmRetriever = calmRetriever(config),
+      batchSize =
+        config.getIntOption("calm.deletion_checker.batch_size").getOrElse(500)
     )
   }
 

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
@@ -3,18 +3,20 @@ package uk.ac.wellcome.platform.calm_deletion_checker
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.Config
+import org.scanamo.Table
+import org.scanamo.generic.auto._
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.platform.calm_api_client.{
   CalmAkkaHttpClient,
   CalmHttpClient,
-  CalmRecord,
   HttpCalmRetriever
 }
-import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-import weco.catalogue.source_model.config.SourceVHSBuilder
+import weco.catalogue.source_model.CalmSourcePayload
 
 import scala.concurrent.ExecutionContext
 
@@ -28,11 +30,17 @@ object Main extends WellcomeTypesafeApp {
     implicit val httpClient: CalmHttpClient =
       new CalmAkkaHttpClient()
 
+    implicit val dynamoClient: DynamoDbClient =
+      DynamoBuilder.buildDynamoClient(config)
+    val dynamoConfig =
+      DynamoBuilder.buildDynamoConfig(config, namespace = "vhs")
+
     new DeletionCheckerWorkerService(
       msgStream = SQSBuilder.buildSQSStream(config),
       messageSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "CALM deletion checker"),
-      calmVHS = SourceVHSBuilder.build[CalmRecord](config),
+      markDeleted =
+        new DeletionMarker(Table[CalmSourcePayload](dynamoConfig.tableName)),
       calmRetriever = calmRetriever(config),
       batchSize =
         config.getIntOption("calm.deletion_checker.batch_size").getOrElse(500)

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
@@ -7,11 +7,14 @@ import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.platform.calm_api_client.{
   CalmAkkaHttpClient,
   CalmHttpClient,
+  CalmRecord,
   HttpCalmRetriever
 }
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import weco.catalogue.source_model.config.SourceVHSBuilder
 
 import scala.concurrent.ExecutionContext
 
@@ -29,6 +32,7 @@ object Main extends WellcomeTypesafeApp {
       msgStream = SQSBuilder.buildSQSStream(config),
       messageSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "CALM deletion checker"),
+      calmVHS = SourceVHSBuilder.build[CalmRecord](config),
       calmRetriever = calmRetriever(config),
       batchSize =
         config.getIntOption("calm.deletion_checker.batch_size").getOrElse(500)

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
@@ -1,12 +1,45 @@
 package uk.ac.wellcome.platform.calm_deletion_checker
 
-import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import com.typesafe.config.Config
+import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.platform.calm_api_client.{
+  CalmAkkaHttpClient,
+  CalmHttpClient,
+  HttpCalmRetriever
+}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
+import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
-import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
-  runWithConfig { _ => () =>
-    Future.successful(Done)
+  runWithConfig { config =>
+    implicit val ec: ExecutionContext = AkkaBuilder.buildExecutionContext()
+    implicit val actorSystem: ActorSystem =
+      AkkaBuilder.buildActorSystem()
+    implicit val materializer: Materializer =
+      AkkaBuilder.buildMaterializer()
+    implicit val httpClient: CalmHttpClient =
+      new CalmAkkaHttpClient()
+
+    new DeletionCheckerWorkerService(
+      SQSBuilder.buildSQSStream(config),
+      SNSBuilder
+        .buildSNSMessageSender(config, subject = "CALM deletion checker"),
+      calmRetriever(config)
+    )
   }
+
+  def calmRetriever(config: Config)(implicit
+                                    ec: ExecutionContext,
+                                    materializer: Materializer,
+                                    httpClient: CalmHttpClient) =
+    new HttpCalmRetriever(
+      url = config.requireString("calm.api.url"),
+      username = config.requireString("calm.api.username"),
+      password = config.requireString("calm.api.password"),
+    )
 }

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/Main.scala
@@ -3,8 +3,6 @@ package uk.ac.wellcome.platform.calm_deletion_checker
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import org.scanamo.Table
-import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.platform.calm_api_client.{
@@ -16,7 +14,6 @@ import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
-import weco.catalogue.source_model.CalmSourcePayload
 
 import scala.concurrent.ExecutionContext
 
@@ -39,8 +36,7 @@ object Main extends WellcomeTypesafeApp {
       msgStream = SQSBuilder.buildSQSStream(config),
       messageSender = SNSBuilder
         .buildSNSMessageSender(config, subject = "CALM deletion checker"),
-      markDeleted =
-        new DeletionMarker(Table[CalmSourcePayload](dynamoConfig.tableName)),
+      markDeleted = new DeletionMarker(dynamoConfig.tableName),
       calmRetriever = calmRetriever(config),
       batchSize =
         config.getIntOption("calm.deletion_checker.batch_size").getOrElse(500)

--- a/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/CalmSourcePayloadGenerators.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/CalmSourcePayloadGenerators.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.calm_deletion_checker
+
+import java.util.UUID
+
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import weco.catalogue.source_model.CalmSourcePayload
+
+trait CalmSourcePayloadGenerators extends S3ObjectLocationGenerators {
+
+  def calmSourcePayloadWith(
+    id: String = UUID.randomUUID().toString,
+    location: S3ObjectLocation = createS3ObjectLocation,
+    version: Int = randomInt(from = 1, to = 10),
+    isDeleted: Boolean = false
+  ): CalmSourcePayload =
+    CalmSourcePayload(
+      id = id,
+      location = location,
+      version = version,
+      isDeleted = isDeleted
+    )
+
+  def calmSourcePayload: CalmSourcePayload = calmSourcePayloadWith()
+
+}

--- a/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionMarkerTest.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionMarkerTest.scala
@@ -1,0 +1,110 @@
+package uk.ac.wellcome.platform.calm_deletion_checker
+
+import org.scalatest.{EitherValues, OptionValues, TryValues}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.{DynamoFormat, Table => ScanamoTable}
+import org.scanamo.syntax._
+import org.scanamo.generic.auto._
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.fixtures.DynamoFixtures
+import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import weco.catalogue.source_model.CalmSourcePayload
+
+import scala.language.higherKinds
+
+case class CalmSourcePayloadWithoutDeletionFlag(
+  id: String,
+  version: Int,
+  location: S3ObjectLocation
+) {
+  def toCalmSourcePayload = CalmSourcePayload(
+    id = id,
+    version = version,
+    location = location,
+  )
+}
+
+class DeletionMarkerTest
+    extends AnyFunSpec
+    with Matchers
+    with TryValues
+    with OptionValues
+    with EitherValues
+    with DynamoFixtures
+    with CalmSourcePayloadGenerators {
+
+  it("marks a record with isDeleted = false as deleted") {
+    val records = Seq.fill(5)(calmSourcePayload)
+    withExistingRecords(records) {
+      case (deletionMarker, table) =>
+        val targetRecord = records.head
+        val result = deletionMarker(targetRecord)
+
+        result.success.value shouldBe targetRecord.copy(isDeleted = true)
+        getRecordFromTable(targetRecord.id, targetRecord.version, table) shouldEqual result.success.value
+    }
+  }
+
+  it("marks a record with no isDeleted attribute as deleted") {
+    val records = Seq.fill(5)(calmSourcePayload).map {
+      case CalmSourcePayload(id, location, version, _) =>
+        CalmSourcePayloadWithoutDeletionFlag(id, version, location)
+    }
+    withExistingRecords(records) {
+      case (deletionMarker, table) =>
+        val targetRecord = records.head.toCalmSourcePayload
+        val result = deletionMarker(targetRecord)
+
+        result.success.value shouldBe targetRecord.copy(isDeleted = true)
+        getRecordFromTable(targetRecord.id, targetRecord.version, table) shouldEqual result.success.value
+    }
+  }
+
+  it("fails if the item is already marked as deleted") {
+    val records = calmSourcePayloadWith(isDeleted = true) +:
+      Seq.fill(4)(calmSourcePayload)
+    withExistingRecords(records) {
+      case (deletionMarker, _) =>
+        val targetRecord = records.head
+        val result = deletionMarker(targetRecord)
+
+        result.failure.exception shouldBe a[ConditionalCheckFailedException]
+    }
+  }
+
+  it("fails if the item does not exist") {
+    withExistingRecords(Seq.fill(5)(calmSourcePayload)) {
+      case (deletionMarker, _) =>
+        val anotherRecord = calmSourcePayload
+        val result = deletionMarker(anotherRecord)
+
+        result.failure.exception shouldBe a[RuntimeException]
+    }
+  }
+
+  override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table =
+    createTableWithHashRangeKey(table)
+
+  def withExistingRecords[T: DynamoFormat, R](records: Seq[T])(
+    testWith: TestWith[(DeletionMarker, Table), R]): R =
+    withLocalDynamoDbTable { table =>
+      putTableItems(records, table)
+      testWith((new DeletionMarker(table.name), table))
+    }
+
+  def getRecordFromTable(
+    id: String,
+    version: Int,
+    table: Table
+  ): CalmSourcePayload =
+    scanamo
+      .exec(
+        ScanamoTable[CalmSourcePayload](table.name)
+          .get("id" === id and "version" === version)
+      )
+      .value
+      .value
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
@@ -11,7 +11,8 @@ sealed trait SourcePayload {
 case class CalmSourcePayload(
   id: String,
   location: S3ObjectLocation,
-  version: Int
+  version: Int,
+  isDeleted: Boolean = false
 ) extends SourcePayload
 
 case class MiroInventorySourcePayload(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.2.0"
+  val defaultVersion = "26.3.0"
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/source/CalmSourceRecord.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/source/CalmSourceRecord.scala
@@ -1,9 +1,0 @@
-package uk.ac.wellcome.platform.reindex.reindex_worker.models.source
-
-import uk.ac.wellcome.storage.s3.S3ObjectLocation
-
-case class CalmSourceRecord(
-  id: String,
-  payload: S3ObjectLocation,
-  version: Int
-)


### PR DESCRIPTION
Things this does:
- Adds a worker service that outlines the flow that will be used (including new features from `SQSStream`)
- Adds a `DeletionMarker` class which updates records in the source Dynamo table to set their `isDeleted` flag to be `true`

Things this does not do:
- There is no checking of whether things are deleted, that's the next thing to be implemented. 

You'll notice that the deletion checker is expected to take batches of records rather than individual ones - I've explained the reasons for that [here](https://github.com/wellcomecollection/docs/blob/calm-deletions-rfc/rfcs/032-calm-deletions/README.md#minimising-calm-api-queries)