### PR TITLE
Make it easier to understand why a Work is Deleted/Invisible

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/InvisibilityReason.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/InvisibilityReason.scala
@@ -7,4 +7,5 @@ object InvisibilityReason {
   case class SourceFieldMissing(info: String) extends InvisibilityReason
   case class InvalidValueInSourceField(info: String) extends InvisibilityReason
   case object UnlinkedHistoricalLibraryMiro extends InvisibilityReason
+  case class UnableToTransform(message: String) extends InvisibilityReason
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/InvisibilityReason.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/InvisibilityReason.scala
@@ -8,4 +8,5 @@ object InvisibilityReason {
   case class InvalidValueInSourceField(info: String) extends InvisibilityReason
   case object UnlinkedHistoricalLibraryMiro extends InvisibilityReason
   case class UnableToTransform(message: String) extends InvisibilityReason
+  case object MetsWorksAreNotVisible extends InvisibilityReason
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -65,7 +65,7 @@ object Work {
     version: Int,
     data: WorkData[State#WorkDataState],
     state: State,
-    deletedReason: Option[DeletedReason] = None,
+    deletedReason: DeletedReason,
   ) extends Work[State]
 }
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.models.work.generators
 
 import java.time.Instant
-
 import uk.ac.wellcome.models.work.internal._
 import WorkState._
+import uk.ac.wellcome.models.work.internal.DeletedReason.DeletedFromSource
 
 import scala.util.Random
 
@@ -116,7 +116,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       )
 
     def deleted(
-      deletedReason: Option[DeletedReason] = None): Work.Deleted[State] =
+      deletedReason: DeletedReason = DeletedFromSource("tests")): Work.Deleted[State] =
       Work.Deleted[State](
         state = work.state,
         data = work.data,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -115,8 +115,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         invisibilityReasons = invisibilityReasons
       )
 
-    def deleted(
-      deletedReason: DeletedReason = DeletedFromSource("tests")): Work.Deleted[State] =
+    def deleted(deletedReason: DeletedReason = DeletedFromSource("tests"))
+      : Work.Deleted[State] =
       Work.Deleted[State](
         state = work.state,
         data = work.data,

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -66,7 +66,7 @@ object CalmTransformer
       state = Source(sourceIdentifier(record), record.retrievedAt),
       data = workData(record).getOrElse(WorkData[DataState.Unidentified]()),
       version = version,
-      deletedReason = Some(reason)
+      deletedReason = reason
     )
 
   private def tryParseValidWork(record: CalmRecord,

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -112,7 +112,7 @@ object CalmTransformer
       case TitleMissing      => SourceFieldMissing("Calm:Title")
       case RefNoMissing      => SourceFieldMissing("Calm:RefNo")
       case LevelMissing      => SourceFieldMissing("Calm:Level")
-      case UnrecognisedLevel => InvalidValueInSourceField("Calm:Level")
+      case UnrecognisedLevel(level) => InvalidValueInSourceField(s"Calm:Level - $level")
     }
 
   def shouldSuppress(record: CalmRecord): Boolean =
@@ -237,7 +237,7 @@ object CalmTransformer
         case "piece"            => Right(WorkType.Standard)
         case level =>
           warn(s"${record.id} has an unrecognised level: $level")
