### PR TITLE
Use the access status to determine availableOnline

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/DerivedWorkData.scala
@@ -44,8 +44,7 @@ object DerivedWorkData {
   //
   private def isAvailableOnline(items: List[Item[_]]): Boolean =
     items.exists { item =>
-      item
-        .locations
+      item.locations
         .collect { case loc: DigitalLocationDeprecated => loc }
         .exists { locationIsAvailable }
     }
@@ -53,13 +52,13 @@ object DerivedWorkData {
   private def locationIsAvailable(loc: DigitalLocationDeprecated): Boolean =
     loc.accessConditions.isEmpty || !allAccessConditionsAreUnavailable(loc)
 
-  private def allAccessConditionsAreUnavailable(loc: DigitalLocationDeprecated): Boolean =
-    loc
-      .accessConditions
+  private def allAccessConditionsAreUnavailable(
+    loc: DigitalLocationDeprecated): Boolean =
+    loc.accessConditions
       .map { _.status }
       .forall {
-        case Some(AccessStatus.Closed) => true
+        case Some(AccessStatus.Closed)      => true
         case Some(AccessStatus.Unavailable) => true
-        case _ => false
+        case _                              => false
       }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -20,6 +20,14 @@ class DerivedDataTest
         derivedWorkData.availableOnline shouldBe true
       }
 
+      it("is true if the digital location isn't on the first item") {
+        val work = denormalisedWork().items(
+          List(createIdentifiedPhysicalItem, createDigitalItem, createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
+
+        derivedWorkData.availableOnline shouldBe true
+      }
+
       it("is false if there isn't a digital location on any items") {
         val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
         val derivedWorkData = DerivedWorkData(work.data)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -26,7 +26,10 @@ class DerivedDataTest
 
       it("is true if the digital location isn't on the first item") {
         val work = denormalisedWork().items(
-          List(createIdentifiedPhysicalItem, createDigitalItem, createIdentifiedPhysicalItem))
+          List(
+            createIdentifiedPhysicalItem,
+            createDigitalItem,
+            createIdentifiedPhysicalItem))
         val derivedWorkData = DerivedWorkData(work.data)
 
         derivedWorkData.availableOnline shouldBe true
@@ -58,18 +61,20 @@ class DerivedDataTest
             denormalisedWork()
               .items(List(
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = Some(status))
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = Some(status))
+                      )
+                    ))
                 ),
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = Some(status))
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = Some(status))
+                      )
+                    ))
                 ),
                 createIdentifiedPhysicalItem
               ))
@@ -86,18 +91,20 @@ class DerivedDataTest
             denormalisedWork()
               .items(List(
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = Some(status)),
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = Some(status)),
+                      )
+                    ))
                 ),
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = None)
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = None)
+                      )
+                    ))
                 ),
                 createIdentifiedPhysicalItem
               ))
@@ -114,19 +121,21 @@ class DerivedDataTest
             denormalisedWork()
               .items(List(
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = Some(status)),
-                      AccessCondition(status = Some(AccessStatus.Open))
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = Some(status)),
+                        AccessCondition(status = Some(AccessStatus.Open))
+                      )
+                    ))
                 ),
                 createDigitalItemWith(
-                  locations = List(createDigitalLocationWith(
-                    accessConditions = List(
-                      AccessCondition(status = Some(status)),
-                    )
-                  ))
+                  locations = List(
+                    createDigitalLocationWith(
+                      accessConditions = List(
+                        AccessCondition(status = Some(status)),
+                      )
+                    ))
                 ),
                 createIdentifiedPhysicalItem
               ))

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -11,28 +11,28 @@ class DerivedDataTest
     with ImageGenerators {
 
   describe("DerivedWorkData") {
+    describe("availableOnline") {
+      it("is true if there's a digital location on an item") {
+        val work = denormalisedWork().items(
+          List(createDigitalItem, createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
 
-    it("sets availableOnline = true if there is a digital location on an item") {
-      val work = denormalisedWork().items(
-        List(createDigitalItem, createIdentifiedPhysicalItem))
-      val derivedWorkData = DerivedWorkData(work.data)
+        derivedWorkData.availableOnline shouldBe true
+      }
 
-      derivedWorkData.availableOnline shouldBe true
-    }
+      it("is false if there isn't a digital location on any items") {
+        val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
 
-    it(
-      "sets availableOnline = false if there is no digital location on any items") {
-      val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
-      val derivedWorkData = DerivedWorkData(work.data)
+        derivedWorkData.availableOnline shouldBe false
+      }
 
-      derivedWorkData.availableOnline shouldBe false
-    }
+      it("is false if there aren't any items") {
+        val work = denormalisedWork().items(Nil)
+        val derivedWorkData = DerivedWorkData(work.data)
 
-    it("handles empty items list") {
-      val work = denormalisedWork().items(Nil)
-      val derivedWorkData = DerivedWorkData(work.data)
-
-      derivedWorkData.availableOnline shouldBe false
+        derivedWorkData.availableOnline shouldBe false
+      }
     }
 
     it("derives contributorAgents from a heterogenous list of contributors") {


### PR DESCRIPTION
Based on Alexandra's comment in #wc-platform-feedback. I had a quick look at this, and drummed up a very conservative rule:

If a digital location has:

*   at least one access condition, and
*   every access condition has a non-empty AccessStatus, and
*   every access status is Closed or Unavailable

then it feels reasonable to say this location doesn't count as "available", and we should set `availableOnline = false`.

/cc @jamieparkinson as the original author of this code, and the person who knows most about this