### PR TITLE
Count the number of locationTypes in the API diff tool

### DIFF
--- a/api/diff_tool/routes.json
+++ b/api/diff_tool/routes.json
@@ -113,5 +113,14 @@
       "include": "items,genres,identifiers"
     },
     "comment": "A redirected Work that had issues in the 2021-02-01 reindex"
+  },
+  {
+    "path": "/works",
+    "params": {
+      "include": "items,genres,identifiers",
+      "aggregations": "items.locations.type",
+      "pageSize": "1"
+    },
+    "comment": "Aggregation of locationType"
   }
 ]


### PR DESCRIPTION
This would have given us a clue that something was up in the latest reindex (this compares the 2021-02-09 and 2021-02-17 indexes):

<img width="1002" alt="Screenshot 2021-02-20 at 18 59 35" src="https://user-images.githubusercontent.com/301220/108605698-ce250080-73ad-11eb-80d0-07aa3e850026.png">
