### PR TITLE
Increase the queue visibility timeout in the deletion checker tests

### DIFF
--- a/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/uk/ac/wellcome/platform/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
@@ -180,7 +180,7 @@ class DeletionCheckerWorkerServiceTest
     batchDuration: FiniteDuration = 100 milliseconds
   )(testWith: TestWith[(QueuePair, MemoryMessageSender), R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueuePair() {
+      withLocalSqsQueuePair(visibilityTimeout = 5) {
         case queuePair @ QueuePair(queue, _) =>
           withSQSStream[NotificationMessage, R](queue) { stream =>
             implicit val ec: ExecutionContext = actorSystem.dispatcher


### PR DESCRIPTION
This test is flaky in CI -- see a recent failed test run: https://buildkite.com/wellcomecollection/catalogue/builds/2968#263e3f60-c9c7-4de6-9bf9-b341ac22fc4c

    Last failure message: List("35", "46", "2a", "63", "30", "30", "63")
    did not contain the same elements as Vector("30", "63", "46", "2a", "35").
    (DeletionCheckerWorkerServiceTest.scala:56)

This is the line that actually fails:

    messageSender.getMessages[CalmSourcePayload]().map(_.id) should
      contain theSameElementsAs deletedRowIds

You can reproduce this failure locally if you insert an artificial delay into the worker service (e.g. `Thread.sleep(1000)`).  If messages don't complete within the default timeout, they get resent, and duplicate messages appear in the messageSender output.

Bumping the queue visibility timeout should fix this.