### PR TITLE
Trim a single trailing period from Sierra subjects

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -74,9 +74,8 @@ object Agent {
     Agent(IdState.Unidentifiable, label)
 
   def normalised[State >: IdState.Unidentifiable.type](
-    label: String): Agent[State] = {
+    label: String): Agent[State] =
     Agent(label.trimTrailing(','))
-  }
 }
 
 case class Organisation[+State](

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -21,7 +21,7 @@ object Concept {
 
   def normalised[State](id: State = IdState.Unidentifiable,
                         label: String): Concept[State] =
-    Concept(id, trimTrailing(label, '.'))
+    Concept(id, label.trimTrailing('.'))
 }
 
 case class Period[+State](
@@ -38,7 +38,7 @@ object Period {
 
   def apply[State >: IdState.Unidentifiable.type](
     label: String): Period[State] = {
-    val normalisedLabel = trimTrailing(label, '.')
+    val normalisedLabel = label.trimTrailing('.')
     Period(
       IdState.Unidentifiable,
       normalisedLabel,
@@ -57,7 +57,7 @@ object Place {
 
   def normalised[State >: IdState.Unidentifiable.type](
     label: String): Place[State] =
-    Place(trimTrailing(label, ':'))
+    Place(label.trimTrailing(':'))
 }
 
 sealed trait AbstractAgent[+State] extends AbstractRootConcept[State] {
@@ -75,7 +75,7 @@ object Agent {
 
   def normalised[State >: IdState.Unidentifiable.type](
     label: String): Agent[State] = {
-    Agent(trimTrailing(label, ','))
+    Agent(label.trimTrailing(','))
   }
 }
 
@@ -91,7 +91,7 @@ object Organisation {
 
   def normalised[State >: IdState.Unidentifiable.type](
     label: String): Organisation[State] =
-    Organisation(trimTrailing(label, ','))
+    Organisation(label.trimTrailing(','))
 }
 
 case class Person[+State](
@@ -113,7 +113,7 @@ object Person {
   ): Person[State] =
     Person(
       id = IdState.Unidentifiable,
-      label = trimTrailing(label, ','),
+      label = label.trimTrailing(','),
       prefix = prefix,
       numeration = numeration)
 }
@@ -130,5 +130,5 @@ object Meeting {
 
   def normalised[State >: IdState.Unidentifiable.type](
     label: String): Meeting[State] =
-    Meeting(trimTrailing(label, ','))
+    Meeting(label.trimTrailing(','))
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/internal/AbstractRootConcept.scala
@@ -21,7 +21,7 @@ object Concept {
 
   def normalised[State](id: State = IdState.Unidentifiable,
                         label: String): Concept[State] =
-    Concept(id, label.trimTrailing('.'))
+    Concept(id, label.trimTrailingPeriod)
 }
 
 case class Period[+State](
@@ -38,7 +38,7 @@ object Period {
 
   def apply[State >: IdState.Unidentifiable.type](
     label: String): Period[State] = {
-    val normalisedLabel = label.trimTrailing('.')
+    val normalisedLabel = label.trimTrailingPeriod
     Period(
       IdState.Unidentifiable,
       normalisedLabel,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
@@ -3,11 +3,12 @@ package uk.ac.wellcome.models.work.text
 import scala.util.matching.Regex
 
 object TextNormalisation {
-  def trimTrailing(s: String, c: Char): String = {
-    // remove the given character and surrounding whitespace from the end of the String
-    // regexp = <any whitespace>c<any whitespace><end> = "\s*[c]\s*$"
-    val regexp = """\s*[""" + Regex.quote(c.toString) + """]\s*$"""
-    s.replaceAll(regexp, "")
+  implicit class TextNormalisationOps(s: String) {
+    /** Remove the given character and any surrounding whitespace */
+    def trimTrailing(c: Char): String = {
+      val regexp = """\s*[""" + Regex.quote(c.toString) + """]\s*$"""
+      s.replaceAll(regexp, "")
+    }
   }
 
   def sentenceCase(s: String): String =

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
@@ -10,6 +10,12 @@ object TextNormalisation {
       s.replaceAll(regexp, "")
     }
 
+    /** Remove a single trailing period, but not ellipses */
+    def trimTrailingPeriod: String =
+      s
+        .replaceAll("""([^\.])\.\s*$""", "$1")
+        .replaceAll("""\s*$""", "")
+
     def sentenceCase: String =
       s.capitalize
   }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
@@ -9,8 +9,8 @@ object TextNormalisation {
       val regexp = """\s*[""" + Regex.quote(c.toString) + """]\s*$"""
       s.replaceAll(regexp, "")
     }
-  }
 
-  def sentenceCase(s: String): String =
-    s.capitalize
+    def sentenceCase: String =
+      s.capitalize
+  }
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/work/text/TextNormalisation.scala
@@ -4,6 +4,7 @@ import scala.util.matching.Regex
 
 object TextNormalisation {
   implicit class TextNormalisationOps(s: String) {
+
     /** Remove the given character and any surrounding whitespace */
     def trimTrailing(c: Char): String = {
       val regexp = """\s*[""" + Regex.quote(c.toString) + """]\s*$"""
@@ -12,8 +13,7 @@ object TextNormalisation {
 
     /** Remove a single trailing period, but not ellipses */
     def trimTrailingPeriod: String =
-      s
-        .replaceAll("""([^\.])\.\s*$""", "$1")
+      s.replaceAll("""([^\.])\.\s*$""", "$1")
         .replaceAll("""\s*$""", "")
 
     def sentenceCase: String =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
@@ -71,7 +71,7 @@ class TextNormalisationTest extends AnyFunSpec with Matchers {
     it("doesn't remove an ellipsis") {
       val examples = Table(
         ("text...", "text..."),
-        ("text... ", "text... ")
+        ("text... ", "text...")
       )
       forAll(examples) { (i: String, o: String) =>
         i.trimTrailingPeriod shouldBe o

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.text.TextNormalisation._
 
-class textNormalisationTest extends AnyFunSpec with Matchers {
+class TextNormalisationTest extends AnyFunSpec with Matchers {
   describe("trimTrailing") {
     it("removes trailing character") {
       val examples = Table(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/TextNormalisationTest.scala
@@ -54,6 +54,31 @@ class TextNormalisationTest extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("trimTrailingPeriod") {
+    it("removes a single trailing period") {
+      val examples = Table(
+        ("text", "text"),
+        ("text.", "text"),
+        (" text. ", " text"),
+        ("text. ", "text"),
+        ("text . ", "text"),
+      )
+      forAll(examples) { (i: String, o: String) =>
+        i.trimTrailingPeriod shouldBe o
+      }
+    }
+
+    it("doesn't remove an ellipsis") {
+      val examples = Table(
+        ("text...", "text..."),
+        ("text... ", "text... ")
+      )
+      forAll(examples) { (i: String, o: String) =>
+        i.trimTrailingPeriod shouldBe o
+      }
+    }
+  }
+
   describe("sentenceCase") {
     it("converts to sentence case") {
       val examples = Table(

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/textNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/textNormalisationTest.scala
@@ -38,7 +38,7 @@ class textNormalisationTest extends AnyFunSpec with Matchers {
         ("a title ... with .... ", "a title ... with ...")
       )
       forAll(examples) { (i: String, o: String) =>
-        trimTrailing(i, '.') shouldBe o
+        i.trimTrailing('.') shouldBe o
       }
     }
 
@@ -49,7 +49,7 @@ class textNormalisationTest extends AnyFunSpec with Matchers {
         ("text^", '^')
       )
       forAll(examples) { (i: String, c: Char) =>
-        trimTrailing(i, c) shouldBe "text"
+        i.trimTrailing(c) shouldBe "text"
       }
     }
   }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/textNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/internal/text/textNormalisationTest.scala
@@ -66,7 +66,7 @@ class textNormalisationTest extends AnyFunSpec with Matchers {
         ("Text teXT", "Text teXT")
       )
       forAll(examples) { (i: String, o: String) =>
-        sentenceCase(i) shouldBe o
+        i.sentenceCase shouldBe o
       }
     }
   }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
@@ -2,14 +2,14 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.models.work.text.TextNormalisation.sentenceCase
+import uk.ac.wellcome.models.work.text.TextNormalisation._
 
 trait MiroGenres {
   def getGenres(miroRecord: MiroRecord): List[Genre[IdState.Unminted]] =
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroRecord.physFormat.toList ++ miroRecord.lcGenre.toList).map { label =>
-      val normalisedLabel = sentenceCase(label)
+      val normalisedLabel = label.sentenceCase
       Genre.normalised(
         label = normalisedLabel,
         concepts = List(Concept.normalised(label = normalisedLabel))

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroSubjects.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroSubjects.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.models.work.internal._
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.models.work.text.TextNormalisation.sentenceCase
+import uk.ac.wellcome.models.work.text.TextNormalisation._
 
 trait MiroSubjects {
 
@@ -26,7 +26,7 @@ trait MiroSubjects {
       }
 
     (keywords ++ keywordsUnauth).map { keyword =>
-      val normalisedLabel = sentenceCase(keyword)
+      val normalisedLabel = keyword.sentenceCase
       Subject(
         label = normalisedLabel,
         concepts = List(Concept(normalisedLabel))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.text.TextNormalisation._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraQueryOps,
@@ -15,7 +16,7 @@ trait SierraConcepts extends SierraQueryOps {
   protected def getLabel(primarySubfields: List[MarcSubfield],
                          subdivisionSubfields: List[MarcSubfield]): String = {
     val orderedSubfields = primarySubfields ++ subdivisionSubfields
-    orderedSubfields.map { _.content }.mkString(" - ")
+    orderedSubfields.map { _.content }.mkString(" - ").trimTrailingPeriod
   }
 
   /** Return a list of the distinct contents of every subfield 0 on

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
 import uk.ac.wellcome.models.work.internal._
+import uk.ac.wellcome.models.work.text.TextNormalisation._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField
@@ -81,10 +82,12 @@ object SierraConceptSubjects
     primarySubfields: List[MarcSubfield],
     varField: VarField): List[AbstractConcept[IdState.Unminted]] =
     primarySubfields.map { subfield =>
+      val label = subfield.content.trimTrailingPeriod
+
       varField.marcTag.get match {
-        case "650" => Concept(label = subfield.content)
-        case "648" => Period(label = subfield.content)
-        case "651" => Place(label = subfield.content)
+        case "650" => Concept(label = label)
+        case "648" => Period(label = label)
+        case "651" => Place(label = label)
       }
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   VarField
 }
 import uk.ac.wellcome.models.work.internal.{IdState, Subject}
+import uk.ac.wellcome.models.work.text.TextNormalisation._
 import weco.catalogue.sierra_adapter.models.SierraBibNumber
 
 trait SierraSubjectsTransformer
@@ -37,4 +38,5 @@ trait SierraSubjectsTransformer
       .subfieldsWithTags(subfieldTags: _*)
       .contents
       .mkString(" ")
+      .trimTrailingPeriod
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -350,4 +350,19 @@ class SierraConceptSubjectsTest
 
     SierraConceptSubjects(bibId, bibData) shouldBe Nil
   }
+
+  it("removes a trailing period from a subject label") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "650",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Diet, Food, and Nutrition.")
+          )
+        )
+      )
+    )
+
+    SierraConceptSubjects(bibId, bibData) shouldBe List(Subject("Diet, Food, and Nutrition", concepts = List(Concept("Diet, Food, and Nutrition"))))
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -363,6 +363,9 @@ class SierraConceptSubjectsTest
       )
     )
 
-    SierraConceptSubjects(bibId, bibData) shouldBe List(Subject("Diet, Food, and Nutrition", concepts = List(Concept("Diet, Food, and Nutrition"))))
+    SierraConceptSubjects(bibId, bibData) shouldBe List(
+      Subject(
+        "Diet, Food, and Nutrition",
+        concepts = List(Concept("Diet, Food, and Nutrition"))))
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
@@ -36,7 +36,7 @@ class SierraOrganisationSubjectsTest
       val subjects = getOrganisationSubjects(bibData)
       subjects should have size 1
 
-      subjects.head.label shouldBe "United States. Supreme Court, Washington, DC. September 29, 2005, pictured."
+      subjects.head.label shouldBe "United States. Supreme Court, Washington, DC. September 29, 2005, pictured"
     }
 
     it("uses repeated subfields for the label if necessary") {
@@ -54,7 +54,7 @@ class SierraOrganisationSubjectsTest
       val subjects = getOrganisationSubjects(bibData)
       subjects should have size 1
 
-      subjects.head.label shouldBe "United States. Army. Cavalry, 7th. Company E, depicted."
+      subjects.head.label shouldBe "United States. Army. Cavalry, 7th. Company E, depicted"
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -308,4 +308,21 @@ class SierraPersonSubjectsTest
       subject.label shouldBe "Aristophanes. Birds."
     }
   }
+
+  it("doesn't remove a trailing ellipsis from a subject label") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "600",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Agate, John,"),
+            MarcSubfield(tag = "d", content = "1676-1720."),
+            MarcSubfield(tag = "t", content = "Sermon preach'd at Exeter, on the 30th of January ...")
+          )
+        )
+      )
+    )
+
+    SierraPersonSubjects(bibId, bibData) shouldBe List(Subject("Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ...", concepts = List(Person("Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ..."))))
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -317,12 +317,19 @@ class SierraPersonSubjectsTest
           subfields = List(
             MarcSubfield(tag = "a", content = "Agate, John,"),
             MarcSubfield(tag = "d", content = "1676-1720."),
-            MarcSubfield(tag = "t", content = "Sermon preach'd at Exeter, on the 30th of January ...")
+            MarcSubfield(
+              tag = "t",
+              content = "Sermon preach'd at Exeter, on the 30th of January ...")
           )
         )
       )
     )
 
-    SierraPersonSubjects(bibId, bibData) shouldBe List(Subject("Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ...", concepts = List(Person("Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ..."))))
+    SierraPersonSubjects(bibId, bibData) shouldBe List(
+      Subject(
+        "Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ...",
+        concepts = List(Person(
+          "Agate, John, 1676-1720. Sermon preach'd at Exeter, on the 30th of January ..."))
+      ))
   }
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/catalogue/issues/1471

This does a bit more tidying up – removing a single trailing period from subject labels and the associated concepts. It's based on two examples (one from Nicola in the platform-feedback channel, one I found while looking through a snapshot).

I imagine we'll find more examples of things that need fixing, so this is "one more step" rather than "completely done".