-          Left(UnrecognisedLevel)
+          Left(UnrecognisedLevel(level))
       }
       .getOrElse(Left(LevelMissing))
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -109,10 +109,11 @@ object CalmTransformer
   private def knownErrToUntransformableReason(
     err: CalmTransformerException): InvisibilityReason =
     err match {
-      case TitleMissing      => SourceFieldMissing("Calm:Title")
-      case RefNoMissing      => SourceFieldMissing("Calm:RefNo")
-      case LevelMissing      => SourceFieldMissing("Calm:Level")
-      case UnrecognisedLevel(level) => InvalidValueInSourceField(s"Calm:Level - $level")
+      case TitleMissing => SourceFieldMissing("Calm:Title")
+      case RefNoMissing => SourceFieldMissing("Calm:RefNo")
+      case LevelMissing => SourceFieldMissing("Calm:Level")
+      case UnrecognisedLevel(level) =>
+        InvalidValueInSourceField(s"Calm:Level - $level")
     }
 
   def shouldSuppress(record: CalmRecord): Boolean =

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/models/CalmTransformerException.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/models/CalmTransformerException.scala
@@ -5,5 +5,5 @@ object CalmTransformerException {
   case object TitleMissing extends CalmTransformerException
   case object RefNoMissing extends CalmTransformerException
   case object LevelMissing extends CalmTransformerException
-  case object UnrecognisedLevel extends CalmTransformerException
+  case class UnrecognisedLevel(level: String) extends CalmTransformerException
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -363,8 +363,7 @@ class CalmTransformerTest
     result shouldBe a[Work.Deleted[_]]
     result
       .asInstanceOf[Work.Deleted[_]]
-      .deletedReason
-      .get shouldBe DeletedFromSource("Calm")
+      .deletedReason shouldBe DeletedFromSource("Calm")
   }
 
   it("transforms to deleted work when CatalogueStatus is suppressible") {
@@ -573,7 +572,7 @@ class CalmTransformerTest
           record.retrievedAt
         ),
         version = version,
-        deletedReason = Some(SuppressedFromSource("Calm"))
+        deletedReason = SuppressedFromSource("Calm")
       )
     )
   }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils.equalsIgnoreCase
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Source
 import uk.ac.wellcome.models.work.internal.DeletedReason.DeletedFromSource
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.MetsWorksAreNotVisible
 
 case class MetsData(
   recordIdentifier: String,
@@ -48,7 +49,8 @@ case class MetsData(
               thumbnail =
                 thumbnail(sourceIdentifier.value, license, accessStatus),
               imageData = imageData(version, license, accessStatus)
-            )
+            ),
+            invisibilityReasons = List(MetsWorksAreNotVisible)
           )
     }
   }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -28,7 +28,9 @@ case class MetsData(
             version = version,
             data = WorkData[DataState.Unidentified](),
             state = Source(sourceIdentifier, modifiedTime),
-            deletedReason = Some(DeletedFromSource("Mets"))))
+            deletedReason = DeletedFromSource("Mets")
+          )
+        )
       case false =>
         for {
           license <- parseLicense

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -75,7 +75,7 @@ class MetsDataTest
         version = version,
         data = WorkData[DataState.Unidentified](),
         state = Source(expectedSourceIdentifier, createdDate),
-        deletedReason = Some(DeletedFromSource("Mets"))
+        deletedReason = DeletedFromSource("Mets")
       )
 
   }

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.internal._
 import WorkState.Source
 import uk.ac.wellcome.models.work.internal.DeletedReason.DeletedFromSource
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.MetsWorksAreNotVisible
 import uk.ac.wellcome.platform.transformer.mets.fixtures.MetsGenerators
 
 class MetsDataTest
@@ -54,7 +55,8 @@ class MetsDataTest
               reason = "METS work"
             )
           )
-        )
+        ),
+        invisibilityReasons = List(MetsWorksAreNotVisible)
       )
   }
 
@@ -118,7 +120,8 @@ class MetsDataTest
               reason = "METS work"
             )
           )
-        )
+        ),
+        invisibilityReasons = List(MetsWorksAreNotVisible)
       )
   }
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -1,15 +1,20 @@
 package uk.ac.wellcome.platform.transformer.miro
 
 import java.time.Instant
-import scala.util.Try
+import scala.util.{Success, Try}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.miro.exceptions.{
+  ShouldNotTransformException,
+  ShouldSuppressException
+}
 import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.platform.transformer.miro.transformers._
 import WorkState.Source
+import uk.ac.wellcome.models.work.internal.DeletedReason.SuppressedFromSource
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.UnableToTransform
 import uk.ac.wellcome.models.work.internal.result.Result
 import weco.catalogue.transformer.Transformer
 
@@ -61,59 +66,79 @@ class MiroRecordTransformer
       modifiedTime = Instant.EPOCH
     )
 
