### PR TITLE
Big boost manifesto: bump boost bifold

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ColorQuery.scala
@@ -33,7 +33,7 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
         maxQueryTerms = Some(1000),
         minShouldMatch = Some("1")
       )
-      .boost(1000)
+      .boost(2000)
 
   // This replicates the logic in palette_encoder.py:get_bin_index
   private def getColorsSignature(colors: Seq[ColorQuery.Hsv],


### PR DESCRIPTION
Following up from https://github.com/wellcomecollection/catalogue/pull/1444, we thought it might be worth making the colour term dominate even other boosted query components