### PR TITLE
Refactor the SierraWindowManager class

### DIFF
--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Main.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/Main.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.sierra_reader
 
 import akka.actor.ActorSystem
+import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
@@ -23,9 +24,10 @@ object Main extends WellcomeTypesafeApp {
 
     val sqsStream = SQSBuilder.buildSQSStream[NotificationMessage](config)
 
+    implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
+
     new SierraReaderWorkerService(
       sqsStream = sqsStream,
-      s3client = S3Builder.buildS3Client(config),
       s3Config = S3Builder.buildS3Config(config),
       readerConfig = ReaderConfigBuilder.buildReaderConfig(config),
       sierraAPIConfig = SierraAPIConfigBuilder.buildSierraConfig(config)

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -37,16 +37,16 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SierraReaderWorkerService(
   sqsStream: SQSStream[NotificationMessage],
-  s3client: AmazonS3,
   s3Config: S3Config,
   readerConfig: ReaderConfig,
   sierraAPIConfig: SierraAPIConfig
-)(implicit actorSystem: ActorSystem, ec: ExecutionContext)
+)(implicit
+  actorSystem: ActorSystem,
+  ec: ExecutionContext,
+  s3Client: AmazonS3)
     extends Logging
     with Runnable {
-  implicit val s = s3client
   val windowManager = new WindowManager(
-    s3client = s3client,
     s3Config = s3Config,
     readerConfig = readerConfig
   )

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
@@ -17,17 +17,16 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 class WindowManager(
-  s3client: AmazonS3,
   s3Config: S3Config,
   readerConfig: ReaderConfig
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, s3Client: AmazonS3)
     extends Logging {
 
   def getCurrentStatus(window: String): Future[WindowStatus] = Future {
     info(
       s"Searching for records from previous invocation of the reader in prefix ${buildWindowShard(window)}")
 
-    val lastExistingKey = s3client
+    val lastExistingKey = s3Client
       .listObjects(s3Config.bucketName, buildWindowShard(window))
       .getObjectSummaries
       .asScala
@@ -51,7 +50,7 @@ class WindowManager(
         val lastBody =
           scala.io.Source
             .fromInputStream(
-              s3client.getObject(s3Config.bucketName, key).getObjectContent
+              s3Client.getObject(s3Config.bucketName, key).getObjectContent
             )
             .mkString
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -26,7 +26,6 @@ trait WorkerServiceFixture extends Akka with SQS with S3Fixtures {
       withSQSStream[NotificationMessage, R](queue) { sqsStream =>
         val workerService = new SierraReaderWorkerService(
           sqsStream = sqsStream,
-          s3client = s3Client,
           s3Config = createS3ConfigWith(bucket),
           readerConfig = readerConfig,
           sierraAPIConfig = sierraAPIConfig

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -140,7 +140,8 @@ class WindowManagerTest
 
   it("throws an error if it can't list the contents of the bucket") {
     withWindowManager(createBucket) { windowManager =>
-      val future = windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
+      val future =
+        windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
 
       whenReady(future.failed) {
         _ shouldBe a[AmazonS3Exception]

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -144,7 +144,7 @@ class WindowManagerTest
         windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
 
       whenReady(future.failed) {
-        _ shouldBe a[AmazonS3Exception]
+        _ shouldBe an[AmazonS3Exception]
       }
     }
   }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -17,8 +17,6 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
 import weco.catalogue.sierra_adapter.models.SierraBibNumber
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class WindowManagerTest
     extends AnyFunSpec
     with Matchers

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -64,7 +64,7 @@ class WindowManagerTest
           windowManager.buildWindowShard(s"[$startDateTime,$endDateTime]")
 
         // We pre-populate S3 with files as if they'd come from a prior run of the reader.
-        s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
+        s3Client.putObject(bucket.name, s"${prefix}0000.json", "[]")
 
         val record = createSierraBibRecordWith(
           id = SierraBibNumber("1794165")
@@ -72,7 +72,7 @@ class WindowManagerTest
 
         s3Client.putObject(
           bucket.name,
-          s"$prefix/0001.json",
+          s"${prefix}0001.json",
           toJson(List(record)).get
         )
 
@@ -91,7 +91,7 @@ class WindowManagerTest
       withWindowManager(bucket) { windowManager =>
         val prefix =
           windowManager.buildWindowShard(s"[$startDateTime,$endDateTime]")
-        s3Client.putObject(bucket.name, s"$prefix/0000.json", "not valid")
+        s3Client.putObject(bucket.name, s"${prefix}0000.json", "not valid")
 
         val result =
           windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
@@ -109,7 +109,7 @@ class WindowManagerTest
         val prefix =
           windowManager.buildWindowShard(s"[$startDateTime,$endDateTime]")
 
-        s3Client.putObject(bucket.name, s"$prefix/0000.json", "[]")
+        s3Client.putObject(bucket.name, s"${prefix}0000.json", "[]")
 
         val result =
           windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
@@ -127,7 +127,7 @@ class WindowManagerTest
         val prefix =
           windowManager.buildWindowShard(s"[$startDateTime,$endDateTime]")
 
-        s3Client.putObject(bucket.name, s"$prefix/000x.json", "[]")
+        s3Client.putObject(bucket.name, s"${prefix}000x.json", "[]")
 
         val result =
           windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -29,7 +29,6 @@ class WindowManagerTest
   private def withWindowManager[R](bucket: Bucket)(
     testWith: TestWith[WindowManager, R]) = {
     val windowManager = new WindowManager(
-      s3client = s3Client,
       s3Config = createS3ConfigWith(bucket),
       readerConfig = ReaderConfig(
         resourceType = SierraResourceTypes.bibs,

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader.services
 
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -135,6 +136,16 @@ class WindowManagerTest
         whenReady(result.failed) {
           _ shouldBe a[SierraReaderException]
         }
+      }
+    }
+  }
+
+  it("throws an error if it can't list the contents of the bucket") {
+    withWindowManager(createBucket) { windowManager =>
+      val future = windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
+
+      whenReady(future.failed) {
+        _ shouldBe a[AmazonS3Exception]
       }
     }
   }


### PR DESCRIPTION
Non-urgent refactoring I spotted while looking at #1415

This makes more use of our shared storage libraries, and more use of Try/Either monads to pass around results – rather than throwing unhandled exceptions. 😱 