-    Try {
-      // Any records that aren't cleared for the Catalogue API should be
-      // discarded immediately.
-      if (!miroMetadata.isClearedForCatalogueAPI) {
-        throw new ShouldNotTransformException(
-          s"Image ${originalMiroRecord.imageNumber} is not cleared for the API!"
-        )
-      }
-
-      // This is an utterly awful hack we have to live with until we get
-      // these corrected in the source data.
-      val miroRecord = MiroRecord.create(toJson(originalMiroRecord).get)
-
-      // These images should really have been removed from the pipeline
-      // already, but we have at least one instance (B0010525).  It was
-      // throwing a MatchError when we tried to pick a license, so handle
-      // it properly here.
-      if (!miroRecord.copyrightCleared.contains("Y")) {
-        throw new ShouldNotTransformException(
-          s"Image ${miroRecord.imageNumber} does not have copyright clearance!"
-        )
-      }
-
-      val (title, description) = getTitleAndDescription(miroRecord)
-
-      val data = WorkData[DataState.Unidentified](
-        otherIdentifiers = getOtherIdentifiers(miroRecord),
-        title = Some(title),
-        format = getFormat,
-        description = description,
-        lettering = miroRecord.suppLettering,
-        createdDate = getCreatedDate(miroRecord),
-        subjects = getSubjects(miroRecord),
-        genres = getGenres(miroRecord),
-        contributors = getContributors(miroRecord),
-        thumbnail = Some(getThumbnail(miroRecord)),
-        items = getItems(miroRecord),
-        imageData = List(getImageData(miroRecord, version = version))
-      )
-
-      Work.Visible[Source](
-        version = version,
-        state = state,
-        data = data
-      )
-    }.recover {
-      case e: ShouldNotTransformException =>
-        debug(s"Should not transform: ${e.getMessage}")
-        Work.Invisible[Source](
-          state = state,
+    if (!miroMetadata.isClearedForCatalogueAPI) {
+      Success(
+        Work.Deleted[Source](
           version = version,
-          data = WorkData()
+          data = WorkData(),
+          state = state,
+          deletedReason = SuppressedFromSource("Miro: isClearedForCatalogueAPI = false")
         )
+      )
+    }
+    // These images should really have been removed from the pipeline
+    // already, but we have at least one instance (B0010525).  It was
+    // throwing a MatchError when we tried to pick a license, so handle
+    // it properly here.
+    else if (!originalMiroRecord.copyrightCleared.contains("Y")) {
+      Success(
+        Work.Deleted[Source](
+          version = version,
+          data = WorkData(),
+          state = state,
+          deletedReason = SuppressedFromSource(s"Miro: image_copyright_cleared = ${originalMiroRecord.copyrightCleared.getOrElse("<empty>")}")
+        )
+      )
+    }
+    else {
+      Try {
+        // This is an utterly awful hack we have to live with until we get
+        // these corrected in the source data.
+        val miroRecord = MiroRecord.create(toJson(originalMiroRecord).get)
+
+        val (title, description) = getTitleAndDescription(miroRecord)
+
+        val data = WorkData[DataState.Unidentified](
+          otherIdentifiers = getOtherIdentifiers(miroRecord),
+          title = Some(title),
+          format = getFormat,
+          description = description,
+          lettering = miroRecord.suppLettering,
+          createdDate = getCreatedDate(miroRecord),
+          subjects = getSubjects(miroRecord),
+          genres = getGenres(miroRecord),
+          contributors = getContributors(miroRecord),
+          thumbnail = Some(getThumbnail(miroRecord)),
+          items = getItems(miroRecord),
+          imageData = List(getImageData(miroRecord, version = version))
+        )
+
+        Work.Visible[Source](
+          version = version,
+          state = state,
+          data = data
+        )
+      }
+        .recover {
+          case e: ShouldSuppressException =>
+            Work.Deleted[Source](
+              version = version,
+              data = WorkData(),
+              state = state,
+              deletedReason = SuppressedFromSource(s"Miro: ${e.getMessage}")
+            )
+
+          case e: ShouldNotTransformException =>
+            debug(s"Should not transform: ${e.getMessage}")
+            Work.Invisible[Source](
+              state = state,
+              version = version,
+              data = WorkData(),
+              invisibilityReasons = List(
+                UnableToTransform(s"Miro: ${e.getMessage}")
+              )
+            )
+        }
     }
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -72,7 +72,8 @@ class MiroRecordTransformer
           version = version,
           data = WorkData(),
           state = state,
-          deletedReason = SuppressedFromSource("Miro: isClearedForCatalogueAPI = false")
+          deletedReason =
+            SuppressedFromSource("Miro: isClearedForCatalogueAPI = false")
         )
       )
     }
