### PR TITLE
Tweak how we transform the holdings data

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksIncludesTest.scala
@@ -815,7 +815,6 @@ class WorksIncludesTest
     def createHoldings(count: Int): List[Holdings] =
       (1 to count).map { _ =>
         Holdings(
-          description = chooseFrom(None, Some(randomAlphanumeric())),
           note = chooseFrom(None, Some(randomAlphanumeric())),
           enumeration =
             collectionOf(min = 0, max = 10) { randomAlphanumeric() }.toList,

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/DisplayHoldings.scala
@@ -10,9 +10,6 @@ import uk.ac.wellcome.models.work.internal.Holdings
 )
 case class DisplayHoldings(
   @Schema(
-    description = "A textual description of the holdings."
-  ) description: Option[String],
-  @Schema(
     description = "Additional information about the holdings."
   ) note: Option[String],
   @Schema(
@@ -28,7 +25,6 @@ case class DisplayHoldings(
 case object DisplayHoldings {
   def apply(h: Holdings): DisplayHoldings =
     DisplayHoldings(
-      description = h.description,
       note = h.note,
       enumeration = h.enumeration,
       locations = h.locations.map { DisplayLocation(_) }

--- a/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/uk/ac/wellcome/display/models/DisplaySerialisationTestBase.scala
@@ -306,7 +306,6 @@ trait DisplaySerialisationTestBase {
   def singleHoldings(h: Holdings): String =
     s"""
        |{
-       |  ${optionalString("description", h.description)}
        |  ${optionalString("note", h.note)}
        |  "enumeration": [
        |    ${h.enumeration

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Holdings.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/Holdings.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.models.work.internal
 
 case class Holdings(
-  description: Option[String],
   note: Option[String],
   enumeration: List[String],
   locations: List[PhysicalLocation]

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -61,7 +61,12 @@ object SierraHoldings extends SierraQueryOps {
             SierraElectronicResources(id, data.varFields)
         }
 
-    (digitalItems, physicalHoldings)
+    // Note: holdings records are sparsely populated, and a lot of the information is
+    // in fields we don't expose to the public.
+    //
+    // Since we also don't identify the Holdings objects we create, we may end up
+    // with duplicates in the transformer output.  This isn't useful, so remove them.
+    (digitalItems, physicalHoldings.distinct)
   }
 
   private def createPhysicalHoldings(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -87,18 +87,25 @@ object SierraHoldings extends SierraQueryOps {
       .map { _.content }
       .mkString(" ")
 
-    val enumeration = SierraHoldingsEnumeration(id, data.varFields)
+    // We prepend the description from 866 ǂa to the list of enumerations because
+    // often this field contains the first line of the enumeration, and it simplifies
+    // the display logic.  They were also presented together on wellcomelibrary.org.
+    val enumeration =
+      if (description.nonEmpty) {
+        List(description) ++ SierraHoldingsEnumeration(id, data.varFields)
+      } else {
+        SierraHoldingsEnumeration(id, data.varFields)
+      }
 
     val locations = List(createLocation(id, data)).flatten
 
     // We should only create the Holdings object if we have some interesting data
     // to include; otherwise we don't.
-    val isNonEmpty = description.nonEmpty || note.nonEmpty || enumeration.nonEmpty
+    val isNonEmpty = note.nonEmpty || enumeration.nonEmpty
 
     if (isNonEmpty) {
       Some(
         Holdings(
-          description = if (description.nonEmpty) Some(description) else None,
           note = if (note.nonEmpty) Some(note) else None,
           enumeration = enumeration,
           locations = locations

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -360,7 +360,7 @@ class SierraHoldingsTest
 
       val holdings = getHoldings(dataMap)
       holdings should have size 1
-      holdings.head.description shouldBe Some("Vol. 3 only")
+      holdings.head.enumeration shouldBe List("Vol. 3 only")
       holdings.head.note shouldBe None
     }
 
@@ -385,11 +385,11 @@ class SierraHoldingsTest
 
       val holdings = getHoldings(dataMap)
       holdings should have size 1
-      holdings.head.description shouldBe None
+      holdings.head.enumeration shouldBe empty
       holdings.head.note shouldBe Some("Another note about the document")
     }
 
-    it("sets both the note and the description") {
+    it("uses both the note and the description") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "866",
@@ -413,7 +413,7 @@ class SierraHoldingsTest
 
       val holdings = getHoldings(dataMap)
       holdings should have size 1
-      holdings.head.description shouldBe Some("Missing Vol. 2")
+      holdings.head.enumeration shouldBe List("Missing Vol. 2")
       holdings.head.note shouldBe Some("Lost in a mysterious fishing accident")
     }
 
@@ -600,10 +600,10 @@ class SierraHoldingsTest
 
       val holdings = getHoldings(dataMap)
       holdings should have size 3
-      holdings.map { _.description } shouldBe Seq(
-        Some("Vol. 1 only"),
-        Some("Vol. 2 only"),
-        Some("Vol. 3 only"),
+      holdings.map { _.enumeration } shouldBe Seq(
+        List("Vol. 1 only"),
+        List("Vol. 2 only"),
+        List("Vol. 3 only"),
       )
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -551,8 +551,7 @@ class SierraHoldingsTest
       locations.head.shelfmark shouldBe Some("/MED")
     }
 
-    it(
-      "skips adding a location if the location code in fixed field 40 is unrecognised") {
+    it("skips adding a location if the location code is unrecognised") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "866",

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -608,6 +608,32 @@ class SierraHoldingsTest
       )
     }
 
+    it("de-duplicates holdings after transformation") {
+      val dataMap = (1 to 3).map { _ =>
+        val varFields = List(
+          createVarFieldWith(
+            marcTag = "866",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "Complete set")
+            )
+          )
+        )
+
+        val holdingsData = SierraHoldingsData(
+          fixedFields =
+            Map("40" -> FixedField(label = "LOCATION", value = "stax ")),
+          varFields = varFields
+        )
+
+        createSierraHoldingsNumber -> holdingsData
+      }.toMap
+
+      getItems(dataMap) shouldBe empty
+
+      val holdings = getHoldings(dataMap)
+      holdings should have size 1
+    }
+
     it("skips holdings that are deleted") {
       val varFields = List(
         createVarFieldWith(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1038,9 +1038,8 @@ class SierraTransformerTest
 
       work.data.holdings shouldBe List(
         Holdings(
-          description = Some("A Jubilant Journal"),
           note = None,
-          enumeration = List(),
+          enumeration = List("A Jubilant Journal"),
           locations = List(
             PhysicalLocation(
               locationType = ClosedStores,


### PR DESCRIPTION
* Remove the `description`; add its value as another entry in `enumeration`. Often they contain similar-looking data, and this makes it easier for the front-end to render. Closes https://github.com/wellcomecollection/platform/issues/5082
* De-duplicate holdings records. A lot of the holdings data is private info we don't expose in the transformed Work, so we can de-duplicate safely. Closes https://github.com/wellcomecollection/platform/issues/5083