### PR TITLE
Speculative Calm API client improvements

### DIFF
--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClient.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClient.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.calm_api_client
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
@@ -32,6 +33,9 @@ trait CalmApiClient {
     implicit p: CalmHttpResponseParser[CalmSummaryRequest])
     : Future[CalmRecord] =
     request(CalmSummaryRequest(pos), cookie)
+
+  def abandon(cookie: Cookie): Future[Done] =
+    request(CalmAbandonRequest, Some(cookie))
 }
 
 // HttpClients turn HttpRequests into HttpResponses via their

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClient.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClient.scala
@@ -26,16 +26,16 @@ trait CalmApiClient {
 
   def search(query: CalmQuery,
              cookie: Option[Cookie] = None): Future[CalmSession] =
-    request(CalmSearchRequest(query), cookie)
+    request(request = CalmSearchRequest(query), cookie = cookie)
 
   // We defer resolution of the summary parser so consumers can suppress fields
   def summary(pos: Int, cookie: Option[Cookie] = None)(
     implicit p: CalmHttpResponseParser[CalmSummaryRequest])
     : Future[CalmRecord] =
-    request(CalmSummaryRequest(pos), cookie)
+    request(request = CalmSummaryRequest(pos), cookie = cookie)
 
   def abandon(cookie: Cookie): Future[Done] =
-    request(CalmAbandonRequest, Some(cookie))
+    request(request = CalmAbandonRequest, cookie = Some(cookie))
 }
 
 // HttpClients turn HttpRequests into HttpResponses via their

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpResponseParser.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmHttpResponseParser.scala
@@ -41,6 +41,10 @@ object CalmHttpResponseParser {
     (resp: HttpResponse, bytes: Array[Byte]) =>
       CalmSearchResponse(bytes, parseCookie(resp))
 
+  implicit val abandonResponseParser
+    : CalmHttpResponseParser[CalmAbandonRequest.type] =
+    (_, bytes: Array[Byte]) => CalmAbandonResponse(bytes)
+
   def createSummaryResponseParser(
     suppressedFields: Set[String]): CalmHttpResponseParser[CalmSummaryRequest] =
     (resp: HttpResponse, bytes: Array[Byte]) =>

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequest.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlRequest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.calm_api_client
 
+import akka.Done
 import weco.catalogue.source_model.calm.CalmRecord
 
 import scala.xml.Elem
@@ -45,4 +46,12 @@ case class CalmSummaryRequest(pos: Int, dbName: String = "Catalog")
       <dbname>{dbName}</dbname>
       <HitLstPos>{pos}</HitLstPos>
     </SummaryHeader>
+}
+
+case object CalmAbandonRequest extends CalmXmlRequest {
+  type Response = Done
+  val action = "Abandon"
+
+  def body: Elem =
+    <Abandon xmlns="http://ds.co.uk/cs/webservices/" />
 }

--- a/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponse.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/uk/ac/wellcome/platform/calm_api_client/CalmXmlResponse.scala
@@ -1,9 +1,12 @@
 package uk.ac.wellcome.platform.calm_api_client
 
+import java.io.ByteArrayInputStream
+
 import scala.util.Try
 import scala.xml.{Elem, Node, NodeSeq, XML}
 import java.time.Instant
 
+import akka.Done
 import akka.http.scaladsl.model.headers.Cookie
 import weco.catalogue.source_model.calm.CalmRecord
 
@@ -147,4 +150,26 @@ object CalmSummaryResponse {
     Try(XML.load(new java.io.ByteArrayInputStream(bytes)))
       .map(CalmSummaryResponse(_, retrievedAt, suppressedFields))
       .toEither
+}
+
+case class CalmAbandonResponse(root: Elem) extends CalmXmlResponse[Done] {
+  val responseTag = "AbandonResponse"
+
+  /** The session abandonment response XML is of the form:
+    *
+    *  <AbandonResponse xmlns="http://ds.co.uk/cs/webservices/" />
+    *
+    *  We just want to make sure it exists here.
+    */
+  def parse: Either[Throwable, Done] =
+    responseNode.map(_ => Done)
+}
+
+object CalmAbandonResponse {
+
+  def apply(bytes: Array[Byte]): Either[Throwable, CalmAbandonResponse] =
+    Try(XML.load(new ByteArrayInputStream(bytes)))
+      .map(CalmAbandonResponse.apply)
+      .toEither
+
 }

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClientTest.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/CalmApiClientTest.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.calm_api_client
 
 import java.time.LocalDate
 
