### PR TITLE
Create the 2021-02-24 pipeline

### DIFF
--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "2021-02-17"
+  val indexDate = "2021-02-24"
 
   def apply(): ElasticConfig =
     ElasticConfig(

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -7,9 +7,9 @@ locals {
   vhs_sierra_read_policy = data.terraform_remote_state.sierra_adapter.outputs.vhs_read_policy
 
   # Sierra adapter topics
-  sierra_merged_items_topic_arn     = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_arn
-  sierra_merged_bibs_topic_arn      = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_arn
-  sierra_merged_holdings_topic_arn  = data.terraform_remote_state.sierra_adapter.outputs.merged_holdings_topic_arn
+  sierra_merged_items_topic_arn    = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_arn
+  sierra_merged_bibs_topic_arn     = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_arn
+  sierra_merged_holdings_topic_arn = data.terraform_remote_state.sierra_adapter.outputs.merged_holdings_topic_arn
 
   # Mets adapter VHS
   mets_adapter_read_policy = data.terraform_remote_state.mets_adapter.outputs.mets_dynamo_read_policy

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -7,8 +7,9 @@ locals {
   vhs_sierra_read_policy = data.terraform_remote_state.sierra_adapter.outputs.vhs_read_policy
 
   # Sierra adapter topics
-  sierra_merged_items_topic_arn = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_arn
-  sierra_merged_bibs_topic_arn  = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_arn
+  sierra_merged_items_topic_arn     = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_arn
+  sierra_merged_bibs_topic_arn      = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_arn
+  sierra_merged_holdings_topic_arn  = data.terraform_remote_state.sierra_adapter.outputs.merged_holdings_topic_arn
 
   # Mets adapter VHS
   mets_adapter_read_policy = data.terraform_remote_state.mets_adapter.outputs.mets_dynamo_read_policy

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -75,26 +75,26 @@ module "catalogue_pipeline_2021-02-24" {
   # If this pipeline is meant to be reindexed, remember to uncomment the
   # reindexer topic names.
 
-  is_reindexing = true
+  is_reindexing = false
 
   sierra_adapter_topic_arns = [
-    local.sierra_reindexer_topic_arn,
+    /*local.sierra_reindexer_topic_arn,*/
     local.sierra_merged_bibs_topic_arn,
     local.sierra_merged_items_topic_arn,
   ]
 
   miro_adapter_topic_arns = [
-    local.miro_reindexer_topic_arn,
+    /*local.miro_reindexer_topic_arn,*/
     local.miro_updates_topic_arn,
   ]
 
   mets_adapter_topic_arns = [
-    local.mets_reindexer_topic_arn,
+    /*local.mets_reindexer_topic_arn,*/
     local.mets_adapter_topic_arn,
   ]
 
   calm_adapter_topic_arns = [
-    local.calm_reindexer_topic_arn,
+    /*local.calm_reindexer_topic_arn,*/
     local.calm_adapter_topic_arn,
     local.calm_deletions_topic_arn,
   ]

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -63,3 +63,69 @@ module "catalogue_pipeline_2021-02-17" {
 
   storage_bucket_name = local.storage_bucket
 }
+
+module "catalogue_pipeline_2021-02-24" {
+  source = "./stack"
+
+  pipeline_date = "2021-02-24"
+  release_label = "stage"
+
+  # Transformer config
+  #
+  # If this pipeline is meant to be reindexed, remember to uncomment the
+  # reindexer topic names.
+
+  is_reindexing = true
+
+  sierra_adapter_topic_arns = [
+    local.sierra_reindexer_topic_arn,
+    local.sierra_merged_bibs_topic_arn,
+    local.sierra_merged_items_topic_arn,
+  ]
+
+  miro_adapter_topic_arns = [
+    local.miro_reindexer_topic_arn,
+    local.miro_updates_topic_arn,
+  ]
+
+  mets_adapter_topic_arns = [
+    local.mets_reindexer_topic_arn,
+    local.mets_adapter_topic_arn,
+  ]
+
+  calm_adapter_topic_arns = [
+    local.calm_reindexer_topic_arn,
+    local.calm_adapter_topic_arn,
+    local.calm_deletions_topic_arn,
+  ]
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  aws_region = local.aws_region
+  vpc_id     = local.vpc_id
+  subnets    = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  rds_cluster_id        = local.rds_cluster_id
+  rds_subnet_group_name = local.rds_subnet_group_name
+
+  # Security groups
+  rds_ids_access_security_group_id   = local.rds_access_security_group_id
+  pipeline_storage_security_group_id = local.pipeline_storage_security_group_id
+
+  traffic_filter_platform_vpce_id   = local.traffic_filter_platform_vpce_id
+  traffic_filter_public_internet_id = local.traffic_filter_public_internet_id
+
+  # Adapter VHS
+  vhs_miro_read_policy   = local.vhs_miro_read_policy
+  vhs_sierra_read_policy = local.vhs_sierra_read_policy
+  vhs_calm_read_policy   = local.vhs_calm_read_policy
+
+  # Inferrer data
+  inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
+
+  shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+
+  storage_bucket_name = local.storage_bucket
+}

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -81,6 +81,7 @@ module "catalogue_pipeline_2021-02-24" {
     /*local.sierra_reindexer_topic_arn,*/
     local.sierra_merged_bibs_topic_arn,
     local.sierra_merged_items_topic_arn,
+    local.sierra_merged_holdings_topic_arn,
   ]
 
   miro_adapter_topic_arns = [

--- a/pipeline/terraform/stack/elastic_pipeline_storage.tf
+++ b/pipeline/terraform/stack/elastic_pipeline_storage.tf
@@ -1,5 +1,5 @@
 locals {
-  es_memory = var.is_reindexing ? "29g" : "15g"
+  es_memory = var.is_reindexing ? "58g" : "15g"
 }
 
 resource "ec_deployment" "pipeline_storage" {

--- a/pipeline/terraform/stack/elastic_pipeline_storage.tf
+++ b/pipeline/terraform/stack/elastic_pipeline_storage.tf
@@ -1,5 +1,5 @@
 locals {
-  es_memory = var.is_reindexing ? "58g" : "15g"
+  es_memory = var.is_reindexing ? "58g" : "8g"
 }
 
 resource "ec_deployment" "pipeline_storage" {

--- a/pipeline/terraform/stack/elastic_pipeline_storage.tf
+++ b/pipeline/terraform/stack/elastic_pipeline_storage.tf
@@ -1,5 +1,5 @@
 locals {
-  es_memory = var.is_reindexing ? "58g" : "8g"
+  es_memory = var.is_reindexing ? "58g" : "15g"
 }
 
 resource "ec_deployment" "pipeline_storage" {

--- a/pipeline/terraform/stack/locals.tf
+++ b/pipeline/terraform/stack/locals.tf
@@ -16,7 +16,11 @@ locals {
   # specified at /infrastructure/critical/rds_id_minter.tf
   base_rds_instances             = 1
   id_minter_rds_max_connections  = (local.base_rds_instances + local.extra_rds_instances) * 45
-  id_minter_task_max_connections = min(9, var.max_capacity)
+  id_minter_task_max_connections = min(9, local.max_capacity)
+
+  # We don't want to overload our databases if we're not reindexing
+  # and don't have extra database capacity provisioned
+  max_capacity = var.is_reindexing ? var.max_capacity : min(3, var.max_capacity)
 
   services = [
     "ingestor_works",

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -136,7 +136,7 @@ module "image_inferrer" {
   subnets = var.subnets
 
   # Any higher than this currently causes latency spikes from Loris
-  max_capacity = min(6, var.max_capacity)
+  max_capacity = min(6, local.max_capacity)
 
   queue_read_policy = module.image_inferrer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_image_ingestor.tf
+++ b/pipeline/terraform/stack/service_image_ingestor.tf
@@ -70,7 +70,7 @@ module "ingestor_images" {
 
   subnets = var.subnets
 
-  max_capacity      = min(5, var.max_capacity)
+  max_capacity      = min(5, local.max_capacity)
   queue_read_policy = module.ingestor_images_queue.read_policy
 
   deployment_service_env  = var.release_label

--- a/pipeline/terraform/stack/service_image_ingestor.tf
+++ b/pipeline/terraform/stack/service_image_ingestor.tf
@@ -4,6 +4,8 @@ module "ingestor_images_queue" {
   topic_arns      = [module.image_inferrer_topic.arn]
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
+
+  visibility_timeout_seconds = 60
 }
 
 # Service

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -1,5 +1,7 @@
 locals {
-  lock_timeout = 240
+  # This was previously 4 minutes, but we saw a handful of messages
+  # land on the DLQ, so we increased it.
+  lock_timeout = 10 * 60
 }
 
 module "matcher_input_queue" {

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -62,7 +62,7 @@ module "matcher" {
   secret_env_vars = local.pipeline_storage_es_service_secrets["matcher"]
 
   subnets           = var.subnets
-  max_capacity      = var.max_capacity
+  max_capacity      = local.max_capacity
   queue_read_policy = module.matcher_input_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -6,8 +6,10 @@ module "merger_queue" {
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
-  # This has to be longer than the `flush_interval_seconds` in the merger
-  visibility_timeout_seconds = 10 * 60
+  # This has to be longer than the `flush_interval_seconds` in the merger.
+  # It also has to be long enough for the Work to actually get processed,
+  # and some of them are quite big.
+  visibility_timeout_seconds = 20 * 60
 }
 
 module "merger" {

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -48,7 +48,7 @@ module "merger" {
   use_fargate_spot = true
 
   subnets           = var.subnets
-  max_capacity      = var.max_capacity
+  max_capacity      = local.max_capacity
   queue_read_policy = module.merger_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -36,7 +36,7 @@ module "calm_transformer" {
   use_fargate_spot = true
 
   subnets      = var.subnets
-  max_capacity = var.max_capacity
+  max_capacity = local.max_capacity
 
   queue_read_policy = module.calm_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -4,6 +4,14 @@ module "mets_transformer_queue" {
   topic_arns      = var.mets_adapter_topic_arns
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
+
+  # The default visibility timeout is 30 seconds, and occasionally we see
+  # works get sent to the DLQ that still got through the transformer --
+  # presumably because they took a bit too long to process.
+  #
+  # Bumping the timeout is an attempt to avoid the messages being
+  # sent to a DLQ.
+  visibility_timeout_seconds = 90
 }
 
 module "mets_transformer" {

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -42,7 +42,7 @@ module "mets_transformer" {
   secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
   subnets           = var.subnets
-  max_capacity      = var.max_capacity
+  max_capacity      = local.max_capacity
   queue_read_policy = module.mets_transformer_queue.read_policy
 
   # The METS transformer is quite CPU intensive, and if it doesn't have enough CPU,

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -39,7 +39,7 @@ module "miro_transformer" {
   use_fargate_spot = true
 
   subnets           = var.subnets
-  max_capacity      = var.max_capacity
+  max_capacity      = local.max_capacity
   queue_read_policy = module.miro_transformer_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -36,7 +36,7 @@ module "sierra_transformer" {
   use_fargate_spot = true
 
   subnets      = var.subnets
-  max_capacity = var.max_capacity
+  max_capacity = local.max_capacity
 
   queue_read_policy = module.sierra_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -36,7 +36,7 @@ module "batcher" {
   shared_logging_secrets = var.shared_logging_secrets
 
   subnets           = var.subnets
-  max_capacity      = min(1, var.max_capacity)
+  max_capacity      = min(1, local.max_capacity)
   queue_read_policy = module.batcher_queue.read_policy
 
   cpu    = 1024

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -49,7 +49,7 @@ module "ingestor_works" {
 
   subnets = var.subnets
 
-  max_capacity      = min(6, var.max_capacity)
+  max_capacity      = min(6, local.max_capacity)
   queue_read_policy = module.ingestor_works_queue.read_policy
 
   cpu    = 2048

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -43,7 +43,7 @@ module "relation_embedder" {
   secret_env_vars = local.pipeline_storage_es_service_secrets["relation_embedder"]
 
   # NOTE: limit to avoid >500 concurrent scroll contexts
-  max_capacity = min(10, var.max_capacity)
+  max_capacity = min(10, local.max_capacity)
 
   subnets           = var.subnets
   queue_read_policy = module.relation_embedder_queue.read_policy

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -4,6 +4,8 @@ module "router_queue" {
   topic_arns      = [module.merger_works_topic.arn]
   aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
+
+  visibility_timeout_seconds = 60
 }
 
 module "router" {

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -42,7 +42,7 @@ module "router" {
   shared_logging_secrets = var.shared_logging_secrets
 
   subnets           = var.subnets
-  max_capacity      = min(10, var.max_capacity)
+  max_capacity      = min(10, local.max_capacity)
   queue_read_policy = module.router_queue.read_policy
 
   cpu    = 1024


### PR DESCRIPTION
This brings in the following changes:

- We get titles for a few more images by looking at subfield $a on field tag $v
- Make it easier to understand why a Work is Deleted/Invisible. We expect to see a lot of Works move from Invisible to Deleted in this reindex. #1399
- The image inferrer will fetch images from DLCS (#1401), and the IIIF Image URLs will point exclusively to the DLCS images (#1403).
- Works now have the "availabilities" property (#1404)
- We get digital items from field 856 on bibs (#1407)