### PR TITLE
Add availabilities property to work

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/ApiWorksTestBase.scala
@@ -35,6 +35,8 @@ trait ApiWorksTestBase
       |   "id": "${work.state.canonicalId}",
       |   "title": "${work.data.title.get}",
       |   "availableOnline": ${hasDigitalLocations(work)},
+      |   "availabilities": [${availabilities(
+         work.state.derivedData.availabilities)}],
       |   "alternativeTitles": []
       |   ${optionalObject("workType", format, work.data.format)}
       | }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -41,6 +41,8 @@ class WorksIncludesTest
                    "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work0.state.derivedData.availabilities)}],
                    "identifiers": [
                      ${identifier(work0.sourceIdentifier)},
                      ${identifier(otherIdentifier0)}
@@ -52,6 +54,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "identifiers": [
                      ${identifier(work1.sourceIdentifier)},
                      ${identifier(otherIdentifier1)}
@@ -82,6 +86,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "identifiers": [
                   ${identifier(work.sourceIdentifier)},
                   ${identifier(otherIdentifier)}
@@ -115,6 +121,8 @@ class WorksIncludesTest
               "title": "${work.data.title.get}",
               "alternativeTitles": [],
               "availableOnline": true,
+              "availabilities": [${availabilities(
+            work.state.derivedData.availabilities)}],
               "items": [ ${items(work.data.items)} ]
             }
           """
@@ -145,6 +153,8 @@ class WorksIncludesTest
                    "title": "${work0.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work0.state.derivedData.availabilities)}],
                    "subjects": [ ${subjects(subjects0)}]
                  },
                  {
@@ -153,6 +163,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "subjects": [ ${subjects(subjects1)}]
                  }
                 ]
@@ -180,6 +192,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "subjects": [ ${subjects(work.data.subjects)}]
               }
             """
@@ -211,6 +225,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "genres": [ ${genres(genres1)}]
                  },
                  {
@@ -219,6 +235,8 @@ class WorksIncludesTest
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work2.state.derivedData.availabilities)}],
                    "genres": [ ${genres(genres2)}]
                  }
                 ]
@@ -247,6 +265,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "genres": [ ${genres(work.data.genres)}]
               }
             """
@@ -282,6 +302,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "contributors": [ ${contributors(contributors1)}]
                  },
                  {
@@ -290,6 +312,8 @@ class WorksIncludesTest
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work2.state.derivedData.availabilities)}],
                    "contributors": [ ${contributors(contributors2)}]
                  }
                 ]
@@ -319,6 +343,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "contributors": [ ${contributors(work.data.contributors)}]
               }
             """
@@ -352,6 +378,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "production": [ ${production(productionEvents1)}]
                  },
                  {
@@ -360,6 +388,8 @@ class WorksIncludesTest
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work2.state.derivedData.availabilities)}],
                    "production": [ ${production(productionEvents2)}]
                  }
                 ]
@@ -387,6 +417,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "production": [ ${production(work.data.production)}]
               }
             """
@@ -420,6 +452,8 @@ class WorksIncludesTest
                    "title": "${work1.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                    "languages": [ ${languages(work1.data.languages)}]
                  },
                  {
@@ -428,6 +462,8 @@ class WorksIncludesTest
                    "title": "${work2.data.title.get}",
                    "alternativeTitles": [],
                    "availableOnline": false,
+                   "availabilities": [${availabilities(
+              work2.state.derivedData.availabilities)}],
                    "languages": [ ${languages(work2.data.languages)}]
                  }
                 ]
@@ -458,6 +494,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "languages": [ ${languages(work.data.languages)}]
               }
             """
@@ -487,6 +525,8 @@ class WorksIncludesTest
                      "title": "${work1.data.title.get}",
                      "alternativeTitles": [],
                      "availableOnline": false,
