### PR TITLE
Case-insensitive matching on the UkLW prefix in 776

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -29,7 +29,10 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
   // This regex matches any string starting with (UkLW), followed by
   // any number of spaces, and then captures everything after the
   // space, which is the bib number we're interested in.
-  private val uklwPrefixRegex: Regex = """\(UkLW\)[\s]*(.+)""".r.anchored
+  //
+  // The UkLW match is case insensitive because there are sufficient
+  // inconsistencies in the source data that it's easier to handle that here.
+  private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
 
   /** We can merge a bib and the digitised version of that bib.  The number
     * of the other bib comes from MARC tag 776 subfield $w.

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -77,6 +77,21 @@ class SierraMergeCandidatesTest
       SierraMergeCandidates(sierraData) shouldBe Nil
     }
 
+    it("checks for the (UkLW) prefix case-insensitively") {
+      val casingVariations = List("UkLW", "uklw", "UkLw", "UKLW")
+      val sierraData = casingVariations.map { uklw =>
+        createSierraBibDataWith(
+          varFields = create776subfieldsWith(
+            ids = List(s"($uklw)$mergeCandidateBibNumber")
+          )
+        )
+      }
+      val mergeCandidates = sierraData.map(SierraMergeCandidates.apply)
+
+      every(mergeCandidates) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
+    }
+
     it("ignores values in 776$$w that aren't prefixed with (UkLW)") {
       val sierraData = createSierraBibDataWith(
         varFields = create776subfieldsWith(


### PR DESCRIPTION
Context: https://wellcome.slack.com/archives/C8X9YKM5X/p1615483335044200

The UkLW match is case insensitive because there are sufficient inconsistencies in the source data that it's easier to handle that here than to fix it in the source data. This was causing physical/digital Sierra bibs not to be linked due to the mergeCandidates not being picked up.