### PR TITLE
Add an implementation of the Sierra 853/863 enumerations field

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -194,7 +194,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
           // I haven't worked out the exact rules around this yet.
           // In some cases, the old Wellcome Library site would join parts with
           // a space.  In others (e.g. "v.130:no.3"), it uses a colon.
-          if (accum.startsWith("no.") && nextPart.startsWith("v.")) {
+          if (accum.startsWith("no.") && nextPart.startsWith("v")) {
             nextPart + ":" + accum
           } else {
             nextPart + " " + accum

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -94,18 +94,10 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
           }
         }
         .filterNot { case (_, value) => value.trim == "-" }
-        .filterNot { case (_, value) =>
-          if (value.count(_ == '-') >= 2) {
-            warn(s"$id: ambiguous range in 85X/86X pair: $value")
-            true
-          } else {
-            false
-          }
-        }
 
     if (parts.exists { case (_, value) => value.contains("-") }) {
-      val startParts = parts.map { case (label, value) => (label, value.split('-').head) }
-      val endParts = parts.map { case (label, value) => (label, value.split('-').last) }
+      val startParts = parts.map { case (label, value) => (label, value.split("-", 2).head) }
+      val endParts = parts.map { case (label, value) => (label, value.split("-", 2).last) }
 
       s"${concatenateParts(startParts)} - ${concatenateParts(endParts)}"
     } else {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import weco.catalogue.sierra_adapter.models.TypedSierraRecordNumber
 
 // The 85X/86X pairs are used to store structured captions -- the 85X contains
 // the labels, the 856X contains the values.
@@ -18,6 +19,6 @@ object SierraHoldingsEnumeration {
   val labelTag = "853"
   val valueTag = "863"
 
-  def apply(varFields: List[VarField]): List[String] =
+  def apply(id: TypedSierraRecordNumber, varFields: List[VarField]): List[String] =
     List()
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -131,12 +131,12 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
       val dateDisplayStrings =
         if (datePartsMap.contains("season")) {
           List(
-            datePartsMap.get("season").flatMap { seasonNames.get },
+            datePartsMap.get("season").flatMap { toNamedSeason },
             datePartsMap.get("year")
           )
-        } else if (seasonNames.contains(datePartsMap.getOrElse("month", ""))) {
+        } else if (toNamedSeason(datePartsMap.getOrElse("month", "")).isDefined) {
           List(
-            datePartsMap.get("month").flatMap { seasonNames.get },
+            datePartsMap.get("month").flatMap { toNamedSeason },
             datePartsMap.get("year")
           )
         } else {
@@ -180,6 +180,15 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
       case (ts, Some(ds)) if ts.nonEmpty && ds.nonEmpty => s"$ts ($ds)"
       case (_, Some(ds)) if ds.nonEmpty => ds
       case (ts, _) => ts
+    }
+  }
+
+  private def toNamedSeason(s: String): Option[String] = {
+    val parts = s.split("/")
+    if (parts.forall(seasonNames.contains)) {
+      Some(parts.map { seasonNames(_) }.mkString("/"))
+    } else {
+      None
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -138,6 +138,15 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     val datePartsMap =
       dateParts
         .map { case (label, value) => label.toLowerCase.stripParens -> value }
+        .map {
+          // If we have a range of months, we just take the first month of the range.
+          // We might revisit this decision later; this was chosen to mimic the output
+          // of the old Wellcome Library site.
+          case (label, value) if label == "month" && value.contains("-") =>
+            (label, value.split("-").head)
+
+          case (label, value) => (label, value)
+        }
         .toMap
 
     // Construct the date string.  We wrap this all in a Try block, and if something

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -93,6 +93,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             case None => None
           }
         }
+        .filterNot { case (_, value) => value.isEmpty }
         .filterNot { case (_, value) =>
           if (value.count(_ == '-') >= 2) {
             warn(s"$id: ambiguous range in 85X/86X pair: $value")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -154,22 +154,24 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     // infrequent that we don't need to write separate paths for every different
     // way this could go wrong.
     val dateString = Try {
+      val year = datePartsMap.get("year").map { _.stripSuffix(".") }
+
       val dateDisplayStrings =
         if (datePartsMap.contains("season")) {
           List(
             datePartsMap.get("season").flatMap { toNamedMonth(id, _) },
-            datePartsMap.get("year")
+            year
           )
         } else if (toNamedMonth(id, datePartsMap.getOrElse("month", "")).isDefined) {
           List(
             datePartsMap.get("month").flatMap { toNamedMonth(id, _) },
-            datePartsMap.get("year")
+            year
           )
         } else {
           List(
             datePartsMap.get("day"),
             datePartsMap.get("month").flatMap { monthNames.get },
-            datePartsMap.get("year"),
+            year
           )
         }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -142,7 +142,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
         } else {
           List(
             datePartsMap.get("day"),
-            datePartsMap.get("month"),
+            datePartsMap.get("month").flatMap { monthNames.get },
             datePartsMap.get("year"),
           )
         }
@@ -190,6 +190,21 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     "22" -> "Summer",
     "23" -> "Autumn",
     "24" -> "Winter"
+  )
+
+  private val monthNames = Map(
+    "01" -> "Jan.",
+    "02" -> "Feb.",
+    "03" -> "Mar.",
+    "04" -> "Apr.",
+    "05" -> "May",
+    "06" -> "June",
+    "07" -> "July",
+    "08" -> "Aug.",
+    "09" -> "Sep.",
+    "10" -> "Oct.",
+    "11" -> "Nov.",
+    "12" -> "Dec."
   )
 
   /** Given an 85X varField from Sierra, try to create a Label.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -148,12 +148,12 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
       val dateDisplayStrings =
         if (datePartsMap.contains("season")) {
           List(
-            datePartsMap.get("season").flatMap { toNamedSeason },
+            datePartsMap.get("season").flatMap { toNamedMonth(id, _) },
             datePartsMap.get("year")
           )
-        } else if (toNamedSeason(datePartsMap.getOrElse("month", "")).isDefined) {
+        } else if (toNamedMonth(id, datePartsMap.getOrElse("month", "")).isDefined) {
           List(
-            datePartsMap.get("month").flatMap { toNamedSeason },
+            datePartsMap.get("month").flatMap { toNamedMonth(id, _) },
             datePartsMap.get("year")
           )
         } else {
@@ -207,23 +207,15 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
   //    03    -> Mar.
   //    21/22 -> Spring/Summer
   //
-  private def toNamedSeason(s: String): Option[String] = {
+  private def toNamedMonth(id: TypedSierraRecordNumber, s: String): Option[String] = {
     val parts = s.split("/")
-    if (parts.forall(seasonNames.contains)) {
-      Some(parts.map { seasonNames(_) }.mkString("/"))
+    if (parts.forall(monthNames.contains)) {
+      Some(parts.map { monthNames(_) }.mkString("/"))
     } else {
+      warn(s"$id: Unable to completely parse ($s) as a named month.season")
       None
     }
   }
-
-  // Seasons are represented as two-digit numeric codes.
-  // See https://help.oclc.org/Metadata_Services/Local_Holdings_Maintenance/OCLC_MARC_local_holdings_format_and_standards/8xx_fields/853_Captions_and_Pattern-Basic_Bibliographic_Unit
-  private val seasonNames = Map(
-    "21" -> "Spring",
-    "22" -> "Summer",
-    "23" -> "Autumn",
-    "24" -> "Winter"
-  )
 
   private val monthNames = Map(
     "01" -> "Jan.",
@@ -237,7 +229,14 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     "09" -> "Sept.",
     "10" -> "Oct.",
     "11" -> "Nov.",
-    "12" -> "Dec."
+    "12" -> "Dec.",
+
+    // Seasons are represented as two-digit numeric codes.
+    // See https://help.oclc.org/Metadata_Services/Local_Holdings_Maintenance/OCLC_MARC_local_holdings_format_and_standards/8xx_fields/853_Captions_and_Pattern-Basic_Bibliographic_Unit
+    "21" -> "Spring",
+    "22" -> "Summer",
+    "23" -> "Autumn",
+    "24" -> "Winter"
   )
 
   /** Given an 85X varField from Sierra, try to create a Label.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -134,6 +134,11 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             datePartsMap.get("season").flatMap { seasonNames.get },
             datePartsMap.get("year")
           )
+        } else if (seasonNames.contains(datePartsMap.getOrElse("month", ""))) {
+          List(
+            datePartsMap.get("month").flatMap { seasonNames.get },
+            datePartsMap.get("year")
+          )
         } else {
           List(
             datePartsMap.get("day"),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -75,7 +75,16 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             None
         }
       }
-      .map { case (label, value) => createString(id, label, value) }
+      .map { case (label, value) =>
+        // We concatenate the contents of the public note in subfield ǂz.
+        // This is completely separate from the logic for combining the
+        // labels/values from the 85X/86X pair.
+        val publicNote =
+          value.varField.subfieldsWithTag("z").map { _.content }.mkString(" ")
+
+        createString(id, label, value) + " " + publicNote
+      }
+      .map { _.trim }
   }
 
   private def createString(id: TypedSierraRecordNumber, label: Label, value: Value): String = {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+
+// The 85X/86X pairs are used to store structured captions -- the 85X contains
+// the labels, the 856X contains the values.
+//
+// e.g. if you had the pair:
+//
+//    853 00 |810|avol.|i(year)
+//    863 40 |810.1|a1|i1995
+//
+// then you combine the label/captions to get "vol.1 (1995)".
+//
+// The behaviour of this class is partly based on the published descriptions,
+// partly on the observed behaviour on the old wellcomelibrary.org website.
+object SierraHoldingsEnumeration {
+  val labelTag = "853"
+  val valueTag = "863"
+
+  def apply(varFields: List[VarField]): List[String] =
+    List()
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -93,6 +93,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             case None => None
           }
         }
+        .filterNot { case (_, value) => value.trim == "-" }
         .filterNot { case (_, value) =>
           if (value.count(_ == '-') >= 2) {
             warn(s"$id: ambiguous range in 85X/86X pair: $value")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -93,7 +93,6 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             case None => None
           }
         }
-        .filterNot { case (_, value) => value.isEmpty }
         .filterNot { case (_, value) =>
           if (value.count(_ == '-') >= 2) {
             warn(s"$id: ambiguous range in 85X/86X pair: $value")
@@ -115,6 +114,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
 
   private def concatenateParts(parts: Seq[(String, String)]): String =
     parts
+      .filterNot { case (_, value) => value.isEmpty }
       .map {
         case (label, value) if label.startsWith("(") =>
           s"($value)"

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, SierraQueryOps, VarField}
 import weco.catalogue.sierra_adapter.models.TypedSierraRecordNumber
+
+import scala.util.{Failure, Success, Try}
 
 // The 85X/86X pairs are used to store structured captions -- the 85X contains
 // the labels, the 856X contains the values.
@@ -15,10 +18,98 @@ import weco.catalogue.sierra_adapter.models.TypedSierraRecordNumber
 //
 // The behaviour of this class is partly based on the published descriptions,
 // partly on the observed behaviour on the old wellcomelibrary.org website.
-object SierraHoldingsEnumeration {
+object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
   val labelTag = "853"
   val valueTag = "863"
 
-  def apply(id: TypedSierraRecordNumber, varFields: List[VarField]): List[String] =
-    List()
+  def apply(id: TypedSierraRecordNumber, varFields: List[VarField]): List[String] = {
+
+    // The 85X and 86X pairs are associated based on the contents of subfield 8.
+    //
+    // The first number of subfield 8 is the link, which is a positive integer.
+    // The second number is the sequence, also an integer, preceded by a decimal point.
+    // e.g. "1.6" has link "1" and sequence "6".
+    //
+    // The 85X fields have a link value only; the 86X fields have a link and a sequence
+    // value.  Go through and extract these values.
+    val labels =
+      varFields
+        .filter { _.marcTag.contains(labelTag) }
+        .flatMap { createLabel(id, _) }
+
+    val values =
+      varFields
+        .filter { _.marcTag.contains(valueTag) }
+        .flatMap { createValue(id, _) }
+
+    // Now we turn this into a Map
+    val labelsLookup = labels
+      .map { case label @ Label(link, _) => link -> label }
+      .toMap
+    assert(labelsLookup.size == labels.size)
+
+    values
+      .flatMap { value =>
+        labelsLookup.get(value.link) match {
+          case Some(label) => Some((label, value))
+          case None =>
+            warn(s"${id.withoutCheckDigit}: an instance of $valueTag refers to a missing sequence number in $labelTag: ${value.varField}")
+            None
+        }
+      }
+      .map { case (label, value) => createString(label, value) }
+  }
+
+  private def createString(label: Label, value: Value): String =
+    value
+      .varField.subfields
+      .filterNot { _.tag == "8" }
+      .flatMap { sf =>
+        label.varField.subfieldsWithTag(sf.tag).headOption match {
+          // This isn't explicitly stated anywhere, but it seems like the presence
+          // of parens around the label means you skip the label text, and wrap
+          // the value in parens.
+          case Some(MarcSubfield(_, subfieldLabel)) if subfieldLabel.startsWith("(") =>
+            Some(s"(${sf.content})")
+
+          case Some(MarcSubfield(_, subfieldLabel)) =>
+            Some(s"$subfieldLabel${sf.content}")
+
+          case None => None
+        }
+      }
+      .mkString(" ")
+
+  private def createLabel(id: TypedSierraRecordNumber, vf: VarField): Option[Label] =
+    vf.subfieldsWithTag("8").headOption match {
+      case Some(MarcSubfield(_, content)) =>
+        Try { content.toInt } match {
+          case Success(link) => Some(Label(link, vf))
+          case Failure(_) =>
+            warn(s"${id.withoutCheckDigit}: an instance of $labelTag subfield ǂ8 has a non-numeric value: $content")
+            None
+        }
+
+      case None =>
+        warn(s"${id.withoutCheckDigit}: an instance of $labelTag is missing subfield ǂ8")
+        None
+    }
+
+  private def createValue(id: TypedSierraRecordNumber, vf: VarField): Option[Value] =
+    vf.subfieldsWithTag("8").headOption match {
+      case Some(MarcSubfield(_, content)) =>
+        Try { content.split('.').map(_.toInt).toSeq } match {
+          case Success(Seq(link, sequence)) => Some(Value(link, sequence, vf))
+          case _ =>
+            warn(s"${id.withoutCheckDigit}: an instance of $labelTag subfield ǂ8 could not be parsed as a link/sequence: $content")
+            None
+        }
+
+      case None =>
+        warn(s"${id.withoutCheckDigit}: an instance of $labelTag is missing subfield ǂ8")
+        None
+    }
+
+  private case class Label(link: Int, varField: VarField)
+  private case class Value(link: Int, sequence: Int, varField: VarField)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -201,7 +201,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     "06" -> "June",
     "07" -> "July",
     "08" -> "Aug.",
-    "09" -> "Sep.",
+    "09" -> "Sept.",
     "10" -> "Oct.",
     "11" -> "Nov.",
     "12" -> "Dec."

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -81,6 +81,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
             None
         }
       }
+      .sortBy { case (_, value) => (value.link, value.sequence)}
       .map { case (label, value) =>
         // We concatenate the contents of the public note in subfield ǂz.
         // This is completely separate from the logic for combining the

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -130,7 +130,10 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
     val dateString = Try {
       val dateDisplayStrings =
         if (datePartsMap.contains("season")) {
-          List(datePartsMap.get("season"), datePartsMap.get("year"))
+          List(
+            datePartsMap.get("season").flatMap { seasonNames.get },
+            datePartsMap.get("year")
+          )
         } else {
           List(
             datePartsMap.get("day"),
@@ -174,6 +177,15 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
       case (ts, _) => ts
     }
   }
+
+  // Seasons are represented as two-digit numeric codes.
+  // See https://help.oclc.org/Metadata_Services/Local_Holdings_Maintenance/OCLC_MARC_local_holdings_format_and_standards/8xx_fields/853_Captions_and_Pattern-Basic_Bibliographic_Unit
+  private val seasonNames = Map(
+    "21" -> "Spring",
+    "22" -> "Summer",
+    "23" -> "Autumn",
+    "24" -> "Winter"
+  )
 
   /** Given an 85X varField from Sierra, try to create a Label.
     *

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -3,10 +3,17 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
 
-class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGenerators with SierraGenerators {
+class SierraHoldingsEnumerationTest
+    extends AnyFunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraGenerators {
   it("returns an empty list if there are no varFields with 853/863") {
     val varFields = List(
       createVarFieldWith(marcTag = "866"),
@@ -68,7 +75,8 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
     )
 
-    getEnumerations(varFields) shouldBe List("v.1:no.1 (1984) - v.35:no.2 (2018)")
+    getEnumerations(varFields) shouldBe List(
+      "v.1:no.1 (1984) - v.35:no.2 (2018)")
   }
 
   it("handles a duplicated field") {
@@ -203,7 +211,8 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
     )
 
-    getEnumerations(varFields) shouldBe List("v.12:no.1 (2009) - v.21:no.1-2 (2018)")
+    getEnumerations(varFields) shouldBe List(
+      "v.12:no.1 (2009) - v.21:no.1-2 (2018)")
   }
 
   it("removes parentheses from a single date") {
@@ -498,7 +507,8 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
     )
 
-    getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2 Current issue on display")
+    getEnumerations(varFields) shouldBe List(
+      "v.1:no.1 - v.2:no.2 Current issue on display")
   }
 
   it("sorts based on the link/sequence number") {
@@ -764,7 +774,8 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
 
       val possibilities = List(
-        List("vol.1 (2001)"), List("v.1 (2001)")
+        List("vol.1 (2001)"),
+        List("v.1 (2001)")
       )
 
       possibilities should contain(getEnumerations(varFields))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -45,6 +45,32 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     }
   }
 
+  it("handles an 853/863 pair that features a range with start/end") {
+    // This is based on b13488557 / h10310770
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "1-35"),
+          MarcSubfield(tag = "b", content = "1-2"),
+          MarcSubfield(tag = "i", content = "1984-2018"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.1:no.1 (1984) - v.35:no.2 (2018)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -154,6 +154,32 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.1 (1979) - v.130:no.1 (2010)")
   }
 
+  it("skips empty values at both ends of a range in field 863") {
+    // This test case is based on b13108487
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "-"),
+          MarcSubfield(tag = "b", content = "1-21"),
+          MarcSubfield(tag = "i", content = "1984-2004")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("no.1 (1984) - no.21 (2004)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -227,6 +227,58 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("2010 - 2020")
   }
 
+  it("maps numeric Season values to names") {
+    // This test case is based on b15268688
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "41-57"),
+          MarcSubfield(tag = "b", content = "4-2"),
+          MarcSubfield(tag = "i", content = "1992-2008"),
+          MarcSubfield(tag = "j", content = "23-21"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.2"),
+          MarcSubfield(tag = "a", content = "57-59"),
+          MarcSubfield(tag = "b", content = "4-1"),
+          MarcSubfield(tag = "i", content = "2008-2009"),
+          MarcSubfield(tag = "j", content = "23-24"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.4"),
+          MarcSubfield(tag = "a", content = "60-61"),
+          MarcSubfield(tag = "b", content = "3-2"),
+          MarcSubfield(tag = "i", content = "2011-2012"),
+          MarcSubfield(tag = "j", content = "22-21"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(season)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List(
+      "v.41:no.4 (Autumn 1992) - v.57:no.2 (Spring 2008)",
+      "v.57:no.4 (Autumn 2008) - v.59:no.1 (Winter 2009)",
+      "v.60:no.3 (Summer 2011) - v.61:no.2 (Spring 2012)"
+    )
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -128,6 +128,32 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("no.1 (1982) - no.101 (2010)")
   }
 
+  it("skips empty values at one end of a range in field 863") {
+    // This test case is based on b13107884
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "1-130"),
+          MarcSubfield(tag = "b", content = "-1"),
+          MarcSubfield(tag = "i", content = "1979-2010")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.1 (1979) - v.130:no.1 (2010)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -399,6 +399,31 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("includes the contents of the public note in subfield ǂz") {
+    // This test case is based on b14975993
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "1-2"),
+          MarcSubfield(tag = "b", content = "1-2"),
+          MarcSubfield(tag = "z", content = "Current issue on display")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2 Current issue on display")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -71,6 +71,37 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.1:no.1 (1984) - v.35:no.2 (2018)")
   }
 
+  it("handles a duplicated 853/863 field") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "10"),
+          MarcSubfield(tag = "a", content = "vol."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "10"),
+          MarcSubfield(tag = "a", content = "vol."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "10.1"),
+          MarcSubfield(tag = "a", content = "1"),
+          MarcSubfield(tag = "i", content = "2001")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("vol.1 (2001)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import weco.catalogue.sierra_adapter.generators.SierraGenerators
+
+class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGenerators with SierraGenerators {
+  it("returns an empty list if there are no varFields with 853/863") {
+    val varFields = List(
+      createVarFieldWith(marcTag = "866"),
+      createVarFieldWith(marcTag = "989"),
+    )
+
+    getEnumerations(varFields) shouldBe List()
+  }
+
+  def getEnumerations(varFields: List[VarField]): List[String] =
+    SierraHoldingsEnumeration(createSierraHoldingsNumber, varFields)
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -501,6 +501,33 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2 Current issue on display")
   }
 
+  it("uses a colon as a separator between 'v' and 'no.'") {
+    // This example is based on b1310812
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "42"),
+          MarcSubfield(tag = "b", content = "1-2")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v"),
+          MarcSubfield(tag = "b", content = "no."),
+        )
+      )
+    )
+
+    // TODO: We might consider normalising this to 'v.' to be consistent with
+    // our other holdings, but not right now -- this is meant to mimic the
+    // behaviour of the old Wellcome Library site.
+    getEnumerations(varFields) shouldBe List("v42:no.1 - v42:no.2")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -339,6 +339,36 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("handles slashes in the season field") {
+    // This test case is based on b3186692x
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = ""),
+          MarcSubfield(tag = "b", content = "1-4"),
+          MarcSubfield(tag = "i", content = "2017-2019"),
+          MarcSubfield(tag = "j", content = "-21/22"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List(
+      "no.1 (2017) - no.4 (Spring/Summer 2019)"
+    )
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -528,6 +528,28 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v42:no.1 - v42:no.2")
   }
 
+  it("trims trailing punctuation from the year") {
+    // This example is based on b1310916
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "1985-2002.")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "year")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("1985 - 2002")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -501,6 +501,53 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2 Current issue on display")
   }
 
+  it("sorts based on the link/sequence number") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.2"),
+          MarcSubfield(tag = "a", content = "1"),
+          MarcSubfield(tag = "b", content = "2")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "2.1"),
+          MarcSubfield(tag = "a", content = "2"),
+          MarcSubfield(tag = "b", content = "1"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "1"),
+          MarcSubfield(tag = "b", content = "1")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "2"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.1:no.1", "v.1:no.2", "v.2:no.1")
+  }
+
   it("uses a colon as a separator between 'v' and 'no.'") {
     // This example is based on b1310812
     val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -180,6 +180,32 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("no.1 (1984) - no.21 (2004)")
   }
 
+  it("handles ranges that contain multiple parts") {
+    // This test case is based on b16734567
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "12-21"),
+          MarcSubfield(tag = "b", content = "1-1-2"),
+          MarcSubfield(tag = "i", content = "2009-2018")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.12:no.1 (2009) - v.21:no.1-2 (2018)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(
@@ -316,31 +342,6 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
 
       getEnumerations(varFields) shouldBe List("vol.1 (1995)")
-    }
-
-    it("skips a range field which is ambiguous") {
-      val varFields = List(
-        createVarFieldWith(
-          marcTag = "863",
-          subfields = List(
-            MarcSubfield(tag = "8", content = "1.1"),
-            MarcSubfield(tag = "a", content = "1-2"),
-            MarcSubfield(tag = "b", content = "1-2"),
-            MarcSubfield(tag = "i", content = "1984-1994-2004"),
-          )
-        ),
-        createVarFieldWith(
-          marcTag = "853",
-          subfields = List(
-            MarcSubfield(tag = "8", content = "1"),
-            MarcSubfield(tag = "a", content = "v."),
-            MarcSubfield(tag = "b", content = "no."),
-            MarcSubfield(tag = "i", content = "(year)"),
-          )
-        )
-      )
-
-      getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2")
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.sierra.generators.MarcGenerators
-import uk.ac.wellcome.platform.transformer.sierra.source.VarField
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
 
 class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGenerators with SierraGenerators {
@@ -14,6 +14,35 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
 
     getEnumerations(varFields) shouldBe List()
+  }
+
+  describe("handles the examples from the Sierra documentation") {
+    // As part of adding holdings records to the Catalogue, I got a document titled
+    // "Storing holdings data in 85X/86X pairs".  It featured a couple of examples
+    // for holdings displays, which I reproduce here.
+
+    it("handles a single 853/863 pair") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "1995")
+          )
+        )
+      )
+
+      getEnumerations(varFields) shouldBe List("vol.1 (1995)")
+    }
   }
 
   def getEnumerations(varFields: List[VarField]): List[String] =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -429,6 +429,29 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("July 2005 - Dec./Jan. 2014/2015")
   }
 
+  it("skips adding a value if it can't parse it as a date") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "2001-2002"),
+          MarcSubfield(tag = "j", content = "XX-YY")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("2001 - 2002")
+  }
+
   it("includes the contents of the public note in subfield ǂz") {
     // This test case is based on b14975993
     val varFields = List(
@@ -590,6 +613,41 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
       )
 
       getEnumerations(varFields) shouldBe List("vol.1 (1995)")
+    }
+
+    it("handles a duplicate 853") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "v."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "2001")
+          )
+        )
+      )
+
+      val possibilities = List(
+        List("vol.1 (2001)"), List("v.1 (2001)")
+      )
+
+      possibilities should contain(getEnumerations(varFields))
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -206,6 +206,27 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.12:no.1 (2009) - v.21:no.1-2 (2018)")
   }
 
+  it("removes parentheses from a single date") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "2010-2020")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("2010 - 2020")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -71,7 +71,7 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("v.1:no.1 (1984) - v.35:no.2 (2018)")
   }
 
-  it("handles a duplicated 853/863 field") {
+  it("handles a duplicated field") {
     val varFields = List(
       createVarFieldWith(
         marcTag = "853",

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -279,6 +279,36 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("maps numeric Season values to names in the month field") {
+    // This test case is based on b24968912
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "1-3"),
+          MarcSubfield(tag = "b", content = "1-2"),
+          MarcSubfield(tag = "i", content = "2015-2017"),
+          MarcSubfield(tag = "j", content = "21-22"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List(
+      "v.1:no.1 (Spring 2015) - v.3:no.2 (Summer 2017)"
+    )
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -369,6 +369,36 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("handles a mix of month/season in the same record") {
+    // This test case is based on b13544019
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "26-47"),
+          MarcSubfield(tag = "b", content = "-2"),
+          MarcSubfield(tag = "i", content = "1996-2017"),
+          MarcSubfield(tag = "j", content = "24-05"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List(
+      "v.26 (Winter 1996) - v.47:no.2 (May 2017)"
+    )
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -45,6 +45,145 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     }
   }
 
+  describe("handles malformed MARC data") {
+    it("skips a field 863 if it has a missing sequence number") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "1995")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "2.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "1995")
+          )
+        )
+      )
+
+      getEnumerations(varFields) shouldBe List("vol.1 (1995)")
+    }
+
+    it("skips a subfield in field 863 if it doesn't have a corresponding label") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "1995")
+          )
+        )
+      )
+
+      getEnumerations(varFields) shouldBe List("vol.1")
+    }
+
+    it("skips a field 863 if it can't parse the link/sequence as two integers") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "2001")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "b.b"),
+            MarcSubfield(tag = "a", content = "2"),
+            MarcSubfield(tag = "i", content = "2002")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "3.3.3"),
+            MarcSubfield(tag = "a", content = "3"),
+            MarcSubfield(tag = "i", content = "2003")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "4"),
+            MarcSubfield(tag = "i", content = "2004")
+          )
+        ),
+      )
+
+      getEnumerations(varFields) shouldBe List("vol.1 (2001)")
+    }
+
+    it("skips a field 853 if it can't find a sequence number") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "a"),
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "vol."),
+            MarcSubfield(tag = "i", content = "(year)")
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "10.1"),
+            MarcSubfield(tag = "a", content = "1"),
+            MarcSubfield(tag = "i", content = "1995")
+          )
+        ),
+      )
+
+      getEnumerations(varFields) shouldBe List("vol.1 (1995)")
+    }
+  }
+
   def getEnumerations(varFields: List[VarField]): List[String] =
     SierraHoldingsEnumeration(createSierraHoldingsNumber, varFields)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -102,6 +102,32 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("vol.1 (2001)")
   }
 
+  it("skips empty values in field 863") {
+    // This is based on b13108608
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = ""),
+          MarcSubfield(tag = "b", content = "1-101"),
+          MarcSubfield(tag = "i", content = "1982-2010")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("no.1 (1982) - no.101 (2010)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -399,6 +399,36 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("handles a range and a slash in the month field") {
+    // This example is based on b1652927
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "2005-2014/2015"),
+          MarcSubfield(tag = "j", content = "07-12/01")
+        )
+      )
+    )
+
+    // TODO: This test case is based on the current behaviour of Encore, but
+    // arguably this is wrong.  The correct output should be
+    //
+    //    July 2005 - Dec. 2014/Jan. 2015
+    //
+    // but we omit fixing this for now.
+    getEnumerations(varFields) shouldBe List("July 2005 - Dec./Jan. 2014/2015")
+  }
+
   it("includes the contents of the public note in subfield ǂz") {
     // This test case is based on b14975993
     val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -208,6 +208,31 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
 
       getEnumerations(varFields) shouldBe List("vol.1 (1995)")
     }
+
+    it("skips a range field which is ambiguous") {
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "863",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "1.1"),
+            MarcSubfield(tag = "a", content = "1-2"),
+            MarcSubfield(tag = "b", content = "1-2"),
+            MarcSubfield(tag = "i", content = "1984-1994-2004"),
+          )
+        ),
+        createVarFieldWith(
+          marcTag = "853",
+          subfields = List(
+            MarcSubfield(tag = "8", content = "1"),
+            MarcSubfield(tag = "a", content = "v."),
+            MarcSubfield(tag = "b", content = "no."),
+            MarcSubfield(tag = "i", content = "(year)"),
+          )
+        )
+      )
+
+      getEnumerations(varFields) shouldBe List("v.1:no.1 - v.2:no.2")
+    }
   }
 
   def getEnumerations(varFields: List[VarField]): List[String] =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -309,6 +309,36 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     )
   }
 
+  it("maps numeric month values to names") {
+    // This test case is based on b14604863
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "a", content = "7-18"),
+          MarcSubfield(tag = "b", content = "1-2"),
+          MarcSubfield(tag = "i", content = "2000-2011"),
+          MarcSubfield(tag = "j", content = "04-08"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "a", content = "v."),
+          MarcSubfield(tag = "b", content = "no."),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List(
+      "v.7:no.1 (Apr. 2000) - v.18:no.2 (Aug. 2011)"
+    )
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -452,6 +452,30 @@ class SierraHoldingsEnumerationTest extends AnyFunSpec with Matchers with MarcGe
     getEnumerations(varFields) shouldBe List("2001 - 2002")
   }
 
+  it("uses the first month of a range") {
+    // This example is based on b3225790
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)")
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "1968-1969"),
+          MarcSubfield(tag = "j", content = "09-11-12")
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("Sept. 1968 - Nov. 1969")
+  }
+
   it("includes the contents of the public note in subfield ǂz") {
     // This test case is based on b14975993
     val varFields = List(


### PR DESCRIPTION
This is part of the work to add holdings to the API.

When you look at a journal on the current library site, you see a list of the issues that we have:

<img width="438" alt="Screenshot 2021-03-08 at 09 40 42" src="https://user-images.githubusercontent.com/301220/110303522-62b87100-7ff2-11eb-9d3f-29554e8e8eba.png">

These strings aren't stored directly in the MARC record. Instead, the record splits the display labels and values, and you have to reconstruct them into human-readable strings. For example, the record is something like:

```
853 v.|bno.|i(year)|j(month)  # labels - v., no., year/month
863 8-69|b-1|i1959-2020|j-21  # v.8 (1959) - v.69:no.1 (Spring 2020)
863 69|b2-3|i2020|j22-23      # v.69:no.2 (Summer 2020) - v.69:no.3 (Autumn 2020)
```

This gives you a lot of flexibility in the MARC, but we shouldn't expose this degree of granularity to API consumers. The catalogue pipeline should parse these MARC records, and turn them into a human-readable string.

This patch adds some code to do this transformation.

Unfortunately, I couldn't find a good set of instructions for how to do this, so I did it by observing the behaviour on the current Wellcome Library site. I saved the complete list of 85X/86X fields, the corresponding strings on the Library website, and I kept comparing the two. They're not an exact match, but I think they're good enough. We can always tweak that logic later (or in some cases, tweak the underlying Sierra record).

I've turned all the “interesting” examples from Sierra into explicit test cases, because I’m not sure there isn’t private information in my file full of Library examples.

Part of https://github.com/wellcomecollection/platform/issues/5076