### PR TITLE
Better handling of non b numbers in 776 subfield $w

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -119,7 +119,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
 
     WorkData[DataState.Unidentified](
       otherIdentifiers = SierraIdentifiers(bibId, bibData),
-      mergeCandidates = SierraMergeCandidates(bibData),
+      mergeCandidates = SierraMergeCandidates(bibId, bibData),
       title = SierraTitle(bibData),
       alternativeTitles = SierraAlternativeTitles(bibData),
       format = SierraFormat(bibData),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -40,18 +40,21 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
     * If the identifier starts with (UkLW), we strip the prefix and use the
     * bib number as a merge candidate.
     *
+    * We ignore any values in 776 subfield ǂw that don't start with (UkLW),
+    * e.g. identifiers that start (OCLC).
+    *
     */
   private def get776mergeCandidates(
     bibData: SierraBibData): List[MergeCandidate[Identifiable]] =
     bibData
       .subfieldsWithTag("776" -> "w")
       .contents
-      .map {
+      .flatMap {
         case uklwPrefixRegex(bibNumber) => Some(bibNumber)
         case _                          => None
       }
       .distinct match {
-      case List(Some(bibNumber)) =>
+      case List(bibNumber) =>
         List(
           MergeCandidate(
             identifier = SourceIdentifier(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -45,15 +45,18 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
     *
     */
   private def get776mergeCandidates(
-    bibData: SierraBibData): List[MergeCandidate[Identifiable]] =
-    bibData
-      .subfieldsWithTag("776" -> "w")
-      .contents
-      .flatMap {
-        case uklwPrefixRegex(bibNumber) => Some(bibNumber)
-        case _                          => None
-      }
-      .distinct match {
+    bibData: SierraBibData): List[MergeCandidate[Identifiable]] = {
+
+    val identifiers =
+      bibData
+        .subfieldsWithTag("776" -> "w")
+        .contents
+        .flatMap {
+          case uklwPrefixRegex(bibNumber) => Some(bibNumber)
+          case _                          => None
+        }
+
+    identifiers.distinct match {
       case List(bibNumber) =>
         List(
           MergeCandidate(
@@ -67,6 +70,7 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
         )
       case _ => Nil
     }
+  }
 
   /*
    * We always try to merge all linked Miro and Sierra works

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import grizzled.slf4j.Logging
 import uk.ac.wellcome.models.work.internal.IdState.Identifiable
 
 import java.util.UUID
@@ -13,16 +14,17 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraQueryOps
 }
 import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.MiroIdParsing
+import weco.catalogue.sierra_adapter.models.SierraBibNumber
 
 import scala.util.Try
 import scala.util.matching.Regex
 
-object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
+object SierraMergeCandidates extends SierraIdentifiedDataTransformer with SierraQueryOps with Logging {
 
   type Output = List[MergeCandidate[Identifiable]]
 
-  def apply(bibData: SierraBibData) =
-    get776mergeCandidates(bibData) ++
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
+    get776mergeCandidates(bibId, bibData) ++
       getSinglePageMiroMergeCandidates(bibData) ++ get035CalmMergeCandidates(
       bibData)
 
@@ -33,6 +35,8 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
   // The UkLW match is case insensitive because there are sufficient
   // inconsistencies in the source data that it's easier to handle that here.
   private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
+
+  private val bnumberRegex: Regex = """b[0-9]{7}[0-9x]""".r.anchored
 
   /** We can merge a bib and the digitised version of that bib.  The number
     * of the other bib comes from MARC tag 776 subfield $w.
@@ -45,6 +49,7 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
     *
     */
   private def get776mergeCandidates(
+    bibId: SierraBibNumber,
     bibData: SierraBibData): List[MergeCandidate[Identifiable]] = {
 
     val identifiers =
@@ -52,8 +57,16 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
         .subfieldsWithTag("776" -> "w")
         .contents
         .flatMap {
-          case uklwPrefixRegex(bibNumber) => Some(bibNumber)
+          case uklwPrefixRegex(bibNumber) => Some(bibNumber.trim)
           case _                          => None
+        }
+        .filter { s =>
+          bnumberRegex.findFirstIn(s) match {
+            case Some(_) => true
+            case None =>
+              warn(s"$bibId: not a b number in field 776 subfield ǂw: $s")
+              false
+          }
         }
 
     identifiers.distinct match {
@@ -63,7 +76,7 @@ object SierraMergeCandidates extends SierraDataTransformer with SierraQueryOps {
             identifier = SourceIdentifier(
               identifierType = IdentifierType("sierra-system-number"),
               ontologyType = "Work",
-              value = bibNumber.trim
+              value = bibNumber
             ),
             reason = "Physical/digitised Sierra work"
           )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -19,7 +19,10 @@ import weco.catalogue.sierra_adapter.models.SierraBibNumber
 import scala.util.Try
 import scala.util.matching.Regex
 
-object SierraMergeCandidates extends SierraIdentifiedDataTransformer with SierraQueryOps with Logging {
+object SierraMergeCandidates
+    extends SierraIdentifiedDataTransformer
+    with SierraQueryOps
+    with Logging {
 
   type Output = List[MergeCandidate[Identifiable]]
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -28,7 +28,8 @@ class SierraMergeCandidatesTest
   val mergeCandidateBibNumber = "b21414440"
   val miroID = "A0123456"
 
-  def getMergeCandidates(bibData: SierraBibData): List[MergeCandidate[Identifiable]] =
+  def getMergeCandidates(
+    bibData: SierraBibData): List[MergeCandidate[Identifiable]] =
     SierraMergeCandidates(createSierraBibNumber, bibData)
 
   describe("physical/digital Sierra work") {
@@ -274,7 +275,8 @@ class SierraMergeCandidatesTest
           create962subfieldsForWellcomeImageUrl(miroID)
       )
 
-      getMergeCandidates(bibData) should contain theSameElementsAs miroMergeCandidate(miroID)
+      getMergeCandidates(bibData) should contain theSameElementsAs miroMergeCandidate(
+        miroID)
     }
 
     it(
@@ -327,16 +329,14 @@ class SierraMergeCandidatesTest
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val bibData = bibDataWith035(calmIds)
 
-      getMergeCandidates(bibData) shouldBe calmIds.map(
-        createCalmMergeCandidate)
+      getMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
     }
     it("dedupes Calm IDs and adds as mergeCandidates") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
 
       val bibData = bibDataWith035(calmIds ++ calmIds)
 
-      getMergeCandidates(bibData) shouldBe calmIds.map(
-        createCalmMergeCandidate)
+      getMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
     }
     it(
       "creates calm merge candidates if it has a mix of calm and non calm identifiers") {
@@ -344,8 +344,7 @@ class SierraMergeCandidatesTest
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds ++ calmIds)
 
-      getMergeCandidates(bibData) shouldBe calmIds.map(
-        createCalmMergeCandidate)
+      getMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
     }
     it("doesn't create merge candidates if there are no calm ids") {
       val otherIds = (1 to 5).map(_.toString)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -28,6 +28,9 @@ class SierraMergeCandidatesTest
   val mergeCandidateBibNumber = "b21414440"
   val miroID = "A0123456"
 
+  def getMergeCandidates(bibData: SierraBibData): List[MergeCandidate[Identifiable]] =
+    SierraMergeCandidates(createSierraBibNumber, bibData)
+
   describe("physical/digital Sierra work") {
     it("extracts the bib number in 776$$w as a mergeCandidate") {
       val sierraData = createSierraBibDataWith(
@@ -36,7 +39,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(sierraData) shouldBe
+      getMergeCandidates(sierraData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -47,7 +50,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(sierraData) shouldBe
+      getMergeCandidates(sierraData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -58,7 +61,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(sierraData) shouldBe
+      getMergeCandidates(sierraData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -74,7 +77,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(sierraData) shouldBe Nil
+      getMergeCandidates(sierraData) shouldBe Nil
     }
 
     it("checks for the (UkLW) prefix case-insensitively") {
@@ -86,7 +89,7 @@ class SierraMergeCandidatesTest
           )
         )
       }
-      val mergeCandidates = sierraData.map(SierraMergeCandidates.apply)
+      val mergeCandidates = sierraData.map(getMergeCandidates)
 
       every(mergeCandidates) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
@@ -99,7 +102,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(sierraData) shouldBe Nil
+      getMergeCandidates(sierraData) shouldBe Nil
     }
 
     it(
@@ -110,7 +113,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) shouldBe Nil
+      getMergeCandidates(bibData) shouldBe Nil
     }
 
     it(
@@ -125,7 +128,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) shouldBe
+      getMergeCandidates(bibData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
 
@@ -139,7 +142,21 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) shouldBe
+      getMergeCandidates(bibData) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
+    }
+
+    it("ignores values that aren't b numbers") {
+      val bibData = createSierraBibDataWith(
+        varFields = create776subfieldsWith(
+          ids = List(
+            s"(UkLW)bxxxxxxxx",
+            s"(UkLW)$mergeCandidateBibNumber",
+          )
+        )
+      )
+
+      getMergeCandidates(bibData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
   }
@@ -150,8 +167,7 @@ class SierraMergeCandidatesTest
         urls = List(s"http://wellcomeimages.org/indexplus/image/$miroID.html")
       )
 
-      SierraMergeCandidates(bibData) shouldBe
-        miroMergeCandidate(miroID)
+      getMergeCandidates(bibData) shouldBe miroMergeCandidate(miroID)
     }
 
     it(
@@ -163,7 +179,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) should contain theSameElementsAs (
+      getMergeCandidates(bibData) should contain theSameElementsAs (
         miroMergeCandidate(miroID) ++ miroMergeCandidate("B0000001")
       )
     }
@@ -176,8 +192,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) shouldBe
-        miroMergeCandidate(miroID)
+      getMergeCandidates(bibData) shouldBe miroMergeCandidate(miroID)
     }
 
     it("does not create a merge candidate if the URL is unrecognised") {
@@ -186,7 +201,7 @@ class SierraMergeCandidatesTest
           "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
       )
 
-      SierraMergeCandidates(bibData) shouldBe Nil
+      getMergeCandidates(bibData) shouldBe Nil
     }
 
     it("creates a merge candidate if the material type is 'Picture'") {
@@ -197,7 +212,7 @@ class SierraMergeCandidatesTest
         )
       )
 
-      SierraMergeCandidates(bibData) shouldBe miroMergeCandidate(miroID)
+      getMergeCandidates(bibData) shouldBe miroMergeCandidate(miroID)
     }
 
     // - - - - - - -  089 fields - - - - - - -
@@ -207,7 +222,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
-      SierraMergeCandidates(bibData) shouldBe miroMergeCandidate(
+      getMergeCandidates(bibData) shouldBe miroMergeCandidate(
         miroID = "V0013889")
     }
 
@@ -217,7 +232,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
-      SierraMergeCandidates(bibData) shouldBe miroMergeCandidate(
+      getMergeCandidates(bibData) shouldBe miroMergeCandidate(
         miroID = "V0013889")
     }
 
@@ -226,7 +241,7 @@ class SierraMergeCandidatesTest
         varFields = create089subfieldsWith(List("V 13889", "V 12"))
       )
 
-      SierraMergeCandidates(bibData) should contain theSameElementsAs (
+      getMergeCandidates(bibData) should contain theSameElementsAs (
         miroMergeCandidate("V0013889") ++ miroMergeCandidate("V0000012")
       )
     }
@@ -238,7 +253,7 @@ class SierraMergeCandidatesTest
             ++ create089subfieldsWith(List("V 13889"))
       )
 
-      SierraMergeCandidates(bibData) should contain theSameElementsAs
+      getMergeCandidates(bibData) should contain theSameElementsAs
         miroMergeCandidate(miroID) ++ miroMergeCandidate("V0013889")
     }
 
