### PR TITLE
Add new AccessStatus types to reflect the Collection Access Policy

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessStatus.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessStatus.scala
@@ -26,7 +26,9 @@ object DisplayAccessStatus {
       case AccessStatus.ByAppointment =>
         DisplayAccessStatus("by-appointment", "By Appointment")
       case AccessStatus.TemporarilyUnavailable =>
-        DisplayAccessStatus("temporarily-unavailable", "Temporarily Unavailable")
+        DisplayAccessStatus(
+          "temporarily-unavailable",
+          "Temporarily Unavailable")
       case AccessStatus.Unavailable =>
         DisplayAccessStatus("unavailable", "Unavailable")
       case AccessStatus.Closed =>

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessStatus.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAccessStatus.scala
@@ -23,12 +23,16 @@ object DisplayAccessStatus {
         DisplayAccessStatus("open-with-advisory", "Open with Advisory")
       case AccessStatus.Restricted =>
         DisplayAccessStatus("restricted", "Restricted")
+      case AccessStatus.ByAppointment =>
+        DisplayAccessStatus("by-appointment", "By Appointment")
+      case AccessStatus.TemporarilyUnavailable =>
+        DisplayAccessStatus("temporarily-unavailable", "Temporarily Unavailable")
+      case AccessStatus.Unavailable =>
+        DisplayAccessStatus("unavailable", "Unavailable")
       case AccessStatus.Closed =>
         DisplayAccessStatus("closed", "Closed")
       case AccessStatus.LicensedResources =>
         DisplayAccessStatus("licensed-resources", "Licensed Resources")
-      case AccessStatus.Unavailable =>
-        DisplayAccessStatus("unavailable", "Unavailable")
       case AccessStatus.PermissionRequired =>
         DisplayAccessStatus("permission-required", "Permission Required")
     }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
@@ -9,6 +9,7 @@ sealed trait AccessStatus { this: AccessStatus =>
   def hasRestrictions: Boolean = this match {
     case AccessStatus.OpenWithAdvisory   => true
     case AccessStatus.Restricted         => true
+    case AccessStatus.ByAppointment      => true
     case AccessStatus.Closed             => true
     case AccessStatus.PermissionRequired => true
     case _                               => false
@@ -17,17 +18,27 @@ sealed trait AccessStatus { this: AccessStatus =>
 
 object AccessStatus {
 
+  // These types should reflect our collections access framework, as described in
+  // Wellcome Collection's Access Policy.
+  // See https://wellcomecollection.org/pages/Wvmu3yAAAIUQ4C7F#access-policy
+  //
+  // This is based on §12 Research access, as retrieved 8 February 2021
+  //
   case object Open extends AccessStatus
 
   case object OpenWithAdvisory extends AccessStatus
 
   case object Restricted extends AccessStatus
 
+  case object ByAppointment extends AccessStatus
+
+  case object TemporarilyUnavailable extends AccessStatus
+
+  case object Unavailable extends AccessStatus
+
   case object Closed extends AccessStatus
 
   case object LicensedResources extends AccessStatus
-
-  case object Unavailable extends AccessStatus
 
   case object PermissionRequired extends AccessStatus
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
@@ -64,11 +64,16 @@ object AccessStatus {
             "cannot be produced",
             "certain restrictions apply",
             "clinical images",
-            "by appointment",
             "the file is restricted",
             "this file is restricted"
           ) =>
         Right(AccessStatus.Restricted)
+
+      case lowerCaseStatus
+          if lowerCaseStatus.startsWith(
+            "by appointment"
+          ) =>
+        Right(AccessStatus.ByAppointment)
 
       case lowerCaseStatus
           if lowerCaseStatus.startsWith(
@@ -83,10 +88,15 @@ object AccessStatus {
       case lowerCaseStatus
           if lowerCaseStatus.startsWith(
             "missing",
-            "temporarily unavailable",
             "deaccessioned"
           ) =>
         Right(AccessStatus.Unavailable)
+
+      case lowerCaseStatus
+          if lowerCaseStatus.startsWith(
+            "temporarily unavailable"
+          ) =>
+        Right(AccessStatus.TemporarilyUnavailable)
 
       case lowerCaseStatus if lowerCaseStatus.startsWith("in copyright") =>
         Right(AccessStatus.LicensedResources)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessStatusTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessStatusTest.scala
@@ -102,7 +102,8 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
       "Temporarily Unavailable.",
     )
     temporarilyUnavailableValues.foreach { str =>
-      AccessStatus.apply(str) shouldBe Right(AccessStatus.TemporarilyUnavailable)
+      AccessStatus.apply(str) shouldBe Right(
+        AccessStatus.TemporarilyUnavailable)
     }
   }
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessStatusTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/AccessStatusTest.scala
@@ -27,7 +27,6 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
       "Restricted access (Data Protection Act)",
       "Cannot Be Produced - View Digitised Version",
       "Certain restrictions apply.",
-      "By Appointment.",
       "Restricted: currently undergoing conservation.",
       "The file is restricted for data protection reasons",
       "This file is restricted for sensitivity reasons"
@@ -40,7 +39,6 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
   it("creates the Unavailable AccessStatus") {
     val unavailableValues = List(
       "Missing.",
-      "Temporarily Unavailable.",
       "Deaccessioned on 01/01/2001"
     )
     unavailableValues.foreach { str =>
@@ -87,6 +85,24 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
     )
     licensedResourcesValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.LicensedResources)
+    }
+  }
+
+  it("creates the ByAppointment AccessStatus") {
+    val byAppointmentValues = List(
+      "By Appointment.",
+    )
+    byAppointmentValues.foreach { str =>
+      AccessStatus.apply(str) shouldBe Right(AccessStatus.ByAppointment)
+    }
+  }
+
+  it("creates the TemporarilyUnavailable AccessStatus") {
+    val temporarilyUnavailableValues = List(
+      "Temporarily Unavailable.",
+    )
+    temporarilyUnavailableValues.foreach { str =>
+      AccessStatus.apply(str) shouldBe Right(AccessStatus.TemporarilyUnavailable)
     }
   }
 


### PR DESCRIPTION
Follows #1353. Closes https://github.com/wellcomecollection/platform/issues/5011

This is something I spotted while doing the Location modelling – these types should reflect our collections access framework, but they weren't quite right. This brings them into sync.