### PR TITLE
 If the location is "in above", try to guess the locationType

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -56,7 +56,8 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
         }
         .map { loc =>
           SierraPhysicalLocationType.fromName(loc.name) match {
-            case Some(LocationType.ClosedStores) => (Some(LocationType.ClosedStores), LocationType.ClosedStores.label)
+            case Some(LocationType.ClosedStores) =>
+              (Some(LocationType.ClosedStores), LocationType.ClosedStores.label)
             case other => (other, loc.name)
           }
         }
@@ -65,7 +66,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
 
     val fallbackLocation = otherLocations match {
       case Seq((Some(locationType), label)) => Some((locationType, label))
-      case _  => None
+      case _                                => None
     }
 
     sierraItemDataMap
@@ -90,11 +91,13 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     itemId: SierraItemNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
-    fallbackLocation: Option[(PhysicalLocationType, String)]): Item[IdState.Unminted] = {
+    fallbackLocation: Option[(PhysicalLocationType, String)])
+    : Item[IdState.Unminted] = {
     debug(s"Attempting to transform $itemId")
     Item(
       title = getItemTitle(itemData),
-      locations = getPhysicalLocation(bibId, itemData, bibData, fallbackLocation).toList,
+      locations =
+        getPhysicalLocation(bibId, itemData, bibData, fallbackLocation).toList,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType("sierra-system-number"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -36,7 +36,38 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
   private def getPhysicalItems(
     bibId: SierraBibNumber,
     sierraItemDataMap: Map[SierraItemNumber, SierraItemData],
-    bibData: SierraBibData): List[Item[IdState.Unminted]] =
+    bibData: SierraBibData): List[Item[IdState.Unminted]] = {
+
+    // Some of the Sierra items have a location like "contained in above"
+    // or "bound in above".
+    //
+    // This is only useful if you know the correct ordering of items on the bib,
+    // which we don't.  This information isn't available in the REST API that
+    // we use to get Sierra data.  See https://github.com/wellcomecollection/platform/issues/4993
+    //
+    // We assume that "in above" refers to another item on the same bib, so if the
+    // non-above locations are unambiguous, we use them instead.
+    val otherLocations =
+      sierraItemDataMap.values
+        .filterNot { _.deleted }
+        .collect { case SierraItemData(_, Some(location), _, _, _) => location }
+        .filterNot { loc =>
+          loc.name.toLowerCase.contains("above") || loc.name == "-" || loc.name == ""
+        }
+        .map { loc =>
+          SierraPhysicalLocationType.fromName(loc.name) match {
+            case Some(LocationType.ClosedStores) => (Some(LocationType.ClosedStores), LocationType.ClosedStores.label)
+            case other => (other, loc.name)
+          }
+        }
+        .toSeq
+        .distinct
+
+    val fallbackLocation = otherLocations match {
+      case Seq((Some(locationType), label)) => Some((locationType, label))
+      case _  => None
+    }
+
     sierraItemDataMap
       .filterNot {
         case (_: SierraItemNumber, itemData: SierraItemData) => itemData.deleted
@@ -47,20 +78,23 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
             bibId = bibId,
             itemId = itemId,
             itemData = itemData,
-            bibData = bibData
+            bibData = bibData,
+            fallbackLocation = fallbackLocation
           )
       }
       .toList
+  }
 
   private def transformItemData(
     bibId: SierraBibNumber,
     itemId: SierraItemNumber,
     itemData: SierraItemData,
-    bibData: SierraBibData): Item[IdState.Unminted] = {
+    bibData: SierraBibData,
+    fallbackLocation: Option[(PhysicalLocationType, String)]): Item[IdState.Unminted] = {
     debug(s"Attempting to transform $itemId")
     Item(
       title = getItemTitle(itemData),
-      locations = getPhysicalLocation(bibId, itemData, bibData).toList,
+      locations = getPhysicalLocation(bibId, itemData, bibData, fallbackLocation).toList,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType("sierra-system-number"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -16,18 +16,20 @@ trait SierraLocation extends SierraQueryOps with Logging {
     bibNumber: SierraBibNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
-    fallbackLocation: Option[(PhysicalLocationType, String)] = None): Option[PhysicalLocation] =
+    fallbackLocation: Option[(PhysicalLocationType, String)] = None)
+    : Option[PhysicalLocation] =
     for {
       sourceLocation <- itemData.location
 
       (locationType, label) <- {
-        val parsedLocationType = SierraPhysicalLocationType.fromName(sourceLocation.name)
+        val parsedLocationType =
+          SierraPhysicalLocationType.fromName(sourceLocation.name)
 
         (parsedLocationType, fallbackLocation) match {
           case (Some(locationType), _) =>
             val label = locationType match {
               case LocationType.ClosedStores => LocationType.ClosedStores.label
-              case _ => sourceLocation.name
+              case _                         => sourceLocation.name
             }
 
             Some((locationType, label))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -8,35 +8,47 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraQueryOps,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLocation
 import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 
 trait SierraLocation extends SierraQueryOps with Logging {
 
-  def getPhysicalLocation(bibNumber: SierraBibNumber,
-                          itemData: SierraItemData,
-                          bibData: SierraBibData): Option[PhysicalLocation] =
-    itemData.location.flatMap {
-      case SierraSourceLocation(_, name) =>
-        SierraPhysicalLocationType.fromName(name).flatMap { locationType =>
-          val label = locationType match {
-            case LocationType.ClosedStores => LocationType.ClosedStores.label
-            case _                         => name
-          }
+  def getPhysicalLocation(
+    bibNumber: SierraBibNumber,
+    itemData: SierraItemData,
+    bibData: SierraBibData,
+    fallbackLocation: Option[(PhysicalLocationType, String)] = None): Option[PhysicalLocation] =
+    for {
+      sourceLocation <- itemData.location
 
-          Some(
-            PhysicalLocation(
-              locationType = locationType,
-              accessConditions = getAccessConditions(bibNumber, bibData),
-              label = label,
-              // This is meant to be a "good enough" implementation of a shelfmark.
-              // We may revisit this in future, and populate it directly from the
-              // MARC fields if we want to be more picky about our rules.
-              shelfmark = itemData.callNumber
-            )
-          )
+      (locationType, label) <- {
+        val parsedLocationType = SierraPhysicalLocationType.fromName(sourceLocation.name)
+
+        (parsedLocationType, fallbackLocation) match {
+          case (Some(locationType), _) =>
+            val label = locationType match {
+              case LocationType.ClosedStores => LocationType.ClosedStores.label
+              case _ => sourceLocation.name
+            }
+
+            Some((locationType, label))
+
+          case (_, Some(fallbackLocation)) =>
+            Some(fallbackLocation)
+
+          case _ => None
         }
-    }
+      }
+
+      physicalLocation = PhysicalLocation(
+        locationType = locationType,
+        accessConditions = getAccessConditions(bibNumber, bibData),
+        label = label,
+        // This is meant to be a "good enough" implementation of a shelfmark.
+        // We may revisit this in future, and populate it directly from the
+        // MARC fields if we want to be more picky about our rules.
+        shelfmark = itemData.callNumber
+      )
+    } yield physicalLocation
 
   private def getAccessConditions(
     bibId: SierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -161,6 +161,102 @@ class SierraItemsTest
       ))
   }
 
+  describe("handling locations which are 'contained in above' or 'bound in above'") {
+    it("skips adding a location if the Sierra location is 'bound in above'") {
+      val itemDataMap = Map(
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("bwith", "bound in above"))
+        )
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items should have size 1
+      items.head.locations shouldBe empty
+    }
+
+    it("adds a location to 'bound/contained in above' if the other locations are unambiguous") {
+      val itemDataMap = Map(
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("bwith", "bound in above"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("cwith", "contained in above"))
+          ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+        )
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items should have size 4
+      items.foreach {
+        _.locations shouldBe List(
+          PhysicalLocation(
+            locationType = LocationType.ClosedStores,
+            label = LocationType.ClosedStores.label
+          )
+        )
+      }
+    }
+
+    it("adds a location to 'bound/contained in above' if the other locations are all closed") {
+      val itemDataMap = Map(
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("bwith", "bound in above"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("cwith", "contained in above"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sobhi", "Closed stores P.B. Hindi"))
+        )
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items should have size 4
+      items.foreach {
+        _.locations shouldBe List(
+          PhysicalLocation(
+            locationType = LocationType.ClosedStores,
+            label = LocationType.ClosedStores.label
+          )
+        )
+      }
+    }
+
+    it("skips adding a location to 'bound/contained in above' if the other locations are ambiguous") {
+      val itemDataMap = Map(
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("bwith", "bound in above"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("cwith", "contained in above"))
+        ),
+        createSierraItemNumber -> createSierraItemDataWith(
+          location = Some(SierraSourceLocation("info", "Open shelves"))
+        )
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items should have size 4
+
+      items.map { _.locations.length }.sorted shouldBe List(0, 0, 1, 1)
+    }
+  }
+
   it("sorts items by sierra-identifier") {
     val itemData = Map(
       SierraItemNumber("0000002") -> createSierraItemData,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -161,7 +161,8 @@ class SierraItemsTest
       ))
   }
 
-  describe("handling locations which are 'contained in above' or 'bound in above'") {
+  describe(
+    "handling locations which are 'contained in above' or 'bound in above'") {
     it("skips adding a location if the Sierra location is 'bound in above'") {
       val itemDataMap = Map(
         createSierraItemNumber -> createSierraItemDataWith(
@@ -175,19 +176,22 @@ class SierraItemsTest
       items.head.locations shouldBe empty
     }
 
-    it("adds a location to 'bound/contained in above' if the other locations are unambiguous") {
+    it(
+      "adds a location to 'bound/contained in above' if the other locations are unambiguous") {
       val itemDataMap = Map(
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+          location =
+            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
-          ),
+        ),
         createSierraItemNumber -> createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+          location =
+            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         )
       )
 
@@ -204,19 +208,22 @@ class SierraItemsTest
       }
     }
 
-    it("adds a location to 'bound/contained in above' if the other locations are all closed") {
+    it(
+      "adds a location to 'bound/contained in above' if the other locations are all closed") {
       val itemDataMap = Map(
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+          location =
+            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sobhi", "Closed stores P.B. Hindi"))
+          location =
+            Some(SierraSourceLocation("sobhi", "Closed stores P.B. Hindi"))
         )
       )
 
@@ -233,13 +240,15 @@ class SierraItemsTest
       }
     }
 
-    it("skips adding a location to 'bound/contained in above' if the other locations are ambiguous") {
+    it(
+      "skips adding a location to 'bound/contained in above' if the other locations are ambiguous") {
       val itemDataMap = Map(
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+          location =
+            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
         createSierraItemNumber -> createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -124,6 +124,64 @@ class SierraLocationTest
       location.shelfmark shouldBe Some("AX1234:Box 1")
     }
 
+    describe("uses fallback locations") {
+      it("returns an empty location if location name is 'bound in above'") {
+        val result = transformer.getPhysicalLocation(
+          bibNumber = createSierraBibNumber,
+          bibData = createSierraBibData,
+          itemData = createSierraItemDataWith(
+            location = Some(SierraSourceLocation("bwith", "bound in above"))
+          )
+        )
+
+        result shouldBe None
+      }
+
+      it("uses the fallback location if location name is 'bound in above'") {
+        val result = transformer.getPhysicalLocation(
+          bibNumber = createSierraBibNumber,
+          bibData = createSierraBibData,
+          itemData = createSierraItemDataWith(
+            location = Some(SierraSourceLocation("bwith", "bound in above"))
+          ),
+          fallbackLocation = Some(
+            (LocationType.OpenShelves, "History of Medicine")
+          )
+        )
+
+        result.get.locationType shouldBe LocationType.OpenShelves
+        result.get.label shouldBe "History of Medicine"
+      }
+
+      it("returns an empty location if location name is 'contained in above'") {
+        val result = transformer.getPhysicalLocation(
+          bibNumber = createSierraBibNumber,
+          bibData = createSierraBibData,
+          itemData = createSierraItemDataWith(
+            location = Some(SierraSourceLocation("cwith", "contained in above"))
+          )
+        )
+
+        result shouldBe None
+      }
+
+      it("uses the fallback location if location name is 'contained in above'") {
+        val result = transformer.getPhysicalLocation(
+          bibNumber = createSierraBibNumber,
+          bibData = createSierraBibData,
+          itemData = createSierraItemDataWith(
+            location = Some(SierraSourceLocation("cwith", "contained in above"))
+          ),
+          fallbackLocation = Some(
+            (LocationType.OpenShelves, "History of Medicine")
+          )
+        )
+
+        result.get.locationType shouldBe LocationType.OpenShelves
+        result.get.label shouldBe "History of Medicine"
+      }
+    }
+
     it("adds 'Open' access condition if ind1 is 0") {
       val bibData = createSierraBibDataWith(
         varFields = List(


### PR DESCRIPTION
Some Sierra locations have names like "bound in above" or "closed in above", which is completely unhelpful for mapping to our fixed vocabulary of location types.

We assume that "in above" refers to a location on one of the other items on this bib, so if we can guess that unambiguously, use that as the location for this item.

This gets the proportion of locations we can map into the new model from 95% to 99%.

Follows #1365; closes https://github.com/wellcomecollection/platform/issues/5019