### PR TITLE
Allow decoding all three forms of Sierra record number in the pipeline

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -32,13 +32,16 @@ sierra_adapter:
       services:
         - id: bibs-merger
         - id: items-merger
+        - id: holdings-merger
     - id: sierra_linker
       services:
-        - id: items-to-dynamo
+        - id: items-linker
+        - id: holdings-linker
     - id: sierra_reader
       services:
         - id: items-reader
         - id: bibs-reader
+        - id: holdings-reader
   name: Sierra Adapter
   role_arn: arn:aws:iam::760097843905:role/platform-ci
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -23,6 +23,7 @@ import uk.ac.wellcome.models.work.internal.InvisibilityReason.{
 }
 import uk.ac.wellcome.models.work.internal.LocationType.OnlineResource
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.{
   SierraBibNumber,
   SierraBibRecord,

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -57,6 +57,9 @@ object Implicits {
       }
     }
 
+  implicit val untypedSierraNumberDecoder: Decoder[UntypedSierraRecordNumber] =
+    createDecoder(new UntypedSierraRecordNumber(_))
+
   implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
     createDecoder(new SierraHoldingsNumber(_))
 

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -16,38 +16,72 @@ object Implicits {
   // This is based on the "Custom key types" section of the Circe docs:
   // https://circe.github.io/circe/codecs/custom-codecs.html#custom-key-types
   //
-  implicit val itemNumberEncoder: KeyEncoder[SierraItemNumber] =
+  implicit val itemNumberKeyEncoder: KeyEncoder[SierraItemNumber] =
     (key: SierraItemNumber) => key.withoutCheckDigit
 
   implicit val holdingsNumberKeyEncoder: KeyEncoder[SierraHoldingsNumber] =
     (key: SierraHoldingsNumber) => key.withoutCheckDigit
 
-  implicit val itemNumberDecoder: KeyDecoder[SierraItemNumber] =
-    (key: String) => Some(SierraItemNumber(key))
+  implicit val itemNumberKeyDecoder: KeyDecoder[SierraItemNumber] =
+    (key: String) => Some(new SierraItemNumber(key))
 
   implicit val holdingsNumberKeyDecoder: KeyDecoder[SierraHoldingsNumber] =
-    (key: String) => Some(SierraHoldingsNumber(key))
+    (key: String) => Some(new SierraHoldingsNumber(key))
 
-  // The API responses from Sierra can return a RecordNumber as a
-  // string or an int.  We need to handle both cases.
-  implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
-    (c: HCursor) =>
-      c.value.as[StringOrInt].flatMap { id =>
-        Try { SierraHoldingsNumber(id.underlying) } match {
+  // We have Sierra record numbers stored in three formats:
+  //
+  //  - a string (from Sierra API responses for bibs and items)
+  //  - a number (from Sierra API responses for holdings)
+  //  - a dict like {"recordNumber": "1234567"} (from the automatically
+  //    derived Circe-encoder in some old case classes)
+  //
+  // We always encode as a string, but we need to cope with all three
+  // forms for decoding.
+  private case class RecordNumberDict(recordNumber: StringOrInt)
+
+  def createDecoder[T](create: String => T): Decoder[T] =
+    (c: HCursor) => {
+      val idString =
+        (c.value.as[StringOrInt], c.value.as[RecordNumberDict]) match {
+          case (Right(value), _) => Right(value.underlying)
+          case (_, Right(value)) => Right(value.recordNumber.underlying)
+          case (Left(err), _) => Left(err)
+        }
+
+      idString.flatMap { id =>
+        Try { create(id) } match {
           case Success(number) => Right(number)
           case Failure(err) =>
             Left(DecodingFailure(err.toString, ops = List.empty))
         }
+      }
     }
+
+  implicit val holdingsNumberDecoder: Decoder[SierraHoldingsNumber] =
+    createDecoder(new SierraHoldingsNumber(_))
+
+  implicit val itemNumberDecoder: Decoder[SierraItemNumber] =
+    createDecoder(new SierraItemNumber(_))
+
+  implicit val bibNumberDecoder: Decoder[SierraBibNumber] =
+    createDecoder(new SierraBibNumber(_))
 
   implicit val holdingsNumberEncoder: Encoder[SierraHoldingsNumber] =
     (number: SierraHoldingsNumber) => Json.fromString(number.withoutCheckDigit)
 
-  implicit val _dec01: Decoder[SierraTransformable] = deriveConfiguredDecoder
-  implicit val _dec02: Decoder[SierraItemRecord] = deriveConfiguredDecoder
-  implicit val _dec03: Decoder[SierraHoldingsRecord] = deriveConfiguredDecoder
+  implicit val itemNumberEncoder: Encoder[SierraItemNumber] =
+    (number: SierraItemNumber) => Json.fromString(number.withoutCheckDigit)
 
-  implicit val _enc01: Encoder[SierraTransformable] = deriveConfiguredEncoder
-  implicit val _enc02: Encoder[SierraItemRecord] = deriveConfiguredEncoder
-  implicit val _enc03: Encoder[SierraHoldingsRecord] = deriveConfiguredEncoder
+  implicit val bibNumberEncoder: Encoder[SierraBibNumber] =
+    (number: SierraBibNumber) => Json.fromString(number.withoutCheckDigit)
+
+  implicit val _dec01: Decoder[SierraItemRecord] = deriveConfiguredDecoder
+  implicit val _dec02: Decoder[SierraHoldingsRecord] = deriveConfiguredDecoder
+  implicit val _dec03: Decoder[SierraBibRecord] = deriveConfiguredDecoder
+  implicit val _dec04: Decoder[SierraTransformable] = deriveConfiguredDecoder
+
+  implicit val _enc01: Encoder[SierraItemRecord] = deriveConfiguredEncoder
+  implicit val _enc02: Encoder[SierraHoldingsRecord] = deriveConfiguredEncoder
+  implicit val _enc03: Encoder[SierraBibRecord] = deriveConfiguredEncoder
+  implicit val _enc04: Encoder[SierraTransformable] = deriveConfiguredEncoder
 }

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/Implicits.scala
@@ -45,7 +45,7 @@ object Implicits {
         (c.value.as[StringOrInt], c.value.as[RecordNumberDict]) match {
           case (Right(value), _) => Right(value.underlying)
           case (_, Right(value)) => Right(value.recordNumber.underlying)
-          case (Left(err), _) => Left(err)
+          case (Left(err), _)    => Left(err)
         }
 
       idString.flatMap { id =>

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraItemRecord.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraItemRecord.scala
@@ -35,7 +35,7 @@ case object SierraItemRecord {
       id = SierraItemNumber(id),
       data = data,
       modifiedDate = modifiedDate,
-      bibIds = bibIds.map { SierraBibNumber }
+      bibIds = bibIds.map { new SierraBibNumber(_) }
     )
   }
 }

--- a/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraRecordNumber.scala
+++ b/sierra_adapter/common/src/main/scala/weco/catalogue/sierra_adapter/models/SierraRecordNumber.scala
@@ -80,9 +80,6 @@ sealed trait TypedSierraRecordNumber extends SierraRecordNumber {
   override def hashCode: Int = this.withCheckDigit.hashCode
 }
 
-class UntypedSierraRecordNumber(val recordNumber: String)
-    extends SierraRecordNumber
-
 // Note: these are deliberately classes rather than case classes so that
 // we can have fine-grained control over how their encoding/decoding works.
 //
@@ -95,6 +92,13 @@ class UntypedSierraRecordNumber(val recordNumber: String)
 // We have a decoder that will handle all three, but if these were case classes
 // we might get the automatically derived Circe encoder.  Making these regular
 // classes will force us to supply our special decoder.
+
+class UntypedSierraRecordNumber(val recordNumber: String)
+    extends SierraRecordNumber
+
+object UntypedSierraRecordNumber {
+  def apply(number: String) = new UntypedSierraRecordNumber(number)
+}
 
 class SierraBibNumber(val recordNumber: String)
     extends TypedSierraRecordNumber {

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraBibRecordTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraBibRecordTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
 
+import Implicits._
+
 class SierraBibRecordTest
     extends AnyFunSpec
     with Matchers

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraHoldingsNumberTest.scala
@@ -24,6 +24,11 @@ class SierraHoldingsNumberTest
       Identity(SierraHoldingsNumber("1234567")))
   }
 
+  it("decodes an old-style JSON record as a HoldingsNumber") {
+    fromJson[Identity]("""{"id": {"recordNumber": "1234567"}}""") shouldBe Success(
+      Identity(SierraHoldingsNumber("1234567")))
+  }
+
   it("fails if the Int is the wrong format") {
     fromJson[Identity]("""{"id": 123456789}""") shouldBe a[Failure[_]]
   }

--- a/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraItemRecordTest.scala
+++ b/sierra_adapter/common/src/test/scala/weco/catalogue/sierra_adapter/models/SierraItemRecordTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
 
+import Implicits._
+
 class SierraItemRecordTest
     extends AnyFunSpec
     with Matchers

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/dynamo/Implicits.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/dynamo/Implicits.scala
@@ -11,21 +11,21 @@ object Implicits {
   implicit val formatBibNumber: DynamoFormat[SierraBibNumber] =
     DynamoFormat
       .coercedXmap[SierraBibNumber, String, IllegalArgumentException](
-        SierraBibNumber,
+        SierraBibNumber(_),
         _.withoutCheckDigit
       )
 
   implicit val formatItemNumber: DynamoFormat[SierraItemNumber] =
     DynamoFormat
       .coercedXmap[SierraItemNumber, String, IllegalArgumentException](
-        SierraItemNumber,
+        SierraItemNumber(_),
         _.withoutCheckDigit
       )
 
   implicit val formatHoldingsNumber: DynamoFormat[SierraHoldingsNumber] =
     DynamoFormat
       .coercedXmap[SierraHoldingsNumber, String, IllegalArgumentException](
-        SierraHoldingsNumber,
+        SierraHoldingsNumber(_),
         _.withoutCheckDigit
       )
 }

--- a/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/services/SierraLinkerWorkerTest.scala
+++ b/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/services/SierraLinkerWorkerTest.scala
@@ -3,13 +3,13 @@ package weco.catalogue.sierra_linker.services
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.{SierraItemNumber, SierraItemRecord}
 import weco.catalogue.sierra_linker.fixtures.WorkerFixture
 import weco.catalogue.sierra_linker.models.{Link, LinkOps}

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
@@ -2,7 +2,6 @@ package weco.catalogue.sierra_merger
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.storage.s3.{
   S3ObjectLocationPrefix
 }
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.UntypedSierraRecordNumber
 
 import scala.concurrent.Future

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/flow/SierraRecordWrapperFlowTest.scala
@@ -96,7 +96,7 @@ class SierraRecordWrapperFlowTest
         val expectedRecord = createSierraItemRecordWith(
           id = id,
           modifiedDate = Instant.parse(updatedDate),
-          bibIds = bibIds.map(SierraBibNumber).toList
+          bibIds = bibIds.map(SierraBibNumber(_)).toList
         )
 
         val json = parse(jsonString).right.get

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/parsers/SierraRecordParserTest.scala
@@ -70,7 +70,7 @@ class SierraRecordParserTest
     val expectedRecord = createSierraItemRecordWith(
       id = id,
       modifiedDate = Instant.parse(updatedDate),
-      bibIds = bibIds.map(SierraBibNumber).toList
+      bibIds = bibIds.map(SierraBibNumber(_)).toList
     )
 
     val json = parse(jsonString).right.get

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerServiceTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.platform.sierra_reader.fixtures.WorkerServiceFixture

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -79,8 +79,9 @@ class WindowManagerTest
         val result =
           windowManager.getCurrentStatus(s"[$startDateTime,$endDateTime]")
 
-        whenReady(result) {
-          _ shouldBe WindowStatus(id = "1794166", offset = 2)
+        whenReady(result) { status =>
+          status.id.get.withoutCheckDigit shouldBe "1794166"
+          status.offset shouldBe 2
         }
       }
     }

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
+import weco.catalogue.sierra_adapter.models.Implicits._
 import weco.catalogue.sierra_adapter.models.SierraBibNumber
 
 class WindowManagerTest

