### PR TITLE
Automatically invalidate CloudFront for /works when removing a Miro image

### DIFF
--- a/scripts/remove_work/README.md
+++ b/scripts/remove_work/README.md
@@ -9,6 +9,9 @@ This script:
 - creates CloudFront invalidations for Loris and wellcomecollection.org
 - updates the Miro VHS inventory
 
+Note: Loris may continue to serve an image from its own cache, even if the original image has been removed from S3.
+Since we're decommissioning Loris soon, we aren't planning to fix this.
+
 ### Usage
 
 ```

--- a/scripts/remove_work/README.md
+++ b/scripts/remove_work/README.md
@@ -6,10 +6,8 @@ This script:
 - (optionally) removes associated images from the image indices
 - suppresses Miro works in the VHS
 - removes images from Loris's S3 buckets
-- creates CloudFront invalidations for Loris
+- creates CloudFront invalidations for Loris and wellcomecollection.org
 - updates the Miro VHS inventory
-
-You also need to create a CloudFront invalidation for `works/<id>` in the wellcomecollection.org distribution.
 
 ### Usage
 

--- a/scripts/remove_work/run.py
+++ b/scripts/remove_work/run.py
@@ -49,7 +49,9 @@ def catalogue_client(service_name):
 
 
 def experience_client(service_name):
-    return aws_client(service_name, role_arn="arn:aws:iam::130871440101:role/experience-developer")
+    return aws_client(
+        service_name, role_arn="arn:aws:iam::130871440101:role/experience-developer"
+    )
 
 
 def get_associated_image_remover(es_host, es_auth, catalogue_id, works_indices):
@@ -315,14 +317,15 @@ def remove_image_from_loris_s3_bucket(miro_id, dry_run):
         s3_client.delete_object(Bucket=bucket, Key=key)
 
 
-def invalidate_cloudfront_path(cloudfront_client, *, domain_name, invalidation_path, dry_run):
+def invalidate_cloudfront_path(
+    cloudfront_client, *, domain_name, invalidation_path, dry_run
+):
     resp = cloudfront_client.list_distributions()
     assert not resp["DistributionList"]["IsTruncated"]
 
     def is_matching_cloudfront_distribution(item):
         has_origin_domain_name = any(
-            i["DomainName"] == domain_name
-            for i in item["Origins"]["Items"]
+            i["DomainName"] == domain_name for i in item["Origins"]["Items"]
         )
 
         has_alias_domain_name = domain_name in item["Aliases"]["Items"]
@@ -336,7 +339,10 @@ def invalidate_cloudfront_path(cloudfront_client, *, domain_name, invalidation_p
     ]
 
     for distribution in matching:
-        print("··· Detected a CloudFront distribution for %s as %s" % (domain_name, distribution["Id"]))
+        print(
+            "··· Detected a CloudFront distribution for %s as %s"
+            % (domain_name, distribution["Id"])
+        )
         print("··· Issuing an invalidation for %s" % invalidation_path)
 
         if not dry_run:
@@ -356,7 +362,7 @@ def create_cloudfront_invalidations(*, catalogue_id, miro_id, dry_run):
         platform_client("cloudfront"),
         domain_name="iiif-origin.wellcomecollection.org",
         invalidation_path="/image/%s.jpg/*" % miro_id,
-        dry_run=dry_run
+        dry_run=dry_run,
     )
 
     print(f"*** Creating a CloudFront invalidation for /works/{catalogue_id}")
@@ -364,7 +370,7 @@ def create_cloudfront_invalidations(*, catalogue_id, miro_id, dry_run):
         experience_client("cloudfront"),
         domain_name="wellcomecollection.org",
         invalidation_path=f"/works/{catalogue_id}",
-        dry_run=dry_run
+        dry_run=dry_run,
     )
 
 
@@ -425,7 +431,9 @@ def main(catalogue_id, index, dry_run):
     suppress_work_in_miro_vhs(miro_id, dry_run)
 
     remove_image_from_loris_s3_bucket(miro_id, dry_run)
-    create_cloudfront_invalidations(catalogue_id=catalogue_id, miro_id=miro_id, dry_run=dry_run)
+    create_cloudfront_invalidations(
+        catalogue_id=catalogue_id, miro_id=miro_id, dry_run=dry_run
+    )
     update_miro_inventory(miro_id, dry_run)
 
 


### PR DESCRIPTION
Use case: I'm a clumsy developer who breaks things when they fiddle around in web consoles. By teaching robots to do things for me, I don't have to risk busting something in the CloudFront console.

There may be a reason this isn't done automatically, in which case let's comment it, otherwise it's one less thing for the next person to do.

I've done a dry run and checked this finds the right CloudFront distro, so I think it's working.