+                     "availabilities": [${availabilities(
+              work1.state.derivedData.availabilities)}],
                      "notes": [
                        {
                          "noteType": {
@@ -514,6 +554,8 @@ class WorksIncludesTest
                      "title": "${work2.data.title.get}",
                      "alternativeTitles": [],
                      "availableOnline": false,
+                     "availabilities": [${availabilities(
+              work2.state.derivedData.availabilities)}],
                      "notes": [
                        {
                          "noteType": {
@@ -549,6 +591,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "notes": [
                    {
                      "noteType": {
@@ -598,6 +642,8 @@ class WorksIncludesTest
                     "title": "${works.head.data.title.get}",
                     "alternativeTitles": [],
                     "availableOnline": false,
+                    "availabilities": [${availabilities(
+              works.head.state.derivedData.availabilities)}],
                     "images": [${workImageIncludes(works.head.data.imageData)}]
                   },
                   {
@@ -606,6 +652,8 @@ class WorksIncludesTest
                     "title": "${works(1).data.title.get}",
                     "alternativeTitles": [],
                     "availableOnline": false,
+                    "availabilities": [${availabilities(
+              works(1).state.derivedData.availabilities)}],
                     "images": [${workImageIncludes(works(1).data.imageData)}]
                   }
                 ]
@@ -635,6 +683,8 @@ class WorksIncludesTest
                 "title": "${work.data.title.get}",
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}],
                 "images": [${workImageIncludes(images)}]
               }
             """
@@ -690,6 +740,8 @@ class WorksIncludesTest
               "title": "0/a/c",
               "alternativeTitles": [],
               "availableOnline": false,
+              "availabilities": [${availabilities(
+              workC.state.derivedData.availabilities)}],
               "parts": [{
                 "id": "${workE.state.canonicalId}",
                 "title": "0/a/c/e",
@@ -717,6 +769,8 @@ class WorksIncludesTest
               "title": "0/a/c",
               "alternativeTitles": [],
               "availableOnline": false,
+              "availabilities": [${availabilities(
+              workC.state.derivedData.availabilities)}],
               "partOf": [
                 {
                   "id": "${workA.state.canonicalId}",
@@ -754,6 +808,8 @@ class WorksIncludesTest
               "title": "0/a/c",
               "alternativeTitles": [],
               "availableOnline": false,
+              "availabilities": [${availabilities(
+              workC.state.derivedData.availabilities)}],
               "precededBy": [{
                 "id": "${workB.state.canonicalId}",
                 "title": "0/a/b",
@@ -781,6 +837,8 @@ class WorksIncludesTest
               "title": "0/a/c",
               "alternativeTitles": [],
               "availableOnline": false,
+              "availabilities": [${availabilities(
+              workC.state.derivedData.availabilities)}],
               "succeededBy": [{
                 "id": "${workD.state.canonicalId}",
                 "title": "0/a/d",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksTest.scala
@@ -42,7 +42,9 @@ class WorksTest
              "id": "${work.state.canonicalId}",
              "title": "${work.data.title.get}",
              "alternativeTitles": [],
-             "availableOnline": false
+             "availableOnline": false,
+             "availabilities": [${availabilities(
+            work.state.derivedData.availabilities)}]
             }
           """
         }
@@ -67,6 +69,8 @@ class WorksTest
              "title": "${work.data.title.get}",
              "alternativeTitles": [],
              "availableOnline": false,
+             "availabilities": [${availabilities(
+            work.state.derivedData.availabilities)}],
              "edition": "Special edition",
              "duration": 3600
             }
@@ -181,7 +185,9 @@ class WorksTest
                "id": "${work.state.canonicalId}",
                "title": "${work.data.title.get}",
                "alternativeTitles": [],
-               "availableOnline": false
+               "availableOnline": false,
+               "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}]
               }
             """
           }
@@ -195,7 +201,9 @@ class WorksTest
                "id": "${altWork.state.canonicalId}",
                "title": "${altWork.data.title.get}",
                "alternativeTitles": [],
-               "availableOnline": false
+               "availableOnline": false,
+               "availabilities": [${availabilities(
+              work.state.derivedData.availabilities)}]
               }
             """
           }
@@ -251,6 +259,8 @@ class WorksTest
                  "title": "${work.data.title.get}",
                  "alternativeTitles": [],
                  "availableOnline": true,
