### PR TITLE
Include the item ID in a warning log about unrecognised locations

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -50,16 +50,23 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     val otherLocations =
       sierraItemDataMap
         .filterNot { case (_, itemData) => itemData.deleted }
-        .collect { case (id, SierraItemData(_, Some(location), _, _, _)) => id -> location }
-        .filterNot { case (_, loc) =>
-          loc.name.toLowerCase.contains("above") || loc.name == "-" || loc.name == ""
+        .collect {
+          case (id, SierraItemData(_, Some(location), _, _, _)) =>
+            id -> location
         }
-        .map { case (id, loc) =>
-          SierraPhysicalLocationType.fromName(id, loc.name) match {
-            case Some(LocationType.ClosedStores) =>
-              (Some(LocationType.ClosedStores), LocationType.ClosedStores.label)
-            case other => (other, loc.name)
-          }
+        .filterNot {
+          case (_, loc) =>
+            loc.name.toLowerCase.contains("above") || loc.name == "-" || loc.name == ""
+        }
+        .map {
+          case (id, loc) =>
+            SierraPhysicalLocationType.fromName(id, loc.name) match {
+              case Some(LocationType.ClosedStores) =>
+                (
+                  Some(LocationType.ClosedStores),
+                  LocationType.ClosedStores.label)
+              case other => (other, loc.name)
+            }
         }
         .toSeq
         .distinct
@@ -96,8 +103,12 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     debug(s"Attempting to transform $itemId")
     Item(
       title = getItemTitle(itemId, itemData),
-      locations =
-        getPhysicalLocation(bibId, itemId, itemData, bibData, fallbackLocation).toList,
+      locations = getPhysicalLocation(
+        bibId,
+        itemId,
+        itemData,
+        bibData,
+        fallbackLocation).toList,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType("sierra-system-number"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -48,14 +48,14 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     // We assume that "in above" refers to another item on the same bib, so if the
     // non-above locations are unambiguous, we use them instead.
     val otherLocations =
-      sierraItemDataMap.values
-        .filterNot { _.deleted }
-        .collect { case SierraItemData(_, Some(location), _, _, _) => location }
-        .filterNot { loc =>
+      sierraItemDataMap
+        .filterNot { case (_, itemData) => itemData.deleted }
+        .collect { case (id, SierraItemData(_, Some(location), _, _, _)) => id -> location }
+        .filterNot { case (_, loc) =>
           loc.name.toLowerCase.contains("above") || loc.name == "-" || loc.name == ""
         }
-        .map { loc =>
-          SierraPhysicalLocationType.fromName(loc.name) match {
+        .map { case (id, loc) =>
+          SierraPhysicalLocationType.fromName(id, loc.name) match {
             case Some(LocationType.ClosedStores) =>
               (Some(LocationType.ClosedStores), LocationType.ClosedStores.label)
             case other => (other, loc.name)
@@ -97,7 +97,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     Item(
       title = getItemTitle(itemId, itemData),
       locations =
-        getPhysicalLocation(bibId, itemData, bibData, fallbackLocation).toList,
+        getPhysicalLocation(bibId, itemId, itemData, bibData, fallbackLocation).toList,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType("sierra-system-number"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -8,12 +8,13 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraQueryOps,
   VarField
 }
-import weco.catalogue.sierra_adapter.models.SierraBibNumber
+import weco.catalogue.sierra_adapter.models.{SierraBibNumber, SierraItemNumber}
 
 trait SierraLocation extends SierraQueryOps with Logging {
 
   def getPhysicalLocation(
     bibNumber: SierraBibNumber,
+    itemNumber: SierraItemNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     fallbackLocation: Option[(PhysicalLocationType, String)] = None)
@@ -23,7 +24,7 @@ trait SierraLocation extends SierraQueryOps with Logging {
 
       (locationType, label) <- {
         val parsedLocationType =
-          SierraPhysicalLocationType.fromName(sourceLocation.name)
+          SierraPhysicalLocationType.fromName(itemNumber, sourceLocation.name)
 
         (parsedLocationType, fallbackLocation) match {
           case (Some(locationType), _) =>

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
@@ -47,7 +47,7 @@ object SierraPhysicalLocationType extends Logging {
         None
 
       case _ =>
-        warn(s"$id: Unable to map Sierra location name to LocationType: $name")
+        warn(s"${id.withCheckDigit}: Unable to map Sierra location name to LocationType: $name")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
@@ -2,9 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal.{LocationType, PhysicalLocationType}
+import weco.catalogue.sierra_adapter.models.TypedSierraRecordNumber
 
 object SierraPhysicalLocationType extends Logging {
-  def fromName(name: String): Option[PhysicalLocationType] =
+  def fromName(id: TypedSierraRecordNumber, name: String): Option[PhysicalLocationType] =
     name.toLowerCase match {
       case lowerCaseName
           if lowerCaseName.hasSubstring(
@@ -46,7 +47,7 @@ object SierraPhysicalLocationType extends Logging {
         None
 
       case _ =>
-        warn(s"Unable to map Sierra location name to LocationType: $name")
+        warn(s"$id: Unable to map Sierra location name to LocationType: $name")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationType.scala
@@ -5,7 +5,8 @@ import uk.ac.wellcome.models.work.internal.{LocationType, PhysicalLocationType}
 import weco.catalogue.sierra_adapter.models.TypedSierraRecordNumber
 
 object SierraPhysicalLocationType extends Logging {
-  def fromName(id: TypedSierraRecordNumber, name: String): Option[PhysicalLocationType] =
+  def fromName(id: TypedSierraRecordNumber,
+               name: String): Option[PhysicalLocationType] =
     name.toLowerCase match {
       case lowerCaseName
           if lowerCaseName.hasSubstring(
@@ -47,7 +48,8 @@ object SierraPhysicalLocationType extends Logging {
         None
 
       case _ =>
-        warn(s"${id.withCheckDigit}: Unable to map Sierra location name to LocationType: $name")
+        warn(
+          s"${id.withCheckDigit}: Unable to map Sierra location name to LocationType: $name")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -25,6 +25,7 @@ class SierraLocationTest
 
   describe("Physical locations") {
     val bibId = createSierraBibNumber
+    val itemId = createSierraItemNumber
     val bibData = createSierraBibData
 
     val locationType = LocationType.ClosedStores
@@ -43,7 +44,7 @@ class SierraLocationTest
         label = LocationType.ClosedStores.label
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -57,7 +58,7 @@ class SierraLocationTest
         label = "Folios"
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -66,14 +67,14 @@ class SierraLocationTest
         location = Some(SierraSourceLocation("", ""))
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
     }
 
     it("returns None if the location field only contains the string 'none'") {
       val itemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("none", "none"))
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
     }
 
     it("returns None if there is no location in the item data") {
@@ -81,7 +82,7 @@ class SierraLocationTest
         location = None
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
     }
 
     it("adds access condition to the location if present") {
@@ -97,7 +98,7 @@ class SierraLocationTest
           )
         )
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         PhysicalLocation(
           locationType = locationType,
           label = label,
@@ -119,7 +120,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
 
       location.shelfmark shouldBe Some("AX1234:Box 1")
     }
@@ -128,6 +129,7 @@ class SierraLocationTest
       it("returns an empty location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
+          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("bwith", "bound in above"))
@@ -140,6 +142,7 @@ class SierraLocationTest
       it("uses the fallback location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
+          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("bwith", "bound in above"))
@@ -156,6 +159,7 @@ class SierraLocationTest
       it("returns an empty location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
+          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("cwith", "contained in above"))
@@ -168,6 +172,7 @@ class SierraLocationTest
       it("uses the fallback location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
+          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("cwith", "contained in above"))
@@ -188,7 +193,7 @@ class SierraLocationTest
           VarField(marcTag = Some("506"), indicator1 = Some("0"))
         )
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         PhysicalLocation(
           locationType = locationType,
           label = label,
@@ -209,7 +214,7 @@ class SierraLocationTest
           )
         )
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         PhysicalLocation(
           locationType = locationType,
           label = label,
@@ -238,7 +243,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe Some(
@@ -259,7 +264,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe Some(
@@ -281,7 +286,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -304,7 +309,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -327,7 +332,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.status shouldBe None
@@ -347,7 +352,7 @@ class SierraLocationTest
           )
         )
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
         PhysicalLocation(
           locationType = locationType,
           label = label,
@@ -369,7 +374,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions should have size 1
 
       location.accessConditions.head.terms shouldBe Some(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationTypeTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalLocationTypeTest.scala
@@ -4,13 +4,17 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.models.work.internal.LocationType
+import weco.catalogue.sierra_adapter.generators.SierraGenerators
 
 class SierraPhysicalLocationTypeTest
     extends AnyFunSpec
     with Matchers
-    with TableDrivenPropertyChecks {
+    with TableDrivenPropertyChecks
+    with SierraGenerators {
   // These test cases are based on location names from every item in the
   // Sierra catalogue, as retrieved at the start of February 2021.
+
+  val id = createSierraBibNumber
 
   it("maps names to ClosedStores") {
     val testCases = Table(
@@ -31,7 +35,7 @@ class SierraPhysicalLocationTypeTest
     )
 
     forAll(testCases) {
-      SierraPhysicalLocationType.fromName(_) shouldBe Some(
+      SierraPhysicalLocationType.fromName(id, _) shouldBe Some(
         LocationType.ClosedStores)
     }
   }
@@ -53,13 +57,13 @@ class SierraPhysicalLocationTypeTest
     )
 
     forAll(testCases) {
-      SierraPhysicalLocationType.fromName(_) shouldBe Some(
+      SierraPhysicalLocationType.fromName(id, _) shouldBe Some(
         LocationType.OpenShelves)
     }
   }
 
   it("maps to the OnExhibition type") {
-    SierraPhysicalLocationType.fromName("On Exhibition") shouldBe Some(
+    SierraPhysicalLocationType.fromName(id, "On Exhibition") shouldBe Some(
       LocationType.OnExhibition)
   }
 
@@ -73,7 +77,7 @@ class SierraPhysicalLocationTypeTest
     )
 
     forAll(testCases) {
-      SierraPhysicalLocationType.fromName(_) shouldBe None
+      SierraPhysicalLocationType.fromName(id, _) shouldBe None
     }
   }
 }


### PR DESCRIPTION
We get warnings in the Sierra transformer logs like:

> Unable to map Sierra location name to LocationType: 215 Information Point

For debugging, it would be useful if this warning included some context – which record does this value come from?

This patch adds that ID to this warning log.