### PR TITLE
Create items from field 856 on bibs

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -130,7 +130,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       edition = SierraEdition(bibData),
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),
-      items = SierraItems(itemDataMap)(bibId, bibData)
+      items = SierraItems(itemDataMap)(bibId, bibData) ++
+        SierraElectronicResources(bibId, varFields = bibData.varFields)
     )
 
   lazy val bibId = sierraTransformable.sierraId

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.models.work.internal.{IdState, Item}
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraQueryOps, VarField}
+import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
+
+// Create items with a DigitalLocation based on the contents of field 856.
+//
+// The 856 field is used to link to external resources, and it has a variety
+// of uses at Wellcome.  Among other things, it links to websites, electronic
+// journals, and links to canned searches in our catalogue.
+//
+// See RFC 035 Modelling MARC 856 "web linking entry"
+// https://github.com/wellcomecollection/docs/pull/48
+//
+// TODO: Update this link to the published version of the RFC
+//
+object SierraElectronicResources extends SierraQueryOps with Logging {
+  def apply(bibId: SierraBibNumber, varFields: List[VarField]): List[Item[IdState.Unminted]] =
+    varFields
+      .filter { _.marcTag.contains("856") }
+      .flatMap(createItem)
+
+  private def createItem(vf: VarField): Option[Item[IdState.Unminted]] = {
+    assert(vf.marcTag.contains("856"))
+
+    None
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -41,7 +41,24 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
         case Some(label) =>
           if (label.split(" ").length <= 7 &&
               label.containsAnyOf("access", "view", "connect"))
-            (None, Some(label))
+            (
+              None,
+              Some(label
+                // e.g. "View resource." ~> "View resource"
+                .stripSuffix(".")
+                .stripSuffix(":")
+                // e.g. "view resource" ~> "View resource"
+                .replaceFirst("^view ", "View ")
+                // These are hard-coded fixes for a couple of known weird records.
+                // We could also fix these in the catalogue, but fixing them here
+                // is cheap and easy.
+                .replace("VIEW FULL TEXT", "View full text")
+                .replace("via  MyiLibrary", "via MyiLibrary")
+                .replace("youtube", "YouTube")
+                .replace("View resource {PDF", "View resource [PDF")
+                .replace("View resource 613.7 KB]", "View resource [613.7 KB]")
+              )
+            )
           else
             (Some(label), None)
 
@@ -89,7 +106,7 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
   private def getLabel(vf: VarField): Option[String] = {
     val labelCandidate =
       vf.subfieldsWithTags("z", "y", "3")
-        .map { _.content }
+        .map { _.content.trim }
         .mkString(" ")
 
     if (labelCandidate.isEmpty) {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -37,12 +37,25 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
       // If the concatenated string is seven words or less, and contains "access",
       // "view" or "connect", we put it in the location "linkText" field.
       // Otherwise, we put it in the item's "title" field.
-      val label = getLabel(vf)
+      val (title, linkText) = getLabel(vf) match {
+        case Some(label) =>
+          if (label.split(" ").length <= 7 &&
+              label.containsAnyOf("access", "view", "connect"))
+            (None, Some(label))
+          else
+            (Some(label), None)
+
+        case None => (None, None)
+      }
 
       Item(
-        title = label,
+        title = title,
         locations = List(
-          DigitalLocation(url = url, locationType = OnlineResource)
+          DigitalLocation(
+            url = url,
+            linkText = linkText,
+            locationType = OnlineResource
+          )
         )
       )
     }
@@ -88,4 +101,9 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
 
   private def isUrl(s: String): Boolean =
     Try { new URL(s) }.isSuccess
+
+  implicit class StringOps(s: String) {
+    def containsAnyOf(substrings: String*): Boolean =
+      substrings.exists { s.toLowerCase.contains(_) }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal.LocationType.OnlineResource
 import uk.ac.wellcome.models.work.internal.{DigitalLocation, IdState, Item}
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraQueryOps, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraQueryOps,
+  VarField
+}
 import uk.ac.wellcome.sierra_adapter.model.SierraBibNumber
 
 import java.net.URL
@@ -21,16 +25,19 @@ import scala.util.Try
 // TODO: Update this link to the published version of the RFC
 //
 object SierraElectronicResources extends SierraQueryOps with Logging {
-  def apply(bibId: SierraBibNumber, varFields: List[VarField]): List[Item[IdState.Unminted]] =
+  def apply(bibId: SierraBibNumber,
+            varFields: List[VarField]): List[Item[IdState.Unminted]] =
     varFields
       .filter { _.marcTag.contains("856") }
-      .flatMap { vf => createItem(bibId, vf) }
+      .flatMap { vf =>
+        createItem(bibId, vf)
+      }
 
-  private def createItem(bibId: SierraBibNumber, vf: VarField): Option[Item[IdState.Unminted]] = {
+  private def createItem(bibId: SierraBibNumber,
+                         vf: VarField): Option[Item[IdState.Unminted]] = {
     assert(vf.marcTag.contains("856"))
 
     getUrl(bibId, vf).map { url =>
-
       // We don't want the link text to be too long (at most seven words), so
       // we apply the following heuristic to the label:
       //
@@ -43,21 +50,23 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
               label.containsAnyOf("access", "view", "connect"))
             (
               None,
-              Some(label
+              Some(
+                label
                 // e.g. "View resource." ~> "View resource"
-                .stripSuffix(".")
-                .stripSuffix(":")
-                // e.g. "view resource" ~> "View resource"
-                .replaceFirst("^view ", "View ")
-                // These are hard-coded fixes for a couple of known weird records.
-                // We could also fix these in the catalogue, but fixing them here
-                // is cheap and easy.
-                .replace("VIEW FULL TEXT", "View full text")
-                .replace("via  MyiLibrary", "via MyiLibrary")
-                .replace("youtube", "YouTube")
-                .replace("View resource {PDF", "View resource [PDF")
-                .replace("View resource 613.7 KB]", "View resource [613.7 KB]")
-              )
+                  .stripSuffix(".")
+                  .stripSuffix(":")
+                  // e.g. "view resource" ~> "View resource"
+                  .replaceFirst("^view ", "View ")
+                  // These are hard-coded fixes for a couple of known weird records.
+                  // We could also fix these in the catalogue, but fixing them here
+                  // is cheap and easy.
+                  .replace("VIEW FULL TEXT", "View full text")
+                  .replace("via  MyiLibrary", "via MyiLibrary")
+                  .replace("youtube", "YouTube")
+                  .replace("View resource {PDF", "View resource [PDF")
+                  .replace(
+                    "View resource 613.7 KB]",
+                    "View resource [613.7 KB]"))
             )
           else
             (Some(label), None)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -2,22 +2,98 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.internal.{DigitalLocation, Item}
+import uk.ac.wellcome.models.work.internal.LocationType.OnlineResource
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
 import uk.ac.wellcome.sierra_adapter.model.SierraGenerators
 
-class SierraElectronicResourcesTest extends AnyFunSpec with Matchers with MarcGenerators with SierraGenerators {
+class SierraElectronicResourcesTest
+  extends AnyFunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraGenerators {
   it("doesn't find any items if there are no instances of field 856") {
-    SierraElectronicResources(
-      bibId = createSierraBibNumber,
-      varFields = List()
-    ) shouldBe empty
+    getElectronicResources(varFields = List()) shouldBe empty
 
-    SierraElectronicResources(
-      bibId = createSierraBibNumber,
+    getElectronicResources(
       varFields = List(
         createVarFieldWith(marcTag = "855"),
         createVarFieldWith(marcTag = "857")
       )
     ) shouldBe empty
   }
+
+  it("returns an Item that uses the URL from 856 ǂu") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "856",
+        subfields = List(
+          MarcSubfield(tag = "u", content = "https://example.org/journal")
+        )
+      )
+    )
+
+    getElectronicResources(varFields) shouldBe List(
+      Item(
+        title = None,
+        locations = List(
+          DigitalLocation(
+            url = "https://example.org/journal",
+            locationType = OnlineResource
+          )
+        )
+      )
+    )
+  }
+
+  it("doesn't add an item if 856 ǂu isn't a URL") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "856",
+        subfields = List(
+          MarcSubfield(tag = "u", content = "search for 'online journals'")
+        )
+      )
+    )
+
+    getElectronicResources(varFields) shouldBe empty
+  }
+
+  it("doesn't add an item if 856 ǂu is repeated") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "856",
+        subfields = List(
+          MarcSubfield(tag = "u", content = "https://example.org/journal"),
+          MarcSubfield(tag = "u", content = "https://example.org/another-journal")
+        )
+      )
+    )
+
+    getElectronicResources(varFields) shouldBe empty
+  }
+
+  it("doesn't add an item if 856 doesn't have an instance of ǂu") {
+    // When we first added 856 on bibs, some of our catalogue records had
+    // the URL in subfield ǂa.  Because it was only a small number of records
+    // and it deviates from the MARC spec, we prefer not to handle it in
+    // the transformer, and instead get it fixed in the catalogue.
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "856",
+        subfields = List(
+          MarcSubfield(tag = "a", content = "https://example.org/journal")
+        )
+      )
+    )
+
+    getElectronicResources(varFields) shouldBe empty
+  }
+
+  def getElectronicResources(varFields: List[VarField]): List[Item[_]] =
+    SierraElectronicResources(
+      bibId = createSierraBibNumber,
+      varFields = varFields
+    )
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -74,6 +74,36 @@ class SierraElectronicResourcesTest
     )
   }
 
