### PR TITLE
Handle Sierra IDs as strings or ints in API responses

### DIFF
--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/json/JsonOps.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/json/JsonOps.scala
@@ -8,9 +8,13 @@ object JsonOps {
   class StringOrInt(val underlying: String)
 
   implicit val decoder: Decoder[StringOrInt] =
-    (c: HCursor) => c.as[String] match {
-      case Right(value) => Right(new StringOrInt(value))
-      case Left(_) => c.as[Int].map { v => new StringOrInt(v.toString) }
+    (c: HCursor) =>
+      c.as[String] match {
+        case Right(value) => Right(new StringOrInt(value))
+        case Left(_) =>
+          c.as[Int].map { v =>
+            new StringOrInt(v.toString)
+          }
     }
 
   implicit val encoder: Encoder[StringOrInt] =

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/json/JsonOps.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/json/JsonOps.scala
@@ -1,0 +1,18 @@
+package weco.catalogue.sierra_adapter.json
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+object JsonOps {
+  // Sierra API responses can return some IDs as a String or an Int.
+  // Parsing the value as an instance of this class will handle it for you.
+  class StringOrInt(val underlying: String)
+
+  implicit val decoder: Decoder[StringOrInt] =
+    (c: HCursor) => c.as[String] match {
+      case Right(value) => Right(new StringOrInt(value))
+      case Left(_) => c.as[Int].map { v => new StringOrInt(v.toString) }
+    }
+
+  implicit val encoder: Encoder[StringOrInt] =
+    (id: StringOrInt) => Json.fromString(id.underlying)
+}

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -40,6 +40,9 @@ object Implicits {
         }
     }
 
+  implicit val holdingsNumberEncoder: Encoder[SierraHoldingsNumber] =
+    (number: SierraHoldingsNumber) => Json.fromString(number.withoutCheckDigit)
+
   implicit val _dec01: Decoder[SierraTransformable] = deriveConfiguredDecoder
   implicit val _dec02: Decoder[SierraItemRecord] = deriveConfiguredDecoder
   implicit val _dec03: Decoder[SierraHoldingsRecord] = deriveConfiguredDecoder

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -4,7 +4,11 @@ import io.circe.generic.extras.semiauto._
 import io.circe._
 import uk.ac.wellcome.json.JsonUtil._
 
+import scala.util.{Failure, Success, Try}
+
 object Implicits {
+  import weco.catalogue.sierra_adapter.json.JsonOps._
+
   // Because the [[SierraTransformable.itemRecords]] field is keyed by
   // [[SierraItemNumber]] in our case class, but JSON only supports string
   // keys, we need to turn the ID into a string when storing as JSON.
@@ -15,14 +19,32 @@ object Implicits {
   implicit val itemNumberEncoder: KeyEncoder[SierraItemNumber] =
     (key: SierraItemNumber) => key.withoutCheckDigit
 
-  implicit val holdingsNumberEncoder: KeyEncoder[SierraHoldingsNumber] =
+  implicit val holdingsNumberKeyEncoder: KeyEncoder[SierraHoldingsNumber] =
     (key: SierraHoldingsNumber) => key.withoutCheckDigit
 
   implicit val itemNumberDecoder: KeyDecoder[SierraItemNumber] =
     (key: String) => Some(SierraItemNumber(key))
 
-  implicit val holdingsNumberDecoder: KeyDecoder[SierraHoldingsNumber] =
+  implicit val holdingsNumberKeyDecoder: KeyDecoder[SierraHoldingsNumber] =
     (key: String) => Some(SierraHoldingsNumber(key))
+
+  // The API responses from Sierra can return a RecordNumber as a
+  // string or an int.  We need to handle both cases.
+  private def createDecoder[T <: TypedSierraRecordNumber](create: String => T): Decoder[T] =
+    (c: HCursor) =>
+      c.value.as[StringOrInt].flatMap {
+        id =>
+          Try { create(id.underlying) } match {
+            case Success(number) => Right(number)
+            case Failure(err) => Left(DecodingFailure(err.toString, ops = List.empty))
+          }
+      }
+
+  implicit val bibNumberDecoder: Decoder[SierraBibNumber] =
+    createDecoder(SierraBibNumber.apply)
+
+  implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
+    createDecoder(SierraHoldingsNumber.apply)
 
   implicit val _dec01: Decoder[SierraTransformable] = deriveConfiguredDecoder
   implicit val _dec02: Decoder[SierraItemRecord] = deriveConfiguredDecoder

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -30,21 +30,15 @@ object Implicits {
 
   // The API responses from Sierra can return a RecordNumber as a
   // string or an int.  We need to handle both cases.
-  private def createDecoder[T <: TypedSierraRecordNumber](create: String => T): Decoder[T] =
+  implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
     (c: HCursor) =>
       c.value.as[StringOrInt].flatMap {
         id =>
-          Try { create(id.underlying) } match {
+          Try { SierraHoldingsNumber(id.underlying) } match {
             case Success(number) => Right(number)
             case Failure(err) => Left(DecodingFailure(err.toString, ops = List.empty))
           }
       }
-
-  implicit val bibNumberDecoder: Decoder[SierraBibNumber] =
-    createDecoder(SierraBibNumber.apply)
-
-  implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
-    createDecoder(SierraHoldingsNumber.apply)
 
   implicit val _dec01: Decoder[SierraTransformable] = deriveConfiguredDecoder
   implicit val _dec02: Decoder[SierraItemRecord] = deriveConfiguredDecoder

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -32,13 +32,13 @@ object Implicits {
   // string or an int.  We need to handle both cases.
   implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
     (c: HCursor) =>
-      c.value.as[StringOrInt].flatMap {
-        id =>
-          Try { SierraHoldingsNumber(id.underlying) } match {
-            case Success(number) => Right(number)
-            case Failure(err) => Left(DecodingFailure(err.toString, ops = List.empty))
-          }
-      }
+      c.value.as[StringOrInt].flatMap { id =>
+        Try { SierraHoldingsNumber(id.underlying) } match {
+          case Success(number) => Right(number)
+          case Failure(err) =>
+            Left(DecodingFailure(err.toString, ops = List.empty))
+        }
+    }
 
   implicit val _dec01: Decoder[SierraTransformable] = deriveConfiguredDecoder
   implicit val _dec02: Decoder[SierraItemRecord] = deriveConfiguredDecoder

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
@@ -2,7 +2,6 @@ package weco.catalogue.sierra_adapter.models
 
 import java.time.Instant
 import uk.ac.wellcome.json.JsonUtil._
-import Implicits._
 
 import scala.util.{Failure, Success}
 
@@ -16,7 +15,7 @@ case class SierraHoldingsRecord(
 
 case object SierraHoldingsRecord {
 
-  private case class SierraAPIData(bibIds: List[SierraBibNumber])
+  private case class SierraAPIData(bibIds: List[Int])
 
   /** This apply method is for parsing JSON bodies that come from the
     * Sierra API.
@@ -25,7 +24,7 @@ case object SierraHoldingsRecord {
             data: String,
             modifiedDate: Instant): SierraHoldingsRecord = {
     val bibIds = fromJson[SierraAPIData](data) match {
-      case Success(apiData) => apiData.bibIds
+      case Success(apiData) => apiData.bibIds.map { v => SierraBibNumber(v.toString )}
       case Failure(e) =>
         throw new IllegalArgumentException(
           s"Error parsing bibIds from JSON <<$data>> ($e)")

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
@@ -24,7 +24,10 @@ case object SierraHoldingsRecord {
             data: String,
             modifiedDate: Instant): SierraHoldingsRecord = {
     val bibIds = fromJson[SierraAPIData](data) match {
-      case Success(apiData) => apiData.bibIds.map { v => SierraBibNumber(v.toString )}
+      case Success(apiData) =>
+        apiData.bibIds.map { v =>
+          SierraBibNumber(v.toString)
+        }
       case Failure(e) =>
         throw new IllegalArgumentException(
           s"Error parsing bibIds from JSON <<$data>> ($e)")

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecord.scala
@@ -1,8 +1,8 @@
 package weco.catalogue.sierra_adapter.models
 
 import java.time.Instant
-
 import uk.ac.wellcome.json.JsonUtil._
+import Implicits._
 
 import scala.util.{Failure, Success}
 
@@ -16,7 +16,7 @@ case class SierraHoldingsRecord(
 
 case object SierraHoldingsRecord {
 
-  private case class SierraAPIData(bibIds: List[String])
+  private case class SierraAPIData(bibIds: List[SierraBibNumber])
 
   /** This apply method is for parsing JSON bodies that come from the
     * Sierra API.
@@ -35,7 +35,7 @@ case object SierraHoldingsRecord {
       id = SierraHoldingsNumber(id),
       data = data,
       modifiedDate = modifiedDate,
-      bibIds = bibIds.map { SierraBibNumber }
+      bibIds = bibIds
     )
   }
 }

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/generators/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/generators/SierraGenerators.scala
@@ -81,7 +81,7 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraItemRecordWith(
     id: SierraItemNumber = createSierraItemNumber,
     data: (SierraItemNumber, Instant, List[SierraBibNumber]) => String =
-      defaultData,
+      defaultItemData,
     modifiedDate: Instant = Instant.now,
     bibIds: List[SierraBibNumber] = List(),
     unlinkedBibIds: List[SierraBibNumber] = List()
@@ -100,7 +100,7 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraHoldingsRecordWith(
     id: SierraHoldingsNumber = createSierraHoldingsNumber,
     data: (SierraHoldingsNumber, Instant, List[SierraBibNumber]) => String =
-      defaultData,
+      defaultHoldingsData,
     modifiedDate: Instant = Instant.now,
     bibIds: List[SierraBibNumber] = List(),
     unlinkedBibIds: List[SierraBibNumber] = List()
@@ -116,14 +116,27 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
-  private def defaultData(id: TypedSierraRecordNumber,
-                          modifiedDate: Instant,
-                          bibIds: List[SierraBibNumber]): String =
+  private def defaultItemData(
+    id: SierraItemNumber,
+    modifiedDate: Instant,
+    bibIds: List[SierraBibNumber]): String =
     s"""
        |{
        |  "id": "$id",
        |  "updatedDate": "${modifiedDate.toString}",
        |  "bibIds": ${toJson(bibIds.map(_.recordNumber)).get}
+       |}
+       |""".stripMargin
+
+  private def defaultHoldingsData(
+    id: SierraHoldingsNumber,
+    modifiedDate: Instant,
+    bibIds: List[SierraBibNumber]): String =
+    s"""
+       |{
+       |  "id": $id,
+       |  "updatedDate": "${modifiedDate.toString}",
+       |  "bibIds": ${toJson(bibIds.map(_.recordNumber.toInt)).get}
        |}
        |""".stripMargin
 

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/generators/SierraGenerators.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/generators/SierraGenerators.scala
@@ -116,10 +116,9 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
-  private def defaultItemData(
-    id: SierraItemNumber,
-    modifiedDate: Instant,
-    bibIds: List[SierraBibNumber]): String =
+  private def defaultItemData(id: SierraItemNumber,
+                              modifiedDate: Instant,
+                              bibIds: List[SierraBibNumber]): String =
     s"""
        |{
        |  "id": "$id",
@@ -128,10 +127,9 @@ trait SierraGenerators extends RandomGenerators {
        |}
        |""".stripMargin
 
-  private def defaultHoldingsData(
-    id: SierraHoldingsNumber,
-    modifiedDate: Instant,
-    bibIds: List[SierraBibNumber]): String =
+  private def defaultHoldingsData(id: SierraHoldingsNumber,
+                                  modifiedDate: Instant,
+                                  bibIds: List[SierraBibNumber]): String =
     s"""
        |{
        |  "id": $id,

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/json/JsonOpsTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/json/JsonOpsTest.scala
@@ -11,8 +11,7 @@ class JsonOpsTest extends AnyFunSpec with Matchers with TryValues {
   import JsonOps._
 
   it("parses a String") {
-    fromJson[StringOrInt](
-      """
+    fromJson[StringOrInt]("""
         |"1234"
         |""".stripMargin).success.value.underlying shouldBe "1234"
   }

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/json/JsonOpsTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/json/JsonOpsTest.scala
@@ -1,0 +1,27 @@
+package weco.catalogue.sierra_adapter.json
+
+import org.scalatest.TryValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.util.Failure
+
+class JsonOpsTest extends AnyFunSpec with Matchers with TryValues {
+  import JsonOps._
+
+  it("parses a String") {
+    fromJson[StringOrInt](
+      """
+        |"1234"
+        |""".stripMargin).success.value.underlying shouldBe "1234"
+  }
+
+  it("parses an Int") {
+    fromJson[StringOrInt]("1234").success.value.underlying shouldBe "1234"
+  }
+
+  it("fails if the input isn't a string or int") {
+    fromJson[StringOrInt]("true") shouldBe a[Failure[_]]
+  }
+}

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
@@ -8,7 +8,10 @@ import weco.catalogue.sierra_adapter.models.Implicits._
 
 import scala.util.{Failure, Success}
 
-class SierraHoldingsNumberTest extends AnyFunSpec with Matchers with SierraGenerators {
+class SierraHoldingsNumberTest
+    extends AnyFunSpec
+    with Matchers
+    with SierraGenerators {
   case class Identity(id: SierraHoldingsNumber)
 
   it("decodes a String as a HoldingsNumber") {

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
@@ -3,11 +3,12 @@ package weco.catalogue.sierra_adapter.models
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.sierra_adapter.generators.SierraGenerators
 import weco.catalogue.sierra_adapter.models.Implicits._
 
 import scala.util.{Failure, Success}
 
-class SierraHoldingsNumberTest extends AnyFunSpec with Matchers {
+class SierraHoldingsNumberTest extends AnyFunSpec with Matchers with SierraGenerators {
   case class Identity(id: SierraHoldingsNumber)
 
   it("decodes a String as a HoldingsNumber") {
@@ -22,5 +23,11 @@ class SierraHoldingsNumberTest extends AnyFunSpec with Matchers {
 
   it("fails if the Int is the wrong format") {
     fromJson[Identity]("""{"id": 123456789}""") shouldBe a[Failure[_]]
+  }
+
+  it("casts a HoldingsNumber to Json and back") {
+    val id = createSierraHoldingsNumber
+
+    fromJson[SierraHoldingsNumber](toJson(id).get).get shouldBe id
   }
 }

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
@@ -11,11 +11,13 @@ class SierraHoldingsNumberTest extends AnyFunSpec with Matchers {
   case class Identity(id: SierraHoldingsNumber)
 
   it("decodes a String as a HoldingsNumber") {
-    fromJson[Identity]("""{"id": "1234567"}""") shouldBe Success(Identity(SierraHoldingsNumber("1234567")))
+    fromJson[Identity]("""{"id": "1234567"}""") shouldBe Success(
+      Identity(SierraHoldingsNumber("1234567")))
   }
 
   it("decodes an Int as a HoldingsNumber") {
-    fromJson[Identity]("""{"id": 1234567}""") shouldBe Success(Identity(SierraHoldingsNumber("1234567")))
+    fromJson[Identity]("""{"id": 1234567}""") shouldBe Success(
+      Identity(SierraHoldingsNumber("1234567")))
   }
 
   it("fails if the Int is the wrong format") {

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
@@ -1,0 +1,24 @@
+package weco.catalogue.sierra_adapter.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.sierra_adapter.models.Implicits._
+
+import scala.util.{Failure, Success}
+
+class SierraHoldingsNumberTest extends AnyFunSpec with Matchers {
+  case class Identity(id: SierraHoldingsNumber)
+
+  it("decodes a String as a HoldingsNumber") {
+    fromJson[Identity]("""{"id": "1234567"}""") shouldBe Success(Identity(SierraHoldingsNumber("1234567")))
+  }
+
+  it("decodes an Int as a HoldingsNumber") {
+    fromJson[Identity]("""{"id": 1234567}""") shouldBe Success(Identity(SierraHoldingsNumber("1234567")))
+  }
+
+  it("fails if the Int is the wrong format") {
+    fromJson[Identity]("""{"id": 123456789}""") shouldBe a[Failure[_]]
+  }
+}

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecordTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecordTest.scala
@@ -26,7 +26,7 @@ class SierraHoldingsRecordTest extends AnyFunSpec with Matchers {
       data = jsonString,
       modifiedDate = Instant.now
     )
-    
+
     record.bibIds shouldBe List(SierraBibNumber("1571482"))
   }
 }

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecordTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsRecordTest.scala
@@ -1,0 +1,32 @@
+package weco.catalogue.sierra_adapter.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class SierraHoldingsRecordTest extends AnyFunSpec with Matchers {
+  it("parses numeric bib IDs from a Sierra API response") {
+    val jsonString =
+      """{
+        |    "id": 1064036,
+        |    "bibIds": [
+        |        1571482
+        |    ],
+        |    "itemIds": [
+        |        1234567
+        |    ],
+        |    "updatedDate": "2003-04-02T13:29:42Z",
+        |    "deleted": false,
+        |    "suppressed": false
+        |}""".stripMargin
+
+    val record = SierraHoldingsRecord(
+      id = "1064036",
+      data = jsonString,
+      modifiedDate = Instant.now
+    )
+    
+    record.bibIds shouldBe List(SierraBibNumber("1571482"))
+  }
+}

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
@@ -5,7 +5,6 @@ import com.typesafe.config.Config
 import org.scanamo.DynamoFormat
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.storage.store.dynamo.DynamoSingleVersionStore
@@ -14,6 +13,7 @@ import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 import weco.catalogue.sierra_adapter.models.SierraRecordTypes._
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.{
   AbstractSierraRecord,
   SierraHoldingsNumber,

--- a/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/SierraLinkerFeatureTest.scala
+++ b/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/SierraLinkerFeatureTest.scala
@@ -21,7 +21,7 @@ class SierraLinkerFeatureTest
     with SierraGenerators
     with WorkerFixture {
 
-  it("reads items from SQS, stores the link, and sends the record onward") {
+  it("links item records") {
     val messageSender = new MemoryMessageSender
 
     val record = createSierraItemRecordWith(
@@ -47,7 +47,7 @@ class SierraLinkerFeatureTest
     }
   }
 
-  it("reads holdings from SQS, stores the link, and sends the record onward") {
+  it("links holdings records") {
     val messageSender = new MemoryMessageSender
 
     val record = createSierraHoldingsRecordWith(

--- a/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
+++ b/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
@@ -3,7 +3,6 @@ package weco.catalogue.sierra_linker.fixtures
 import io.circe.{Decoder, Encoder}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
@@ -11,6 +10,7 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.monitoring.Metrics
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.{
   AbstractSierraRecord,
   SierraHoldingsNumber,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
@@ -2,9 +2,9 @@ package uk.ac.wellcome.platform.sierra_reader.parsers
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate, LocalTime, ZoneOffset}
-
 import io.circe.Json
 import io.circe.optics.JsonPath.root
+import weco.catalogue.sierra_adapter.json.JsonOps._
 import weco.catalogue.sierra_adapter.models.AbstractSierraRecord
 
 object SierraRecordParser {
@@ -50,5 +50,8 @@ object SierraRecordParser {
   }
 
   private def getId(json: Json): String =
-    root.id.string.getOption(json).get
+    root.id.as[StringOrInt]
+      .getOption(json)
+      .map { _.underlying }
+      .get
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParser.scala
@@ -50,7 +50,8 @@ object SierraRecordParser {
   }
 
   private def getId(json: Json): String =
-    root.id.as[StringOrInt]
+    root.id
+      .as[StringOrInt]
       .getOption(json)
       .map { _.underlying }
       .get

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -24,6 +24,7 @@ import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.{
   AbstractSierraRecord,
   SierraBibRecord,

--- a/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/source/SierraPageSource.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/source/SierraPageSource.scala
@@ -121,10 +121,12 @@ class SierraPageSource(
   // holdings return it as an int.
   //
   private def getLastId(entries: List[Json]): Int = {
-    root.id.as[StringOrInt]
+    root.id
+      .as[StringOrInt]
       .getOption(entries.last)
       .getOrElse(
-        throw new RuntimeException("Couldn't find ID in last item of list response")
+        throw new RuntimeException(
+          "Couldn't find ID in last item of list response")
       )
       .underlying
       .toInt

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page1.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page1.json
@@ -1,0 +1,1606 @@
+{
+    "total": 50,
+    "start": 0,
+    "entries": [
+        {
+            "id": 1047360,
+            "bibIds": [
+                1353779
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1353779"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "a",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "p",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "z",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:22:11Z",
+            "createdDate": "2000-05-15T16:33:06Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063913,
+            "bibIds": [
+                1568891
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1568891"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:25:54Z",
+            "createdDate": "2003-02-14T14:59:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063914,
+            "bibIds": [
+                1568898
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1568898"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:26:35Z",
+            "createdDate": "2003-02-14T16:43:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063915,
+            "bibIds": [
+                1568899
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1568899"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:27:06Z",
+            "createdDate": "2003-02-14T17:00:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063924,
+            "bibIds": [
+                1568954
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1568954"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:27:44Z",
+            "createdDate": "2003-02-17T14:16:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063930,
+            "bibIds": [
+                1568962
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1568962"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:28:16Z",
+            "createdDate": "2003-02-17T14:55:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063939,
+            "bibIds": [
+                1569001
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569001"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:29:02Z",
+            "createdDate": "2003-02-17T16:25:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063952,
+            "bibIds": [
+                1569456
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569456"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:29:18Z",
+            "createdDate": "2003-02-24T15:19:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063953,
+            "bibIds": [
+                1569473
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569473"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:29:48Z",
+            "createdDate": "2003-02-24T16:29:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063954,
+            "bibIds": [
+                1569480
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569480"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:30:13Z",
+            "createdDate": "2003-02-24T17:03:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063959,
+            "bibIds": [
+                1569538
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569538"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:50:52Z",
+            "createdDate": "2003-02-25T12:10:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063960,
+            "bibIds": [
+                1569557
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569557"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:51:23Z",
+            "createdDate": "2003-02-25T14:44:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063961,
+            "bibIds": [
+                1551179
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1551179"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T09:04:13Z",
+            "createdDate": "2003-02-26T14:34:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063965,
+            "bibIds": [
+                1569788
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569788"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:52:03Z",
+            "createdDate": "2003-02-28T11:05:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063967,
+            "bibIds": [
+                1569793
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569793"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:52:24Z",
+            "createdDate": "2003-02-28T11:40:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063968,
+            "bibIds": [
+                1569800
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569800"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:52:49Z",
+            "createdDate": "2003-02-28T12:28:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063969,
+            "bibIds": [
+                1569842
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1569842"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:53:04Z",
+            "createdDate": "2003-02-28T16:42:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063970,
+            "bibIds": [
+                1560179
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1560179"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-03T10:10:14Z",
+            "createdDate": "2003-03-03T09:53:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063972,
+            "bibIds": [
+                1563093
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1563093"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-04T08:50:13Z",
+            "createdDate": "2003-03-03T16:39:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063977,
+            "bibIds": [
+                1570147
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570147"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-11T11:52:49Z",
+            "createdDate": "2003-03-06T10:47:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063978,
+            "bibIds": [
+                1570153
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570153"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-06T11:53:59Z",
+            "createdDate": "2003-03-06T11:23:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063980,
+            "bibIds": [
+                1570173
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570173"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:29:47Z",
+            "createdDate": "2003-03-06T14:18:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063981,
+            "bibIds": [
+                1570184
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570184"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:30:13Z",
+            "createdDate": "2003-03-06T14:45:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063983,
+            "bibIds": [
+                1570199
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570199"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:30:53Z",
+            "createdDate": "2003-03-06T15:31:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063984,
+            "bibIds": [
+                1570212
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570212"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:31:25Z",
+            "createdDate": "2003-03-06T16:34:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063987,
+            "bibIds": [
+                1570273
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570273"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:32:07Z",
+            "createdDate": "2003-03-07T14:13:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063989,
+            "bibIds": [
+                1570308
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570308"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:32:43Z",
+            "createdDate": "2003-03-07T15:52:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063991,
+            "bibIds": [
+                1567353
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1567353"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-11T10:43:13Z",
+            "createdDate": "2003-03-10T17:32:35Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063994,
+            "bibIds": [
+                1570495
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570495"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:33:08Z",
+            "createdDate": "2003-03-11T12:13:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063996,
+            "bibIds": [
+                1570525
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570525"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:34:00Z",
+            "createdDate": "2003-03-11T15:04:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063997,
+            "bibIds": [
+                1570532
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570532"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:35:07Z",
+            "createdDate": "2003-03-11T16:18:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1063998,
+            "bibIds": [
+                1570533
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570533"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-18T14:35:27Z",
+            "createdDate": "2003-03-11T16:45:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064006,
+            "bibIds": [
+                1570764
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570764"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:15:36Z",
+            "createdDate": "2003-03-14T11:09:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064007,
+            "bibIds": [
+                1570778
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570778"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:16:11Z",
+            "createdDate": "2003-03-14T13:56:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064008,
+            "bibIds": [
+                1570768
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570768"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:16:36Z",
+            "createdDate": "2003-03-14T14:11:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064010,
+            "bibIds": [
+                1570821
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570821"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:17:22Z",
+            "createdDate": "2003-03-14T16:07:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064012,
+            "bibIds": [
+                1570924
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570924"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:17:58Z",
+            "createdDate": "2003-03-17T14:33:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064014,
+            "bibIds": [
+                1570986
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570986"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:18:36Z",
+            "createdDate": "2003-03-17T17:04:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064015,
+            "bibIds": [
+                1570991
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1570991"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:19:11Z",
+            "createdDate": "2003-03-18T10:43:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064016,
+            "bibIds": [
+                1571026
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571026"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:58:33Z",
+            "createdDate": "2003-03-18T11:20:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064017,
+            "bibIds": [
+                1571034
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571034"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-03-24T14:58:35Z",
+            "createdDate": "2003-03-18T12:11:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064018,
+            "bibIds": [
+                1571067
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571067"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:22:46Z",
+            "createdDate": "2003-03-18T14:44:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064020,
+            "bibIds": [
+                1571096
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571096"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:23:21Z",
+            "createdDate": "2003-03-18T16:57:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064022,
+            "bibIds": [
+                1571112
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571112"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:23:52Z",
+            "createdDate": "2003-03-19T11:28:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064024,
+            "bibIds": [
+                1571205
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571205"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:24:28Z",
+            "createdDate": "2003-03-20T11:01:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064025,
+            "bibIds": [
+                1571229
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571229"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:25:08Z",
+            "createdDate": "2003-03-20T11:39:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064028,
+            "bibIds": [
+                1571245
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571245"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:26:04Z",
+            "createdDate": "2003-03-20T14:21:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064031,
+            "bibIds": [
+                1571265
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571265"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:27:48Z",
+            "createdDate": "2003-03-20T16:16:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064032,
+            "bibIds": [
+                1571323
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571323"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:28:15Z",
+            "createdDate": "2003-03-21T17:15:00Z",
+            "deleted": false,
+            "suppressed": false
+        },
+        {
+            "id": 1064035,
+            "bibIds": [
+                1571460
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571460"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:29:26Z",
+            "createdDate": "2003-03-25T14:46:00Z",
+            "deleted": false,
+            "suppressed": false
+        }
+    ]
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page2.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page2.json
@@ -1,0 +1,38 @@
+{
+    "total": 1,
+    "start": 0,
+    "entries": [
+        {
+            "id": 1064036,
+            "bibIds": [
+                1571482
+            ],
+            "bibIdLinks": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1571482"
+            ],
+            "itemIds": [
+
+            ],
+            "itemIdLinks": [
+
+            ],
+            "inheritLocation": false,
+            "accountingUnit": 0,
+            "labelCode": "n",
+            "serialCode1": "-",
+            "serialCode2": "-",
+            "receivingLocationCode": "l",
+            "vendorCode": "none",
+            "serialCode3": "-",
+            "serialCode4": "-",
+            "updateCount": "-",
+            "pieceCount": 0,
+            "eCheckInCode": " ",
+            "mediaTypeCode": " ",
+            "updatedDate": "2003-04-02T13:29:42Z",
+            "createdDate": "2003-03-25T16:44:00Z",
+            "deleted": false,
+            "suppressed": false
+        }
+    ]
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page3.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/__files/holdings-2003-page3.json
@@ -1,0 +1,6 @@
+{
+    "code": 107,
+    "specificCode": 0,
+    "httpStatus": 404,
+    "name": "Record not found"
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page1.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page1.json
@@ -1,0 +1,19 @@
+{
+  "id" : "a3c2bbef-e364-404d-96d0-3e949c0d2447",
+  "name" : "holdings",
+  "request" : {
+    "url" : "/holdings?updatedDate=%5B2003-03-03T03%3A00%3A00Z%2C2003-04-04T04%3A00%3A00Z%5D&fields=updatedDate",
+    "method" : "GET",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer fake-token"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "holdings-2003-page1.json"
+  },
+  "uuid" : "a3c2bbef-e364-404d-96d0-3e949c0d2447",
+  "persistent" : true
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page2.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page2.json
@@ -2,7 +2,7 @@
   "id" : "22eaddc9-eb87-4166-9828-79d88aca0f7b",
   "name" : "holdings",
   "request" : {
-    "url" : "/holdings?updatedDate=%5B2003-03-03T03%3A00%3A00Z%2C2003-04-04T04%3A00%3A00Z%5D&id=%5B1376920,%5D&fields=updatedDate",
+    "url" : "/holdings?updatedDate=%5B2003-03-03T03%3A00%3A00Z%2C2003-04-04T04%3A00%3A00Z%5D&fields=updatedDate&id=%5B1064036%2C%5D",
     "method" : "GET",
     "headers" : {
       "Authorization" : {

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page2.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page2.json
@@ -1,0 +1,19 @@
+{
+  "id" : "22eaddc9-eb87-4166-9828-79d88aca0f7b",
+  "name" : "holdings",
+  "request" : {
+    "url" : "/holdings?updatedDate=%5B2003-03-03T03%3A00%3A00Z%2C2003-04-04T04%3A00%3A00Z%5D&id=%5B1376920,%5D&fields=updatedDate",
+    "method" : "GET",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer fake-token"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "holdings-2003-page2.json"
+  },
+  "uuid" : "22eaddc9-eb87-4166-9828-79d88aca0f7b",
+  "persistent" : true
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
@@ -1,0 +1,19 @@
+{
+  "id" : "5ebcf6e4-65cd-4ed2-9cab-b7a3ad80d6a9",
+  "name" : "holdings",
+  "request" : {
+    "url" : "/holdings?updatedDate=%5B2005-05-05T05%3A00%3A00Z%2C2005-10-10T10%3A00%3A00Z%5D&id=%5B1381001,%5D&fields=updatedDate",
+    "method" : "GET",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer fake-token"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "holdings-2003-page3.json"
+  },
+  "uuid" : "5ebcf6e4-65cd-4ed2-9cab-b7a3ad80d6a9",
+  "persistent" : true
+}

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
@@ -2,7 +2,7 @@
   "id" : "5ebcf6e4-65cd-4ed2-9cab-b7a3ad80d6a9",
   "name" : "holdings",
   "request" : {
-    "url" : "/holdings?updatedDate=%5B2005-05-05T05%3A00%3A00Z%2C2005-10-10T10%3A00%3A00Z%5D&id=%5B1381001,%5D&fields=updatedDate",
+    "url" : "/holdings?updatedDate=%5B2003-03-03T03%3A00%3A00Z%2C2003-04-04T04%3A00%3A00Z%5D&fields=updatedDate&id=%5B1064037%2C%5D",
     "method" : "GET",
     "headers" : {
       "Authorization" : {

--- a/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
+++ b/sierra_adapter/sierra_reader/src/test/resources/wiremock/mappings/holdings-2003-page3.json
@@ -11,7 +11,7 @@
     }
   },
   "response" : {
-    "status" : 200,
+    "status" : 404,
     "bodyFileName" : "holdings-2003-page3.json"
   },
   "uuid" : "5ebcf6e4-65cd-4ed2-9cab-b7a3ad80d6a9",

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -50,4 +50,9 @@ trait WorkerServiceFixture
     resourceType = SierraResourceTypes.items,
     fields = "updatedDate,deleted,deletedDate,bibIds,fixedFields,varFields"
   )
+
+  val holdingsReaderConfig: ReaderConfig = ReaderConfig(
+    resourceType = SierraResourceTypes.holdings,
+    fields = "updatedDate"
+  )
 }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -83,7 +83,7 @@ class SierraRecordParserTest
 
   it("parses a holdings record") {
     val jsonString =
-        """{
+      """{
           |    "id": 1064036,
           |    "bibIds": [
           |        1571482

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -12,6 +12,8 @@ import weco.catalogue.sierra_adapter.models.{
   AbstractSierraRecord,
   SierraBibNumber,
   SierraBibRecord,
+  SierraHoldingsNumber,
+  SierraHoldingsRecord,
   SierraItemRecord
 }
 
@@ -75,6 +77,36 @@ class SierraRecordParserTest
 
     assertSierraRecordsAreEqual(
       SierraRecordParser(SierraItemRecord.apply)(json),
+      expectedRecord
+    )
+  }
+
+  it("parses a holdings record") {
+    val jsonString =
+        """{
+          |    "id": 1064036,
+          |    "bibIds": [
+          |        1571482
+          |    ],
+          |    "itemIds": [
+          |        1234567
+          |    ],
+          |    "updatedDate": "2003-04-02T13:29:42Z",
+          |    "deleted": false,
+          |    "suppressed": false
+          |}""".stripMargin
+
+    val expectedRecord = createSierraHoldingsRecordWith(
+      id = SierraHoldingsNumber("1064036"),
+      modifiedDate = Instant.parse("2003-04-02T13:29:42Z"),
+      bibIds = List(SierraBibNumber("1571482")),
+      data = (_, _, _) => jsonString
+    )
+
+    val json = parse(jsonString).right.get
+
+    assertSierraRecordsAreEqual(
+      SierraRecordParser(SierraHoldingsRecord.apply)(json),
       expectedRecord
     )
   }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.platform.sierra_reader.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
@@ -24,8 +25,7 @@ class SierraReaderWorkerServiceTest
     with ScalaFutures
     with WorkerServiceFixture {
 
-  it(
-    "reads a window message from SQS, retrieves the bibs from Sierra and writes them to S3") {
+  it("fetches bibs from Sierra") {
     val body =
       """
         |{
@@ -39,7 +39,7 @@ class SierraReaderWorkerServiceTest
         withWorkerService(
           bucket,
           queue,
-          readerConfig = bibsReaderConfig.copy(batchSize = 10)) { service =>
+          readerConfig = bibsReaderConfig.copy(batchSize = 10)) { _ =>
           sendNotificationToSQS(queue = queue, body = body)
 
           val pageNames = List("0000.json", "0001.json", "0002.json").map {
@@ -61,8 +61,7 @@ class SierraReaderWorkerServiceTest
     }
   }
 
-  it(
-    "reads a window message from SQS, retrieves the items from Sierra and writes them to S3") {
+  it("fetches items from Sierra") {
     val body =
       """
         |{
@@ -74,7 +73,7 @@ class SierraReaderWorkerServiceTest
     withLocalS3Bucket { bucket =>
       withLocalSqsQueue() { queue =>
         withWorkerService(bucket, queue, readerConfig = itemsReaderConfig) {
-          service =>
+          _ =>
             sendNotificationToSQS(queue = queue, body = body)
 
             val pageNames = List(
@@ -118,8 +117,7 @@ class SierraReaderWorkerServiceTest
 
             val pageNames = List(
               "0000.json",
-              "0001.json",
-              "0002.json")
+              "0001.json")
               .map { label =>
                 s"records_holdings/2003-03-03T03-00-00Z__2003-04-04T04-00-00Z/$label"
               } ++ List(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -200,8 +200,9 @@ class SierraReaderWorkerServiceTest
     getObjectFromS3[List[SierraItemRecord]](
       S3ObjectLocation(bucket = bucket.name, key = key))
 
-  private def getHoldingsRecordsFromS3(bucket: Bucket,
-                                       key: String): List[SierraHoldingsRecord] =
+  private def getHoldingsRecordsFromS3(
+    bucket: Bucket,
+    key: String): List[SierraHoldingsRecord] =
     getObjectFromS3[List[SierraHoldingsRecord]](
       S3ObjectLocation(bucket = bucket.name, key = key))
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -114,9 +114,7 @@ class SierraReaderWorkerServiceTest
           _ =>
             sendNotificationToSQS(queue = queue, body = body)
 
-            val pageNames = List(
-              "0000.json",
-              "0001.json")
+            val pageNames = List("0000.json", "0001.json")
               .map { label =>
                 s"records_holdings/2003-03-03T03-00-00Z__2003-04-04T04-00-00Z/$label"
               } ++ List(

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
-import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.platform.sierra_reader.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.fixtures.S3Fixtures

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -11,7 +11,12 @@ import uk.ac.wellcome.platform.sierra_reader.fixtures.WorkerServiceFixture
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
-import weco.catalogue.sierra_adapter.models.{SierraBibRecord, SierraItemRecord}
+import weco.catalogue.sierra_adapter.models.Implicits._
+import weco.catalogue.sierra_adapter.models.{
+  SierraBibRecord,
+  SierraHoldingsRecord,
+  SierraItemRecord
+}
 
 class SierraReaderWorkerServiceTest
     extends AnyFunSpec
@@ -124,8 +129,8 @@ class SierraReaderWorkerServiceTest
               // There are 51 item records in the Sierra wiremock so we expect 3 files
               listKeysInBucket(bucket = bucket) shouldBe pageNames
 
-              getItemRecordsFromS3(bucket, pageNames(0)) should have size 50
-              getItemRecordsFromS3(bucket, pageNames(1)) should have size 1
+              getHoldingsRecordsFromS3(bucket, pageNames(0)) should have size 50
+              getHoldingsRecordsFromS3(bucket, pageNames(1)) should have size 1
             }
         }
       }
@@ -193,6 +198,11 @@ class SierraReaderWorkerServiceTest
   private def getItemRecordsFromS3(bucket: Bucket,
                                    key: String): List[SierraItemRecord] =
     getObjectFromS3[List[SierraItemRecord]](
+      S3ObjectLocation(bucket = bucket.name, key = key))
+
+  private def getHoldingsRecordsFromS3(bucket: Bucket,
+                                       key: String): List[SierraHoldingsRecord] =
+    getObjectFromS3[List[SierraHoldingsRecord]](
       S3ObjectLocation(bucket = bucket.name, key = key))
 
   it("returns a SierraReaderException if it receives an invalid message") {

--- a/sierra_adapter/sierra_reader/src/test/scala/weco/catalogue/sierra_reader/source/SierraStreamSourceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/weco/catalogue/sierra_reader/source/SierraStreamSourceTest.scala
@@ -35,6 +35,22 @@ class SierraStreamSourceTest
     }
   }
 
+  it("fetches holdings from Sierra") {
+    val sierraSource = SierraSource(sierraAPIConfig)(
+      resourceType = "holdings",
+      params = Map(
+        "updatedDate" -> "[2003-03-03T03:00:00Z,2003-04-04T04:00:00Z]",
+        "fields" -> "updatedDate"))
+
+    withMaterializer { implicit materializer =>
+      val eventualJson = sierraSource.take(1).runWith(Sink.head[Json])
+
+      whenReady(eventualJson) {
+        root.id.int.getOption(_) shouldBe Some(1047360)
+      }
+    }
+  }
+
   it("paginates through results") {
     val sierraSource = SierraSource(sierraAPIConfig)(
       resourceType = "items",


### PR DESCRIPTION
Tentative fix for https://github.com/wellcomecollection/platform/issues/5065, follows #1420 and #1421

This patch updates the Sierra adapter to parse IDs as strings or ints, because the API responses are inconsistent. We stringify internally, but we'll need to be able to keep reading them as both because we pass around the raw Sierra API responses.