### PR TITLE
Add the license/shelfmark/link_text fields to our Location models

### DIFF
--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
@@ -45,6 +45,10 @@ case class DisplayDigitalLocation(
     description = "Who to credit the image to"
   ) credit: Option[String] = None,
   @Schema(
+    `type` = "String",
+    description = "Text that can be used when linking to the item - for example, 'View this journal' rather than the raw URL"
+  ) linkText: Option[String] = None,
+  @Schema(
     description =
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: Option[DisplayLicense] = None,
@@ -60,6 +64,7 @@ object DisplayDigitalLocation {
     DisplayDigitalLocation(
       locationType = DisplayLocationType(location.locationType),
       url = location.url,
+      linkText = location.linkText,
       credit = location.credit,
       license = location.license.map(DisplayLicense(_)),
       accessConditions =

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
@@ -46,7 +46,8 @@ case class DisplayDigitalLocation(
   ) credit: Option[String] = None,
   @Schema(
     `type` = "String",
-    description = "Text that can be used when linking to the item - for example, 'View this journal' rather than the raw URL"
+    description =
+      "Text that can be used when linking to the item - for example, 'View this journal' rather than the raw URL"
   ) linkText: Option[String] = None,
   @Schema(
     description =
@@ -89,8 +90,7 @@ case class DisplayPhysicalLocation(
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: Option[DisplayLicense] = None,
   @Schema(
-    description =
-      "The specific shelf where this item can be found"
+    description = "The specific shelf where this item can be found"
   ) shelfmark: Option[String] = None,
   @Schema(
     description = "Information about any access restrictions placed on the work"

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
@@ -89,6 +89,10 @@ case class DisplayPhysicalLocation(
       "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
   ) license: Option[DisplayLicense] = None,
   @Schema(
+    description =
+      "The specific shelf where this item can be found"
+  ) shelfmark: Option[String] = None,
+  @Schema(
     description = "Information about any access restrictions placed on the work"
   ) accessConditions: List[DisplayAccessCondition] = Nil,
   @JsonKey("type") @Schema(name = "type") ontologyType: String =
@@ -101,6 +105,7 @@ object DisplayPhysicalLocation {
       locationType = DisplayLocationType(location.locationType),
       label = location.label,
       license = location.license.map(DisplayLicense(_)),
+      shelfmark = location.shelfmark,
       accessConditions =
         location.accessConditions.map(DisplayAccessCondition(_))
     )

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayLocation.scala
@@ -80,6 +80,10 @@ case class DisplayPhysicalLocation(
     description = "The title or other short name of the location."
   ) label: String,
   @Schema(
+    description =
+      "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
+  ) license: Option[DisplayLicense] = None,
+  @Schema(
     description = "Information about any access restrictions placed on the work"
   ) accessConditions: List[DisplayAccessCondition] = Nil,
   @JsonKey("type") @Schema(name = "type") ontologyType: String =
@@ -91,6 +95,7 @@ object DisplayPhysicalLocation {
     DisplayPhysicalLocation(
       locationType = DisplayLocationType(location.locationType),
       label = location.label,
+      license = location.license.map(DisplayLicense(_)),
       accessConditions =
         location.accessConditions.map(DisplayAccessCondition(_))
     )

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -81,7 +81,7 @@ class DisplayLocationTest extends AnyFunSpec with Matchers {
       val locationType = LocationType("iiif-image")
       val url = "https://wellcomelibrary.org/iiif/b2201508/manifest"
 
-      val digitalLocation = DigitalLocation(url, locationType)
+      val digitalLocation = DigitalLocation(url = url, locationType = locationType)
 
       DisplayLocation(digitalLocation) shouldBe DisplayDigitalLocation(
         locationType = DisplayLocationType(locationType),
@@ -97,6 +97,17 @@ class DisplayLocationTest extends AnyFunSpec with Matchers {
 
       val displayLocation = DisplayDigitalLocation(digitalLocation)
       displayLocation.license shouldBe Some(DisplayLicense(License.PDM))
+    }
+
+    it("copies the link_text from a DigitalLocation") {
+      val digitalLocation = DigitalLocation(
+        locationType = LocationType("iiif-image"),
+        url = "https://example.org/journals/browse.aspx",
+        linkText = Some("View this journal")
+      )
+
+      val displayLocation = DisplayDigitalLocation(digitalLocation)
+      displayLocation.linkText shouldBe Some("View this journal")
     }
   }
 }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -74,6 +74,17 @@ class DisplayLocationTest extends AnyFunSpec with Matchers {
       val displayLocation = DisplayPhysicalLocation(physicalLocation)
       displayLocation.license shouldBe Some(DisplayLicense(License.CCBY))
     }
+
+    it("copies the shelfmark from a PhysicalLocation") {
+      val physicalLocation = PhysicalLocation(
+        locationType = LocationType("sgmed"),
+        label = "A shelved summary of signed stories",
+        shelfmark = Some("PP/Shelved:Box 1")
+      )
+
+      val displayLocation = DisplayPhysicalLocation(physicalLocation)
+      displayLocation.shelfmark shouldBe Some("PP/Shelved:Box 1")
+    }
   }
 
   describe("DisplayDigitalLocation") {

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -63,6 +63,17 @@ class DisplayLocationTest extends AnyFunSpec with Matchers {
         locationType = DisplayLocationType(locationType),
         locationLabel)
     }
+
+    it("copies the License from a PhysicalLocation") {
+      val physicalLocation = PhysicalLocation(
+        locationType = LocationType("sgmed"),
+        label = "A licensed letter of liberal leanings",
+        license = Some(License.CCBY)
+      )
+
+      val displayLocation = DisplayPhysicalLocation(physicalLocation)
+      displayLocation.license shouldBe Some(DisplayLicense(License.CCBY))
+    }
   }
 
   describe("DisplayDigitalLocation") {

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationTest.scala
@@ -92,7 +92,8 @@ class DisplayLocationTest extends AnyFunSpec with Matchers {
       val locationType = LocationType("iiif-image")
       val url = "https://wellcomelibrary.org/iiif/b2201508/manifest"
 
-      val digitalLocation = DigitalLocation(url = url, locationType = locationType)
+      val digitalLocation =
+        DigitalLocation(url = url, locationType = locationType)
 
       DisplayLocation(digitalLocation) shouldBe DisplayDigitalLocation(
         locationType = DisplayLocationType(locationType),

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -60,6 +60,7 @@ trait DisplaySerialisationTestBase {
       "url": "${digitalLocation.url}"
       ${optionalObject("license", license, digitalLocation.license)},
       ${optionalString("credit", digitalLocation.credit)}
+      ${optionalString("linkText", digitalLocation.linkText)}
       "accessConditions": ${accessConditions(digitalLocation.accessConditions)}
     }"""
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -71,6 +71,7 @@ trait DisplaySerialisationTestBase {
         "locationType": ${locationType(loc.locationType)},
         "label": "${loc.label}",
         ${optionalObject("license", license, loc.license)}
+        ${optionalString("shelfmark", loc.shelfmark)}
         "accessConditions": ${accessConditions(loc.accessConditions)}
        }
      """

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -69,6 +69,7 @@ trait DisplaySerialisationTestBase {
         "type": "PhysicalLocation",
         "locationType": ${locationType(loc.locationType)},
         "label": "${loc.label}",
+        ${optionalObject("license", license, loc.license)}
         "accessConditions": ${accessConditions(loc.accessConditions)}
        }
      """

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkTest.scala
@@ -83,6 +83,7 @@ class DisplayWorkTest
           url = location.url,
           credit = location.credit,
           license = location.license.map(DisplayLicense(_)),
+          linkText = location.linkText,
           accessConditions =
             location.accessConditions.map(DisplayAccessCondition(_))
         )

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.models.work.internal
 sealed trait Location {
   val locationType: LocationType
   val accessConditions: List[AccessCondition]
+  val license: Option[License]
 
   def hasRestrictions: Boolean =
     accessConditions.exists(_.hasRestrictions)
@@ -19,5 +20,6 @@ case class DigitalLocation(
 case class PhysicalLocation(
   locationType: LocationType,
   label: String,
+  license: Option[License] = None,
   accessConditions: List[AccessCondition] = Nil
 ) extends Location

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
@@ -14,6 +14,7 @@ case class DigitalLocation(
   locationType: LocationType,
   license: Option[License] = None,
   credit: Option[String] = None,
+  linkText: Option[String] = None,
   accessConditions: List[AccessCondition] = Nil
 ) extends Location
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
@@ -22,5 +22,6 @@ case class PhysicalLocation(
   locationType: LocationType,
   label: String,
   license: Option[License] = None,
+  shelfmark: Option[String] = None,
   accessConditions: List[AccessCondition] = Nil
 ) extends Location

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
@@ -42,6 +42,7 @@ trait LocationGenerators extends RandomGenerators {
     url = url,
     license = license,
     credit = chooseFrom(None, Some(s"Credit line: ${randomAlphanumeric()}")),
+    linkText = chooseFrom(None, Some(s"Link text: ${randomAlphanumeric()}")),
     accessConditions = accessConditions
   )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
@@ -24,6 +24,7 @@ trait LocationGenerators extends RandomGenerators {
         Some(License.OGL),
         Some(License.PDM)
       ),
+      shelfmark = chooseFrom(None, Some(s"Shelfmark: ${randomAlphanumeric()}")),
       accessConditions = accessConditions
     )
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
@@ -18,6 +18,12 @@ trait LocationGenerators extends RandomGenerators {
     PhysicalLocation(
       locationType = locationType,
       label = label,
+      license = chooseFrom(
+        None,
+        Some(License.CCBY),
+        Some(License.OGL),
+        Some(License.PDM)
+      ),
       accessConditions = accessConditions
     )
 

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -30,8 +30,8 @@ class MetsDataTest
 
     val url = s"https://wellcomelibrary.org/iiif/$bibNumber/manifest"
     val digitalLocation = DigitalLocation(
-      url,
-      LocationType("iiif-presentation"),
+      url = url,
+      locationType = LocationType("iiif-presentation"),
       license = Some(License.CCBYNC))
 
     val createdDate = Instant.now()
@@ -92,7 +92,11 @@ class MetsDataTest
 
     val url = s"https://wellcomelibrary.org/iiif/$bibNumber/manifest"
     val digitalLocation =
-      DigitalLocation(url, LocationType("iiif-presentation"), license = None)
+      DigitalLocation(
+        url = url,
+        locationType = LocationType("iiif-presentation"),
+        license = None
+      )
 
     val createdDate = Instant.now()
 
@@ -139,7 +143,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -155,7 +159,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -170,7 +174,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -186,7 +190,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -204,7 +208,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -221,7 +225,7 @@ class MetsDataTest
           Item(
             IdState.Unidentifiable,
             _,
-            List(DigitalLocation(_, _, license, _, _)))) =>
+            List(DigitalLocation(_, _, license, _, _, _)))) =>
         license shouldBe Some(License.InCopyright)
     }
   }
@@ -238,8 +242,8 @@ class MetsDataTest
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        s"https://dlcs.io/thumbs/wellcome/5/location.jp2/full/!200,200/0/default.jpg",
-        LocationType("thumbnail-image"),
+        url = s"https://dlcs.io/thumbs/wellcome/5/location.jp2/full/!200,200/0/default.jpg",
+        locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBYNC)
       )
     )
@@ -259,8 +263,8 @@ class MetsDataTest
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        s"https://dlcs.io/thumbs/wellcome/5/title.jp2/full/!200,200/0/default.jpg",
-        LocationType("thumbnail-image"),
+        url = s"https://dlcs.io/thumbs/wellcome/5/title.jp2/full/!200,200/0/default.jpg",
+        locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBYNC)
       )
     )
@@ -294,8 +298,8 @@ class MetsDataTest
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        s"https://wellcomelibrary.org/pdfthumbs/$bibNumber/0/$assetId.jpg",
-        LocationType("thumbnail-image"),
+        url = s"https://wellcomelibrary.org/pdfthumbs/$bibNumber/0/$assetId.jpg",
+        locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBYNC)
       )
     )
@@ -359,7 +363,7 @@ class MetsDataTest
     ).toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
     inside(result.right.get.data.items.head.locations.head) {
-      case DigitalLocation(_, _, _, _, accessConditions) =>
+      case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List(
           AccessCondition(
             status = Some(AccessStatus.OpenWithAdvisory)
@@ -412,7 +416,7 @@ class MetsDataTest
     ).toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
     inside(result.right.get.data.items.head.locations.head) {
-      case DigitalLocation(_, _, _, _, accessConditions) =>
+      case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List(
           AccessCondition(
             status = Some(AccessStatus.Restricted),
@@ -429,7 +433,7 @@ class MetsDataTest
     ).toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
     inside(result.right.get.data.items.head.locations.head) {
-      case DigitalLocation(_, _, _, _, accessConditions) =>
+      case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List()
     }
   }
@@ -441,7 +445,7 @@ class MetsDataTest
     ).toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]
     inside(result.right.get.data.items.head.locations.head) {
-      case DigitalLocation(_, _, _, _, accessConditions) =>
+      case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe
           List(
             AccessCondition(

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -242,7 +242,8 @@ class MetsDataTest
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        url = s"https://dlcs.io/thumbs/wellcome/5/location.jp2/full/!200,200/0/default.jpg",
+        url =
+          s"https://dlcs.io/thumbs/wellcome/5/location.jp2/full/!200,200/0/default.jpg",
         locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBYNC)
       )
@@ -263,7 +264,8 @@ class MetsDataTest
     result shouldBe a[Right[_, _]]
     result.right.get.data.thumbnail shouldBe Some(
       DigitalLocation(
-        url = s"https://dlcs.io/thumbs/wellcome/5/title.jp2/full/!200,200/0/default.jpg",
+        url =
+          s"https://dlcs.io/thumbs/wellcome/5/title.jp2/full/!200,200/0/default.jpg",
         locationType = LocationType("thumbnail-image"),
         license = Some(License.CCBYNC)
       )


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/catalogue/pull/1357; closes https://github.com/wellcomecollection/platform/issues/5012

* The link_text field on DigitalLocation is for text to display instead of the URL in links (e.g. "View this journal"). It comes from Sierra holdings records, and it's useful when the URL itself is an ugly mess.
* The license field on PhysicalLocation is mostly hypothetical (I don't know if we'll populate it immediately), but license is core enough to the model that we do want it
* The shelfmark field on PhysicalLocation will be for shelf data on Sierra items

This patch just adds the field to our models and enough to get our existing tests compiling; actually populating these fields will come in another patch.