### PR TITLE
Remove .jpg from iiif digital locations in miro transformer

### DIFF
--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
@@ -6,8 +6,8 @@ import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 trait MiroLocation extends MiroLicenses with MiroContributorCodes {
 
   private val imageUriTemplates = Map(
-    "thumbnail" -> "%s/image/%s.jpg/full/300,/0/default.jpg",
-    "info" -> "%s/image/%s.jpg/info.json"
+    "thumbnail" -> "%s/image/%s/full/300,/0/default.jpg",
+    "info" -> "%s/image/%s/info.json"
   )
 
   def buildImageApiURL(miroId: String, templateName: String): String = {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
@@ -41,8 +41,7 @@ class MiroImageDataTest
         version = 1,
         locations = List(
           DigitalLocation(
-            url =
-              "https://iiif.wellcomecollection.org/image/B0011308/info.json",
+            url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
             locationType = LocationType.IIIFImageAPI,
             license = Some(License.CC0),
             credit = Some("Ezra Feilden")

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
@@ -42,7 +42,7 @@ class MiroImageDataTest
         locations = List(
           DigitalLocation(
             url =
-              "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+              "https://iiif.wellcomecollection.org/image/B0011308/info.json",
             locationType = LocationType.IIIFImageAPI,
             license = Some(License.CC0),
             credit = Some("Ezra Feilden")

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -25,7 +25,7 @@ class MiroItemsTest
           id = IdState.Unidentifiable,
           locations = List(DigitalLocation(
             url =
-              "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+              "https://iiif.wellcomecollection.org/image/B0011308/info.json",
             locationType = LocationType.IIIFImageAPI,
             license = Some(License.CC0),
             credit = Some("Ezra Feilden")

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -24,8 +24,7 @@ class MiroItemsTest
         Item(
           id = IdState.Unidentifiable,
           locations = List(DigitalLocation(
-            url =
-              "https://iiif.wellcomecollection.org/image/B0011308/info.json",
+            url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
             locationType = LocationType.IIIFImageAPI,
             license = Some(License.CC0),
             credit = Some("Ezra Feilden")

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
@@ -23,7 +23,7 @@ class MiroLocationTest
         imageNumber = "B0011308"
       )
     ) shouldBe DigitalLocation(
-      url = "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+      url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
       locationType = LocationType.IIIFImageAPI,
       license = Some(License.CC0),
       credit = Some("Ezra Feilden")

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -306,7 +306,7 @@ class MiroRecordTransformerTest
     )
 
     val expectedDigitalLocation = DigitalLocation(
-      url = "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+      url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
       license = Some(License.CCBY),
       credit = Some("Ezra Feilden"),
       locationType = LocationType.IIIFImageAPI
@@ -320,7 +320,7 @@ class MiroRecordTransformerTest
     )
 
     val expectedLocation = DigitalLocation(
-      url = "https://iiif.wellcomecollection.org/image/B0011308.jpg/info.json",
+      url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
       locationType = LocationType.IIIFImageAPI,
       license = Some(License.CCBY),
       credit = None
@@ -345,7 +345,7 @@ class MiroRecordTransformerTest
     work.data.thumbnail shouldBe Some(
       DigitalLocation(
         url =
-          s"https://iiif.wellcomecollection.org/image/$miroId.jpg/full/300,/0/default.jpg",
+          s"https://iiif.wellcomecollection.org/image/$miroId/full/300,/0/default.jpg",
         locationType = LocationType.ThumbnailImage,
         license = Some(License.CCBY)
       )


### PR DESCRIPTION
Due to the recent changes to register miro images with DLCS and update the IIIF CloudFront distribution, the ".jpg" in IIIF identifiers is no longer required.

e.g. https://iiif.wellcomecollection.org/image/B0009851/full/1338%2C/0/default.jpg

This change removes the additional `.jpg` required by images registered with Loris.