### PR TITLE
Normalise genres - strip punctuation/whitespace, fix capitalisation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,1 @@
+Add more options for normalising `Genre` data.

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -19,7 +19,7 @@ object Concept {
     label: String): Concept[State] =
     Concept(IdState.Unidentifiable, label)
 
-  def normalised[State](id: State, label: String): Concept[State] =
+  def normalised[State](id: State = IdState.Unidentifiable, label: String): Concept[State] =
     Concept(id, trimTrailing(label, '.'))
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -19,7 +19,8 @@ object Concept {
     label: String): Concept[State] =
     Concept(IdState.Unidentifiable, label)
 
-  def normalised[State](id: State = IdState.Unidentifiable, label: String): Concept[State] =
+  def normalised[State](id: State = IdState.Unidentifiable,
+                        label: String): Concept[State] =
     Concept(id, trimTrailing(label, '.'))
 }
 

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
@@ -4,3 +4,18 @@ case class Genre[+State](
   label: String,
   concepts: List[AbstractConcept[State]] = Nil
 )
+
+object Genre {
+  def normalised[State](label: String, concepts: List[AbstractConcept[State]]): Genre[State] = {
+    val normalisedLabel =
+      label
+        .stripSuffix(".")
+        .trim
+        .replace("Electronic Books", "Electronic books")
+
+    Genre(
+      label = normalisedLabel,
+      concepts = concepts
+    )
+  }
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Genre.scala
@@ -6,7 +6,9 @@ case class Genre[+State](
 )
 
 object Genre {
-  def normalised[State](label: String, concepts: List[AbstractConcept[State]]): Genre[State] = {
+  def normalised[State](
+    label: String,
+    concepts: List[AbstractConcept[State]]): Genre[State] = {
     val normalisedLabel =
       label
         .stripSuffix(".")

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
@@ -10,9 +10,9 @@ trait MiroGenres {
     // <image_phys_format> and <image_lc_genre>.
     (miroRecord.physFormat.toList ++ miroRecord.lcGenre.toList).map { label =>
       val normalisedLabel = sentenceCase(label)
-      Genre(
+      Genre.normalised(
         label = normalisedLabel,
-        concepts = List(Concept(normalisedLabel))
+        concepts = List(Concept.normalised(label = normalisedLabel))
       )
     }.distinct
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenresTest.scala
@@ -68,6 +68,15 @@ class MiroGenresTest
     )
   }
 
+  it("removes trailing punctuation from genre labels") {
+    transformRecordAndCheckGenres(
+      miroRecord = createMiroRecordWith(
+        physFormat = Some("Printed books.")
+      ),
+      expectedGenreLabels = List("Printed books")
+    )
+  }
+
   private def transformRecordAndCheckGenres(
     miroRecord: MiroRecord,
     expectedGenreLabels: List[String]

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
@@ -89,9 +89,9 @@ trait SierraConcepts extends SierraQueryOps {
     : List[AbstractConcept[IdState.Unminted]] =
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
-        case "v" | "x" => Concept(label = subfield.content)
+        case "v" | "x" => Concept.normalised(label = subfield.content)
         case "y"       => Period(label = subfield.content)
-        case "z"       => Place(label = subfield.content)
+        case "z"       => Place.normalised(label = subfield.content)
       }
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
@@ -1,11 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.models.work.internal.{
-  AbstractConcept,
-  Concept,
-  Genre,
-  IdState
-}
+import uk.ac.wellcome.models.work.internal.{Concept, Genre, IdState}
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData,
@@ -63,7 +58,7 @@ object SierraGenres
         val concepts = getPrimaryConcept(primarySubfields, varField = varField) ++ getSubdivisions(
           subdivisionSubfields)
 
-        Genre(label = label, concepts = concepts)
+        Genre.normalised(label = label, concepts = concepts)
       }
       .distinct
 
@@ -71,9 +66,9 @@ object SierraGenres
   // only concept which might be identified.
   private def getPrimaryConcept(
     primarySubfields: List[MarcSubfield],
-    varField: VarField): List[AbstractConcept[IdState.Unminted]] =
+    varField: VarField): List[Concept[IdState.Unminted]] =
     primarySubfields.map { subfield =>
-      val concept = Concept(label = subfield.content)
+      val concept = Concept.normalised(label = subfield.content)
       concept.copy(id = identifyConcept(concept, varField))
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenresTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenresTest.scala
@@ -179,32 +179,32 @@ class SierraGenresTest
         createVarFieldWith(
           marcTag = "655",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Electronic journals.")
+            MarcSubfield(tag = "a", content = "Electronic journals")
           )
         ),
         createVarFieldWith(
           marcTag = "655",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Electronic journals.")
+            MarcSubfield(tag = "a", content = "Electronic journals")
           )
         ),
         createVarFieldWith(
           marcTag = "655",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Periodical.")
+            MarcSubfield(tag = "a", content = "Periodical")
           )
         ),
         createVarFieldWith(
           marcTag = "655",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Periodicals."),
+            MarcSubfield(tag = "a", content = "Periodicals"),
             MarcSubfield(tag = "2", content = "rbgenr")
           )
         ),
         createVarFieldWith(
           marcTag = "655",
           subfields = List(
-            MarcSubfield(tag = "a", content = "Periodicals."),
+            MarcSubfield(tag = "a", content = "Periodicals"),
             MarcSubfield(tag = "2", content = "lcgft")
           )
         ),
@@ -212,7 +212,7 @@ class SierraGenresTest
     )
 
     val expectedGenres =
-      List("Electronic journals.", "Periodical.", "Periodicals.")
+      List("Electronic journals", "Periodical", "Periodicals")
         .map { label =>
           Genre(
             label = label,
@@ -258,6 +258,29 @@ class SierraGenresTest
           concepts = List(
             Concept(label = "A2 Content"),
             Concept(label = "V2 Content")
+          ))
+      )
+    SierraGenres(bibData) shouldBe expectedSubjects
+  }
+
+  it("strips punctuation from Sierra genres") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "655",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Printed books.")
+          )
+        )
+      )
+    )
+
+    val expectedSubjects =
+      List(
+        Genre(
+          label = "Printed books",
+          concepts = List(
+            Concept(label = "Printed books")
           ))
       )
     SierraGenres(bibData) shouldBe expectedSubjects


### PR DESCRIPTION
None of these transformations affect the meaning of this data, but it should display more consistently, e.g. users won't see two entries for "Electronic [Bb]ooks" in the genre filter.

Closes https://github.com/wellcomecollection/platform/issues/5072