### PR TITLE
Boost the colour query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -33,6 +33,7 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
         maxQueryTerms = Some(1000),
         minShouldMatch = Some("1")
       )
+      .boost(1000)
 
   // This replicates the logic in palette_encoder.py:get_bin_index
   private def getColorsSignature(colors: Seq[ColorQuery.Hsv],


### PR DESCRIPTION
The colour query, whilst it is scored, is not currently boosted. This leads to confusing results: although we don't want to ignore other aspects of query relevance, when a colour filter is active we want the top results to clearly reflect the chosen colour(s). Adding a boost resolves this.