### PR TITLE
Keep track of all the other Works that redirect to a given Work

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -75,7 +75,8 @@ class WorksController(elasticsearchService: ElasticsearchService,
 
   def workRedirect(work: Work.Redirected[Indexed]): Route =
     extractUri { uri =>
-      val newPath = (work.redirectTarget.canonicalId :: uri.path.reverse.tail).reverse
+      val newPath =
+        (work.redirectTarget.canonicalId :: uri.path.reverse.tail).reverse
 
       // We use a relative URL here so that redirects keep you on the same host.
       //

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksController.scala
@@ -75,7 +75,7 @@ class WorksController(elasticsearchService: ElasticsearchService,
 
   def workRedirect(work: Work.Redirected[Indexed]): Route =
     extractUri { uri =>
-      val newPath = (work.redirect.canonicalId :: uri.path.reverse.tail).reverse
+      val newPath = (work.redirectTarget.canonicalId :: uri.path.reverse.tail).reverse
 
       // We use a relative URL here so that redirects keep you on the same host.
       //

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksRedirectsTest.scala
@@ -11,7 +11,7 @@ class WorksRedirectsTest extends ApiWorksTestBase {
       sourceIdentifier = createSourceIdentifier
     )
   )
-  val redirectId = redirectedWork.redirect.canonicalId
+  val redirectId = redirectedWork.redirectTarget.canonicalId
 
   it("returns a TemporaryRedirect if looking up a redirected work") {
     withWorksApi {

--- a/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
+++ b/common/elasticsearch/src/main/scala/uk/ac/wellcome/elasticsearch/WorksIndexConfig.scala
@@ -166,7 +166,8 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       objectField("deletedReason")
         .fields(keywordField("type"))
         .dynamic("false"),
-      objectField("redirect").dynamic("false"),
+      objectField("redirectTarget").dynamic("false"),
+      objectField("redirectSources").dynamic(false),
       version
     )
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -27,7 +27,9 @@ sealed trait Work[State <: WorkState] {
     val outData = transition.data(data)
     this match {
       case Work.Visible(version, _, _, redirectSources) =>
-        Work.Visible(version, outData, outState, redirectSources.map { transition.redirect })
+        Work.Visible(version, outData, outState, redirectSources.map {
+          transition.redirect
+        })
       case Work.Invisible(version, _, _, invisibilityReasons) =>
         Work.Invisible(version, outData, outState, invisibilityReasons)
       case Work.Deleted(version, _, _, deletedReason) =>

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -26,8 +26,8 @@ sealed trait Work[State <: WorkState] {
     val outState = transition.state(state, data, args)
     val outData = transition.data(data)
     this match {
-      case Work.Visible(version, _, _) =>
-        Work.Visible(version, outData, outState)
+      case Work.Visible(version, _, _, redirectSources) =>
+        Work.Visible(version, outData, outState, redirectSources.map { transition.redirect })
       case Work.Invisible(version, _, _, invisibilityReasons) =>
         Work.Invisible(version, outData, outState, invisibilityReasons)
       case Work.Deleted(version, _, _, deletedReason) =>
@@ -44,6 +44,7 @@ object Work {
     version: Int,
     data: WorkData[State#WorkDataState],
     state: State,
+    redirectSources: Seq[State#WorkDataState#Id] = Nil
   ) extends Work[State]
 
   case class Redirected[State <: WorkState](

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -32,8 +32,8 @@ sealed trait Work[State <: WorkState] {
         Work.Invisible(version, outData, outState, invisibilityReasons)
       case Work.Deleted(version, _, _, deletedReason) =>
         Work.Deleted(version, outData, outState, deletedReason)
-      case Work.Redirected(version, redirect, _) =>
-        Work.Redirected(version, transition.redirect(redirect), outState)
+      case Work.Redirected(version, redirectTarget, _) =>
+        Work.Redirected(version, transition.redirect(redirectTarget), outState)
     }
   }
 }
@@ -48,7 +48,7 @@ object Work {
 
   case class Redirected[State <: WorkState](
     version: Int,
-    redirect: State#WorkDataState#Id,
+    redirectTarget: State#WorkDataState#Id,
     state: State,
   ) extends Work[State] {
     val data = WorkData[State#WorkDataState]()

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -124,7 +124,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         deletedReason = deletedReason
       )
 
-    def redirected(redirectTarget: State#WorkDataState#Id): Work.Redirected[State] =
+    def redirected(
+      redirectTarget: State#WorkDataState#Id): Work.Redirected[State] =
       Work.Redirected[State](
         state = work.state,
         version = work.version,
@@ -135,7 +136,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       Work
         .Visible[State](version = version, data = work.data, state = work.state)
 
-    def withRedirectSources(redirectSources: Seq[State#WorkDataState#Id]): Work.Visible[State] =
+    def withRedirectSources(
+      redirectSources: Seq[State#WorkDataState#Id]): Work.Visible[State] =
       Work.Visible[State](
         version = work.version,
         data = work.data,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -124,11 +124,11 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         deletedReason = deletedReason
       )
 
-    def redirected(redirect: State#WorkDataState#Id): Work.Redirected[State] =
+    def redirected(redirectTarget: State#WorkDataState#Id): Work.Redirected[State] =
       Work.Redirected[State](
         state = work.state,
         version = work.version,
-        redirect = redirect
+        redirectTarget = redirectTarget
       )
 
     def withVersion(version: Int): Work.Visible[State] =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -135,6 +135,14 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       Work
         .Visible[State](version = version, data = work.data, state = work.state)
 
+    def withRedirectSources(redirectSources: Seq[State#WorkDataState#Id]): Work.Visible[State] =
+      Work.Visible[State](
+        version = work.version,
+        data = work.data,
+        state = work.state,
+        redirectSources = redirectSources
+      )
+
     def title(title: String): Work.Visible[State] =
       work.map(_.copy(title = Some(title)))
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
@@ -72,6 +72,8 @@ class WorkTest extends AnyFunSpec with Matchers with WorkGenerators {
 
     val w = identifiedWork().withRedirectSources(redirectSources)
 
-    w.transition[Merged](Instant.now).asInstanceOf[Work.Visible[Merged]].redirectSources shouldBe redirectSources
+    w.transition[Merged](Instant.now)
+      .asInstanceOf[Work.Visible[Merged]]
+      .redirectSources shouldBe redirectSources
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/WorkTest.scala
@@ -5,9 +5,13 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil.{fromJson, toJson}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
-import uk.ac.wellcome.models.work.generators.IdentifiersGenerators
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.models.work.internal.IdState.Identified
+import uk.ac.wellcome.models.work.internal.WorkState.Merged
 
-class WorkTest extends AnyFunSpec with Matchers with IdentifiersGenerators {
+import java.time.Instant
+
+class WorkTest extends AnyFunSpec with Matchers with WorkGenerators {
 
   // This is based on a real failure.  We deployed a version of the API
   // with a newer model than was in Elasticsearch -- in particular, it had
@@ -59,5 +63,15 @@ class WorkTest extends AnyFunSpec with Matchers with IdentifiersGenerators {
     }
     caught.getMessage should startWith(
       "Attempt to decode value on failed cursor")
+  }
+
+  it("preserves redirect sources when transitioning Work.Visible") {
+    val redirectSources = (1 to 3).map { _ =>
+      Identified(createCanonicalId, createSourceIdentifier)
+    }
+
+    val w = identifiedWork().withRedirectSources(redirectSources)
+
+    w.transition[Merged](Instant.now).asInstanceOf[Work.Visible[Merged]].redirectSources shouldBe redirectSources
   }
 }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
@@ -96,7 +96,7 @@ class IdMinterFeatureTest
       withIdentifiersTable { identifiersTableConfig =>
         val work = sourceWork()
           .redirected(
-            redirect =
+            redirectTarget =
               IdState.Identifiable(sourceIdentifier = createSourceIdentifier))
         val inputIndex = createIndex(List(work))
         val outputIndex = mutable.Map.empty[String, Work[Identified]]
@@ -121,7 +121,7 @@ class IdMinterFeatureTest
           identifiedWork.state.canonicalId shouldBe sentId
           identifiedWork
             .asInstanceOf[Work.Redirected[Identified]]
-            .redirect
+            .redirectTarget
             .canonicalId shouldNot be(empty)
         }
       }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/models/MergeResult.scala
@@ -7,5 +7,5 @@ import uk.ac.wellcome.models.work.internal._
  * MergeResult holds the resultant target after all fields have been merged,
  * and the images that were created in the process
  */
-case class MergeResult(mergedTarget: Work[Identified],
+case class MergeResult(mergedTarget: Work.Visible[Identified],
                        imageDataWithSources: Seq[ImageDataWithSource])

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -111,7 +111,7 @@ trait Merger extends MergerLogging {
         source.sourceIdentifier,
         source.state.canonicalId,
         source.state.modifiedTime),
-      redirect =
+      redirectTarget =
         IdState.Identified(target.state.canonicalId, target.sourceIdentifier)
     )
 
@@ -148,8 +148,8 @@ object Merger {
           Work.Visible(version, f(data), state)
         case Work.Invisible(version, data, state, reasons) =>
           Work.Invisible(version, f(data), state, reasons)
-        case Work.Redirected(version, redirect, state) =>
-          Work.Redirected(version, redirect, state)
+        case Work.Redirected(version, redirectTarget, state) =>
+          Work.Redirected(version, redirectTarget, state)
         case Work.Deleted(version, data, state, reason) =>
           Work.Deleted(version, f(data), state, reason)
       }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -97,9 +97,8 @@ trait Merger extends MergerLogging {
           logResult(result, redirects.toList, remaining.toList)
 
           val redirectedIdentifiers =
-            redirectedSources.map {
-              s =>
-                IdState.Identified(s.id, s.sourceIdentifier)
+            redirectedSources.map { s =>
+              IdState.Identified(s.id, s.sourceIdentifier)
             }.toSeq
 
           val targetWork: Work.Visible[Identified] =
@@ -153,7 +152,8 @@ trait Merger extends MergerLogging {
 
 object Merger {
   // Parameter can't be `State` as that shadows the Cats type
-  implicit class WorkMergingOps[StateT <: WorkState](work: Work.Visible[StateT]) {
+  implicit class WorkMergingOps[StateT <: WorkState](
+    work: Work.Visible[StateT]) {
     def mapData(
       f: WorkData[StateT#WorkDataState] => WorkData[StateT#WorkDataState]
     ): Work.Visible[StateT] =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -107,7 +107,7 @@ trait Merger extends MergerLogging {
               version = result.mergedTarget.version,
               data = result.mergedTarget.data,
               state = result.mergedTarget.state,
-              redirectSources = redirectedIdentifiers //result.mergedTarget.redirectSources ++ redirectedIdentifiers
+              redirectSources = result.mergedTarget.redirectSources ++ redirectedIdentifiers
             )
 
           MergerOutcome(

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -96,8 +96,23 @@ trait Merger extends MergerLogging {
           val redirects = redirectedSources.map(redirectSourceToTarget(target))
           logResult(result, redirects.toList, remaining.toList)
 
+          val redirectedIdentifiers =
+            redirectedSources.map {
+              s =>
+                IdState.Identified(s.id, s.sourceIdentifier)
+            }.toSeq
+
+          val targetWork: Work.Visible[Identified] =
+            Work.Visible[Identified](
+              version = result.mergedTarget.version,
+              data = result.mergedTarget.data,
+              state = result.mergedTarget.state,
+              redirectSources = //result.mergedTarget.redirectSources ++ redirectedIdentifiers
+                redirectedIdentifiers
+            )
+
           MergerOutcome(
-            resultWorks = redirects.toList ++ remaining ++ deleted :+ result.mergedTarget,
+            resultWorks = redirects.toList ++ remaining ++ deleted :+ targetWork,
             imagesWithSources = result.imageDataWithSources
           )
       }
@@ -139,20 +154,11 @@ trait Merger extends MergerLogging {
 
 object Merger {
   // Parameter can't be `State` as that shadows the Cats type
-  implicit class WorkMergingOps[StateT <: WorkState](work: Work[StateT]) {
+  implicit class WorkMergingOps[StateT <: WorkState](work: Work.Visible[StateT]) {
     def mapData(
       f: WorkData[StateT#WorkDataState] => WorkData[StateT#WorkDataState]
-    ): Work[StateT] =
-      work match {
-        case Work.Visible(version, data, state, redirectSources) =>
-          Work.Visible(version, f(data), state, redirectSources)
-        case Work.Invisible(version, data, state, reasons) =>
-          Work.Invisible(version, f(data), state, reasons)
-        case Work.Redirected(version, redirectTarget, state) =>
-          Work.Redirected(version, redirectTarget, state)
-        case Work.Deleted(version, data, state, reason) =>
-          Work.Deleted(version, f(data), state, reason)
-      }
+    ): Work.Visible[StateT] =
+      work.copy(data = f(work.data))
   }
 }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -107,8 +107,7 @@ trait Merger extends MergerLogging {
               version = result.mergedTarget.version,
               data = result.mergedTarget.data,
               state = result.mergedTarget.state,
-              redirectSources = //result.mergedTarget.redirectSources ++ redirectedIdentifiers
-                redirectedIdentifiers
+              redirectSources = redirectedIdentifiers //result.mergedTarget.redirectSources ++ redirectedIdentifiers
             )
 
           MergerOutcome(

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -144,8 +144,8 @@ object Merger {
       f: WorkData[StateT#WorkDataState] => WorkData[StateT#WorkDataState]
     ): Work[StateT] =
       work match {
-        case Work.Visible(version, data, state) =>
-          Work.Visible(version, f(data), state)
+        case Work.Visible(version, data, state, redirectSources) =>
+          Work.Visible(version, f(data), state, redirectSources)
         case Work.Invisible(version, data, state, reasons) =>
           Work.Invisible(version, f(data), state, reasons)
         case Work.Redirected(version, redirectTarget, state) =>

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/FeatureTestSugar.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/FeatureTestSugar.scala
@@ -29,7 +29,7 @@ trait FeatureTestSugar {
     def apply(left: Work[Identified]): MatchResult = MatchResult(
       left.isInstanceOf[Work.Redirected[Identified]] && left
         .asInstanceOf[Work.Redirected[Identified]]
-        .redirect
+        .redirectTarget
         .sourceIdentifier == expectedRedirectTo.sourceIdentifier,
       s"${left.sourceIdentifier} was not redirected to ${expectedRedirectTo.sourceIdentifier}",
       s"${left.sourceIdentifier} was redirected to ${expectedRedirectTo.sourceIdentifier}"

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -37,7 +37,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
         val redirect = baseWork.asInstanceOf[Work.Redirected[Merged]]
         val redirectTarget =
           resultWorks.head.asInstanceOf[Work.Visible[Merged]]
-        redirect.redirect.sourceIdentifier shouldBe redirectTarget.sourceIdentifier
+        redirect.redirectTarget.sourceIdentifier shouldBe redirectTarget.sourceIdentifier
     }
   }
 
@@ -65,7 +65,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
             work.state.canonicalId,
             work.state.modifiedTime),
           version = work.version,
-          redirect = IdState.Identified(
+          redirectTarget = IdState.Identified(
             works.head.state.canonicalId,
             works.head.sourceIdentifier)
         )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -135,8 +135,7 @@ class MergerTest
     val mergerOutput = FirstWorkMerger.merge(targetWork +: sourceWorks)
 
     val mergedWork: Work.Visible[Merged] = mergerOutput.mergedWorksWithTime(now)
-      .collect { case w: Work.Visible[Merged] => w }
-      .filter { w => w.sourceIdentifier == targetWork.sourceIdentifier }
+      .collect { case w: Work.Visible[Merged] if w.sourceIdentifier == targetWork.sourceIdentifier => w }
       .head
 
     mergedWork.redirectSources should contain allElementsOf existingRedirectSources

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -86,8 +86,11 @@ class MergerTest
   val mergedWorks = FirstWorkMerger.merge(inputWorks)
 
   it("returns a single target work as specified") {
-    val mergedWork: Work.Visible[Identified] = mergedWorks.mergedWorksWithTime(now)
-      .filter { w => w.sourceIdentifier == inputWorks.head.sourceIdentifier }
+    val mergedWork: Work.Visible[Identified] = mergedWorks
+      .mergedWorksWithTime(now)
+      .filter { w =>
+        w.sourceIdentifier == inputWorks.head.sourceIdentifier
+      }
       .head
       .asInstanceOf[Work.Visible[Identified]]
 
@@ -99,13 +102,18 @@ class MergerTest
   }
 
   it("sets the redirectSources on the merged work") {
-    val mergedWork: Work.Visible[Identified] = mergedWorks.mergedWorksWithTime(now)
-      .filter { w => w.sourceIdentifier == inputWorks.head.sourceIdentifier }
+    val mergedWork: Work.Visible[Identified] = mergedWorks
+      .mergedWorksWithTime(now)
+      .filter { w =>
+        w.sourceIdentifier == inputWorks.head.sourceIdentifier
+      }
       .head
       .asInstanceOf[Work.Visible[Identified]]
 
     mergedWork.redirectSources should contain theSameElementsAs
-      inputWorks.tail.tail.map { w => IdState.Identified(w.id, w.sourceIdentifier) }
+      inputWorks.tail.tail.map { w =>
+        IdState.Identified(w.id, w.sourceIdentifier)
+      }
   }
 
   it(
@@ -130,16 +138,25 @@ class MergerTest
     val targetWork = identifiedWork()
       .withRedirectSources(existingRedirectSources)
 
-    val sourceWorks = (1 to 5).map { _ => identifiedWork() }
+    val sourceWorks = (1 to 5).map { _ =>
+      identifiedWork()
+    }
 
     val mergerOutput = FirstWorkMerger.merge(targetWork +: sourceWorks)
 
-    val mergedWork: Work.Visible[Merged] = mergerOutput.mergedWorksWithTime(now)
-      .collect { case w: Work.Visible[Merged] if w.sourceIdentifier == targetWork.sourceIdentifier => w }
+    val mergedWork: Work.Visible[Merged] = mergerOutput
+      .mergedWorksWithTime(now)
+      .collect {
+        case w: Work.Visible[Merged]
+            if w.sourceIdentifier == targetWork.sourceIdentifier =>
+          w
+      }
       .head
 
     mergedWork.redirectSources should contain allElementsOf existingRedirectSources
     mergedWork.redirectSources should contain allElementsOf
-      sourceWorks.tail.map { w => IdState.Identified(w.id, w.sourceIdentifier)}
+      sourceWorks.tail.map { w =>
+        IdState.Identified(w.id, w.sourceIdentifier)
+      }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -33,7 +33,8 @@ class MergerTest
   val mergedOtherIdentifiers =
     (0 to 3).map(_ => createSierraSystemSourceIdentifier).toList
 
-  object TestItemsRule extends FieldMergeRule {
+  // Copies the items from the second work
+  object CopyItemsRule extends FieldMergeRule {
     type FieldData = List[Item[IdState.Minted]]
 
     override def merge(
@@ -45,7 +46,8 @@ class MergerTest
       )
   }
 
-  object TestOtherIdentifiersRule extends FieldMergeRule {
+  // Copies the identifiers from works 3–(last)
+  object CopyOtherIdentifiers extends FieldMergeRule {
     type FieldData = List[SourceIdentifier]
 
     override def merge(
@@ -56,7 +58,8 @@ class MergerTest
         sources = sources.tail.tail)
   }
 
-  object TestMerger extends Merger {
+  // Merges everything into the first Work in a given input.
+  object FirstWorkMerger extends Merger {
     import Merger.WorkMergingOps
 
     override protected def findTarget(
@@ -67,8 +70,8 @@ class MergerTest
       target: Work.Visible[Identified],
       sources: Seq[Work[Identified]]): State[MergeState, MergeResult] =
       for {
-        items <- TestItemsRule(target, sources).redirectSources
-        otherIdentifiers <- TestOtherIdentifiersRule(target, sources).redirectSources
+        items <- CopyItemsRule(target, sources).redirectSources
+        otherIdentifiers <- CopyOtherIdentifiers(target, sources).redirectSources
       } yield
         MergeResult(
           mergedTarget = target
@@ -82,7 +85,7 @@ class MergerTest
         )
   }
 
-  val mergedWorks = TestMerger.merge(inputWorks)
+  val mergedWorks = FirstWorkMerger.merge(inputWorks)
 
   it("returns a single target work as specified") {
     mergedWorks.mergedWorksWithTime(now) should contain(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -227,7 +227,7 @@ class MergerWorkerServiceTest
 
           redirectedWorks should have size 1
           redirectedWorks.head.sourceIdentifier shouldBe digitisedWork.sourceIdentifier
-          redirectedWorks.head.redirect shouldBe IdState.Identified(
+          redirectedWorks.head.redirectTarget shouldBe IdState.Identified(
             sourceIdentifier = physicalWork.sourceIdentifier,
             canonicalId = physicalWork.state.canonicalId)
 
@@ -282,7 +282,7 @@ class MergerWorkerServiceTest
           redirectedWorks should have size 2
           redirectedWorks.map(_.sourceIdentifier) should contain only
             (digitisedWork.sourceIdentifier, miroWork.sourceIdentifier)
-          redirectedWorks.map(_.redirect) should contain only
+          redirectedWorks.map(_.redirectTarget) should contain only
             IdState.Identified(
               sourceIdentifier = physicalWork.sourceIdentifier,
               canonicalId = physicalWork.state.canonicalId)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -156,7 +156,7 @@ class PlatformMergerTest
           modifiedTime = now
         ),
         version = miroWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
@@ -202,7 +202,7 @@ class PlatformMergerTest
           sourceIdentifier = miroWork.sourceIdentifier,
           modifiedTime = now),
         version = miroWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = zeroItemSierraWork.state.canonicalId,
           sourceIdentifier = zeroItemSierraWork.sourceIdentifier)
       )
@@ -258,7 +258,7 @@ class PlatformMergerTest
           sourceIdentifier = miroWork.sourceIdentifier,
           modifiedTime = now),
         version = miroWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraDigitalWork.state.canonicalId,
           sourceIdentifier = sierraDigitalWork.sourceIdentifier)
       )
@@ -300,7 +300,7 @@ class PlatformMergerTest
         sourceIdentifier = miroWork.sourceIdentifier,
         modifiedTime = now),
       version = miroWork.version,
-      redirect = IdState.Identified(
+      redirectTarget = IdState.Identified(
         canonicalId = multipleItemsSierraWork.state.canonicalId,
         sourceIdentifier = multipleItemsSierraWork.sourceIdentifier)
     )
@@ -334,7 +334,7 @@ class PlatformMergerTest
           sourceIdentifier = metsWork.sourceIdentifier,
           modifiedTime = now),
         version = metsWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
@@ -401,7 +401,7 @@ class PlatformMergerTest
           sourceIdentifier = metsWork.sourceIdentifier,
           modifiedTime = now),
         version = metsWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPictureWork.state.canonicalId,
           sourceIdentifier = sierraPictureWork.sourceIdentifier)
       )
@@ -458,7 +458,7 @@ class PlatformMergerTest
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
           modifiedTime = now),
         version = sierraDigitisedWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
@@ -470,7 +470,7 @@ class PlatformMergerTest
           sourceIdentifier = miroWork.sourceIdentifier,
           modifiedTime = now),
         version = miroWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
@@ -482,7 +482,7 @@ class PlatformMergerTest
           sourceIdentifier = metsWork.sourceIdentifier,
           modifiedTime = now),
         version = metsWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
           sourceIdentifier = sierraPhysicalWork.sourceIdentifier)
       )
@@ -532,7 +532,7 @@ class PlatformMergerTest
           sourceIdentifier = metsWork.sourceIdentifier,
           modifiedTime = now),
         version = metsWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,
           sourceIdentifier = multipleItemsSierraWork.sourceIdentifier)
       )
@@ -571,7 +571,7 @@ class PlatformMergerTest
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
           modifiedTime = now),
         version = sierraDigitisedWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,
           sourceIdentifier = multipleItemsSierraWork.sourceIdentifier)
       )
@@ -583,7 +583,7 @@ class PlatformMergerTest
           sourceIdentifier = metsWork.sourceIdentifier,
           modifiedTime = now),
         version = metsWork.version,
-        redirect = IdState.Identified(
+        redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,
           sourceIdentifier = multipleItemsSierraWork.sourceIdentifier)
       )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -469,7 +469,9 @@ class PlatformMergerTest
       redirectSources = Seq(
         IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
         IdState.Identified(miroWork.id, miroWork.sourceIdentifier),
-        IdState.Identified(sierraDigitisedWork.id, sierraDigitisedWork.sourceIdentifier),
+        IdState.Identified(
+          sierraDigitisedWork.id,
+          sierraDigitisedWork.sourceIdentifier),
       )
     )
 
@@ -589,7 +591,9 @@ class PlatformMergerTest
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
         IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
-        IdState.Identified(sierraDigitisedWork.id, sierraDigitisedWork.sourceIdentifier)
+        IdState.Identified(
+          sierraDigitisedWork.id,
+          sierraDigitisedWork.sourceIdentifier)
       )
     )
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -135,6 +135,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -186,6 +187,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = zeroItemSierraWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           otherIdentifiers = data.otherIdentifiers ++ miroWork.identifiers,
@@ -238,6 +240,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraDigitalWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
@@ -288,6 +291,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           imageData = miroWork.data.imageData,
@@ -316,6 +320,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           items = List(
@@ -382,6 +387,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPictureWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           items = List(
@@ -436,6 +442,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = sierraPhysicalWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
@@ -518,6 +525,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           thumbnail = metsWork.data.thumbnail,
@@ -556,6 +564,7 @@ class PlatformMergerTest
 
     val expectedMergedWork = multipleItemsSierraWork
       .transition[Merged](now)
+      .asInstanceOf[Work.Visible[Merged]]
       .mapData { data =>
         data.copy(
           otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitisedWork.identifiers,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -13,7 +13,6 @@ class PlatformMergerTest
     extends AnyFunSpec
     with SourceWorkGenerators
     with Matchers {
-  import Merger.WorkMergingOps
 
   val digitalLocationCCBYNC = createDigitalLocationWith(
     license = Some(License.CCBYNC))
@@ -133,21 +132,23 @@ class PlatformMergerTest
     val sierraItem = sierraPhysicalWork.data.items.head
     val miroItem = miroWork.data.items.head
 
-    val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
-          thumbnail = miroWork.data.thumbnail,
-          items = List(
-            sierraItem.copy(
-              locations = sierraItem.locations ++ miroItem.locations
-            )
-          ),
-          imageData = miroWork.data.imageData,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = sierraPhysicalWork.version,
+      data = sierraPhysicalWork.data.copy(
+        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers ++ miroWork.identifiers,
+        thumbnail = miroWork.data.thumbnail,
+        items = List(
+          sierraItem.copy(
+            locations = sierraItem.locations ++ miroItem.locations
+          )
+        ),
+        imageData = miroWork.data.imageData,
+      ),
+      state = sierraPhysicalWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
@@ -185,17 +186,19 @@ class PlatformMergerTest
 
     result.mergedWorksWithTime(now).size shouldBe 2
 
-    val expectedMergedWork = zeroItemSierraWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          otherIdentifiers = data.otherIdentifiers ++ miroWork.identifiers,
-          thumbnail = miroWork.data.thumbnail,
-          items = miroWork.data.items,
-          imageData = miroWork.data.imageData,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = zeroItemSierraWork.version,
+      data = zeroItemSierraWork.data.copy(
+        otherIdentifiers = zeroItemSierraWork.data.otherIdentifiers ++ miroWork.identifiers,
+        thumbnail = miroWork.data.thumbnail,
+        items = miroWork.data.items,
+        imageData = miroWork.data.imageData,
+      ),
+      state = zeroItemSierraWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
@@ -238,21 +241,23 @@ class PlatformMergerTest
     val sierraItem = sierraDigitalWork.data.items.head
     val miroItem = miroWork.data.items.head
 
-    val expectedMergedWork = sierraDigitalWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
-          thumbnail = miroWork.data.thumbnail,
-          items = List(
-            sierraItem.copy(
-              locations = sierraItem.locations ++ miroItem.locations
-            )
-          ),
-          imageData = miroWork.data.imageData,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = sierraDigitalWork.version,
+      data = sierraDigitalWork.data.copy(
+        otherIdentifiers = sierraDigitalWork.data.otherIdentifiers ++ miroWork.identifiers,
+        thumbnail = miroWork.data.thumbnail,
+        items = List(
+          sierraItem.copy(
+            locations = sierraItem.locations ++ miroItem.locations
+          )
+        ),
+        imageData = miroWork.data.imageData,
+      ),
+      state = sierraDigitalWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
@@ -289,14 +294,16 @@ class PlatformMergerTest
 
     result.mergedWorksWithTime(now).size shouldBe 2
 
-    val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          imageData = miroWork.data.imageData,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = multipleItemsSierraWork.version,
+      data = multipleItemsSierraWork.data.copy(
+        imageData = miroWork.data.imageData,
+      ),
+      state = multipleItemsSierraWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedMiro = Work.Redirected[Merged](
       state = Merged(
@@ -318,19 +325,21 @@ class PlatformMergerTest
     val physicalItem = sierraPhysicalWork.data.items.head
     val digitalItem = metsWork.data.items.head
 
-    val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          items = List(
-            physicalItem.copy(
-              locations = physicalItem.locations ++ digitalItem.locations
-            )
-          ),
-          thumbnail = metsWork.data.thumbnail,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = sierraPhysicalWork.version,
+      data = sierraPhysicalWork.data.copy(
+        items = List(
+          physicalItem.copy(
+            locations = physicalItem.locations ++ digitalItem.locations
+          )
+        ),
+        thumbnail = metsWork.data.thumbnail,
+      ),
+      state = sierraPhysicalWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
@@ -385,20 +394,22 @@ class PlatformMergerTest
     val physicalItem = sierraPictureWork.data.items.head
     val digitalItem = metsWork.data.items.head
 
-    val expectedMergedWork = sierraPictureWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          items = List(
-            physicalItem.copy(
-              locations = physicalItem.locations ++ digitalItem.locations
-            )
-          ),
-          imageData = metsWork.data.imageData,
-          thumbnail = metsWork.data.thumbnail,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = sierraPictureWork.version,
+      data = sierraPictureWork.data.copy(
+        items = List(
+          physicalItem.copy(
+            locations = physicalItem.locations ++ digitalItem.locations
+          )
+        ),
+        imageData = metsWork.data.imageData,
+        thumbnail = metsWork.data.thumbnail,
+      ),
+      state = sierraPictureWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedWork =
       Work.Redirected[Merged](
@@ -440,23 +451,27 @@ class PlatformMergerTest
     val sierraItem = sierraPhysicalWork.data.items.head
     val metsItem = metsWork.data.items.head
 
-    val expectedMergedWork = sierraPhysicalWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
-            ++ sierraDigitisedWork.identifiers
-            ++ miroWork.identifiers,
-          thumbnail = metsWork.data.thumbnail,
-          items = List(
-            sierraItem.copy(
-              locations = sierraItem.locations ++ metsItem.locations
-            )
-          ),
-          imageData = miroWork.data.imageData,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = sierraPhysicalWork.version,
+      data = sierraPhysicalWork.data.copy(
+        otherIdentifiers = sierraPhysicalWork.data.otherIdentifiers
+          ++ sierraDigitisedWork.identifiers
+          ++ miroWork.identifiers,
+        thumbnail = metsWork.data.thumbnail,
+        items = List(
+          sierraItem.copy(
+            locations = sierraItem.locations ++ metsItem.locations
+          )
+        ),
+        imageData = miroWork.data.imageData,
+      ),
+      state = sierraPhysicalWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(miroWork.id, miroWork.sourceIdentifier),
+        IdState.Identified(sierraDigitisedWork.id, sierraDigitisedWork.sourceIdentifier),
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedDigitalWork =
       Work.Redirected[Merged](
@@ -523,15 +538,17 @@ class PlatformMergerTest
       multipleItemsSierraWork.data.items
     val metsItem = metsWork.data.items.head
 
-    val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          thumbnail = metsWork.data.thumbnail,
-          items = sierraItems :+ metsItem,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = multipleItemsSierraWork.version,
+      data = multipleItemsSierraWork.data.copy(
+        thumbnail = metsWork.data.thumbnail,
+        items = sierraItems :+ metsItem,
+      ),
+      state = multipleItemsSierraWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+      )
+    )
 
     val expectedMetsRedirectedWork =
       Work.Redirected[Merged](
@@ -562,16 +579,19 @@ class PlatformMergerTest
     val sierraItems = multipleItemsSierraWork.data.items
     val metsItem = metsWork.data.items.head
 
-    val expectedMergedWork = multipleItemsSierraWork
-      .transition[Merged](now)
-      .asInstanceOf[Work.Visible[Merged]]
-      .mapData { data =>
-        data.copy(
-          otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitisedWork.identifiers,
-          thumbnail = metsWork.data.thumbnail,
-          items = sierraItems :+ metsItem,
-        )
-      }
+    val expectedMergedWork = Work.Visible[Merged](
+      version = multipleItemsSierraWork.version,
+      data = multipleItemsSierraWork.data.copy(
+        otherIdentifiers = multipleItemsSierraWork.data.otherIdentifiers ++ sierraDigitisedWork.identifiers,
+        thumbnail = metsWork.data.thumbnail,
+        items = sierraItems :+ metsItem,
+      ),
+      state = multipleItemsSierraWork.transition[Merged](now).state,
+      redirectSources = Seq(
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
+        IdState.Identified(sierraDigitisedWork.id, sierraDigitisedWork.sourceIdentifier)
+      )
+    )
 
     val expectedRedirectedDigitalWork =
       Work.Redirected[Merged](

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -467,9 +467,9 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
+        IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
         IdState.Identified(miroWork.id, miroWork.sourceIdentifier),
         IdState.Identified(sierraDigitisedWork.id, sierraDigitisedWork.sourceIdentifier),
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
       )
     )
 


### PR DESCRIPTION
This means that redirects are tracked symmetrically in the index: if `A -> B`, then we'll record this on both A and B.

This is just useful for debugging in general, and closes https://github.com/wellcomecollection/platform/issues/5043. We should be able to use this to find out if merged pairs haven't been indexed consistently when we do redirects.