### PR TITLE
Give the METS adapter permission to talk to the Internet

### DIFF
--- a/calm_adapter/terraform/adapter_worker.tf
+++ b/calm_adapter/terraform/adapter_worker.tf
@@ -39,6 +39,10 @@ module "adapter_worker" {
   shared_logging_secrets   = local.shared_logging_secrets
   elastic_cloud_vpce_sg_id = local.elastic_cloud_vpce_sg_id
 
+  security_group_ids = [
+    aws_security_group.egress.id,
+  ]
+
   deployment_service_env  = local.release_label
   deployment_service_name = "calm-adapter"
 }

--- a/calm_adapter/terraform/security_groups.tf
+++ b/calm_adapter/terraform/security_groups.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "egress" {
+  name        = "${local.namespace}_egress"
+  description = "Allows all egress traffic from the group"
+  vpc_id      = local.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/mets_adapter/terraform/security_groups.tf
+++ b/mets_adapter/terraform/security_groups.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "egress" {
+  name        = "${local.namespace}_egress"
+  description = "Allows all egress traffic from the group"
+  vpc_id      = local.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/mets_adapter/terraform/worker.tf
+++ b/mets_adapter/terraform/worker.tf
@@ -27,5 +27,9 @@ module "worker" {
   subnets                = local.private_subnets
   shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
 
+  security_group_ids = [
+    aws_security_group.egress.id
+  ]
+
   elastic_cloud_vpce_sg_id = data.terraform_remote_state.shared_infra.outputs.ec_platform_privatelink_sg_id
 }


### PR DESCRIPTION
Previously it was failing at startup, with an error that sounded like it couldn't talk to Secrets Manager.  It was the same error in this Stack Overflow question: https://stackoverflow.com/q/61265108/1558022

AFAICT, the previous version had no way to contact the public Internet -- including both Secrets Manager and the storage service.  I'm not quite sure how that happened, but it seems to be working now.