### PR TITLE
Add a Holdings type to the Work model

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,1 @@
+Add the `Holdings` type to the Work model.

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -35,6 +35,7 @@ object SingleWorkParams extends QueryParamsUtils {
     decodeOneOfCommaSeparated(
       "identifiers" -> WorkInclude.Identifiers,
       "items" -> WorkInclude.Items,
+      "holdings" -> WorkInclude.Holdings,
       "subjects" -> WorkInclude.Subjects,
       "genres" -> WorkInclude.Genres,
       "contributors" -> WorkInclude.Contributors,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -146,6 +146,7 @@ trait SingleWorkSwagger {
           allowableValues = Array(
             "identifiers",
             "items",
+            "holdings",
             "subjects",
             "genres",
             "contributors",
@@ -351,6 +352,7 @@ trait MultipleWorksSwagger {
           allowableValues = Array(
             "identifiers",
             "items",
+            "holdings",
             "subjects",
             "genres",
             "contributors",

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -157,7 +157,8 @@ trait SingleWorkSwagger {
             "succeededBy",
             "precededBy",
             "partOf",
-            "parts")),
+            "parts"
+          )),
         required = false,
       )
     )
@@ -363,7 +364,8 @@ trait MultipleWorksSwagger {
             "succeededBy",
             "precededBy",
             "partOf",
-            "parts")),
+            "parts"
+          )),
         required = false,
       ),
       new Parameter(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.Assertion
 class WorksErrorsTest extends ApiWorksTestBase {
 
   val includesString =
-    "['identifiers', 'items', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+    "['identifiers', 'items', 'holdings', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -813,16 +813,16 @@ class WorksIncludesTest
 
   describe("holdings includes") {
     def createHoldings(count: Int): List[Holdings] =
-      (1 to count)
-        .map { _ =>
-          Holdings(
-            description = chooseFrom(None, Some(randomAlphanumeric())),
-            note = chooseFrom(None, Some(randomAlphanumeric())),
-            enumeration = collectionOf(min = 0, max = 10) { randomAlphanumeric() }.toList,
-            locations = collectionOf(min = 0, max = 5) { createPhysicalLocation }.toList
-          )
-        }
-        .toList
+      (1 to count).map { _ =>
+        Holdings(
+          description = chooseFrom(None, Some(randomAlphanumeric())),
+          note = chooseFrom(None, Some(randomAlphanumeric())),
+          enumeration =
+            collectionOf(min = 0, max = 10) { randomAlphanumeric() }.toList,
+          locations =
+            collectionOf(min = 0, max = 5) { createPhysicalLocation }.toList
+        )
+      }.toList
 
     it("on the list endpoint") {
       withWorksApi {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -810,4 +810,82 @@ class WorksIncludesTest
       }
     }
   }
+
+  describe("holdings includes") {
+    def createHoldings(count: Int): List[Holdings] =
+      (1 to count)
+        .map { _ =>
+          Holdings(
+            description = chooseFrom(None, Some(randomAlphanumeric())),
+            note = chooseFrom(None, Some(randomAlphanumeric())),
+            enumeration = collectionOf(min = 0, max = 10) { randomAlphanumeric() }.toList,
+            locations = collectionOf(min = 0, max = 5) { createPhysicalLocation }.toList
+          )
+        }
+        .toList
+
+    it("on the list endpoint") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          val works = List(
+            indexedWork().holdings(createHoldings(3)),
+            indexedWork().holdings(createHoldings(4))
+          ).sortBy { _.state.canonicalId }
+
+          insertIntoElasticsearch(worksIndex, works: _*)
+
+          assertJsonResponse(routes, s"/$apiPrefix/works?include=holdings") {
+            Status.OK -> s"""
+              {
+                ${resultList(apiPrefix, totalResults = works.size)},
+                "results": [
+                  {
+                    "type": "Work",
+                    "id": "${works.head.state.canonicalId}",
+                    "title": "${works.head.data.title.get}",
+                    "alternativeTitles": [],
+                    "availabilities": [${availabilities(
+              works.head.state.availabilities)}],
+                    "holdings": [${listOfHoldings(works.head.data.holdings)}]
+                  },
+                  {
+                    "type": "Work",
+                    "id": "${works(1).state.canonicalId}",
+                    "title": "${works(1).data.title.get}",
+                    "alternativeTitles": [],
+                    "availabilities": [${availabilities(
+              works(1).state.availabilities)}],
+                    "holdings": [${listOfHoldings(works(1).data.holdings)}]
+                  }
+                ]
+              }
+            """
+          }
+      }
+    }
+
+    it("on a single work endpoint") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          val work = indexedWork().holdings(createHoldings(3))
+
+          insertIntoElasticsearch(worksIndex, work)
+
+          assertJsonResponse(
+            routes,
+            s"/$apiPrefix/works/${work.state.canonicalId}?include=holdings") {
+            Status.OK -> s"""
+              {
+                ${singleWorkResult(apiPrefix)},
+                "id": "${work.state.canonicalId}",
+                "title": "${work.data.title.get}",
+                "alternativeTitles": [],
+                "availabilities": [${availabilities(work.state.availabilities)}],
+                "holdings": [${listOfHoldings(work.data.holdings)}]
+              }
+            """
+          }
+      }
+    }
+  }
 }

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
@@ -16,7 +16,8 @@ case class DisplayHoldings(
     description = "Additional information about the holdings."
   ) note: Option[String],
   @Schema(
-    description = "A list of individual issues or parts that make up the holdings."
+    description =
+      "A list of individual issues or parts that make up the holdings."
   ) enumeration: List[String],
   @Schema(
     description = "List of locations where the holdings are stored."

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.display.models
+
+import io.circe.generic.extras.JsonKey
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.ac.wellcome.models.work.internal.Holdings
+
+@Schema(
+  name = "Holdings",
+  description = "A collection of materials owned by the library."
+)
+case class DisplayHoldings(
+  @Schema(
+    description = "A textual description of the holdings."
+  ) description: Option[String],
+  @Schema(
+    description = "Additional information about the holdings."
+  ) note: Option[String],
+  @Schema(
+    description = "A list of individual issues or parts that make up the holdings."
+  ) enumeration: List[String],
+  @Schema(
+    description = "List of locations where the holdings are stored."
+  ) locations: List[DisplayLocation],
+  @JsonKey("type") @Schema(name = "type") ontologyType: String = "Holdings"
+)
+
+case object DisplayHoldings {
+  def apply(h: Holdings): DisplayHoldings =
+    DisplayHoldings(
+      description = h.description,
+      note = h.note,
+      enumeration = h.enumeration,
+      locations = h.locations.map { DisplayLocation(_) }
+    )
+}

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayWork.scala
@@ -76,6 +76,10 @@ case class DisplayWork(
     description = "List of items related to this work."
   ) items: Option[List[DisplayItem]] = None,
   @Schema(
+    `type` = "List[uk.ac.wellcome.Display.models.DisplayHoldings]",
+    description = "List of holdings related to this work."
+  ) holdings: Option[List[DisplayHoldings]] = None,
+  @Schema(
     description = "Ways in which the work is available to access",
     `type` = "List[uk.ac.wellcome.display.modules.DisplayAvailability]"
   ) availabilities: List[DisplayAvailability] = Nil,
@@ -159,6 +163,10 @@ object DisplayWork {
           Some(work.data.items.map {
             DisplayItem(_, includesIdentifiers = includes.identifiers)
           })
+        else None,
+      holdings =
+        if (includes.holdings)
+          Some(work.data.holdings.map { DisplayHoldings(_) })
         else None,
       availabilities = work.state.availabilities.toList.map {
         DisplayAvailability(_)

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorksIncludes.scala
@@ -5,6 +5,7 @@ sealed trait WorkInclude
 object WorkInclude {
   case object Identifiers extends WorkInclude
   case object Items extends WorkInclude
+  case object Holdings extends WorkInclude
   case object Subjects extends WorkInclude
   case object Genres extends WorkInclude
   case object Contributors extends WorkInclude
@@ -21,6 +22,7 @@ object WorkInclude {
 case class WorksIncludes(
   identifiers: Boolean,
   items: Boolean,
+  holdings: Boolean,
   subjects: Boolean,
   genres: Boolean,
   contributors: Boolean,
@@ -41,6 +43,7 @@ case object WorksIncludes {
     WorksIncludes(
       identifiers = includes.contains(WorkInclude.Identifiers),
       items = includes.contains(WorkInclude.Items),
+      holdings = includes.contains(WorkInclude.Holdings),
       subjects = includes.contains(WorkInclude.Subjects),
       genres = includes.contains(WorkInclude.Genres),
       contributors = includes.contains(WorkInclude.Contributors),
@@ -60,6 +63,7 @@ case object WorksIncludes {
     WorksIncludes(
       identifiers = true,
       items = true,
+      holdings = true,
       subjects = true,
       genres = true,
       contributors = true,

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -309,7 +309,11 @@ trait DisplaySerialisationTestBase {
        |  ${optionalString("description", h.description)}
        |  ${optionalString("note", h.note)}
        |  "enumeration": [
-       |    ${h.enumeration.map { en => '"' + en + '"'}.mkString(",")}
+       |    ${h.enumeration
+         .map { en =>
+           '"' + en + '"'
+         }
+         .mkString(",")}
        |  ],
        |  "locations": [${locations(h.locations)}],
        |  "type": "Holdings"

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -69,8 +69,8 @@ trait DisplaySerialisationTestBase {
        {
         "type": "PhysicalLocation",
         "locationType": ${locationType(loc.locationType)},
-        "label": "${loc.label}",
-        ${optionalObject("license", license, loc.license)}
+        "label": "${loc.label}"
+        ${optionalObject("license", license, loc.license)},
         ${optionalString("shelfmark", loc.shelfmark)}
         "accessConditions": ${accessConditions(loc.accessConditions)}
        }
@@ -302,4 +302,20 @@ trait DisplaySerialisationTestBase {
          "type": "LocationType"
        }
      """ stripMargin
+
+  def singleHoldings(h: Holdings): String =
+    s"""
+       |{
+       |  ${optionalString("description", h.description)}
+       |  ${optionalString("note", h.note)}
+       |  "enumeration": [
+       |    ${h.enumeration.map { en => '"' + en + '"'}.mkString(",")}
+       |  ],
+       |  "locations": [${locations(h.locations)}],
+       |  "type": "Holdings"
+       |}
+       |""".stripMargin
+
+  def listOfHoldings(hs: List[Holdings]): String =
+    hs.map { singleHoldings }.mkString(",")
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Holdings.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Holdings.scala
@@ -1,0 +1,8 @@
+package uk.ac.wellcome.models.work.internal
+
+case class Holdings(
+  description: Option[String] = None,
+  note: Option[String] = None,
+  enumeration: List[String],
+  locations: List[Location] = Nil
+)

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Work.scala
@@ -95,6 +95,7 @@ case class WorkData[State <: DataState](
   notes: List[Note] = Nil,
   duration: Option[Int] = None,
   items: List[Item[State#MaybeId]] = Nil,
+  holdings: List[Holdings] = Nil,
   collectionPath: Option[CollectionPath] = None,
   imageData: List[ImageData[State#Id]] = Nil,
   workType: WorkType = WorkType.Standard,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -231,6 +231,9 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
     def duration(newDuration: Int): Work.Visible[State] =
       work.map(_.copy(duration = Some(newDuration)))
 
+    def holdings(newHoldings: List[Holdings]): Work.Visible[State] =
+      work.map(_.copy(holdings = newHoldings))
+
     def map(f: WorkData[State#WorkDataState] => WorkData[State#WorkDataState])
       : Work.Visible[State] = {
       val nextData = f(work.data)

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -76,6 +76,7 @@ class SnapshotGeneratorFeatureTest
                 "genres": [],
                 "subjects": [],
                 "items": [],
+                "holdings": [],
                 "production": [],
                 "languages": [],
                 "alternativeTitles": [],

--- a/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/uk/ac/wellcome/platform/snapshot_generator/services/SnapshotServiceTest.scala
@@ -150,7 +150,7 @@ class SnapshotServiceTest
           result.snapshotResult.documentCount shouldBe works.length
           result.snapshotResult.displayModel shouldBe expectedDisplayWorkClassName
 
-          result.snapshotResult.startedAt shouldBe >(
+          result.snapshotResult.startedAt shouldBe >=(
             result.snapshotJob.requestedAt)
           result.snapshotResult.finishedAt shouldBe >=(
             result.snapshotResult.startedAt)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5076; this implements the type described in the RFC: https://github.com/wellcomecollection/docs/pull/50

Actually populating it will come in a separate patch.