@@ -249,7 +264,7 @@ class SierraMergeCandidatesTest
           create962subfieldsForWellcomeImageUrl("V0036036EL")
       )
 
-      SierraMergeCandidates(bibData) should contain theSameElementsAs
+      getMergeCandidates(bibData) should contain theSameElementsAs
         miroMergeCandidate("V0036036EL")
     }
 
@@ -259,8 +274,7 @@ class SierraMergeCandidatesTest
           create962subfieldsForWellcomeImageUrl(miroID)
       )
 
-      val result = SierraMergeCandidates(bibData)
-      result should contain theSameElementsAs miroMergeCandidate(miroID)
+      getMergeCandidates(bibData) should contain theSameElementsAs miroMergeCandidate(miroID)
     }
 
     it(
@@ -270,7 +284,7 @@ class SierraMergeCandidatesTest
           create962subfieldsForWellcomeImageUrl("V0012345EBR")
       )
 
-      SierraMergeCandidates(bibData) should contain theSameElementsAs
+      getMergeCandidates(bibData) should contain theSameElementsAs
         miroMergeCandidate("V0036036") ++ miroMergeCandidate("V0012345EBR")
     }
   }
@@ -291,12 +305,12 @@ class SierraMergeCandidatesTest
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber) ++
           miroMergeCandidate(miroID)
 
