### PR TITLE
Add a script for fetching a snapshot of Sierra records

### DIFF
--- a/sierra_adapter/.gitignore
+++ b/sierra_adapter/.gitignore
@@ -1,0 +1,1 @@
+_snapshots

--- a/sierra_adapter/dynamo.py
+++ b/sierra_adapter/dynamo.py
@@ -1,0 +1,26 @@
+import decimal
+import json
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, value):
+        if isinstance(value, decimal.Decimal) and int(value) == value:
+            return int(value)
+
+
+def get_table_item_count(session, *, table_name):
+    """
+    Counts the items in a DynamoDB table.
+    """
+    dynamo = session.client("dynamodb")
+    describe_resp = dynamo.describe_table(TableName=table_name)
+    return describe_resp["Table"]["ItemCount"]
+
+
+def scan_table(session, *, table_name):
+    """
+    Generates all the items in a DynamoDB table.
+    """
+    dynamo = session.resource("dynamodb").meta.client
+    for page in dynamo.get_paginator("scan").paginate(TableName=table_name):
+        yield from page["Items"]

--- a/sierra_adapter/get_sierra_records_snapshot.py
+++ b/sierra_adapter/get_sierra_records_snapshot.py
@@ -145,11 +145,13 @@ def get_new_records(session, *, locations, snapshot_path):
             for line in infile:
                 row = json.loads(line)
 
-                latest_location = locations.pop(row['id'])
+                latest_location = locations.pop(row["id"])
 
-                if latest_location != row['location']:
-                    row['location'] = latest_location
-                    row['record'] = fetch_transformable(s3_client, location=latest_location)
+                if latest_location != row["location"]:
+                    row["location"] = latest_location
+                    row["record"] = fetch_transformable(
+                        s3_client, location=latest_location
+                    )
 
                 yield row
     except FileNotFoundError:
@@ -161,18 +163,14 @@ def get_new_records(session, *, locations, snapshot_path):
         record = fetch_transformable(s3_client, location=location)
 
         record = {
-            'bib': record.get('maybeBibRecord'),
-            'items': {
-                item_id: item_record['data']
-                for item_id, item_record in record['itemRecords'].items()
-            }
+            "bib": record.get("maybeBibRecord"),
+            "items": {
+                item_id: item_record["data"]
+                for item_id, item_record in record["itemRecords"].items()
+            },
         }
 
-        yield {
-            'id': id,
-            'location': location,
-            'record': record,
-        }
+        yield {"id": id, "location": location, "record": record}
 
 
 def freshen_sierra_records_snapshot(session, *, snapshot_path):
@@ -185,7 +183,7 @@ def freshen_sierra_records_snapshot(session, *, snapshot_path):
     with gzip.open(tmp_path, "wb") as outfile:
         for record in tqdm.tqdm(
             get_new_records(session, locations=locations, snapshot_path=snapshot_path),
-            total=len(locations)
+            total=len(locations),
         ):
             line = json.dumps(record) + "\n"
             outfile.write(line.encode("utf8"))
@@ -207,9 +205,7 @@ if __name__ == "__main__":
         )
 
         upload_file_to_s3(
-            bucket=SNAPSHOT_BUCKET,
-            key=SNAPSHOT_KEY,
-            filename=LOCAL_SNAPSHOT_PATH
+            bucket=SNAPSHOT_BUCKET, key=SNAPSHOT_KEY, filename=LOCAL_SNAPSHOT_PATH
         )
 
     print("")

