### PR TITLE
Don't attach imageData on the work that's attached to an image

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
@@ -25,12 +25,20 @@ case class ParentWork(
 
 object ParentWork {
 
+  // These parent works get attached to images.  In general we include all
+  // the WorkData fields, in case they're useful later -- but we deliberately
+  // omit the ImageData, because it's unnecessary and dramatically increases
+  // the size of an image.
+  //
+  // On one work with a lot of images, the size of the JSON for a single image
+  // in the images-initial index went from 3.3MB to 10KB.
+
   implicit class MergedToParentWork(work: Work[WorkState.Merged]) {
     def toParentWork: ParentWork =
       ParentWork(
         id = IdState
           .Identified(work.state.canonicalId, work.state.sourceIdentifier),
-        data = work.data,
+        data = work.data.copy(imageData = Nil),
         version = work.version
       )
   }
@@ -42,7 +50,7 @@ object ParentWork {
           sourceIdentifier = work.state.sourceIdentifier,
           canonicalId = work.state.canonicalId
         ),
-        data = work.data,
+        data = work.data.copy(imageData = Nil),
         version = work.version
       )
   }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
@@ -11,7 +11,9 @@ class ParentWorkTest extends AnyFunSpec with Matchers with ImageGenerators {
     it("removes the imageData from a merged work") {
       val w =
         mergedWork()
-          .imageData((1 to 3).map { _ => createImageData.toIdentified }.toList)
+          .imageData((1 to 3).map { _ =>
+            createImageData.toIdentified
+          }.toList)
 
       w.toParentWork.data.imageData shouldBe empty
     }
@@ -19,7 +21,9 @@ class ParentWorkTest extends AnyFunSpec with Matchers with ImageGenerators {
     it("removes the imageData from an identified work") {
       val w =
         identifiedWork()
-          .imageData((1 to 3).map { _ => createImageData.toIdentified }.toList)
+          .imageData((1 to 3).map { _ =>
+            createImageData.toIdentified
+          }.toList)
 
       w.toParentWork.data.imageData shouldBe empty
     }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
@@ -1,0 +1,27 @@
+package weco.catalogue.internal_model.image
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.generators.ImageGenerators
+
+class ParentWorkTest extends AnyFunSpec with Matchers with ImageGenerators {
+  import ParentWork._
+
+  describe("toParentWork") {
+    it("removes the imageData from a merged work") {
+      val w =
+        mergedWork()
+          .imageData((1 to 3).map { _ => createImageData.toIdentified }.toList)
+
+      w.toParentWork.data.imageData shouldBe empty
+    }
+
+    it("removes the imageData from an identified work") {
+      val w =
+        identifiedWork()
+          .imageData((1 to 3).map { _ => createImageData.toIdentified }.toList)
+
+      w.toParentWork.data.imageData shouldBe empty
+    }
+  }
+}


### PR DESCRIPTION
This is the actual fix for wellcomecollection/platform#5090 (I'll close the ticket once everything is merged and I've bumped the internal model in the API).

As per the comment, this is redundant information that massively swells the size of works.

I did consider making the `imageData` field on `WorkData` an `Option[List]` so we could distinguish between "no image data" and "image data removed", but it got messy and I don't think the distinction is that important.