### PR TITLE
The Sierra adapter should behave in an idempotent way

### DIFF
--- a/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
+++ b/sierra_adapter/sierra_bib_merger/src/main/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMerger.scala
@@ -20,7 +20,8 @@ object BibMerger {
 
     val isNewerData = sierraTransformable.maybeBibRecord match {
       case Some(bibData) =>
-        sierraBibRecord.modifiedDate.isAfter(bibData.modifiedDate)
+        sierraBibRecord.modifiedDate.isAfter(bibData.modifiedDate) ||
+          sierraBibRecord.modifiedDate == bibData.modifiedDate
       case None => true
     }
 

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -38,9 +38,9 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
         bibRecord = bibRecord
       )
 
-      BibMerger.mergeBibRecord(transformable, bibRecord) shouldBe Some(transformable)
+      BibMerger.mergeBibRecord(transformable, bibRecord) shouldBe Some(
+        transformable)
     }
-
 
     it("returns None when merging a stale update") {
       val oldBibRecord = createSierraBibRecordWith(

--- a/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
+++ b/sierra_adapter/sierra_bib_merger/src/test/scala/uk/ac/wellcome/platform/sierra_bib_merger/merger/BibMergerTest.scala
@@ -31,6 +31,17 @@ class BibMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       caught.getMessage shouldEqual s"Non-matching bib ids ${bibRecord.id} != ${transformable.sierraId}"
     }
 
+    it("returns the transformable if you merge the same record more than once") {
+      val bibRecord = createSierraBibRecord
+
+      val transformable = SierraTransformable(
+        bibRecord = bibRecord
+      )
+
+      BibMerger.mergeBibRecord(transformable, bibRecord) shouldBe Some(transformable)
+    }
+
+
     it("returns None when merging a stale update") {
       val oldBibRecord = createSierraBibRecordWith(
         modifiedDate = olderDate

--- a/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemMerger.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemMerger.scala
@@ -30,7 +30,8 @@ object ItemMerger {
     //
     val isNewerData = sierraTransformable.itemRecords.get(itemRecord.id) match {
       case Some(existing) =>
-        itemRecord.modifiedDate.isAfter(existing.modifiedDate)
+        itemRecord.modifiedDate.isAfter(existing.modifiedDate) ||
+          itemRecord.modifiedDate == existing.modifiedDate
       case None => true
     }
 

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemMergerTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/links/ItemMergerTest.scala
@@ -41,7 +41,7 @@ class ItemMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
       itemRecords = Map(itemRecord.id -> newerRecord))
   }
 
-  it("returns None if you apply the same update more than once") {
+  it("returns the record if you apply the same update more than once") {
     val bibId = createSierraBibNumber
     val record = createSierraItemRecordWith(
       bibIds = List(bibId)
@@ -52,7 +52,7 @@ class ItemMergerTest extends AnyFunSpec with Matchers with SierraGenerators {
     val transformable1 = ItemMerger.mergeItemRecord(sierraTransformable, record)
     val transformable2 = ItemMerger.mergeItemRecord(transformable1.get, record)
 
-    transformable2 shouldBe None
+    transformable2 shouldBe transformable1
   }
 
   it("returns None when merging item records with stale data") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.sierra_item_merger.services
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.platform.sierra_item_merger.fixtures.SierraItemMergerFixtures
 import uk.ac.wellcome.sierra_adapter.model.Implicits._
@@ -23,6 +24,7 @@ import weco.catalogue.source_model.store.SourceVHS
 
 class SierraItemMergerUpdaterServiceTest
     extends AnyFunSpec
+    with EitherValues
     with SierraGenerators
     with SierraItemMergerFixtures
     with SourceVHSFixture {
@@ -53,56 +55,6 @@ class SierraItemMergerUpdaterServiceTest
       bibId.withoutCheckDigit,
       expectedSierraTransformable,
       sourceVHS)
-  }
-
-  it("only updates records that have changed") {
-    val bibId1 = createSierraBibNumber // doesn't exist yet
-    val bibId2 = createSierraBibNumber // exists, not linked to the item
-    val bibId3 = createSierraBibNumber // exists, linked to the item
-
-    val bibIds = List(bibId1, bibId3, bibId2)
-
-    val itemRecord = createSierraItemRecordWith(bibIds = bibIds)
-
-    val transformable2 =
-      createSierraTransformableWith(sierraId = bibId2, itemRecords = List.empty)
-
-    val transformable3 =
-      createSierraTransformableWith(
-        sierraId = bibId3,
-        itemRecords = List(itemRecord))
-
-    val sourceVHS = createSourceVHSWith(
-      initialEntries = Map(
-        Version(bibId2.withoutCheckDigit, 0) -> transformable2,
-        Version(bibId3.withoutCheckDigit, 0) -> transformable3
-      )
-    )
-    val sierraUpdaterService = new SierraItemMergerUpdaterService(sourceVHS)
-
-    val expectedTransformable1 =
-      createSierraTransformableWith(
-        sierraId = bibId1,
-        maybeBibRecord = None,
-        itemRecords = List(itemRecord)
-      )
-
-    val expectedTransformable2 =
-      transformable2.copy(itemRecords = Map(itemRecord.id -> itemRecord))
-
-    val expectedTransformable3 =
-      transformable3.copy(itemRecords = Map(itemRecord.id -> itemRecord))
-
-    val result = sierraUpdaterService.update(itemRecord)
-
-    result shouldBe a[Right[_, _]]
-    result.right.get.map { _.id } should contain theSameElementsAs List(
-      Version(bibId1.withoutCheckDigit, 0),
-      Version(bibId2.withoutCheckDigit, 1))
-
-    assertStored(bibId1.withoutCheckDigit, expectedTransformable1, sourceVHS)
-    assertStored(bibId2.withoutCheckDigit, expectedTransformable2, sourceVHS)
-    assertStored(bibId3.withoutCheckDigit, expectedTransformable3, sourceVHS)
   }
 
   it("updates an item if it receives an update with a newer date") {
@@ -376,6 +328,26 @@ class SierraItemMergerUpdaterServiceTest
       transformable,
       sourceVHS
     )
+  }
+
+  it("re-sends an item if it receives the same update twice") {
+    val bibId = createSierraBibNumber
+
+    val itemRecord = createSierraItemRecordWith(
+      modifiedDate = newerDate,
+      bibIds = List(bibId)
+    )
+
+    val sourceVHS = createSourceVHS[SierraTransformable]
+    val sierraUpdaterService = new SierraItemMergerUpdaterService(sourceVHS)
+
+    (1 to 5).foreach { _ =>
+      val result = sierraUpdaterService.update(itemRecord)
+        result shouldBe a[Right[_, _]]
+      result.value should not be empty
+    }
+
+    sourceVHS.underlying.getLatest(bibId.withoutCheckDigit) shouldBe a[Right[_, _]]
   }
 
   it("adds an item to the record if the bibId exists but has no itemData") {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/uk/ac/wellcome/platform/sierra_item_merger/services/SierraItemMergerUpdaterServiceTest.scala
@@ -343,11 +343,12 @@ class SierraItemMergerUpdaterServiceTest
 
     (1 to 5).foreach { _ =>
       val result = sierraUpdaterService.update(itemRecord)
-        result shouldBe a[Right[_, _]]
+      result shouldBe a[Right[_, _]]
       result.value should not be empty
     }
 
-    sourceVHS.underlying.getLatest(bibId.withoutCheckDigit) shouldBe a[Right[_, _]]
+    sourceVHS.underlying.getLatest(bibId.withoutCheckDigit) shouldBe a[Right[_,
+                                                                             _]]
   }
 
   it("adds an item to the record if the bibId exists but has no itemData") {

--- a/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/main/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMerger.scala
@@ -8,7 +8,7 @@ object SierraItemRecordMerger extends Logging {
   def mergeItems(existingLink: SierraItemLink,
                  newRecord: SierraItemRecord): Option[SierraItemLink] =
     if (existingLink.modifiedDate.isBefore(newRecord.modifiedDate) ||
-      existingLink.modifiedDate == newRecord.modifiedDate) {
+        existingLink.modifiedDate == newRecord.modifiedDate) {
       Some(
         SierraItemLink(
           modifiedDate = newRecord.modifiedDate,

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -127,24 +127,28 @@ class SierraItemRecordMergerTest
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }
 
+  it("returns the link if it has the same modified date as the one already stored") {
+    val record = createSierraItemRecord
+    val link = SierraItemLink(record)
+
+    SierraItemRecordMerger.mergeItems(link, record) shouldBe Some(link)
+  }
+
   it("returns None if it receives an outdated update") {
     val bibIds = createSierraBibNumbers(count = 5)
 
-    val existingRecord = createSierraItemRecordWith(
-      modifiedDate = newerDate,
+    val oldRecord = createSierraItemRecordWith(
+      modifiedDate = olderDate,
       bibIds = bibIds.slice(0, 3)
     )
+
     val newRecord = createSierraItemRecordWith(
-      id = existingRecord.id,
+      id = oldRecord.id,
       modifiedDate = newerDate,
       bibIds = bibIds
     )
+    val newLink = SierraItemLink(newRecord)
 
-    val mergedRecord =
-      SierraItemRecordMerger.mergeItems(
-        existingLink = SierraItemLink(existingRecord),
-        newRecord = newRecord)
-
-    mergedRecord shouldBe None
+    SierraItemRecordMerger.mergeItems(newLink, oldRecord) shouldBe None
   }
 }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/merger/SierraItemRecordMergerTest.scala
@@ -127,7 +127,8 @@ class SierraItemRecordMergerTest
     mergedRecord.unlinkedBibIds shouldBe List(bibIds(2))
   }
 
-  it("returns the link if it has the same modified date as the one already stored") {
+  it(
+    "returns the link if it has the same modified date as the one already stored") {
     val record = createSierraItemRecord
     val link = SierraItemLink(record)
 

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -88,7 +88,10 @@ class SierraItemsToDynamoWorkerServiceTest
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
 
-            messageSender.getMessages[SierraItemRecord] shouldBe (1 to 5).map { _ => record }
+            messageSender.getMessages[SierraItemRecord] shouldBe (1 to 5).map {
+              _ =>
+                record
+            }
           }
         }
     }

--- a/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_items_to_dynamo/src/test/scala/uk/ac/wellcome/platform/sierra_items_to_dynamo/services/SierraItemsToDynamoWorkerServiceTest.scala
@@ -72,7 +72,29 @@ class SierraItemsToDynamoWorkerServiceTest
     }
   }
 
-  it("only applies an update once, even if it's sent multiple times") {
+  it("always forwards the newest item, even if it's sent multiple times") {
+    val record = createSierraItemRecord
+
+    val messageSender = new MemoryMessageSender
+
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorkerService(queue, messageSender = messageSender) { _ =>
+          (1 to 5).foreach { _ =>
+            sendNotificationToSQS(queue = queue, message = record)
+          }
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+
+            messageSender.getMessages[SierraItemRecord] shouldBe (1 to 5).map { _ => record }
+          }
+        }
+    }
+  }
+
+  it("skips an item which is older than the stored link") {
     val bibIds = createSierraBibNumbers(count = 5)
 
     val bibIds1 = List(bibIds(0), bibIds(1), bibIds(2))
@@ -90,13 +112,9 @@ class SierraItemsToDynamoWorkerServiceTest
       bibIds = bibIds2
     )
 
-    val expectedLink = SierraItemRecordMerger
-      .mergeItems(existingLink = SierraItemLink(record1), newRecord = record2)
-      .get
-
     val store = MemoryVersionedStore[SierraItemNumber, SierraItemLink](
       initialEntries = Map(
-        Version(record1.id, 1) -> SierraItemLink(record1)
+        Version(record2.id, 1) -> SierraItemLink(record2)
       )
     )
 
@@ -105,17 +123,13 @@ class SierraItemsToDynamoWorkerServiceTest
     withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
         withWorkerService(queue, store, messageSender = messageSender) { _ =>
-          (1 to 5).foreach { _ =>
-            sendNotificationToSQS(queue = queue, message = record2)
-          }
+          sendNotificationToSQS(queue = queue, message = record1)
 
           eventually {
             assertQueueEmpty(queue)
             assertQueueEmpty(dlq)
 
-            messageSender.getMessages[SierraItemRecord] shouldBe Seq(
-              record2.copy(unlinkedBibIds = expectedLink.unlinkedBibIds)
-            )
+            messageSender.messages shouldBe empty
           }
         }
     }


### PR DESCRIPTION
Spotted while working on wellcomecollection/platform#5003

The Sierra adapters have the following failure mode:

* $service receives an update A
* it stores update A
* it tries to send update A to the next $service, but fails
* $service re-receives update A
* it sees update A is already stored, and discards it

This is not ideal – it's better to always resend an update if it looks the same as what we've already got, just to be sure. (We still discard updates that are strictly older than what's stored.)

This means we can force a service to resend the onward message by resending the input message.