--- a/sierra_adapter/get_sierra_records_snapshot.py
+++ b/sierra_adapter/get_sierra_records_snapshot.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+"""
+This script creates a snapshot of Sierra records.  These snapshots are
+useful if you want to analyse all the Sierra data in one go, e.g.
+
+    "What are all the values in the 'location' field on an item record?"
+
+You need AWS credentials that can use the platform-developer and
+platform-read_only roles.
+
+Creating the initial snapshot takes a *very* long time (think days), so we
+keep a shared copy in S3.  This script will automatically download the
+latest snapshot from S3, and upload an updated version.
+"""
+
+import datetime
+import gzip
+import json
+import os
+import uuid
+
+import boto3
+import click
+import tqdm
+
+from dynamo import DecimalEncoder, get_table_item_count, scan_table
+from s3 import download_object_from_s3, upload_file_to_s3
+
+
+READ_ONLY_ROLE_ARN = "arn:aws:iam::760097843905:role/platform-read_only"
+DEVELOPER_ROLE_ARN = "arn:aws:iam::760097843905:role/platform-developer"
+
+SNAPSHOT_BUCKET = "wellcomecollection-platform-infra"
+SNAPSHOT_KEY = "sierra_records.json.gz"
+
+LOCAL_SNAPSHOT_DIR = "_snapshots"
+LOCAL_SNAPSHOT_PATH = os.path.join(LOCAL_SNAPSHOT_DIR, "sierra_records.json.gz")
+
+TABLE_NAME = "vhs-sierra-sierra-adapter-20200604"
+
+EXAMPLE_SCRIPT = f"""
+import gzip
+import json
+import pprint
+
+
+def get_sierra_records():
+    for line in gzip.open({LOCAL_SNAPSHOT_PATH!r}):
+        yield json.loads(line)
+
+
+if __name__ == '__main__':
+    for record in get_sierra_records():
+        pprint.pprint(record)
+        break
+""".strip()
+
+
+def get_aws_session(*, role_arn):
+    sts_client = boto3.client("sts")
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
+    )
+    credentials = assumed_role_object["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def download_existing_snapshot(session):
+    click.echo(
+        "*** Downloading existing snapshot from %s"
+        % click.style(f"s3://{SNAPSHOT_BUCKET}/{SNAPSHOT_KEY}", "yellow")
+    )
+    os.makedirs(os.path.dirname(LOCAL_SNAPSHOT_PATH), exist_ok=True)
+
+    download_object_from_s3(
+        session, bucket=SNAPSHOT_BUCKET, key=SNAPSHOT_KEY, filename=LOCAL_SNAPSHOT_PATH
+    )
+
+
+def get_locations(session, *, table_name):
+    """
+    Gets the id -> location lookup from DynamoDB.
+
+    The result is cached once a day, to avoid excessive lookups.
+    """
+    today = datetime.date.today().strftime("%Y-%m-%d")
+    out_path = os.path.join(
+        LOCAL_SNAPSHOT_DIR, f"dynamo__{table_name}__{today}.json.gz"
+    )
+
+    if not os.path.exists(out_path):
+        print("***, Fetching items from DynamoDB...")
+        item_count = get_table_item_count(session, table_name=TABLE_NAME)
+
+        tmp_id = str(uuid.uuid4())
+        tmp_path = f"{out_path}.{tmp_id}.tmp"
+
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+        with gzip.open(tmp_path, "w") as outfile:
+            for item in tqdm.tqdm(
+                scan_table(session, table_name=table_name), total=item_count
+            ):
+                line = json.dumps(item, cls=DecimalEncoder) + "\n"
+                outfile.write(line.encode("utf8"))
+
+        os.rename(tmp_path, out_path)
+
+    locations = {}
+
+    for line in gzip.open(out_path, "rb"):
+        row = json.loads(line)
+        locations[row["id"]] = row["payload"]
+
+    return locations
+
+
+def fetch_transformable(s3_client, *, location):
+    s3_obj = s3_client.get_object(Bucket=location["bucket"], Key=location["key"])
+
+    transformable = json.load(s3_obj["Body"])
+
+    if transformable.get("maybeBibRecord") is not None:
+        transformable["maybeBibRecord"]["data"] = json.loads(
+            transformable["maybeBibRecord"]["data"]
+        )
+
+    for item_record in transformable["itemRecords"].values():
+        item_record["data"] = json.loads(item_record["data"])
+
+    return transformable
+
+
+def get_new_records(session, *, locations, snapshot_path):
+    s3_client = session.client("s3")
+
+    # First look at every record we've already saved, and compare it to
+    # the current location.
+    try:
+        with gzip.open(snapshot_path) as infile:
+            for line in infile:
+                row = json.loads(line)
+
+                latest_location = locations.pop(row['id'])
+
+                if latest_location != row['location']:
+                    row['location'] = latest_location
+                    row['record'] = fetch_transformable(s3_client, location=latest_location)
+
+                yield row
+    except FileNotFoundError:
+        pass
+
+    # Now go through the list of remaining locations -- we've never
+    # fetched these before, so we need to fetch them fresh.
+    for id, location in locations.items():
+        record = fetch_transformable(s3_client, location=location)
+
+        record = {
+            'bib': record.get('maybeBibRecord'),
+            'items': {
+                item_id: item_record['data']
+                for item_id, item_record in record['itemRecords'].items()
+            }
+        }
+
+        yield {
+            'id': id,
+            'location': location,
+            'record': record,
+        }
+
+
+def freshen_sierra_records_snapshot(session, *, snapshot_path):
+    locations = get_locations(session, table_name=TABLE_NAME)
+
+    # Now go ahead and fetch all the Sierra records from S3.
+    tmp_id = str(uuid.uuid4())
+    tmp_path = f"{LOCAL_SNAPSHOT_PATH}.{tmp_id}.tmp"
+
+    with gzip.open(tmp_path, "wb") as outfile:
+        for record in tqdm.tqdm(
+            get_new_records(session, locations=locations, snapshot_path=snapshot_path),
+            total=len(locations)
+        ):
+            line = json.dumps(record) + "\n"
+            outfile.write(line.encode("utf8"))
+
+    os.rename(tmp_path, snapshot_path)
+
+
+if __name__ == "__main__":
+    read_only_session = get_aws_session(role_arn=READ_ONLY_ROLE_ARN)
+
+    # download_existing_snapshot(read_only_session)
+
+    if click.confirm(
+        "Do you want to update the snapshot with the latest Sierra records? "
+        "(Only do this if you're running on an EC2 instance)"
+    ):
+        freshen_sierra_records_snapshot(
+            session=read_only_session, snapshot_path=LOCAL_SNAPSHOT_PATH
+        )
+
+        upload_file_to_s3(
+            bucket=SNAPSHOT_BUCKET,
+            key=SNAPSHOT_KEY,
+            filename=LOCAL_SNAPSHOT_PATH
+        )
+
+    print("")
+    print(f"Your snapshot has been saved to {LOCAL_SNAPSHOT_PATH}")
+    print("")
+    print("Here's some Python to get you started:")
+    print("")
+    print(click.style(EXAMPLE_SCRIPT, "blue"))

--- a/sierra_adapter/s3.py
+++ b/sierra_adapter/s3.py
@@ -1,0 +1,52 @@
+import os
+
+import tqdm
+
+
+def download_object_from_s3(session, *, bucket, key, version_id=None, filename):
+    """
+    Download an object from S3 with a progress bar using tqdm.
+
+    See https://alexwlchan.net/2021/02/s3-progress-bars/
+    """
+    s3 = session.client("s3")
+
+    kwargs = {"Bucket": bucket, "Key": key}
+
+    if version_id is not None:
+        kwargs["VersionId"] = version_id
+
+    object_size = s3.head_object(**kwargs)["ContentLength"]
+
+    if version_id is not None:
+        ExtraArgs = {"VersionId": version_id}
+    else:
+        ExtraArgs = None
+
+    with tqdm.tqdm(total=object_size, unit="B", unit_scale=True, desc=filename) as pbar:
+        s3.download_file(
+            Bucket=bucket,
+            Key=key,
+            ExtraArgs=ExtraArgs,
+            Filename=filename,
+            Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
+        )
+
+
+def upload_file_to_s3(session, *, bucket, key, filename):
+    """
+    Upload a file to S3 with a progress bar using tqdm.
+
+    See https://alexwlchan.net/2021/02/s3-progress-bars/
+    """
+    file_size = os.stat(filename).st_size
+
+    s3 = session.client("s3")
+
+    with tqdm.tqdm(total=file_size, unit="B", unit_scale=True, desc=filename) as pbar:
+        s3.upload_file(
+            Filename=filename,
+            Bucket=bucket,
+            Key=key,
+            Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
+        )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5025

This script saves a snapshot of our Sierra records to S3. This is what an individual line of that snapshot looks like (pretty-printed):

```json
{
  "id": "1806550",
  "location": {
    "bucket": "wellcomecollection-vhs-sierra-sierra-adapter-20200604",
    "key": "1806550/0/e19cd2db-fcff-4043-a496-aee96cbf7b4a"
  },
  "record": {
    "bib": {
      "data": {
        "deleted": true,
        "deletedDate": "2016-05-11",
        "fixedFields": {
        },
        "id": "1806550",
        "locations": [

        ],
        "orders": [

        ],
        "varFields": [

        ]
      },
      "id": {
        "recordNumber": "1806550"
      },
      "modifiedDate": "2016-05-11T23:59:59.999999999Z"
    },
    "items": {
    }
  }
}
```

Actually building the whole thing takes a very long time, so it includes the location of the S3 object pointed to by DynamoDB. If that hasn't changed since the last time the snapshot was fetched, we can skip re-fetching it from S3.

Long-term I think we should consider moving away from using Dynamo/S3 pointers in this way. We could fit 99% of Sierra records into a DynamoDB row, and just move out the largest ones (with a conservative limit, say 200KB so the record would fit in SNS/SQS and DynamoDB). That would reduce costs and make them much easier to manage.