### PR TITLE
Add support for bibs/holdings in the generic Sierra merger

### DIFF
--- a/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraTransformable.scala
+++ b/sierra_adapter/common/src/main/scala/uk/ac/wellcome/sierra_adapter/model/SierraTransformable.scala
@@ -3,7 +3,8 @@ package uk.ac.wellcome.sierra_adapter.model
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,
-  itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map()
+  itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map(),
+  holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map()
 )
 
 object SierraTransformable {

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
@@ -132,14 +132,18 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraTransformableWith(
     sierraId: SierraBibNumber = createSierraBibNumber,
     maybeBibRecord: Option[SierraBibRecord] = Some(createSierraBibRecord),
-    itemRecords: List[SierraItemRecord] = List()
+    itemRecords: List[SierraItemRecord] = List(),
+    holdingsRecords: List[SierraHoldingsRecord] = List()
   ): SierraTransformable =
     SierraTransformable(
       sierraId = sierraId,
       maybeBibRecord = maybeBibRecord,
-      itemRecords = itemRecords.map { record: SierraItemRecord =>
-        record.id -> record
-      }.toMap
+      itemRecords = itemRecords
+        .map { record => record.id -> record }
+        .toMap,
+      holdingsRecords = holdingsRecords
+        .map { record => record.id -> record }
+        .toMap
     )
 
   def createSierraTransformable: SierraTransformable =

--- a/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/uk/ac/wellcome/sierra_adapter/model/SierraGenerators.scala
@@ -138,12 +138,12 @@ trait SierraGenerators extends RandomGenerators {
     SierraTransformable(
       sierraId = sierraId,
       maybeBibRecord = maybeBibRecord,
-      itemRecords = itemRecords
-        .map { record => record.id -> record }
-        .toMap,
-      holdingsRecords = holdingsRecords
-        .map { record => record.id -> record }
-        .toMap
+      itemRecords = itemRecords.map { record =>
+        record.id -> record
+      }.toMap,
+      holdingsRecords = holdingsRecords.map { record =>
+        record.id -> record
+      }.toMap
     )
 
   def createSierraTransformable: SierraTransformable =

--- a/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import uk.ac.wellcome.sierra_adapter.model.SierraTransformable
+import uk.ac.wellcome.sierra_adapter.model.{SierraItemRecord, SierraTransformable}
 import uk.ac.wellcome.sierra_adapter.model.Implicits._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -19,7 +19,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
-    val updater = new Updater(
+    val updater = new Updater[SierraItemRecord](
       sourceVHS = SourceVHSBuilder.build[SierraTransformable](config)
     )
 

--- a/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
@@ -4,7 +4,10 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import uk.ac.wellcome.sierra_adapter.model.{SierraItemRecord, SierraTransformable}
+import uk.ac.wellcome.sierra_adapter.model.{
+  SierraItemRecord,
+  SierraTransformable
+}
 import uk.ac.wellcome.sierra_adapter.model.Implicits._
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
@@ -26,9 +26,11 @@ object RecordOps {
   }
 
   implicit val bibRecordOps = new RecordOps[SierraBibRecord] {
-    override def getBibIds(r: SierraBibRecord): List[SierraBibNumber] = List(r.id)
+    override def getBibIds(r: SierraBibRecord): List[SierraBibNumber] =
+      List(r.id)
 
-    override def getUnlinkedBibIds(r: SierraBibRecord): List[SierraBibNumber] = List()
+    override def getUnlinkedBibIds(r: SierraBibRecord): List[SierraBibNumber] =
+      List()
   }
 
   implicit val itemRecordOps = new RecordOps[SierraItemRecord] {
@@ -43,7 +45,8 @@ object RecordOps {
     override def getBibIds(r: SierraHoldingsRecord): List[SierraBibNumber] =
       r.bibIds
 
-    override def getUnlinkedBibIds(r: SierraHoldingsRecord): List[SierraBibNumber] =
+    override def getUnlinkedBibIds(
+      r: SierraHoldingsRecord): List[SierraBibNumber] =
       r.unlinkedBibIds
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
@@ -5,6 +5,7 @@ import uk.ac.wellcome.sierra_adapter.model.{
   AbstractSierraRecord,
   SierraBibNumber,
   SierraBibRecord,
+  SierraHoldingsRecord,
   SierraItemRecord
 }
 
@@ -35,6 +36,14 @@ object RecordOps {
       r.bibIds
 
     override def getUnlinkedBibIds(r: SierraItemRecord): List[SierraBibNumber] =
+      r.unlinkedBibIds
+  }
+
+  implicit val holdingsRecordOps = new RecordOps[SierraHoldingsRecord] {
+    override def getBibIds(r: SierraHoldingsRecord): List[SierraBibNumber] =
+      r.bibIds
+
+    override def getUnlinkedBibIds(r: SierraHoldingsRecord): List[SierraBibNumber] =
       r.unlinkedBibIds
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
+++ b/sierra_adapter/sierra_item_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
@@ -4,6 +4,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.sierra_adapter.model.{
   AbstractSierraRecord,
   SierraBibNumber,
+  SierraBibRecord,
   SierraItemRecord
 }
 
@@ -23,13 +24,17 @@ object RecordOps {
       ops.getUnlinkedBibIds(r)
   }
 
-  implicit val itemRecordOps = new RecordOps[SierraItemRecord] {
-    override def getBibIds(
-      itemRecord: SierraItemRecord): List[SierraBibNumber] =
-      itemRecord.bibIds
+  implicit val bibRecordOps = new RecordOps[SierraBibRecord] {
+    override def getBibIds(r: SierraBibRecord): List[SierraBibNumber] = List(r.id)
 
-    override def getUnlinkedBibIds(
-      itemRecord: SierraItemRecord): List[SierraBibNumber] =
-      itemRecord.unlinkedBibIds
+    override def getUnlinkedBibIds(r: SierraBibRecord): List[SierraBibNumber] = List()
+  }
+
+  implicit val itemRecordOps = new RecordOps[SierraItemRecord] {
+    override def getBibIds(r: SierraItemRecord): List[SierraBibNumber] =
+      r.bibIds
+
+    override def getUnlinkedBibIds(r: SierraItemRecord): List[SierraBibNumber] =
+      r.unlinkedBibIds
   }
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
@@ -139,6 +139,26 @@ trait SierraRecordMergerFeatureTestCases[Record <: AbstractSierraRecord[_]]
   }
 }
 
+class SierraBibRecordMergerFeatureTest
+  extends SierraRecordMergerFeatureTestCases[SierraBibRecord]
+    with RecordMergerFixtures {
+  override def withWorker[R](queue: Queue, sourceVHS: SourceVHS[SierraTransformable])(testWith: TestWith[(Worker[SierraBibRecord, String], MemoryMessageSender), R]): R =
+    withRunningWorker[SierraBibRecord, R](queue, sourceVHS) {
+      testWith
+    }
+
+  override val recordCanBeLinkedToMultipleBibs = false
+
+  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraBibRecord =
+    createSierraBibRecordWith(id = bibIds.head)
+
+  override implicit val encoder: Encoder[SierraBibRecord] = deriveEncoder
+
+  override implicit val transformableOps: TransformableOps[SierraBibRecord] =
+    TransformableOps.bibTransformableOps
+}
+
+
 class SierraItemRecordMergerFeatureTest
     extends SierraRecordMergerFeatureTestCases[SierraItemRecord]
     with RecordMergerFixtures {

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
@@ -158,7 +158,6 @@ class SierraBibRecordMergerFeatureTest
     TransformableOps.bibTransformableOps
 }
 
-
 class SierraItemRecordMergerFeatureTest
     extends SierraRecordMergerFeatureTestCases[SierraItemRecord]
     with RecordMergerFixtures {
@@ -178,4 +177,21 @@ class SierraItemRecordMergerFeatureTest
 
   override implicit val transformableOps: TransformableOps[SierraItemRecord] =
     TransformableOps.itemTransformableOps
+}
+
+class SierraHoldingsRecordMergerFeatureTest
+  extends SierraRecordMergerFeatureTestCases[SierraHoldingsRecord]
+    with RecordMergerFixtures {
+  override def withWorker[R](queue: Queue, sourceVHS: SourceVHS[SierraTransformable])(testWith: TestWith[(Worker[SierraHoldingsRecord, String], MemoryMessageSender), R]): R =
+    withRunningWorker[SierraHoldingsRecord, R](queue, sourceVHS) {
+      testWith
+    }
+
+  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraHoldingsRecord =
+    createSierraHoldingsRecordWith(bibIds = bibIds)
+
+  override implicit val encoder: Encoder[SierraHoldingsRecord] = deriveEncoder
+
+  override implicit val transformableOps: TransformableOps[SierraHoldingsRecord] =
+    TransformableOps.holdingsTransformableOps
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
@@ -140,16 +140,20 @@ trait SierraRecordMergerFeatureTestCases[Record <: AbstractSierraRecord[_]]
 }
 
 class SierraBibRecordMergerFeatureTest
-  extends SierraRecordMergerFeatureTestCases[SierraBibRecord]
+    extends SierraRecordMergerFeatureTestCases[SierraBibRecord]
     with RecordMergerFixtures {
-  override def withWorker[R](queue: Queue, sourceVHS: SourceVHS[SierraTransformable])(testWith: TestWith[(Worker[SierraBibRecord, String], MemoryMessageSender), R]): R =
+  override def withWorker[R](queue: Queue,
+                             sourceVHS: SourceVHS[SierraTransformable])(
+    testWith: TestWith[(Worker[SierraBibRecord, String], MemoryMessageSender),
+                       R]): R =
     withRunningWorker[SierraBibRecord, R](queue, sourceVHS) {
       testWith
     }
 
   override val recordCanBeLinkedToMultipleBibs = false
 
-  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraBibRecord =
+  override def createRecordWith(
+    bibIds: List[SierraBibNumber]): SierraBibRecord =
     createSierraBibRecordWith(id = bibIds.head)
 
   override implicit val encoder: Encoder[SierraBibRecord] = deriveEncoder
@@ -180,18 +184,24 @@ class SierraItemRecordMergerFeatureTest
 }
 
 class SierraHoldingsRecordMergerFeatureTest
-  extends SierraRecordMergerFeatureTestCases[SierraHoldingsRecord]
+    extends SierraRecordMergerFeatureTestCases[SierraHoldingsRecord]
     with RecordMergerFixtures {
-  override def withWorker[R](queue: Queue, sourceVHS: SourceVHS[SierraTransformable])(testWith: TestWith[(Worker[SierraHoldingsRecord, String], MemoryMessageSender), R]): R =
+  override def withWorker[R](queue: Queue,
+                             sourceVHS: SourceVHS[SierraTransformable])(
+    testWith: TestWith[(Worker[SierraHoldingsRecord, String],
+                        MemoryMessageSender),
+                       R]): R =
     withRunningWorker[SierraHoldingsRecord, R](queue, sourceVHS) {
       testWith
     }
 
-  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraHoldingsRecord =
+  override def createRecordWith(
+    bibIds: List[SierraBibNumber]): SierraHoldingsRecord =
     createSierraHoldingsRecordWith(bibIds = bibIds)
 
   override implicit val encoder: Encoder[SierraHoldingsRecord] = deriveEncoder
 
-  override implicit val transformableOps: TransformableOps[SierraHoldingsRecord] =
+  override implicit val transformableOps
+    : TransformableOps[SierraHoldingsRecord] =
     TransformableOps.holdingsTransformableOps
 }

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
@@ -345,7 +345,7 @@ class TransformableOpsTest
           holdingsRecords = Map(olderRecord.id -> newerRecord))
       }
 
-      it("returns the record if you apply the same update more than once") {
+      it("returns the same record if you apply the same update more than once") {
         val bibId = createSierraBibNumber
         val record = createSierraHoldingsRecordWith(
           bibIds = List(bibId)

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
@@ -36,7 +36,8 @@ class TransformableOpsTest
         caught.getMessage shouldEqual s"Non-matching bib ids ${bibRecord.id} != ${transformable.sierraId}"
       }
 
-      it("returns the transformable if you merge the same record more than once") {
+      it(
+        "returns the transformable if you merge the same record more than once") {
         val bibRecord = createSierraBibRecord
 
         val transformable = SierraTransformable(bibRecord)
@@ -75,7 +76,8 @@ class TransformableOpsTest
           bibRecord = oldBibRecord
         )
 
-        transformable.add(newBibRecord).get.maybeBibRecord shouldBe Some(newBibRecord)
+        transformable.add(newBibRecord).get.maybeBibRecord shouldBe Some(
+          newBibRecord)
       }
     }
 

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
@@ -37,7 +37,7 @@ class TransformableOpsTest
       }
 
       it(
-        "returns the transformable if you merge the same record more than once") {
+        "returns the same transformable if you merge the same record more than once") {
         val bibRecord = createSierraBibRecord
 
         val transformable = SierraTransformable(bibRecord)

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/models/TransformableOpsTest.scala
@@ -36,8 +36,7 @@ class TransformableOpsTest
         caught.getMessage shouldEqual s"Non-matching bib ids ${bibRecord.id} != ${transformable.sierraId}"
       }
 
-      it(
-        "returns the same transformable if you merge the same record more than once") {
+      it("returns the same transformable if you merge the same record more than once") {
         val bibRecord = createSierraBibRecord
 
         val transformable = SierraTransformable(bibRecord)

--- a/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/services/UpdaterTest.scala
+++ b/sierra_adapter/sierra_item_merger/src/test/scala/weco/catalogue/sierra_merger/services/UpdaterTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.sierra_adapter.model.Implicits._
 import uk.ac.wellcome.sierra_adapter.model.{
   SierraGenerators,
+  SierraItemRecord,
   SierraTransformable
 }
 import uk.ac.wellcome.storage.maxima.Maxima
@@ -31,7 +32,7 @@ class UpdaterTest
 
   it("creates a record if it receives an item with a bibId that doesn't exist") {
     val sourceVHS = createSourceVHS[SierraTransformable]
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val bibId = createSierraBibNumber
     val newItemRecord = createSierraItemRecordWith(
@@ -76,7 +77,7 @@ class UpdaterTest
         Version(bibId.withoutCheckDigit, 0) -> oldTransformable
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val newItemRecord = itemRecord.copy(
       data = """{"data": "newer"}""",
@@ -124,7 +125,7 @@ class UpdaterTest
         Version(bibId2.withoutCheckDigit, 0) -> sierraTransformable2
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -192,7 +193,7 @@ class UpdaterTest
         Version(bibId2.withoutCheckDigit, 0) -> sierraTransformable2
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -253,7 +254,7 @@ class UpdaterTest
         Version(bibId2.withoutCheckDigit, 0) -> sierraTransformable2
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val unlinkItemRecord = itemRecord.copy(
       bibIds = List(bibId2),
@@ -313,7 +314,7 @@ class UpdaterTest
         Version(bibId.withoutCheckDigit, 0) -> transformable
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val oldItemRecord = itemRecord.copy(
       modifiedDate = olderDate
@@ -339,7 +340,7 @@ class UpdaterTest
     )
 
     val sourceVHS = createSourceVHS[SierraTransformable]
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     (1 to 5).foreach { _ =>
       val result = updater.update(itemRecord)
@@ -363,7 +364,7 @@ class UpdaterTest
         Version(bibId.withoutCheckDigit, 0) -> transformable
       )
     )
-    val updater = new Updater(sourceVHS)
+    val updater = new Updater[SierraItemRecord](sourceVHS)
 
     val itemRecord = createSierraItemRecordWith(
       bibIds = List(bibId)
@@ -422,7 +423,7 @@ class UpdaterTest
       }
     )
 
-    val brokenUpdater = new Updater(sourceVHS)
+    val brokenUpdater = new Updater[SierraItemRecord](sourceVHS)
 
     val itemRecord = createSierraItemRecordWith(
       bibIds = List(createSierraBibNumber)
@@ -442,7 +443,7 @@ class UpdaterTest
       }
     )
 
-    val brokenUpdater = new Updater(sourceVHS)
+    val brokenUpdater = new Updater[SierraItemRecord](sourceVHS)
 
     val itemRecord = createSierraItemRecordWith(
       bibIds = List(createSierraBibNumber)


### PR DESCRIPTION
Part of wellcomecollection/platform#5003, follows #1408

This adds support for bibs/holdings in the generic Sierra merger. Mostly this is copy/paste stuff: either the bibs code from the existing bib merger, or the items code with /s/items/holdings.

Right now you can only merge bibs/holdings in the tests; I'll do another PR to wire up the config and clean up the old services.