### PR TITLE
Point the integration tests build badge at the correct branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | CI Pipeline       | Status                                                                                                                                                                    |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Build             | [![Build status](https://badge.buildkite.com/0ca819db1215b66ecb17019d8ee5331d8e537094d051141219.svg?branch=master)](https://buildkite.com/wellcomecollection/catalogue)   |
-| Integration tests | [![Build status](https://badge.buildkite.com/31a06ac64ab4f09ca5bc5930e21a57889c3f02561260f18ae6.svg?branch=master)](https://buildkite.com/wellcomecollection/integration) |
+| Integration tests | [![Build status](https://badge.buildkite.com/31a06ac64ab4f09ca5bc5930e21a57889c3f02561260f18ae6.svg?branch=main)](https://buildkite.com/wellcomecollection/integration) |
 
 ## Purpose
 


### PR DESCRIPTION
Right now the badge says the build is failing, but if you click through to Buildkite you see it's green.