### PR TITLE
Rename SourceWork to ParentWork

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/Implicits.scala
@@ -130,7 +130,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec62: Decoder[Work[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec63: Decoder[SourceWorks] =
+  implicit val _dec63: Decoder[ParentWorks] =
     deriveConfiguredDecoder
   implicit val _dec64: Decoder[ImageSource] =
     deriveConfiguredDecoder
@@ -258,7 +258,7 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc62: Encoder[Work[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc63: Encoder[SourceWorks] =
+  implicit val _enc63: Encoder[ParentWorks] =
     deriveConfiguredEncoder
   implicit val _enc64: Encoder[ImageSource] =
     deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
@@ -26,7 +26,7 @@ object DerivedImageData extends DerivedDataCommon {
 
   private def sourceContributorAgents(source: ImageSource): List[String] =
     source match {
-      case SourceWorks(canonicalWork, redirectedWork) =>
+      case ParentWorks(canonicalWork, redirectedWork) =>
         contributorAgentLabels(canonicalWork.data.contributors)
       case _ => Nil
     }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
@@ -8,27 +8,26 @@ sealed trait ImageSource {
   val version: Int
 }
 
-case class SourceWorks(
-  canonicalWork: SourceWork,
-  redirectedWork: Option[SourceWork] = None
+case class ParentWorks(
+  canonicalWork: ParentWork,
+  redirectedWork: Option[ParentWork] = None
 ) extends ImageSource {
   override val id = canonicalWork.id
   override val version =
     canonicalWork.version + redirectedWork.map(_.version).getOrElse(0)
 }
 
-case class SourceWork(
+case class ParentWork(
   id: IdState.Identified,
   data: WorkData[DataState.Identified],
   version: Int,
 )
 
-object SourceWork {
+object ParentWork {
 
-  implicit class MergedWorkToSourceWork(work: Work[WorkState.Merged]) {
-
-    def toSourceWork: SourceWork =
-      SourceWork(
+  implicit class MergedToParentWork(work: Work[WorkState.Merged]) {
+    def toParentWork: ParentWork =
+      ParentWork(
         id = IdState
           .Identified(work.state.canonicalId, work.state.sourceIdentifier),
         data = work.data,
@@ -36,10 +35,9 @@ object SourceWork {
       )
   }
 
-  implicit class IdentifiedWorkToSourceWork(work: Work[WorkState.Identified]) {
-
-    def toSourceWork: SourceWork =
-      SourceWork(
+  implicit class IdentifiedToParentWork(work: Work[WorkState.Identified]) {
+    def toParentWork: ParentWork =
+      ParentWork(
         id = IdState.Identified(
           sourceIdentifier = work.state.sourceIdentifier,
           canonicalId = work.state.canonicalId

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -68,15 +68,6 @@ trait ImageGenerators
           sourceIdentifier = imageData.id.sourceIdentifier
         )
       )
-    def toInitialImageWith(canonicalId: String = createCanonicalId,
-                           modifiedTime: Instant = instantInLast30Days,
-                           sourceWorks: SourceWorks = SourceWorks(
-                             canonicalWork = mergedWork().toSourceWork,
-                             redirectedWork = None
-                           )): Image[Initial] =
-      imageData
-        .toIdentifiedWith(canonicalId)
-        .toInitialImageWith(modifiedTime, sourceWorks)
 
     def toAugmentedImageWith(
       canonicalId: String = createCanonicalId,
@@ -109,7 +100,9 @@ trait ImageGenerators
           redirectedWork)
 
     def toIdentified = toIdentifiedWith()
-    def toInitialImage = toInitialImageWith()
+
+    def toInitialImage: Image[Initial] =
+      imageData.toIdentified.toInitialImage
 
     def toAugmentedImage = toAugmentedImageWith()
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -65,17 +65,16 @@ trait ImageGenerators
       parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = Some(
         sierraIdentifiedWork())): Image[ImageState.Augmented] =
-      imageData
-        .toIdentified
+      imageData.toIdentified
         .toAugmentedImageWith(
           inferredData = inferredData,
           parentWork = parentWork,
           redirectedWork = redirectedWork)
 
     def toIndexedImageWith(
-      inferredData: Option[InferredData] = createInferredData): Image[ImageState.Indexed] =
-      imageData
-        .toIdentified
+      inferredData: Option[InferredData] = createInferredData)
+      : Image[ImageState.Indexed] =
+      imageData.toIdentified
         .toIndexedImageWith(inferredData = inferredData)
 
     def toIdentified: ImageData[IdState.Identified] =
@@ -115,14 +114,12 @@ trait ImageGenerators
 
     def toAugmentedImageWith(
       inferredData: Option[InferredData] = createInferredData,
-      modifiedTime: Instant = instantInLast30Days,
       parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = Some(
         sierraIdentifiedWork())
     ): Image[ImageState.Augmented] =
       imageData
         .toInitialImageWith(
-          modifiedTime = modifiedTime,
           parentWorks = image.ParentWorks(
             canonicalWork = parentWork.toParentWork,
             redirectedWork = redirectedWork.map(_.toParentWork))
@@ -130,18 +127,10 @@ trait ImageGenerators
         .transition[ImageState.Augmented](inferredData)
 
     def toIndexedImageWith(
-      inferredData: Option[InferredData] = createInferredData,
-      modifiedTime: Instant = instantInLast30Days,
-      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = Some(
-        sierraIdentifiedWork())): Image[ImageState.Indexed] =
+      inferredData: Option[InferredData] = createInferredData)
+      : Image[ImageState.Indexed] =
       imageData
-        .toAugmentedImageWith(
-          modifiedTime = modifiedTime,
-          parentWork = parentWork,
-          redirectedWork = redirectedWork,
-          inferredData = inferredData
-        )
+        .toAugmentedImageWith(inferredData = inferredData)
         .transition[ImageState.Indexed]()
 
     def toInitialImage = toInitialImageWith()

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -3,7 +3,7 @@ package weco.catalogue.internal_model.generators
 import uk.ac.wellcome.models.work.generators._
 import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType}
 import weco.catalogue.internal_model.image
-import weco.catalogue.internal_model.image.SourceWork._
+import weco.catalogue.internal_model.image.ParentWork._
 import weco.catalogue.internal_model.image.ImageState.{Indexed, Initial}
 import weco.catalogue.internal_model.image._
 import weco.catalogue.internal_model.locations.{
@@ -113,15 +113,15 @@ trait ImageGenerators
     imageData: ImageData[IdState.Identified]) {
     def toInitialImageWith(
       modifiedTime: Instant = instantInLast30Days,
-      sourceWorks: SourceWorks = SourceWorks(
-        canonicalWork = mergedWork().toSourceWork,
+      parentWorks: ParentWorks = ParentWorks(
+        canonicalWork = mergedWork().toParentWork,
         redirectedWork = None
       )
     ): Image[ImageState.Initial] = Image[ImageState.Initial](
       version = imageData.version,
       locations = imageData.locations,
       modifiedTime = modifiedTime,
-      source = sourceWorks,
+      source = parentWorks,
       state = ImageState.Initial(
         sourceIdentifier = imageData.id.sourceIdentifier,
         canonicalId = imageData.id.canonicalId
@@ -138,9 +138,9 @@ trait ImageGenerators
       imageData
         .toInitialImageWith(
           modifiedTime = modifiedTime,
-          sourceWorks = image.SourceWorks(
-            canonicalWork = parentWork.toSourceWork,
-            redirectedWork = redirectedWork.map(_.toSourceWork))
+          parentWorks = image.ParentWorks(
+            canonicalWork = parentWork.toParentWork,
+            redirectedWork = redirectedWork.map(_.toParentWork))
         )
         .transition[ImageState.Augmented](inferredData)
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -60,46 +60,31 @@ trait ImageGenerators
   implicit class UnidentifiedImageDataOps(
     imageData: ImageData[IdState.Identifiable]) {
 
-    def toIdentifiedWith(
-      canonicalId: String = createCanonicalId): ImageData[IdState.Identified] =
-      imageData.copy(
-        id = IdState.Identified(
-          canonicalId = canonicalId,
-          sourceIdentifier = imageData.id.sourceIdentifier
-        )
-      )
-
     def toAugmentedImageWith(
-      canonicalId: String = createCanonicalId,
       inferredData: Option[InferredData] = createInferredData,
-      modifiedTime: Instant = instantInLast30Days,
       parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = Some(
         sierraIdentifiedWork())): Image[ImageState.Augmented] =
       imageData
-        .toIdentifiedWith(canonicalId)
+        .toIdentified
         .toAugmentedImageWith(
-          inferredData,
-          modifiedTime,
-          parentWork,
-          redirectedWork)
+          inferredData = inferredData,
+          parentWork = parentWork,
+          redirectedWork = redirectedWork)
 
     def toIndexedImageWith(
-      canonicalId: String = createCanonicalId,
-      inferredData: Option[InferredData] = createInferredData,
-      modifiedTime: Instant = instantInLast30Days,
-      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = Some(
-        sierraIdentifiedWork())): Image[ImageState.Indexed] =
+      inferredData: Option[InferredData] = createInferredData): Image[ImageState.Indexed] =
       imageData
-        .toIdentifiedWith(canonicalId)
-        .toIndexedImageWith(
-          inferredData,
-          modifiedTime,
-          parentWork,
-          redirectedWork)
+        .toIdentified
+        .toIndexedImageWith(inferredData = inferredData)
 
-    def toIdentified = toIdentifiedWith()
+    def toIdentified: ImageData[IdState.Identified] =
+      imageData.copy(
+        id = IdState.Identified(
+          canonicalId = createCanonicalId,
+          sourceIdentifier = imageData.id.sourceIdentifier
+        )
+      )
 
     def toInitialImage: Image[Initial] =
       imageData.toIdentified.toInitialImage

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.platform.merger.models.{
 import weco.catalogue.internal_model.identifiers.{DataState, IdState}
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.image
-import weco.catalogue.internal_model.image.{ImageData, SourceWorks}
+import weco.catalogue.internal_model.image.{ImageData, ParentWorks}
 import weco.catalogue.internal_model.work.{Work, WorkData, WorkState}
 
 /*

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -165,7 +165,7 @@ object Merger {
 }
 
 object PlatformMerger extends Merger {
-  import weco.catalogue.internal_model.image.SourceWork._
+  import weco.catalogue.internal_model.image.ParentWork._
   import Merger.WorkMergingOps
 
   override def findTarget(
@@ -189,8 +189,8 @@ object PlatformMerger extends Merger {
           imageDataWithSources = standaloneImages(target).map { image =>
             ImageDataWithSource(
               image,
-              SourceWorks(
-                canonicalWork = target.toSourceWork,
+              ParentWorks(
+                canonicalWork = target.toParentWork,
                 redirectedWork = None
               )
             )
@@ -217,11 +217,11 @@ object PlatformMerger extends Merger {
           imageDataWithSources = sourceImageData.map { imageData =>
             ImageDataWithSource(
               imageData = imageData,
-              source = image.SourceWorks(
-                canonicalWork = work.toSourceWork,
+              source = image.ParentWorks(
+                canonicalWork = work.toParentWork,
                 redirectedWork = sources
                   .find { _.data.imageData.contains(imageData) }
-                  .map(_.toSourceWork)
+                  .map(_.toParentWork)
               )
             )
           }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -6,10 +6,10 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.models.index.MergedWorkIndexConfig.sourceIdentifier
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.WorkFsm._
-import weco.catalogue.internal_model.image.SourceWork._
+import weco.catalogue.internal_model.image.ParentWork._
 import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.image.SourceWorks
+import weco.catalogue.internal_model.image.ParentWorks
 import weco.catalogue.internal_model.locations.{
   DigitalLocation,
   License,
@@ -174,9 +174,9 @@ class PlatformMergerTest
     val expectedImage =
       miroWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        sourceWorks = SourceWorks(
-          canonicalWork = expectedMergedWork.toSourceWork,
-          redirectedWork = Some(miroWork.toSourceWork)
+        parentWorks = ParentWorks(
+          canonicalWork = expectedMergedWork.toParentWork,
+          redirectedWork = Some(miroWork.toParentWork)
         )
       )
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
@@ -223,9 +223,9 @@ class PlatformMergerTest
     val expectedImage =
       miroWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        sourceWorks = SourceWorks(
-          canonicalWork = expectedMergedWork.toSourceWork,
-          redirectedWork = Some(miroWork.toSourceWork)
+        parentWorks = ParentWorks(
+          canonicalWork = expectedMergedWork.toParentWork,
+          redirectedWork = Some(miroWork.toParentWork)
         )
       )
 
@@ -281,9 +281,9 @@ class PlatformMergerTest
 
     val expectedImage = miroWork.data.imageData.head.toInitialImageWith(
       modifiedTime = now,
-      sourceWorks = SourceWorks(
-        canonicalWork = expectedMergedWork.toSourceWork,
-        redirectedWork = Some(miroWork.toSourceWork)
+      parentWorks = ParentWorks(
+        canonicalWork = expectedMergedWork.toParentWork,
+        redirectedWork = Some(miroWork.toParentWork)
       )
     )
 
@@ -434,9 +434,9 @@ class PlatformMergerTest
     val expectedImage =
       metsWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        sourceWorks = SourceWorks(
-          canonicalWork = expectedMergedWork.toSourceWork,
-          redirectedWork = Some(metsWork.toSourceWork)
+        parentWorks = ParentWorks(
+          canonicalWork = expectedMergedWork.toParentWork,
+          redirectedWork = Some(metsWork.toParentWork)
         )
       )
 
@@ -521,9 +521,9 @@ class PlatformMergerTest
 
     val expectedImage = miroWork.data.imageData.head.toInitialImageWith(
       modifiedTime = now,
-      sourceWorks = SourceWorks(
-        canonicalWork = expectedMergedWork.toSourceWork,
-        redirectedWork = Some(miroWork.toSourceWork)
+      parentWorks = ParentWorks(
+        canonicalWork = expectedMergedWork.toParentWork,
+        redirectedWork = Some(miroWork.toParentWork)
       )
     )
 
@@ -647,8 +647,8 @@ class PlatformMergerTest
     result.mergedImagesWithTime(now).head shouldBe miroWork.data.imageData.head
       .toInitialImageWith(
         modifiedTime = now,
-        sourceWorks = SourceWorks(
-          canonicalWork = miroWork.toSourceWork,
+        parentWorks = ParentWorks(
+          canonicalWork = miroWork.toParentWork,
           redirectedWork = None
         )
       )


### PR DESCRIPTION
Some more refactoring for wellcomecollection/platform#5090

This is mostly ditching the model "WorkSource" to avoid confusion with a "source Work" and tidying up ImageGenerators, and then the actual fix will come in the _next_ PR.