### PR TITLE
Add holdings to the Sierra reader

### DIFF
--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraHoldingsRecord.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraHoldingsRecord.scala
@@ -19,8 +19,8 @@ case object SierraHoldingsRecord {
   private case class SierraAPIData(bibIds: List[String])
 
   /** This apply method is for parsing JSON bodies that come from the
-   * Sierra API.
-   */
+    * Sierra API.
+    */
   def apply(id: String,
             data: String,
             modifiedDate: Instant): SierraHoldingsRecord = {

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraHoldingsRecord.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraHoldingsRecord.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.sierra_adapter.model
+
+import java.time.Instant
+
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.util.{Failure, Success}
+
+case class SierraHoldingsRecord(
+  id: SierraHoldingsNumber,
+  data: String,
+  modifiedDate: Instant,
+  bibIds: List[SierraBibNumber],
+  unlinkedBibIds: List[SierraBibNumber] = List()
+) extends AbstractSierraRecord
+
+case object SierraHoldingsRecord {
+
+  private case class SierraAPIData(bibIds: List[String])
+
+  /** This apply method is for parsing JSON bodies that come from the
+   * Sierra API.
+   */
+  def apply(id: String,
+            data: String,
+            modifiedDate: Instant): SierraHoldingsRecord = {
+    val bibIds = fromJson[SierraAPIData](data) match {
+      case Success(apiData) => apiData.bibIds
+      case Failure(e) =>
+        throw new IllegalArgumentException(
+          s"Error parsing bibIds from JSON <<$data>> ($e)")
+    }
+
+    SierraHoldingsRecord(
+      id = SierraHoldingsNumber(id),
+      data = data,
+      modifiedDate = modifiedDate,
+      bibIds = bibIds.map { SierraBibNumber }
+    )
+  }
+}

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraRecordNumber.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraRecordNumber.scala
@@ -25,8 +25,8 @@ sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
   /** Returns the ID with the check digit and prefix. */
   def withCheckDigit: String = {
     val prefix = recordType match {
-      case SierraRecordTypes.bibs  => "b"
-      case SierraRecordTypes.items => "i"
+      case SierraRecordTypes.bibs     => "b"
+      case SierraRecordTypes.items    => "i"
       case SierraRecordTypes.holdings => "h"
       case _ =>
         throw new RuntimeException(
@@ -77,6 +77,6 @@ case class SierraItemNumber(recordNumber: String)
 }
 
 case class SierraHoldingsNumber(recordNumber: String)
-  extends SierraTypedRecordNumber {
+    extends SierraTypedRecordNumber {
   val recordType: SierraRecordTypes.Value = SierraRecordTypes.holdings
 }

--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraRecordNumber.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraRecordNumber.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.sierra_adapter.model
 
 object SierraRecordTypes extends Enumeration {
-  val bibs, items = Value
+  val bibs, items, holdings = Value
 }
 
 trait SierraRecordNumber {
@@ -27,6 +27,7 @@ sealed trait SierraTypedRecordNumber extends SierraRecordNumber {
     val prefix = recordType match {
       case SierraRecordTypes.bibs  => "b"
       case SierraRecordTypes.items => "i"
+      case SierraRecordTypes.holdings => "h"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"
@@ -73,4 +74,9 @@ case class SierraBibNumber(recordNumber: String)
 case class SierraItemNumber(recordNumber: String)
     extends SierraTypedRecordNumber {
   val recordType: SierraRecordTypes.Value = SierraRecordTypes.items
+}
+
+case class SierraHoldingsNumber(recordNumber: String)
+  extends SierraTypedRecordNumber {
+  val recordType: SierraRecordTypes.Value = SierraRecordTypes.holdings
 }

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
@@ -40,6 +40,9 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraItemNumber: SierraItemNumber =
     SierraItemNumber(createSierraRecordNumberString)
 
+  def createSierraHoldingsNumber: SierraHoldingsNumber =
+    SierraHoldingsNumber(createSierraRecordNumberString)
+
   protected def createTitleVarfield(
     title: String = s"title-${randomAlphanumeric()}"): String =
     s"""
@@ -78,7 +81,7 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraItemRecordWith(
     id: SierraItemNumber = createSierraItemNumber,
     data: (SierraItemNumber, Instant, List[SierraBibNumber]) => String =
-      defaultItemData,
+      defaultData,
     modifiedDate: Instant = Instant.now,
     bibIds: List[SierraBibNumber] = List(),
     unlinkedBibIds: List[SierraBibNumber] = List()
@@ -94,9 +97,29 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
-  private def defaultItemData(id: SierraItemNumber,
-                              modifiedDate: Instant,
-                              bibIds: List[SierraBibNumber]) =
+  def createSierraHoldingsRecordWith(
+    id: SierraHoldingsNumber = createSierraHoldingsNumber,
+    data: (SierraHoldingsNumber, Instant, List[SierraBibNumber]) => String =
+      defaultData,
+    modifiedDate: Instant = Instant.now,
+    bibIds: List[SierraBibNumber] = List(),
+    unlinkedBibIds: List[SierraBibNumber] = List()
+  ): SierraHoldingsRecord = {
+    val recordData = data(id, modifiedDate, bibIds)
+
+    SierraHoldingsRecord(
+      id = id,
+      data = recordData,
+      modifiedDate = modifiedDate,
+      bibIds = bibIds,
+      unlinkedBibIds = unlinkedBibIds
+    )
+  }
+
+
+  private def defaultData(id: SierraTypedRecordNumber,
+                          modifiedDate: Instant,
+                          bibIds: List[SierraBibNumber]): String =
     s"""
        |{
        |  "id": "$id",

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
@@ -116,7 +116,6 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
-
   private def defaultData(id: SierraTypedRecordNumber,
                           modifiedDate: Instant,
                           bibIds: List[SierraBibNumber]): String =

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.platform.sierra_reader.config.builders
 
 import com.typesafe.config.Config
 import uk.ac.wellcome.platform.sierra_reader.config.models.ReaderConfig
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes.{
-  bibs,
-  items
-}
+import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes._
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object ReaderConfigBuilder {
@@ -13,6 +10,7 @@ object ReaderConfigBuilder {
     val resourceType = config.requireString("reader.resourceType") match {
       case s: String if s == bibs.toString  => bibs
       case s: String if s == items.toString => items
+      case s: String if s == holdings.toString => holdings
       case s: String =>
         throw new IllegalArgumentException(
           s"$s is not a valid Sierra resource type")

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
@@ -8,8 +8,8 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 object ReaderConfigBuilder {
   def buildReaderConfig(config: Config): ReaderConfig = {
     val resourceType = config.requireString("reader.resourceType") match {
-      case s: String if s == bibs.toString  => bibs
-      case s: String if s == items.toString => items
+      case s: String if s == bibs.toString     => bibs
+      case s: String if s == items.toString    => items
       case s: String if s == holdings.toString => holdings
       case s: String =>
         throw new IllegalArgumentException(

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraResourceTypes.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/models/SierraResourceTypes.scala
@@ -1,5 +1,5 @@
 package uk.ac.wellcome.platform.sierra_reader.models
 
 object SierraResourceTypes extends Enumeration {
-  val bibs, items = Value
+  val bibs, items, holdings = Value
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader.services
 
 import java.time.Instant
-
 import akka.Done
 import akka.actor.ActorSystem
 import com.amazonaws.services.s3.AmazonS3
@@ -25,6 +24,7 @@ import uk.ac.wellcome.sierra.{SierraSource, ThrottleRate}
 import uk.ac.wellcome.sierra_adapter.model.{
   AbstractSierraRecord,
   SierraBibRecord,
+  SierraHoldingsRecord,
   SierraItemRecord
 }
 import uk.ac.wellcome.storage.Identified
@@ -118,8 +118,9 @@ class SierraReaderWorkerService(
 
   private def createRecord: (String, String, Instant) => AbstractSierraRecord =
     readerConfig.resourceType match {
-      case SierraResourceTypes.bibs  => SierraBibRecord.apply
-      case SierraResourceTypes.items => SierraItemRecord.apply
+      case SierraResourceTypes.bibs     => SierraBibRecord.apply
+      case SierraResourceTypes.items    => SierraItemRecord.apply
+      case SierraResourceTypes.holdings => SierraHoldingsRecord.apply
     }
 
   private def toJson(records: Seq[AbstractSierraRecord]): Json =
@@ -128,5 +129,7 @@ class SierraReaderWorkerService(
         records.asInstanceOf[Seq[SierraBibRecord]].asJson
       case SierraResourceTypes.items =>
         records.asInstanceOf[Seq[SierraItemRecord]].asJson
+      case SierraResourceTypes.holdings =>
+        records.asInstanceOf[Seq[SierraHoldingsRecord]].asJson
     }
 }


### PR DESCRIPTION
Part of wellcomecollection/platform#5003, pulled out of #1394.

This PR establishes some types for holdings records, and adds them to the Sierra reader. I'll wire it up in Terraform later; this is just about getting the Scala app to know what holdings are.