### PR TITLE
Handle an HTTP 413 Request Too Large error from Elasticsearch

### DIFF
--- a/common/pipeline_storage/docker-compose.yml
+++ b/common/pipeline_storage/docker-compose.yml
@@ -12,3 +12,8 @@ elasticsearch:
     - "transport.host=0.0.0.0"
     - "cluster.name=wellcome"
     - "discovery.type=single-node"
+
+    # This is deliberately much lower than the default (100mb), because we want
+    # to test that our code works correctly when it exceeds this limit, but without
+    # queuing up 100mb+ of documents in-memory during tests.
+    - "http.max_content_length=1mb"

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -61,19 +61,20 @@ class ElasticIndexer[T: Indexable](
             // Either we'll narrow it down to a single document that's to big to be
             // indexed, or we'll index everything successfully.
             case response if response.status == 413 =>
-
               // If there's only one document left, there's nothing to do --
               // this document is Just Too Big.
               // https://twitter.com/smolrobots/status/1001226918107246592
               if (documents.size == 1) {
-                warn(s"HTTP 413 from Elasticsearch for a single document (${indexable.id(documents.head)})")
+                warn(s"HTTP 413 from Elasticsearch for a single document (${indexable
+                  .id(documents.head)})")
                 Future.successful(Left(documents))
               }
 
               // Slice the documents in two, and index them both separately.
               // We'll combine the results.
               else {
-                warn(s"HTTP 413 from Elasticsearch (${documents.size} documents); trying smaller slices")
+                warn(
+                  s"HTTP 413 from Elasticsearch (${documents.size} documents); trying smaller slices")
                 val (slice0, slice1) = documents.splitAt(documents.size / 2)
 
                 val futures: Future[Seq[Either[Seq[T], Seq[T]]]] =

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/ElasticIndexer.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.pipeline_storage
 
 import scala.concurrent.{ExecutionContext, Future}
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.bulk.{BulkResponse, BulkResponseItem}
+import com.sksamuel.elastic4s.requests.bulk.BulkResponseItem
 import com.sksamuel.elastic4s.requests.common.VersionType.ExternalGte
-import com.sksamuel.elastic4s.{ElasticClient, Index, Response}
+import com.sksamuel.elastic4s.{ElasticClient, Index}
 import com.sksamuel.elastic4s.{Indexable => ElasticIndexable}
 import io.circe.{Encoder, Printer}
 import grizzled.slf4j.Logging
@@ -52,11 +52,46 @@ class ElasticIndexer[T: Indexable](
           .execute {
             bulk(inserts)
           }
-          .map { response: Response[BulkResponse] =>
-            if (response.isError) {
+          .flatMap {
+
+            // An HTTP 413 Request Too Large error means we tried to index too
+            // many documents at once.  In this case, we split the list in half
+            // and try to index both halves separately.
+            //
+            // Either we'll narrow it down to a single document that's to big to be
+            // indexed, or we'll index everything successfully.
+            case response if response.status == 413 =>
+
+              // If there's only one document left, there's nothing to do --
+              // this document is Just Too Big.
+              // https://twitter.com/smolrobots/status/1001226918107246592
+              if (documents.size == 1) {
+                warn(s"HTTP 413 from Elasticsearch for a single document (${indexable.id(documents.head)})")
+                Future.successful(Left(documents))
+              }
+
+              // Slice the documents in two, and index them both separately.
+              // We'll combine the results.
+              else {
+                warn(s"HTTP 413 from Elasticsearch (${documents.size} documents); trying smaller slices")
+                val (slice0, slice1) = documents.splitAt(documents.size / 2)
+
+                val futures: Future[Seq[Either[Seq[T], Seq[T]]]] =
+                  Future.sequence(Seq(apply(slice0), apply(slice1)))
+
+                futures.map {
+                  case Seq(Right(docs0), Right(docs1)) => Right(docs0 ++ docs1)
+                  case Seq(Left(docs0), Left(docs1))   => Left(docs0 ++ docs1)
+                  case Seq(Left(docs0), _)             => Left(docs0)
+                  case Seq(_, Left(docs1))             => Left(docs1)
+                }
+              }
+
+            case response if response.isError =>
               error(s"Error from Elasticsearch: $response")
-              Left(documents)
-            } else {
+              Future.successful(Left(documents))
+
+            case response =>
               debug(s"Bulk response = $response")
               val bulkResponse = response.result
               val actualFailures = bulkResponse.failures.filterNot {
@@ -69,11 +104,12 @@ class ElasticIndexer[T: Indexable](
                   failure.id
                 }
 
-                Left(documents.filter(doc => {
-                  failedIds.contains(indexable.id(doc))
-                }))
-              } else Right(documents)
-            }
+                Future.successful(
+                  Left(documents.filter(doc => {
+                    failedIds.contains(indexable.id(doc))
+                  }))
+                )
+              } else Future.successful(Right(documents))
           }
       }
 
@@ -95,5 +131,4 @@ class ElasticIndexer[T: Indexable](
 
     alreadyIndexedHasHigherVersion
   }
-
 }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
@@ -207,36 +207,106 @@ class ElasticIndexerTest
     }
   }
 
