### PR TITLE
Re-check that we have relevant changes before looking for a release file

### DIFF
--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     local_head = local_current_head()
 
     if is_default_branch():
-        latest_sha = get_sha1_for_tag("latest")
+        latest_sha = get_sha1_for_tag("latest-sbt-release")
         commit_range = f"{latest_sha}..{local_head}"
     else:
         remote_head = remote_default_head()
@@ -120,14 +120,7 @@ if __name__ == "__main__":
             sys.exit(0)
 
     if should_check_release(args.project_name):
-        latest_sha = get_sha1_for_tag("latest-sbt-release")
-        commit_range = f"{latest_sha}..{local_head}"
-        changed_paths = get_changed_paths(commit_range, globs=change_globs)
-
-        if should_run_sbt_project(sbt_repo, args.project_name, changed_paths):
-            check_release_file(commit_range)
-        else:
-            print(f"Not checking release file because there are no changes between latest-sbt-release and this commit")
+        check_release_file(commit_range)
 
     # Perform make tasks
     make(f"{args.project_name}-test")

--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -122,7 +122,12 @@ if __name__ == "__main__":
     if should_check_release(args.project_name):
         latest_sha = get_sha1_for_tag("latest-sbt-release")
         commit_range = f"{latest_sha}..{local_head}"
-        check_release_file(commit_range)
+        changed_paths = get_changed_paths(commit_range, globs=change_globs)
+
+        if should_run_sbt_project(sbt_repo, args.project_name, changed_paths):
+            check_release_file(commit_range)
+        else:
+            print(f"Not checking release file because there are no changes between latest-sbt-release and this commit")
 
     # Perform make tasks
     make(f"{args.project_name}-test")


### PR DESCRIPTION
This is yet another attempt to stabilise CI with the internal_model deployment.

Here's my current best guess for what's going on, based on looking at https://buildkite.com/wellcomecollection/catalogue/builds/3342#0b14305c-7c3c-4b71-82e6-8309380ba8e2

Suppose we have the following sequence of commits:

<img width="748" alt="Screenshot 2021-03-09 at 09 40 14" src="https://user-images.githubusercontent.com/301220/110450812-754aad00-80bb-11eb-8fd0-81c528e5be98.png">

When you merge, we compare "merge commit" and "where you forked" – which shows up all the changes in both the yellow/square and green/triangle commits. This means that if there are changes to `internal_model` in the yellow/square commits, we'll run the `internal_model` task.

But the diff we really care about for checking a release note is between "current state of master" and "merge commit" – so let's re-check for relevant changes on the commit range we care about, before breaking a build for non-release note.