@@ -86,11 +87,12 @@ class MiroRecordTransformer
           version = version,
           data = WorkData(),
           state = state,
-          deletedReason = SuppressedFromSource(s"Miro: image_copyright_cleared = ${originalMiroRecord.copyrightCleared.getOrElse("<empty>")}")
+          deletedReason = SuppressedFromSource(
+            s"Miro: image_copyright_cleared = ${originalMiroRecord.copyrightCleared
+              .getOrElse("<empty>")}")
         )
       )
-    }
-    else {
+    } else {
       Try {
         // This is an utterly awful hack we have to live with until we get
         // these corrected in the source data.
@@ -118,8 +120,7 @@ class MiroRecordTransformer
           state = state,
           data = data
         )
-      }
-        .recover {
+      }.recover {
           case e: ShouldSuppressException =>
             Work.Deleted[Source](
               version = version,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -121,25 +121,25 @@ class MiroRecordTransformer
           data = data
         )
       }.recover {
-          case e: ShouldSuppressException =>
-            Work.Deleted[Source](
-              version = version,
-              data = WorkData(),
-              state = state,
-              deletedReason = SuppressedFromSource(s"Miro: ${e.getMessage}")
-            )
+        case e: ShouldSuppressException =>
+          Work.Deleted[Source](
+            version = version,
+            data = WorkData(),
+            state = state,
+            deletedReason = SuppressedFromSource(s"Miro: ${e.getMessage}")
+          )
 
-          case e: ShouldNotTransformException =>
-            debug(s"Should not transform: ${e.getMessage}")
-            Work.Invisible[Source](
-              state = state,
-              version = version,
-              data = WorkData(),
-              invisibilityReasons = List(
-                UnableToTransform(s"Miro: ${e.getMessage}")
-              )
+        case e: ShouldNotTransformException =>
+          debug(s"Should not transform: ${e.getMessage}")
+          Work.Invisible[Source](
+            state = state,
+            version = version,
+            data = WorkData(),
+            invisibilityReasons = List(
+              UnableToTransform(s"Miro: ${e.getMessage}")
             )
-        }
+          )
+      }
     }
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/exceptions/ShouldSuppressException.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/exceptions/ShouldSuppressException.scala
@@ -1,0 +1,4 @@
+package uk.ac.wellcome.platform.transformer.miro.exceptions
+
+class ShouldSuppressException(message: String)
+  extends RuntimeException(message)

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/exceptions/ShouldSuppressException.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/exceptions/ShouldSuppressException.scala
@@ -1,4 +1,3 @@
 package uk.ac.wellcome.platform.transformer.miro.exceptions
 
