### PR TITLE
Holdings should only have a single location

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Holdings.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Holdings.scala
@@ -5,5 +5,5 @@ import weco.catalogue.internal_model.locations.PhysicalLocation
 case class Holdings(
   note: Option[String],
   enumeration: List[String],
-  locations: List[PhysicalLocation]
+  location: Option[PhysicalLocation]
 )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -94,7 +94,7 @@ object SierraHoldings extends SierraQueryOps {
         SierraHoldingsEnumeration(id, data.varFields)
       }
 
-    val locations = List(createLocation(id, data)).flatten
+    val location = createLocation(id, data)
 
     // We should only create the Holdings object if we have some interesting data
     // to include; otherwise we don't.
@@ -105,7 +105,7 @@ object SierraHoldings extends SierraQueryOps {
         Holdings(
           note = if (note.nonEmpty) Some(note) else None,
           enumeration = enumeration,
-          locations = locations
+          location = location
         )
       )
     } else {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -18,7 +18,8 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessStatus,
-  DigitalLocation
+  DigitalLocation,
+  PhysicalLocation
 }
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.catalogue.sierra_adapter.generators.SierraGenerators
@@ -482,10 +483,12 @@ class SierraHoldingsTest
       val holdings = getHoldings(dataMap)
       holdings should have size 1
 
-      val locations = holdings.head.locations
-      locations should have size 1
-      locations.head.locationType shouldBe ClosedStores
-      locations.head.label shouldBe "Closed stores"
+      holdings.head.location shouldBe Some(
+        PhysicalLocation(
+          locationType = ClosedStores,
+          label = ClosedStores.label
+        )
+      )
     }
 
     it("uses the location type from fixed field 40 (open shelves)") {
@@ -510,10 +513,12 @@ class SierraHoldingsTest
       val holdings = getHoldings(dataMap)
       holdings should have size 1
 
-      val locations = holdings.head.locations
-      locations should have size 1
-      locations.head.locationType shouldBe OpenShelves
-      locations.head.label shouldBe "Journals"
+      holdings.head.location shouldBe Some(
+        PhysicalLocation(
+          locationType = OpenShelves,
+          label = "Journals"
+        )
+      )
     }
 
     it("uses 949 subfield ǂa as the shelfmark") {
@@ -544,9 +549,7 @@ class SierraHoldingsTest
       val holdings = getHoldings(dataMap)
       holdings should have size 1
 
-      val locations = holdings.head.locations
-      locations should have size 1
-      locations.head.shelfmark shouldBe Some("/MED")
+      holdings.head.location.get.shelfmark shouldBe Some("/MED")
     }
 
     it("skips adding a location if the location code is unrecognised") {
@@ -571,7 +574,7 @@ class SierraHoldingsTest
       val holdings = getHoldings(dataMap)
       holdings should have size 1
 
-      holdings.head.locations shouldBe empty
+      holdings.head.location shouldBe None
     }
 
     it("creates multiple holdings based on multiple data blocks") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1031,7 +1031,7 @@ class SierraTransformerTest
         Holdings(
           note = None,
           enumeration = List("A Jubilant Journal"),
-          locations = List(
+          location = Some(
             PhysicalLocation(
               locationType = ClosedStores,
               label = ClosedStores.label


### PR DESCRIPTION
We create the location on a holdings record from fixed field 40, which only occurs once on a Sierra record.  That means we can simplify the holdings model -- rather than an arbitrary list, instead we make it a singular location.

Note that some holdings instances won't have a location -- e.g. if it's a Sierra location code we can't map to a location type.  That's why this is an Option[Location] rather than a required field.

Closes https://github.com/wellcomecollection/platform/issues/5092