--- a/sierra_adapter/sierra_window_generator/src/build_windows.py
+++ b/sierra_adapter/sierra_window_generator/src/build_windows.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     minutes = int(args["--window_length"] or 30)
     resource = args["--resource"]
 
-    assert resource in ("bibs", "items")
+    assert resource in ("bibs", "items", "holdings")
 
     client = boto3.client("sns")
 
@@ -78,6 +78,5 @@ if __name__ == "__main__":
     ):
         client.publish(
             TopicArn=f"arn:aws:sns:eu-west-1:760097843905:sierra_{resource}_reharvest_windows",
-            Message=json.dumps(window),
-            Subject=f"Window sent by {__file__}",
+            Message=json.dumps(window)
         )

--- a/sierra_adapter/sierra_window_generator/src/build_windows.py
+++ b/sierra_adapter/sierra_window_generator/src/build_windows.py
@@ -78,5 +78,5 @@ if __name__ == "__main__":
     ):
         client.publish(
             TopicArn=f"arn:aws:sns:eu-west-1:760097843905:sierra_{resource}_reharvest_windows",
-            Message=json.dumps(window)
+            Message=json.dumps(window),
         )

--- a/sierra_adapter/terraform/stack/bucket_notifications.tf
+++ b/sierra_adapter/terraform/stack/bucket_notifications.tf
@@ -14,4 +14,11 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_prefix       = "records_items/"
     filter_suffix       = ".json"
   }
+
+  lambda_function {
+    lambda_function_arn = module.holdings_reader.demultiplexer_arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "records_holdings/"
+    filter_suffix       = ".json"
+  }
 }


### PR DESCRIPTION
Tentatively fixes https://github.com/wellcomecollection/platform/issues/5066, part of https://github.com/wellcomecollection/platform/issues/5003

Right now, the holdings data is getting all the way through the adapter, but the Sierra transformer can't parse it.

Adding holdings to the Sierra adapter has exacerbated and existing issue: Sierra record numbers can be JSON-encoded in multiple formats. Depending on exactly where you look in the pipeline, you may find it as:

* a string (e.g. `"1234567"`)
* a number (e.g. `1234567`)
* a dict (e.g. `{"recordNumber": "1234567"}`)

The Sierra API provides the first two, and automatic case class encoders from Circe provide the third.

This patch adds a custom encoder/decoder that will always encoder to a string, but can decode from any of these three formats.

I've also turned the RecordNumber types into regular classes, which means the automatic decoders/encoders won't kick in – the compiler will require us to supply an encoder, because `JsonUtil._` won't work, and then we can be sure we're using this new decoder.