+                 "availabilities": [${availabilities(
+            work.state.derivedData.availabilities)}],
                  "thumbnail": ${location(work.data.thumbnail.get)}
                 }
               ]

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAvailability.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayAvailability.scala
@@ -1,0 +1,22 @@
+package uk.ac.wellcome.display.models
+
+import io.circe.generic.extras.JsonKey
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.ac.wellcome.models.work.internal.Availability
+
+@Schema(
+  name = "Availability"
+)
+case class DisplayAvailability(
+  @Schema id: String,
+  @Schema label: String,
+  @JsonKey("type") @Schema(name = "type") ontologyType: String = "Availability"
+)
+
+object DisplayAvailability {
+  def apply(availability: Availability): DisplayAvailability =
+    DisplayAvailability(
+      id = availability.id,
+      label = availability.label
+    )
+}

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -80,6 +80,10 @@ case class DisplayWork(
     `type` = "Boolean"
   ) availableOnline: Boolean = false,
   @Schema(
+    description = "Ways in which the work is available to access",
+    `type` = "List[uk.ac.wellcome.display.modules.DisplayAvailability]"
+  ) availabilities: List[DisplayAvailability] = Nil,
+  @Schema(
     description = "Relates a work to its production events."
   ) production: Option[List[DisplayProductionEvent]] = None,
   @Schema(
@@ -161,6 +165,9 @@ object DisplayWork {
           })
         else None,
       availableOnline = work.state.derivedData.availableOnline,