+import akka.Done
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers.{
   Authorization,
@@ -51,6 +52,15 @@ class CalmApiClientTest
             "1",
             Map("RecordID" -> List("1")),
             retrievedAt)
+        }
+      }
+    }
+
+    it("performs abandon requests") {
+      val responses = List(abandonResponse)
+      withTestHttpCalmApiClient(responses) { apiClient =>
+        whenReady(apiClient.abandon(Cookie(cookie))) { response =>
+          response shouldBe Done
         }
       }
     }

--- a/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/fixtures/CalmResponseGenerators.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/uk/ac/wellcome/platform/calm_api_client/fixtures/CalmResponseGenerators.scala
@@ -57,4 +57,19 @@ trait CalmResponseGenerators {
       </soap:Envelope>.toString,
       protocol
     )
+
+  def abandonResponse: HttpResponse =
+    HttpResponse(
+      200,
+      Nil,
+      <soap:Envelope
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+      xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <AbandonResponse xmlns="http://ds.co.uk/cs/webservices/" />
+        </soap:Body>
+      </soap:Envelope>.toString,
+      protocol
+    )
 }

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DefectiveChecker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DefectiveChecker.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.calm_deletion_checker
 
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.calm_api_client.{
   CalmApiClient,
   CalmQuery,
@@ -65,16 +66,23 @@ trait DefectiveChecker[Item] {
 
 class ApiDeletionChecker(calmApiClient: CalmApiClient)(
   implicit ec: ExecutionContext)
-    extends DefectiveChecker[CalmSourcePayload] {
+    extends DefectiveChecker[CalmSourcePayload]
+    with Logging {
 
   def test(records: Set[CalmSourcePayload]): Future[Int] =
-    calmApiClient
-      .search(
-        records
-          .map(record => CalmQuery.RecordId(record.id))
-          .reduce[CalmQuery](_ or _)
-      )
-      .map {
+    for {
+      session <- calmApiClient
+        .search(
+          records
+            .map(record => CalmQuery.RecordId(record.id))
+            .reduce[CalmQuery](_ or _)
+        )
+      _ <- calmApiClient.abandon(session.cookie).recover {
+        case abandonError =>
+          warn(s"Error abandoning session: ${abandonError.getMessage}")
+      }
+    } yield
+      session match {
         case CalmSession(n, _) if n <= records.size => records.size - n
         case CalmSession(n, _) =>
           throw new RuntimeException(

--- a/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DefectiveChecker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/uk/ac/wellcome/platform/calm_deletion_checker/DefectiveChecker.scala
@@ -77,6 +77,8 @@ class ApiDeletionChecker(calmApiClient: CalmApiClient)(
             .map(record => CalmQuery.RecordId(record.id))
             .reduce[CalmQuery](_ or _)
         )
+      // Performing a search creates a new session which we'll never use.
+      // Abandon it here to give the Calm API a chance.
       _ <- calmApiClient.abandon(session.cookie).recover {
         case abandonError =>
           warn(s"Error abandoning session: ${abandonError.getMessage}")


### PR DESCRIPTION
I suspect that a major factor in the fact that the deletion checker kicked over the Calm API was not abandoning sessions created by searches - I'd hoped that it'd be OK with this, but perhaps not. Depending on how lazy its data fetching is, it may be holding the search results (on the order of thousands of records _per batch_) for each created session until expiry. That would be bad.

So, in the absence of any more info, I've made it abandon each session and also log a bit more. I won't be trying this out until I've managed to talk to someone from D&T about the Calm server.