### PR TITLE
Add a script for cleaning up old indexes in the API cluster

### DIFF
--- a/api/cleanup_unused_api_indexes.py
+++ b/api/cleanup_unused_api_indexes.py
@@ -56,7 +56,7 @@ def list_indexes(es_client):
     """
     Returns a list of indexes in the Elasticsearch cluster, sorted by index name.
     """
-    resp = es_client.get("/_cat/indices", params={"format": "json"})
+    resp = es_client.get("/_cat/indices/works-*,images-*", params={"format": "json"})
     resp.raise_for_status()
 
     return sorted(

--- a/api/cleanup_unused_api_indexes.py
+++ b/api/cleanup_unused_api_indexes.py
@@ -182,8 +182,3 @@ if __name__ == "__main__":
             prod_index_name=prod_index_name,
             stage_index_name=stage_index_name,
         )
-
-    #
-    # from pprint import pprint
-    #
-    # pprint(list_indexes(es_client))

--- a/api/cleanup_unused_api_indexes.py
+++ b/api/cleanup_unused_api_indexes.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import json
+
+import boto3
+
+
+def get_session_with_role(role_arn):
+    """
+    Returns a boto3.Session that uses the given role ARN.
+    """
+    sts_client = boto3.client("sts")
+
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
+    )
+    credentials = assumed_role_object["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_api_es_client(session):
+    """
+    Returns an Elasticsearch client for the catalogue cluster.
+    """
+    secrets = session.client("secretsmanager")
+
+    credentials = json.loads(
+        secrets.get_secret_value(SecretId="elasticsearch/api_cleanup/credentials")[
+            "SecretString"
+        ]
+    )
+
+    return credentials
+
+
+if __name__ == "__main__":
+    session = get_session_with_role(
+        role_arn="arn:aws:iam::760097843905:role/platform-developer"
+    )
+
+    print(get_api_es_client(session))


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5009; related to https://github.com/wellcomecollection/platform/issues/4526

The script fetches some cluster credentials from Elasticsearch, then uses the [cat indices API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html) to get a list of indexes.

If an index starts with `works-` or `images-` and looks like it's older than the indexes used by the API, it will offer ask for confirmation that it's okay to delete. It only deletes an index with explicit confirmation.

Here's a screenshot of a run where I cleaned up all the current old indexes:

<img width="842" alt="Screenshot 2021-02-08 at 11 39 36" src="https://user-images.githubusercontent.com/301220/107215159-d9b61600-6a02-11eb-957a-3ec2430bd20e.png">