-class ShouldSuppressException(message: String)
-  extends RuntimeException(message)
+class ShouldSuppressException(message: String) extends RuntimeException(message)

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodes.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodes.scala
@@ -70,7 +70,8 @@ trait MiroContributorCodes {
     )
 
     if (creditCode == "GUS" && gusMiroIds.contains(miroId)) {
-      throw new ShouldSuppressException("we do not expose image_source_code = GUS")
+      throw new ShouldSuppressException(
+        "we do not expose image_source_code = GUS")
     }
 
     contributorMap.get(creditCode) match {

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodes.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodes.scala
@@ -1,10 +1,9 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
-import java.io.InputStream
-
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldSuppressException
 
+import java.io.InputStream
 import scala.io.Source
 
 trait MiroContributorCodes {
@@ -71,9 +70,7 @@ trait MiroContributorCodes {
     )
 
     if (creditCode == "GUS" && gusMiroIds.contains(miroId)) {
-      throw new ShouldNotTransformException(
-        s"Image $miroId from contributor GUS should not be sent to the pipeline"
-      )
+      throw new ShouldSuppressException("we do not expose image_source_code = GUS")
     }
 
     contributorMap.get(creditCode) match {

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.models.work.internal._
-import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.miro.exceptions.{
+  ShouldNotTransformException,
+  ShouldSuppressException
+}
 
 trait MiroLicenses {
 
@@ -26,7 +29,7 @@ trait MiroLicenses {
       // These images need more data.
       case None =>
         throw new ShouldNotTransformException(
-          s"Image $miroId has no usage restriction specified!")
+          "Nothing in the image_use_restrictions field")
 
       case Some(useRestrictions) =>
         useRestrictions match {
@@ -47,11 +50,9 @@ trait MiroLicenses {
           // catalogue data -- for now, explicitly mark these as "do not transform"
           // so they don't end up on the DLQ.
           case "Do not use" =>
-            throw new ShouldNotTransformException(
-              s"Image $miroId has usage restriction 'Do not use'")
+            throw new ShouldSuppressException("image_use_restrictions = 'Do not use'")
           case "Image withdrawn, see notes" =>
-            throw new ShouldNotTransformException(
-              s"Image $miroId has usage restriction 'Image withdrawn'")
+            throw new ShouldSuppressException("image_use_restrictions = 'Image withdrawn, see notes'")
         }
     }
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -50,9 +50,11 @@ trait MiroLicenses {
           // catalogue data -- for now, explicitly mark these as "do not transform"
           // so they don't end up on the DLQ.
           case "Do not use" =>
-            throw new ShouldSuppressException("image_use_restrictions = 'Do not use'")
+            throw new ShouldSuppressException(
+              "image_use_restrictions = 'Do not use'")
           case "Image withdrawn, see notes" =>
-            throw new ShouldSuppressException("image_use_restrictions = 'Image withdrawn, see notes'")
+            throw new ShouldSuppressException(
+              "image_use_restrictions = 'Image withdrawn, see notes'")
         }
     }
 

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroContributorCodesTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldSuppressException
 
 class MiroContributorCodesTest extends AnyFunSpec with Matchers {
   it("looks up a contributor code in the general map") {
@@ -26,10 +26,10 @@ class MiroContributorCodesTest extends AnyFunSpec with Matchers {
   }
 
   it("rejects some images from contributor code GUS") {
-    val caught = intercept[ShouldNotTransformException] {
+    val caught = intercept[ShouldSuppressException] {
       transformer.lookupContributorCode(miroId = "B0009891", code = "GUS")
     }
-    caught.getMessage shouldBe s"Image B0009891 from contributor GUS should not be sent to the pipeline"
+    caught.getMessage shouldBe "we do not expose image_source_code = GUS"
   }
 
   it("allows images from contributor code GUS which aren't on the ban list") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.internal.License
-import uk.ac.wellcome.platform.transformer.miro.exceptions.ShouldNotTransformException
+import uk.ac.wellcome.platform.transformer.miro.exceptions.{
+  ShouldNotTransformException,
+  ShouldSuppressException
+}
 
 class MiroLicensesTest extends AnyFunSpec with Matchers {
   it("finds a recognised license") {
@@ -15,13 +18,13 @@ class MiroLicensesTest extends AnyFunSpec with Matchers {
   }
 
   it("rejects restrictions 'Do not use'") {
-    intercept[ShouldNotTransformException] {
+    intercept[ShouldSuppressException] {
       chooseLicense(Some("Do not use"))
     }
   }
 
   it("rejects restrictions 'Image withdrawn, see notes'") {
-    intercept[ShouldNotTransformException] {
+    intercept[ShouldSuppressException] {
       chooseLicense(Some("Image withdrawn, see notes"))
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -29,6 +29,7 @@ import uk.ac.wellcome.models.work.internal.DeletedReason.{
   DeletedFromSource,
   SuppressedFromSource
 }
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.{SourceFieldMissing, UnableToTransform}
 
 class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     extends Logging {
@@ -48,7 +49,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           Work.Invisible[Source](
             state = Source(sourceIdentifier, Instant.EPOCH),
             version = version,
-            data = WorkData()
+            data = WorkData(),
+            invisibilityReasons = List(SourceFieldMissing("bibData"))
           )
         )
       }
@@ -101,7 +103,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           Work.Invisible[Source](
             state = state,
             version = version,
-            data = WorkData()
+            data = WorkData(),
+            invisibilityReasons = List(UnableToTransform(e.getMessage))
           )
       }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -73,14 +73,14 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           Work.Deleted[Source](
             version = version,
             state = state,
-            deletedReason = Some(DeletedFromSource("Sierra")),
+            deletedReason = DeletedFromSource("Sierra"),
             data = WorkData()
           )
         } else if (bibData.suppressed) {
           Work.Deleted[Source](
             version = version,
             state = state,
-            deletedReason = Some(SuppressedFromSource("Sierra")),
+            deletedReason = SuppressedFromSource("Sierra"),
             data = WorkData()
           )
         } else {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -29,7 +29,10 @@ import uk.ac.wellcome.models.work.internal.DeletedReason.{
   DeletedFromSource,
   SuppressedFromSource
 }
-import uk.ac.wellcome.models.work.internal.InvisibilityReason.{SourceFieldMissing, UnableToTransform}
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.{
+  SourceFieldMissing,
+  UnableToTransform
+}
 
 class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     extends Logging {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
@@ -24,7 +24,7 @@ object SierraTitle extends SierraDataTransformer with SierraQueryOps {
     val marc245Field = bibData
       .nonrepeatableVarfieldWithTag("245")
       .getOrElse(
-        throw new ShouldNotTransformException("Could not find varField 245!")
+        throw new ShouldNotTransformException("Could not find field 245 to create title")
       )
 
     val components =
@@ -35,7 +35,7 @@ object SierraTitle extends SierraDataTransformer with SierraQueryOps {
         .map { _.content }
 
     if (components.isEmpty) {
-      throw new ShouldNotTransformException("No fields to construct title!")
+      throw new ShouldNotTransformException("No subfields in field 245 for constructing the title")
     }
 
     Some(components.mkString(" "))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
@@ -24,7 +24,8 @@ object SierraTitle extends SierraDataTransformer with SierraQueryOps {
     val marc245Field = bibData
       .nonrepeatableVarfieldWithTag("245")
       .getOrElse(
-        throw new ShouldNotTransformException("Could not find field 245 to create title")
+        throw new ShouldNotTransformException(
+          "Could not find field 245 to create title")
       )
 
     val components =
@@ -35,7 +36,8 @@ object SierraTitle extends SierraDataTransformer with SierraQueryOps {
         .map { _.content }
 
     if (components.isEmpty) {
-      throw new ShouldNotTransformException("No subfields in field 245 for constructing the title")
+      throw new ShouldNotTransformException(
+        "No subfields in field 245 for constructing the title")
     }
 
     Some(components.mkString(" "))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -125,7 +125,7 @@ class SierraTitleTest
       val caught = intercept[ShouldNotTransformException] {
         SierraTitle(bibData)
       }
-      caught.getMessage should startWith("Could not find varField 245!")
+      caught.getMessage should startWith("Could not find field 245 to create title")
     }
 
     it("if there are no subfields a, b or c") {
@@ -140,7 +140,7 @@ class SierraTitleTest
       val caught = intercept[ShouldNotTransformException] {
         SierraTitle(bibData)
       }
-      caught.getMessage should startWith("No fields to construct title!")
+      caught.getMessage should startWith("No subfields in field 245 for constructing the title")
     }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitleTest.scala
@@ -125,7 +125,8 @@ class SierraTitleTest
       val caught = intercept[ShouldNotTransformException] {
         SierraTitle(bibData)
       }
-      caught.getMessage should startWith("Could not find field 245 to create title")
+      caught.getMessage should startWith(
+        "Could not find field 245 to create title")
     }
 
     it("if there are no subfields a, b or c") {
@@ -140,7 +141,8 @@ class SierraTitleTest
       val caught = intercept[ShouldNotTransformException] {
         SierraTitle(bibData)
       }
-      caught.getMessage should startWith("No subfields in field 245 for constructing the title")
+      caught.getMessage should startWith(
+        "No subfields in field 245 for constructing the title")
     }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -357,7 +357,7 @@ class SierraTransformerTest
 
     work shouldBe a[Work.Deleted[_]]
     val deletedWork = work.asInstanceOf[Work.Deleted[_]]
-    deletedWork.deletedReason shouldBe Some(DeletedFromSource("Sierra"))
+    deletedWork.deletedReason shouldBe DeletedFromSource("Sierra")
   }
 
   it("deletes works with 'suppressed': true")  {
@@ -377,7 +377,7 @@ class SierraTransformerTest
 
     work shouldBe a[Work.Deleted[_]]
     val deletedWork = work.asInstanceOf[Work.Deleted[_]]
-    deletedWork.deletedReason shouldBe Some(SuppressedFromSource("Sierra"))
+    deletedWork.deletedReason shouldBe SuppressedFromSource("Sierra")
   }
 
   it("transforms bib records that don't have a title") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -25,6 +25,10 @@ import uk.ac.wellcome.models.work.internal.DeletedReason.{
   DeletedFromSource,
   SuppressedFromSource
 }
+import uk.ac.wellcome.models.work.internal.InvisibilityReason.{
+  SourceFieldMissing,
+  UnableToTransform
+}
 
 class SierraTransformerTest
     extends AnyFunSpec
@@ -219,7 +223,8 @@ class SierraTransformerTest
   it("returns an InvisibleWork if there isn't any bib data") {
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = None,
-      modifiedDate = Instant.EPOCH
+      modifiedDate = Instant.EPOCH,
+      invisibilityReasons = List(SourceFieldMissing("bibData"))
     )
   }
 
@@ -227,7 +232,8 @@ class SierraTransformerTest
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = None,
       modifiedDate = Instant.EPOCH,
-      itemRecords = List(createSierraItemRecord)
+      itemRecords = List(createSierraItemRecord),
+      invisibilityReasons = List(SourceFieldMissing("bibData"))
     )
   }
 
@@ -865,7 +871,8 @@ class SierraTransformerTest
 
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = Some(bibRecord),
-      modifiedDate = bibRecord.modifiedDate
+      modifiedDate = bibRecord.modifiedDate,
+      invisibilityReasons = List(UnableToTransform("Could not find varField 245!"))
     )
   }
 
@@ -985,7 +992,8 @@ class SierraTransformerTest
   private def assertTransformReturnsInvisibleWork(
     maybeBibRecord: Option[SierraBibRecord],
     modifiedDate: Instant,
-    itemRecords: List[SierraItemRecord] = List()): Assertion = {
+    itemRecords: List[SierraItemRecord] = List(),
+    invisibilityReasons: List[InvisibilityReason]): Assertion = {
     val id = createSierraBibNumber
 
     val sierraTransformable = createSierraTransformableWith(
@@ -1006,7 +1014,8 @@ class SierraTransformerTest
         modifiedDate
       ),
       version = 1,
-      data = WorkData()
+      data = WorkData(),
+      invisibilityReasons = invisibilityReasons
     )
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -366,7 +366,7 @@ class SierraTransformerTest
     deletedWork.deletedReason shouldBe DeletedFromSource("Sierra")
   }
 
-  it("deletes works with 'suppressed': true")  {
+  it("deletes works with 'suppressed': true") {
     val id = createSierraBibNumber
     val title = "Hi Diddle Dee Dee"
     val data =
@@ -872,7 +872,8 @@ class SierraTransformerTest
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = Some(bibRecord),
       modifiedDate = bibRecord.modifiedDate,
-      invisibilityReasons = List(UnableToTransform("Could not find field 245 to create title"))
+      invisibilityReasons =
+        List(UnableToTransform("Could not find field 245 to create title"))
     )
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -872,7 +872,7 @@ class SierraTransformerTest
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = Some(bibRecord),
       modifiedDate = bibRecord.modifiedDate,
-      invisibilityReasons = List(UnableToTransform("Could not find varField 245!"))
+      invisibilityReasons = List(UnableToTransform("Could not find field 245 to create title"))
     )
   }
 


### PR DESCRIPTION
Follows #1398. This is the patch I was actually writing.

A conversation in the #digirati channel this morning had me looking in the API index at invisible works. We do have a field where we can record why a particular work was deleted/suppressed/marked as invisible, but we weren't using it very consistently. This patch makes more use of that field, so it will be easier to understand work visibility in future.