+  describe("sets the label") {
+    it("uses the concatenated contents of 856 ǂz, ǂy and ǂ3") {
+      // None of our records use all three subfields (they all use one or two),
+      // but we do it here to make testing simple.
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/journal"),
+            MarcSubfield(tag = "3", content = "Related archival materials:"),
+            MarcSubfield(tag = "z", content = "available to library members."),
+            MarcSubfield(tag = "z", content = "Cambridge Books Online."),
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = Some("Related archival materials: available to library members. Cambridge Books Online."),
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/journal",
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+  }
+
   describe("skips adding an item") {
     it("if there are no instances of field 856") {
       getElectronicResources(varFields = List()) shouldBe empty

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -13,17 +13,6 @@ class SierraElectronicResourcesTest
     with Matchers
     with MarcGenerators
     with SierraGenerators {
-  it("doesn't find any items if there are no instances of field 856") {
-    getElectronicResources(varFields = List()) shouldBe empty
-
-    getElectronicResources(
-      varFields = List(
-        createVarFieldWith(marcTag = "855"),
-        createVarFieldWith(marcTag = "857")
-      )
-    ) shouldBe empty
-  }
-
   it("returns an Item that uses the URL from 856 ǂu") {
     val varFields = List(
       createVarFieldWith(
@@ -47,48 +36,99 @@ class SierraElectronicResourcesTest
     )
   }
 
-  it("doesn't add an item if 856 ǂu isn't a URL") {
+  it("returns multiple Items if field 856 is repeated") {
     val varFields = List(
       createVarFieldWith(
         marcTag = "856",
         subfields = List(
-          MarcSubfield(tag = "u", content = "search for 'online journals'")
+          MarcSubfield(tag = "u", content = "https://example.org/journal")
         )
-      )
-    )
-
-    getElectronicResources(varFields) shouldBe empty
-  }
-
-  it("doesn't add an item if 856 ǂu is repeated") {
-    val varFields = List(
+      ),
       createVarFieldWith(
         marcTag = "856",
         subfields = List(
-          MarcSubfield(tag = "u", content = "https://example.org/journal"),
           MarcSubfield(tag = "u", content = "https://example.org/another-journal")
         )
       )
     )
 
-    getElectronicResources(varFields) shouldBe empty
-  }
-
-  it("doesn't add an item if 856 doesn't have an instance of ǂu") {
-    // When we first added 856 on bibs, some of our catalogue records had
-    // the URL in subfield ǂa.  Because it was only a small number of records
-    // and it deviates from the MARC spec, we prefer not to handle it in
-    // the transformer, and instead get it fixed in the catalogue.
-    val varFields = List(
-      createVarFieldWith(
-        marcTag = "856",
-        subfields = List(
-          MarcSubfield(tag = "a", content = "https://example.org/journal")
+    getElectronicResources(varFields) shouldBe List(
+      Item(
+        title = None,
+        locations = List(
+          DigitalLocation(
+            url = "https://example.org/journal",
+            locationType = OnlineResource
+          )
+        )
+      ),
+      Item(
+        title = None,
+        locations = List(
+          DigitalLocation(
+            url = "https://example.org/another-journal",
+            locationType = OnlineResource
+          )
         )
       )
     )
+  }
 
-    getElectronicResources(varFields) shouldBe empty
+  describe("skips adding an item") {
+    it("if there are no instances of field 856") {
+      getElectronicResources(varFields = List()) shouldBe empty
+
+      getElectronicResources(
+        varFields = List(
+          createVarFieldWith(marcTag = "855"),
+          createVarFieldWith(marcTag = "857")
+        )
+      ) shouldBe empty
+    }
+
+    it("if 856 ǂu isn't a URL") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "search for 'online journals'")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe empty
+    }
+
+    it("if 856 ǂu is repeated") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/journal"),
+            MarcSubfield(tag = "u", content = "https://example.org/another-journal")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe empty
+    }
+
+    it("if 856 doesn't have an instance of ǂu") {
+      // When we first added 856 on bibs, some of our catalogue records had
+      // the URL in subfield ǂa.  Because it was only a small number of records
+      // and it deviates from the MARC spec, we prefer not to handle it in
+      // the transformer, and instead get it fixed in the catalogue.
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "https://example.org/journal")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe empty
+    }
   }
 
   def getElectronicResources(varFields: List[VarField]): List[Item[_]] =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
+import uk.ac.wellcome.sierra_adapter.model.SierraGenerators
+
+class SierraElectronicResourcesTest extends AnyFunSpec with Matchers with MarcGenerators with SierraGenerators {
+  it("doesn't find any items if there are no instances of field 856") {
+    SierraElectronicResources(
+      bibId = createSierraBibNumber,
+      varFields = List()
+    ) shouldBe empty
+
+    SierraElectronicResources(
+      bibId = createSierraBibNumber,
+      varFields = List(
+        createVarFieldWith(marcTag = "855"),
+        createVarFieldWith(marcTag = "857")
+      )
+    ) shouldBe empty
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -102,6 +102,114 @@ class SierraElectronicResourcesTest
         )
       )
     }
+
+    it("puts the label in the linkText if it's ≤7 words and contains 'view', 'access' or 'connect'") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/viewer"),
+            MarcSubfield(tag = "3", content = "View online")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/resource"),
+            MarcSubfield(tag = "z", content = "Access resource")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/journal"),
+            MarcSubfield(tag = "z", content = "Connect to journal")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/viewer",
+              linkText = Some("View online"),
+              locationType = OnlineResource
+            )
+          )
+        ),
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/resource",
+              linkText = Some("Access resource"),
+              locationType = OnlineResource
+            )
+          )
+        ),
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/journal",
+              linkText = Some("Connect to journal"),
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+
+    it("puts the label in the item title if it's ≤7 words but doesn't contain 'view', 'access' or 'connect'") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/oxford"),
+            MarcSubfield(tag = "3", content = "Oxford Libraries Online")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = Some("Oxford Libraries Online"),
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/oxford",
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+
+    it("trims whitespace from the underlying subfields") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/resource"),
+            MarcSubfield(tag = "3", content = "View resource ")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/journal",
+              linkText = Some("View resource"),
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
   }
 
   describe("skips adding an item") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -202,8 +202,83 @@ class SierraElectronicResourcesTest
           title = None,
           locations = List(
             DigitalLocation(
-              url = "https://example.org/journal",
+              url = "https://example.org/resource",
               linkText = Some("View resource"),
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+
+    it("strips trailing punctuation") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/resource"),
+            MarcSubfield(tag = "3", content = "View resource.")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/resource",
+              linkText = Some("View resource"),
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+
+    it("title cases the word 'view' at the start of the label") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/resource"),
+            MarcSubfield(tag = "3", content = "view resource")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/resource",
+              linkText = Some("View resource"),
+              locationType = OnlineResource
+            )
+          )
+        )
+      )
+    }
+
+    it("doesn't title case 'view' if it's not at the start of the label") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "856",
+          subfields = List(
+            MarcSubfield(tag = "u", content = "https://example.org/resource"),
+            MarcSubfield(tag = "3", content = "You can view this resource online")
+          )
+        )
+      )
+
+      getElectronicResources(varFields) shouldBe List(
+        Item(
+          title = None,
+          locations = List(
+            DigitalLocation(
+              url = "https://example.org/resource",
+              linkText = Some("You can view this resource online"),
               locationType = OnlineResource
             )
           )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -5,11 +5,14 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.internal.{DigitalLocation, Item}
 import uk.ac.wellcome.models.work.internal.LocationType.OnlineResource
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import uk.ac.wellcome.sierra_adapter.model.SierraGenerators
 
 class SierraElectronicResourcesTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with MarcGenerators
     with SierraGenerators {
@@ -47,7 +50,9 @@ class SierraElectronicResourcesTest
       createVarFieldWith(
         marcTag = "856",
         subfields = List(
-          MarcSubfield(tag = "u", content = "https://example.org/another-journal")
+          MarcSubfield(
+            tag = "u",
+            content = "https://example.org/another-journal")
         )
       )
     )
@@ -92,7 +97,8 @@ class SierraElectronicResourcesTest
 
       getElectronicResources(varFields) shouldBe List(
         Item(
-          title = Some("Related archival materials: available to library members. Cambridge Books Online."),
+          title = Some(
+            "Related archival materials: available to library members. Cambridge Books Online."),
           locations = List(
             DigitalLocation(
               url = "https://example.org/journal",
@@ -103,7 +109,8 @@ class SierraElectronicResourcesTest
       )
     }
 
-    it("puts the label in the linkText if it's ≤7 words and contains 'view', 'access' or 'connect'") {
+    it(
+      "puts the label in the linkText if it's ≤7 words and contains 'view', 'access' or 'connect'") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "856",
@@ -162,7 +169,8 @@ class SierraElectronicResourcesTest
       )
     }
 
-    it("puts the label in the item title if it's ≤7 words but doesn't contain 'view', 'access' or 'connect'") {
+    it(
+      "puts the label in the item title if it's ≤7 words but doesn't contain 'view', 'access' or 'connect'") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "856",
@@ -267,7 +275,9 @@ class SierraElectronicResourcesTest
           marcTag = "856",
           subfields = List(
             MarcSubfield(tag = "u", content = "https://example.org/resource"),
-            MarcSubfield(tag = "3", content = "You can view this resource online")
+            MarcSubfield(
+              tag = "3",
+              content = "You can view this resource online")
           )
         )
       )
@@ -318,7 +328,9 @@ class SierraElectronicResourcesTest
           marcTag = "856",
           subfields = List(
             MarcSubfield(tag = "u", content = "https://example.org/journal"),
-            MarcSubfield(tag = "u", content = "https://example.org/another-journal")
+            MarcSubfield(
+              tag = "u",
+              content = "https://example.org/another-journal")
           )
         )
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -965,13 +965,12 @@ class SierraTransformerTest
                             modifiedDate: Instant,
                             bibIds: List[SierraBibNumber]) =
     s"""
-                                                                                                               |{
-                                                                                                               |  "id": "$id",
-                                                                                                               |  "updatedDate": "${modifiedDate.toString}",
-                                                                                                               |  "bibIds": ${toJson(
-         bibIds).get}
-                                                                                                               |}
-                                                                                                               |""".stripMargin
+      |{
+      |  "id": "$id",
+      |  "updatedDate": "${modifiedDate.toString}",
+      |  "bibIds": ${toJson(bibIds).get}
+      |}
+      |""".stripMargin
 
   private def transformDataToWork(
     id: SierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -928,16 +928,17 @@ class SierraTransformerTest
 
     val items = work.data.items
 
-    items should contain(Item(
-      title = None,
-      locations = List(
-        DigitalLocation(
-          url = "https://example.org/journal",
-          linkText = Some("View this journal"),
-          locationType = OnlineResource
+    items should contain(
+      Item(
+        title = None,
+        locations = List(
+          DigitalLocation(
+            url = "https://example.org/journal",
+            linkText = Some("View this journal"),
+            locationType = OnlineResource
+          )
         )
-      )
-    ))
+      ))
   }
 
   describe("throws a TransformerException when passed invalid data") {


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5050, based on the current state of https://github.com/wellcomecollection/docs/pull/48

This adds an initial implementation of field 856 on bibs, so we can deploy something that the Experience team can use and experiment with. We may come back and tweak some of these rules later.

The parsing code for field 856 is split out as separate from the bib/item parsing logic because I expect we'll want to reuse it when we pull field 856 from holdings records.