+      availabilities = work.state.derivedData.availabilities.map {
+        DisplayAvailability(_)
+      },
       production =
         if (includes.production) Some(work.data.production.map {
           DisplayProductionEvent(_, includesIdentifiers = includes.identifiers)

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayLocationsSerialisationTest.scala
@@ -32,7 +32,9 @@ class DisplayLocationsSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ${items(work.data.items)} ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -56,7 +58,9 @@ class DisplayLocationsSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ${items(work.data.items)} ],
-      | "availableOnline": true
+      | "availableOnline": true,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -81,7 +85,9 @@ class DisplayLocationsSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ${items(work.data.items)} ],
-      | "availableOnline": true
+      | "availableOnline": true,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -112,7 +118,9 @@ class DisplayLocationsSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ${items(work.data.items)} ],
-      | "availableOnline": true
+      | "availableOnline": true,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -221,6 +221,9 @@ trait DisplaySerialisationTestBase {
   def production(production: List[ProductionEvent[IdState.Minted]]) =
     production.map(productionEvent).mkString(",")
 
+  def availabilities(availabilities: List[Availability]) =
+    availabilities.map(availability).mkString(",")
+
   def languages(ls: List[Language]): String =
     ls.map(language).mkString(",")
 
@@ -234,6 +237,15 @@ trait DisplaySerialisationTestBase {
 
   def workImageIncludes(images: List[ImageData[IdState.Identified]]) =
     images.map(workImageInclude).mkString(",")
+
+  def availability(availability: Availability): String =
+    s"""
+      {
+        "id": "${availability.id}",
+        "label": "${availability.label}",
+        "type": "Availability"
+      }
+     """.stripMargin
 
   def productionEvent(event: ProductionEvent[IdState.Minted]): String =
     s"""

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplayWorkSerialisationTest.scala
@@ -38,7 +38,9 @@ class DisplayWorkSerialisationTest
       | "lettering": "${work.data.lettering.get}",
       | "alternativeTitles": [],
       | "createdDate": ${period(work.data.createdDate.get)},
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -56,7 +58,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ${items(work.data.items)} ],
-      | "availableOnline": true
+      | "availableOnline": true,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -76,7 +80,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "items": [ ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -96,7 +102,8 @@ class DisplayWorkSerialisationTest
     val item = createIdentifiedItemWith(locations = List(location))
     val workWithCopyright = indexedWork().items(List(item))
 
-    val expectedJson = s"""
+    val expectedJson =
+      s"""
       |{
       | "type": "Work",
       | "id": "${workWithCopyright.state.canonicalId}",
@@ -118,7 +125,9 @@ class DisplayWorkSerialisationTest
       |     ]
       |   }
       | ],
-      | "availableOnline": true
+      | "availableOnline": true,
+      | "availabilities": [${availabilities(
+           workWithCopyright.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -144,7 +153,9 @@ class DisplayWorkSerialisationTest
       | "title": "${workWithSubjects.data.title.get}",
       | "alternativeTitles": [],
       | "subjects": [${subjects(workWithSubjects.data.subjects)}],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            workWithSubjects.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -163,14 +174,17 @@ class DisplayWorkSerialisationTest
       createProductionEventList(count = 3)
     )
 
-    val expectedJson = s"""
+    val expectedJson =
+      s"""
       |{
       | "type": "Work",
       | "id": "${workWithProduction.state.canonicalId}",
       | "title": "${workWithProduction.data.title.get}",
       | "alternativeTitles": [],
       | "production": [${production(workWithProduction.data.production)}],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+           workWithProduction.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -207,7 +221,9 @@ class DisplayWorkSerialisationTest
       | "lettering": "${work.data.lettering.get}",
       | "createdDate": ${period(work.data.createdDate.get)},
       | "contributors": [${contributor(work.data.contributors.head)}],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -235,7 +251,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "genres": [ ${genres(work.data.genres)} ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -277,7 +295,9 @@ class DisplayWorkSerialisationTest
       |     "type": "Note"
       |   }
       | ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -301,7 +321,9 @@ class DisplayWorkSerialisationTest
       |   ${identifier(work.sourceIdentifier)},
       |   ${identifier(otherIdentifier)}
       | ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -321,7 +343,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "identifiers": [ ${identifier(work.sourceIdentifier)} ],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -343,7 +367,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "images": [${workImageIncludes(work.data.imageData)}],
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 
@@ -369,7 +395,9 @@ class DisplayWorkSerialisationTest
       | "title": "${work.data.title.get}",
       | "alternativeTitles": [],
       | "thumbnail": ${location(work.data.thumbnail.get)},
-      | "availableOnline": false
+      | "availableOnline": false,
+      | "availabilities": [${availabilities(
+                            work.state.derivedData.availabilities)}]
       |}
     """.stripMargin
 

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -149,6 +149,7 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       objectField("derivedData")
         .fields(
           booleanField("availableOnline"),
+          objectField("availabilities").fields(keywordField("id")),
           keywordField("contributorAgents")
         )
         .dynamic("false")

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -145,11 +145,6 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec71: Decoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  implicit val _dec72: Decoder[LocationType] = LocationType.locationTypeDecoder
-  implicit val _dec73: Decoder[DigitalLocationType] =
-    LocationType.digitalLocationTypeDecoder
-  implicit val _dec74: Decoder[PhysicalLocationType] =
-    LocationType.physicalLocationTypeDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
   implicit val _enc01: Encoder[Note] = deriveConfiguredEncoder
@@ -278,9 +273,4 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc71: Encoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredEncoder
-  implicit val _enc72: Encoder[LocationType] = LocationType.locationTypeEncoder
-  implicit val _enc73: Encoder[DigitalLocationType] =
-    LocationType.digitalLocationTypeEncoder
-  implicit val _enc74: Encoder[PhysicalLocationType] =
-    LocationType.physicalLocationTypeEncoder
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessCondition.scala
@@ -11,5 +11,7 @@ case class AccessCondition(
       case accessCondition                   => Some(accessCondition)
     }
 
+  def isAvailable: Boolean = status.exists(_.isAvailable)
+
   def hasRestrictions: Boolean = status.exists(_.hasRestrictions)
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AccessStatus.scala
@@ -6,6 +6,12 @@ sealed trait AccessStatus { this: AccessStatus =>
 
   def name: String = this.getClass.getSimpleName.stripSuffix("$")
 
+  def isAvailable: Boolean = this match {
+    case AccessStatus.Open             => true
+    case AccessStatus.OpenWithAdvisory => true
+    case _                             => false
+  }
+
   def hasRestrictions: Boolean = this match {
     case AccessStatus.OpenWithAdvisory   => true
     case AccessStatus.Restricted         => true

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Availability.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Availability.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.models.work.internal
+
+sealed trait Availability {
+  val id: String
+  val label: String
+}
+
+object Availability {
+  case object Online extends Availability {
+    val id = "online"
+    val label = "Online"
+  }
+
+  case object InLibrary extends Availability {
+    val id = "in-library"
+    val label = "In the library"
+  }
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Availability.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Availability.scala
@@ -1,11 +1,24 @@
 package uk.ac.wellcome.models.work.internal
 
-sealed trait Availability {
+import enumeratum.{Enum, EnumEntry}
+import io.circe.{Decoder, Encoder}
+
+sealed trait Availability extends EnumEntry {
   val id: String
   val label: String
+
+  override lazy val entryName: String = id
 }
 
-object Availability {
+object Availability extends Enum[Availability] {
+  val values = findValues
+
+  implicit val availabilityEncoder: Encoder[Availability] =
+    Encoder.forProduct1("id")(_.id)
+
+  implicit val availabilityDecoder: Decoder[Availability] =
+    Decoder.forProduct1("id")(Availability.withName)
+
   case object Online extends Availability {
     val id = "online"
     val label = "Online"

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/License.scala
@@ -2,49 +2,27 @@ package uk.ac.wellcome.models.work.internal
 
 import enumeratum.EnumEntry
 import enumeratum.Enum
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder}
 
 sealed trait License extends EnumEntry {
   val id: String
   val label: String
   val url: String
+
+  override lazy val entryName: String = id
 }
 
 object License extends Enum[License] {
   val values = findValues
 
-  implicit val licenseEncoder: Encoder[License] = Encoder.instance[License] {
-    license =>
-      Json.obj(
-        ("id", Json.fromString(license.id))
-      )
-  }
+  implicit val licenseEncoder: Encoder[License] =
+    Encoder.forProduct1("id")(_.id)
 
-  implicit val licenseDecoder: Decoder[License] = Decoder.instance[License] {
-    cursor =>
-      for {
-        id <- cursor.downField("id").as[String]
-      } yield {
-        createLicense(id)
-      }
-  }
-
-  private val licenseIdIndex = {
-    val idPairs = values.map { license =>
-      license.id -> license
-    }
-
-    // Check we don't have any duplicate IDs
-    assert(idPairs.toMap.size == idPairs.size)
-
-    idPairs.toMap
-  }
+  implicit val licenseDecoder: Decoder[License] =
+    Decoder.forProduct1("id")(License.withName)
 
   def createLicense(id: String): License =
-    licenseIdIndex.get(id) match {
-      case Some(license) => license
-      case _             => throw new Exception(s"$id is not a valid license id")
-    }
+    License.withName(id)
 
   case object CCBY extends License {
     val id = "cc-by"

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Location.scala
@@ -5,6 +5,9 @@ sealed trait Location {
   val accessConditions: List[AccessCondition]
   val license: Option[License]
 
+  def isAvailable: Boolean =
+    accessConditions.exists(_.isAvailable)
+
   def hasRestrictions: Boolean =
     accessConditions.exists(_.hasRestrictions)
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -36,21 +36,30 @@ trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
   def createUnidentifiableItem: Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith()
 
-  def createIdentifiedPhysicalItem =
+  def createIdentifiedPhysicalItem: Item[IdState.Identified] =
     createIdentifiedItemWith(locations = List(createPhysicalLocation))
 
-  def createDigitalItem =
+  def createDigitalItem: Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith(locations = List(createDigitalLocation))
 
-  def createDigitalItemWith(locations: List[Location]) =
+  def createDigitalItemWith(
+    accessStatus: AccessStatus): Item[IdState.Unidentifiable.type] =
+    createDigitalItemWith(
+      locations = List(
+        createDigitalLocationWith(accessConditions =
+          List(createAccessConditionWith(status = Some(accessStatus))))))
+
+  def createDigitalItemWith(
+    locations: List[Location]): Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith(locations = locations)
 
-  def createDigitalItemWith(license: Option[License]) =
+  def createDigitalItemWith(
+    license: Option[License]): Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith(
       locations = List(createDigitalLocationWith(license = license))
     )
 
-  def createCalmItem =
+  def createCalmItem: Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith(
       locations = List(
         createPhysicalLocationWith(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/LocationGenerators.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.models.work.generators
 import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.models.work.internal.{
   AccessCondition,
+  AccessStatus,
   DigitalLocation,
   DigitalLocationType,
   License,
@@ -63,4 +64,12 @@ trait LocationGenerators extends RandomGenerators {
     createDigitalLocationWith(
       locationType = LocationType.IIIFPresentationAPI
     )
+
+  def createAccessConditionWith(
+    status: Option[AccessStatus] = Some(AccessStatus.Open)
+  ): AccessCondition = AccessCondition(
+    status = status,
+    terms = None,
+    to = None
+  )
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/DerivedDataTest.scala
@@ -12,46 +12,83 @@ class DerivedDataTest
 
   describe("DerivedWorkData") {
 
-    it("sets availableOnline = true if there is a digital location on an item") {
-      val work = denormalisedWork().items(
-        List(createDigitalItem, createIdentifiedPhysicalItem))
-      val derivedWorkData = DerivedWorkData(work.data)
+    describe("availableOnline") {
+      it(
+        "sets availableOnline = true if there is a digital location on an item") {
+        val work = denormalisedWork().items(
+          List(createDigitalItem, createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
 
-      derivedWorkData.availableOnline shouldBe true
+        derivedWorkData.availableOnline shouldBe true
+      }
+
+      it("sets availableOnline = false if there is no digital location on any items") {
+        val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
+
+        derivedWorkData.availableOnline shouldBe false
+      }
+
+      it("handles empty items list") {
+        val work = denormalisedWork().items(Nil)
+        val derivedWorkData = DerivedWorkData(work.data)
+
+        derivedWorkData.availableOnline shouldBe false
+      }
     }
 
-    it(
-      "sets availableOnline = false if there is no digital location on any items") {
-      val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
-      val derivedWorkData = DerivedWorkData(work.data)
+    describe("availabilities") {
+      it("adds Availability.Online if there is a digital location with an Open or OpenWithAdvisory access status") {
+        val openWork = denormalisedWork().items(
+          List(createDigitalItemWith(accessStatus = AccessStatus.Open)))
+        val openWithAdvisoryWork = denormalisedWork().items(List(
+          createDigitalItemWith(accessStatus = AccessStatus.OpenWithAdvisory)))
+        val derivedOpenWorkData = DerivedWorkData(openWork.data)
+        val derivedOpenWithAdvisoryWorkData =
+          DerivedWorkData(openWithAdvisoryWork.data)
 
-      derivedWorkData.availableOnline shouldBe false
+        derivedOpenWorkData.availabilities should contain only Availability.Online
+        derivedOpenWithAdvisoryWorkData.availabilities should contain only Availability.Online
+      }
+
+      it("adds Availability.InLibrary if there is a physical location") {
+        val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
+        val derivedWorkData = DerivedWorkData(work.data)
+
+        derivedWorkData.availabilities should contain only Availability.InLibrary
+      }
+
+      it("adds Availability.Online and Availability.InLibrary if the conditions for both are satisfied") {
+        val work = denormalisedWork().items(
+          List(
+            createIdentifiedPhysicalItem,
+            createDigitalItemWith(accessStatus = AccessStatus.Open)))
+        val derivedWorkData = DerivedWorkData(work.data)
+
+        derivedWorkData.availabilities should contain allOf (Availability.InLibrary, Availability.Online)
+      }
     }
 
-    it("handles empty items list") {
-      val work = denormalisedWork().items(Nil)
-      val derivedWorkData = DerivedWorkData(work.data)
+    describe("contributorAgents") {
+      it("derives contributorAgents from a heterogenous list of contributors") {
+        val agents = List(
+          Agent("0048146"),
+          Organisation("PKK"),
+          Person("Salt Bae"),
+          Meeting("Brunch, 18th Jan 2021")
+        )
+        val work =
+          denormalisedWork().contributors(
+            agents.map(Contributor(_, roles = Nil)))
+        val derivedWorkData = DerivedWorkData(work.data)
 
-      derivedWorkData.availableOnline shouldBe false
-    }
-
-    it("derives contributorAgents from a heterogenous list of contributors") {
-      val agents = List(
-        Agent("0048146"),
-        Organisation("PKK"),
-        Person("Salt Bae"),
-        Meeting("Brunch, 18th Jan 2021")
-      )
-      val work =
-        denormalisedWork().contributors(agents.map(Contributor(_, roles = Nil)))
-      val derivedWorkData = DerivedWorkData(work.data)
-
-      derivedWorkData.contributorAgents shouldBe List(
-        "Agent:0048146",
-        "Organisation:PKK",
-        "Person:Salt Bae",
-        "Meeting:Brunch, 18th Jan 2021"
-      )
+        derivedWorkData.contributorAgents shouldBe List(
+          "Agent:0048146",
+          "Organisation:PKK",
+          "Person:Salt Bae",
+          "Meeting:Brunch, 18th Jan 2021"
+        )
+      }
     }
   }
 

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -80,6 +80,7 @@ class SnapshotGeneratorFeatureTest
                 "languages": [],
                 "alternativeTitles": [],
                 "availableOnline": false,
+                "availabilities": [],
                 "notes": [],
                 "images": [],
                 "parts": [],


### PR DESCRIPTION
What this does:
- Adds a type `Availability` for representing works that are available `Online` or `InLibrary`.
- Adds a list of these, `availabilities`, to a work's `derivedData`.
- Adds these `availabilities` to the display model.
- Removes some logic related to en/decoding enumeratum enums which enumeratum could already do for us.

What this does not do:
- `availableOnline` is still there, it'll be removed when this feature is done.
- There is no filtering or aggregating on `availabilities` - this comes next.
- Archives do not yet inherit availability from their `parts`