-  it("indexes documents that are too big to index in one request") {
-    // This collection has to exceed the ``http.max_content_length`` setting
-    // in Elasticsearch.  If that happens, we get a 413 Request Too Large error.
-    //
-    // The default value of the setting is 100mb; to avoid queuing up that many
-    // documents in this test, we've turned the limit down to 1mb in the
-    // Docker Compose file for these tests.
-    val title = randomAlphanumeric(length = 20000)
-    val documents = (1 to 100)
-      .map { _ => createDocument.copy(title = title) }
+  describe("handles documents that are too big to index in one request") {
+    it("indexes a lot of small documents that add up to something big") {
+      // This collection has to exceed the ``http.max_content_length`` setting
+      // in Elasticsearch.  If that happens, we get a 413 Request Too Large error.
+      //
+      // The default value of the setting is 100mb; to avoid queuing up that many
+      // documents in this test, we've turned the limit down to 1mb in the
+      // Docker Compose file for these tests.
+      val title = randomAlphanumeric(length = 20000)
+      val documents = (1 to 100)
+        .map { _ => createDocument.copy(title = title) }
 
-    withContext() { implicit index: Index =>
-      withIndexer { indexer =>
-        val future = indexer(documents)
+      withContext() { implicit index: Index =>
+        withIndexer { indexer =>
+          val future = indexer(documents)
 
-        whenReady(future) { resp =>
-          resp shouldBe a[Right[_, _]]
-          resp.value should contain theSameElementsAs documents
+          whenReady(future) { resp =>
+            resp shouldBe a[Right[_, _]]
+            resp.value should contain theSameElementsAs documents
+          }
+
+          // Because Elasticsearch isn't strongly consistent, it may take a
+          // few seconds for the count response to be accurate.
+          eventually {
+            val countFuture = elasticClient.execute {
+              count(index.name)
+            }
+
+            whenReady(countFuture) {
+              _.result.count shouldBe documents.size
+            }
+          }
         }
+      }
+    }
 
-        // Because Elasticsearch isn't strongly consistent, it may take a
-        // few seconds for the count response to be accurate.
-        eventually {
-          val countFuture = elasticClient.execute {
-            count(index.name)
+    it("fails to index a single big document") {
+      val title = randomAlphanumeric(length = 2000000)
+      val documents = Seq(createDocument.copy(title = title))
+
+      withContext() { implicit index: Index =>
+        withIndexer { indexer =>
+          val future = indexer(documents)
+
+          whenReady(future) {
+            _.left.value shouldBe documents
+          }
+        }
+      }
+    }
+
+    it("fails to index two big documents") {
+      val title = randomAlphanumeric(length = 2000000)
+      val documents = Seq(
+        createDocument.copy(title = title),
+        createDocument.copy(title = title)
+      )
+
+      withContext() { implicit index: Index =>
+        withIndexer { indexer =>
+          val future = indexer(documents)
+
+          whenReady(future) {
+            _.left.value shouldBe documents
+          }
+        }
+      }
+    }
+
+    val smallDocument = createDocument
+    val bigDocument = createDocument.copy(title = randomAlphanumeric(length = 2000000))
+
+    it("indexes everything except the single big document (big document last)") {
+      val documents = Seq(smallDocument, bigDocument)
+
+      withContext() { implicit index: Index =>
+        withIndexer { indexer =>
+          val future = indexer(documents)
+
+          whenReady(future) {
+            _.left.value shouldBe Seq(bigDocument)
           }
 
-          whenReady(countFuture) {
-            _.result.count shouldBe documents.size
+          assertElasticsearchEventuallyHas(index, smallDocument)
+        }
+      }
+    }
+
+    it("indexes everything except the single big document (big document first)") {
+      val documents = Seq(bigDocument, smallDocument)
+
+      withContext() { implicit index: Index =>
+        withIndexer { indexer =>
+          val future = indexer(documents)
+
+          whenReady(future) {
+            _.left.value shouldBe Seq(bigDocument)
           }
+
+          assertElasticsearchEventuallyHas(index, smallDocument)
         }
       }
     }

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
@@ -217,7 +217,9 @@ class ElasticIndexerTest
       // Docker Compose file for these tests.
       val title = randomAlphanumeric(length = 20000)
       val documents = (1 to 100)
-        .map { _ => createDocument.copy(title = title) }
+        .map { _ =>
+          createDocument.copy(title = title)
+        }
 
       withContext() { implicit index: Index =>
         withIndexer { indexer =>
@@ -277,7 +279,8 @@ class ElasticIndexerTest
     }
 
     val smallDocument = createDocument
-    val bigDocument = createDocument.copy(title = randomAlphanumeric(length = 2000000))
+    val bigDocument =
+      createDocument.copy(title = randomAlphanumeric(length = 2000000))
 
     it("indexes everything except the single big document (big document last)") {
       val documents = Seq(smallDocument, bigDocument)


### PR DESCRIPTION
This error occurs when we try to index more documents than Elasticsearch can handle in a single request. Unfortunately, we can't just trust the queue logic to redrive these and hope we'll luck out – we have single messages that can hit this error.

Thus, we divide and conquer -- split the list of documents in two, and index both halves separately.  Eventually we will either index everything, or find the single document that can't be indexed (and everything else will index successfully).

In theory this could cause recursion issues; unfortunately I couldn't see a good way to make this tail-recursive.

In practice I don't think that'll be too much of an issue -- we only see 413s a handful of times during a reindex, and I think a single recursion will fix it.  If not, we'll find out quickly!

Closes https://github.com/wellcomecollection/platform/issues/5036