-      SierraMergeCandidates(sierraData) shouldBe expectedMergeCandidates
+      getMergeCandidates(sierraData) shouldBe expectedMergeCandidates
     }
 
     it("returns an empty list if there is no MARC tag 776 or 962") {
       val sierraData = createSierraBibDataWith(varFields = List())
-      SierraMergeCandidates(sierraData) shouldBe Nil
+      getMergeCandidates(sierraData) shouldBe Nil
     }
   }
 
@@ -306,14 +320,14 @@ class SierraMergeCandidatesTest
       val calmId = randomUUID.toString
       val bibData = bibDataWith035(List(calmId))
 
-      SierraMergeCandidates(bibData) shouldBe List(
+      getMergeCandidates(bibData) shouldBe List(
         createCalmMergeCandidate(calmId))
     }
     it("adds multiple Calm IDs as mergeCandidates") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val bibData = bibDataWith035(calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+      getMergeCandidates(bibData) shouldBe calmIds.map(
         createCalmMergeCandidate)
     }
     it("dedupes Calm IDs and adds as mergeCandidates") {
@@ -321,7 +335,7 @@ class SierraMergeCandidatesTest
 
       val bibData = bibDataWith035(calmIds ++ calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+      getMergeCandidates(bibData) shouldBe calmIds.map(
         createCalmMergeCandidate)
     }
     it(
@@ -330,14 +344,14 @@ class SierraMergeCandidatesTest
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds ++ calmIds)
 
-      SierraMergeCandidates(bibData) shouldBe calmIds.map(
+      getMergeCandidates(bibData) shouldBe calmIds.map(
         createCalmMergeCandidate)
     }
     it("doesn't create merge candidates if there are no calm ids") {
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds)
 
-      SierraMergeCandidates(bibData) shouldBe Nil
+      getMergeCandidates(bibData) shouldBe Nil
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -128,6 +128,20 @@ class SierraMergeCandidatesTest
       SierraMergeCandidates(bibData) shouldBe
         physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
     }
+
+    it("ignores non-UkLW prefixed values") {
+      val bibData = createSierraBibDataWith(
+        varFields = create776subfieldsWith(
+          ids = List(
+            s"(OCLC)123456789",
+            s"(UkLW)$mergeCandidateBibNumber",
+          )
+        )
+      )
+
+      SierraMergeCandidates(bibData) shouldBe
+        physicalAndDigitalSierraMergeCandidate(mergeCandidateBibNumber)
+    }
   }
 
   describe("Miro/Sierra work") {


### PR DESCRIPTION
Victoria spotted a bug where two works weren't being merged correctly; it's because they had two values in 776 subfield $w, even though only one of them is the UkLW that we use for merging:

```
776 1  |iPrint version:|tThesaurus anatomicus primus [-decimus] 
       ... Het eerste [-tiende] anatomisch cabinet
       |w(OCoLC)28467848|w(UkLW)b1121837x 
```

This patch will cause the transformer to identify the single b number in this field, and also warn if we see values in this field that don't look like valid b numbers, because those need to be raised with Collections to be fixed at source.