### PR TITLE
Create the 2021-03-19 pipeline

### DIFF
--- a/infrastructure/modules/worker/main.tf
+++ b/infrastructure/modules/worker/main.tf
@@ -40,6 +40,9 @@ module "autoscaling" {
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
+
+  scale_down_adjustment = var.scale_down_adjustment
+  scale_up_adjustment   = var.scale_up_adjustment
 }
 
 module "task_definition" {

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -56,7 +56,7 @@ variable "scale_up_adjustment" {
 }
 
 variable "scale_down_adjustment" {
-  type   = number
+  type    = number
   default = -1
 }
 

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -50,6 +50,16 @@ variable "max_capacity" {
   default = 1
 }
 
+variable "scale_up_adjustment" {
+  type    = number
+  default = 1
+}
+
+variable "scale_down_adjustment" {
+  type   = number
+  default = -1
+}
+
 variable "cpu" {
   type    = number
   default = 512

--- a/infrastructure/modules/workers_with_sidecar/main.tf
+++ b/infrastructure/modules/workers_with_sidecar/main.tf
@@ -44,6 +44,9 @@ module "autoscaling" {
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
+
+  scale_down_adjustment = var.scale_down_adjustment
+  scale_up_adjustment   = var.scale_up_adjustment
 }
 
 module "task_definition" {

--- a/infrastructure/modules/workers_with_sidecar/variables.tf
+++ b/infrastructure/modules/workers_with_sidecar/variables.tf
@@ -44,7 +44,7 @@ variable "scale_up_adjustment" {
 }
 
 variable "scale_down_adjustment" {
-  type   = number
+  type    = number
   default = -1
 }
 

--- a/infrastructure/modules/workers_with_sidecar/variables.tf
+++ b/infrastructure/modules/workers_with_sidecar/variables.tf
@@ -38,6 +38,16 @@ variable "max_capacity" {
   default = 1
 }
 
+variable "scale_up_adjustment" {
+  type    = number
+  default = 1
+}
+
+variable "scale_down_adjustment" {
+  type   = number
+  default = -1
+}
+
 variable "cpu" {
   type    = number
   default = 512

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,7 +1,7 @@
-module "catalogue_pipeline_2021-03-15" {
+module "catalogue_pipeline_2021-03-19" {
   source = "./stack"
 
-  pipeline_date = "2021-03-15"
+  pipeline_date = "2021-03-19"
   release_label = "stage"
 
   # Transformer config
@@ -9,27 +9,27 @@ module "catalogue_pipeline_2021-03-15" {
   # If this pipeline is meant to be reindexed, remember to uncomment the
   # reindexer topic names.
 
-  is_reindexing = false
+  is_reindexing = true
 
   sierra_adapter_topic_arns = [
-    /*local.sierra_reindexer_topic_arn,*/
+    local.sierra_reindexer_topic_arn,
     local.sierra_merged_bibs_topic_arn,
     local.sierra_merged_items_topic_arn,
     local.sierra_merged_holdings_topic_arn,
   ]
 
   miro_adapter_topic_arns = [
-    /*local.miro_reindexer_topic_arn,*/
+    local.miro_reindexer_topic_arn,
     local.miro_updates_topic_arn,
   ]
 
   mets_adapter_topic_arns = [
-    /*local.mets_reindexer_topic_arn,*/
+    local.mets_reindexer_topic_arn,
     local.mets_adapter_topic_arn,
   ]
 
   calm_adapter_topic_arns = [
-    /*local.calm_reindexer_topic_arn,*/
+    local.calm_reindexer_topic_arn,
     local.calm_adapter_topic_arn,
     local.calm_deletions_topic_arn,
   ]

--- a/pipeline/terraform/modules/service/main.tf
+++ b/pipeline/terraform/modules/service/main.tf
@@ -27,6 +27,9 @@ module "worker" {
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
 
+  scale_down_adjustment = var.scale_down_adjustment
+  scale_up_adjustment   = var.scale_up_adjustment
+
   deployment_service_env  = var.deployment_service_env
   deployment_service_name = var.deployment_service_name
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/modules/service/variables.tf
+++ b/pipeline/terraform/modules/service/variables.tf
@@ -59,7 +59,7 @@ variable "scale_up_adjustment" {
 }
 
 variable "scale_down_adjustment" {
-  type   = number
+  type    = number
   default = -1
 }
 

--- a/pipeline/terraform/modules/service/variables.tf
+++ b/pipeline/terraform/modules/service/variables.tf
@@ -29,15 +29,6 @@ variable "elastic_cloud_vpce_sg_id" {
 
 variable "queue_read_policy" {}
 
-variable "max_capacity" {
-  type = number
-}
-
-variable "desired_task_count" {
-  type    = number
-  default = 1
-}
-
 variable "cpu" {
   type    = number
   default = 512
@@ -48,9 +39,28 @@ variable "memory" {
   default = 1024
 }
 
+variable "desired_task_count" {
+  type    = number
+  default = 1
+}
+
 variable "min_capacity" {
   type    = number
   default = 0
+}
+
+variable "max_capacity" {
+  type = number
+}
+
+variable "scale_up_adjustment" {
+  type    = number
+  default = 1
+}
+
+variable "scale_down_adjustment" {
+  type   = number
+  default = -1
 }
 
 variable "launch_type" {

--- a/pipeline/terraform/modules/services_with_manager/main.tf
+++ b/pipeline/terraform/modules/services_with_manager/main.tf
@@ -34,6 +34,9 @@ module "worker" {
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
 
+  scale_down_adjustment = var.scale_down_adjustment
+  scale_up_adjustment   = var.scale_up_adjustment
+
   deployment_service_env  = var.deployment_service_env
   deployment_service_name = var.deployment_service_name
 

--- a/pipeline/terraform/modules/services_with_manager/variables.tf
+++ b/pipeline/terraform/modules/services_with_manager/variables.tf
@@ -50,7 +50,7 @@ variable "scale_up_adjustment" {
 }
 
 variable "scale_down_adjustment" {
-  type   = number
+  type    = number
   default = -1
 }
 

--- a/pipeline/terraform/modules/services_with_manager/variables.tf
+++ b/pipeline/terraform/modules/services_with_manager/variables.tf
@@ -11,11 +11,6 @@ variable "cluster_arn" {
 variable "service_name" {
 }
 
-variable "desired_task_count" {
-  type    = number
-  default = 1
-}
-
 variable "security_group_ids" {
   type    = list(string)
   default = []
@@ -35,6 +30,11 @@ variable "host_memory" {
   default = 1024
 }
 
+variable "desired_task_count" {
+  type    = number
+  default = 1
+}
+
 variable "max_capacity" {
   type = number
 }
@@ -42,6 +42,16 @@ variable "max_capacity" {
 variable "min_capacity" {
   type    = number
   default = 0
+}
+
+variable "scale_up_adjustment" {
+  type    = number
+  default = 1
+}
+
+variable "scale_down_adjustment" {
+  type   = number
+  default = -1
 }
 
 variable "launch_type" {

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -21,6 +21,5 @@ module "inference_capacity_provider" {
   subnets = var.subnets
   security_group_ids = [
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id
   ]
 }

--- a/pipeline/terraform/stack/security_groups.tf
+++ b/pipeline/terraform/stack/security_groups.tf
@@ -13,16 +13,3 @@ resource "aws_security_group" "service_egress" {
     ]
   }
 }
-
-resource "aws_security_group" "interservice" {
-  name        = "${local.namespace_hyphen}_interservice"
-  description = "Allow traffic between services"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-}

--- a/pipeline/terraform/stack/security_groups.tf
+++ b/pipeline/terraform/stack/security_groups.tf
@@ -12,4 +12,8 @@ resource "aws_security_group" "service_egress" {
       "0.0.0.0/0",
     ]
   }
+
+  tags = {
+    Name = "${local.namespace_hyphen}_egress"
+  }
 }

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -57,6 +57,9 @@ module "id_minter" {
     var.max_capacity
   )
 
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   subnets           = var.subnets
   queue_read_policy = module.id_minter_queue.read_policy
 

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -18,9 +18,8 @@ module "id_minter" {
   container_image = local.id_minter_image
 
   security_group_ids = [
-    # TODO: Do we need egress/interservice groups?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
     var.rds_ids_access_security_group_id,
   ]
 

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -124,11 +124,7 @@ module "image_inferrer" {
 
     flush_interval_seconds = 30
 
-    # This was previously set at 6, I've tried turning it down to stem
-    # the number of out-of-memory errors we get from the image inferrer.
-    #
-    # See https://github.com/wellcomecollection/platform/issues/5020
-    batch_size = 1
+    batch_size = 25
   }
 
   manager_secret_env_vars = local.pipeline_storage_es_service_secrets["inferrer"]

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -30,9 +30,7 @@ module "image_inferrer" {
 
   service_name = "${local.namespace_hyphen}_image_inferrer"
   security_group_ids = [
-    # TODO: Do we need interservice?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -134,6 +134,9 @@ module "image_inferrer" {
   # Any higher than this currently causes latency spikes from Loris
   max_capacity = min(6, local.max_capacity)
 
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.image_inferrer_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_image_ingestor.tf
+++ b/pipeline/terraform/stack/service_image_ingestor.tf
@@ -75,7 +75,11 @@ module "ingestor_images" {
 
   subnets = var.subnets
 
-  max_capacity      = min(5, local.max_capacity)
+  max_capacity = min(5, local.max_capacity)
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.ingestor_images_queue.read_policy
 
   deployment_service_env  = var.release_label

--- a/pipeline/terraform/stack/service_image_ingestor.tf
+++ b/pipeline/terraform/stack/service_image_ingestor.tf
@@ -20,9 +20,8 @@ module "ingestor_images" {
   service_name    = "${local.namespace_hyphen}_ingestor_images"
   container_image = local.ingestor_images_image
   security_group_ids = [
-    # TODO: Do we need any of these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -75,8 +75,13 @@ module "matcher" {
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["matcher"]
 
-  subnets           = var.subnets
-  max_capacity      = local.max_capacity
+  subnets = var.subnets
+
+  max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.matcher_input_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -42,9 +42,8 @@ module "matcher" {
   service_name    = "${local.namespace_hyphen}_matcher"
   container_image = local.matcher_image
   security_group_ids = [
-    # TODO: Do we need any of these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -48,8 +48,13 @@ module "merger" {
 
   use_fargate_spot = true
 
-  subnets           = var.subnets
-  max_capacity      = local.max_capacity
+  subnets = var.subnets
+
+  max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.merger_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -17,9 +17,8 @@ module "merger" {
   service_name    = "${local.namespace_hyphen}_merger"
   container_image = local.merger_image
   security_group_ids = [
-    # TODO: Do we need any of these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -36,8 +36,12 @@ module "calm_transformer" {
 
   use_fargate_spot = true
 
-  subnets      = var.subnets
+  subnets = var.subnets
+
   max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
 
   queue_read_policy = module.calm_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -11,9 +11,8 @@ module "calm_transformer" {
   service_name    = "${local.namespace_hyphen}_calm_transformer"
   container_image = local.transformer_calm_image
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -42,8 +42,13 @@ module "mets_transformer" {
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["transformer"]
 
-  subnets           = var.subnets
-  max_capacity      = local.max_capacity
+  subnets = var.subnets
+
+  max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.mets_transformer_queue.read_policy
 
   # The METS transformer is quite CPU intensive, and if it doesn't have enough CPU,

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -19,9 +19,8 @@ module "mets_transformer" {
   service_name    = "${local.namespace_hyphen}_mets_transformer"
   container_image = local.transformer_mets_image
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -11,9 +11,8 @@ module "miro_transformer" {
   service_name    = "${local.namespace_hyphen}_miro_transformer"
   container_image = local.transformer_miro_image
   security_group_ids = [
-    # TODO: Do we need any of these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -39,8 +39,13 @@ module "miro_transformer" {
 
   use_fargate_spot = true
 
-  subnets           = var.subnets
-  max_capacity      = local.max_capacity
+  subnets = var.subnets
+
+  max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.miro_transformer_queue.read_policy
 
   depends_on = [

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -36,8 +36,12 @@ module "sierra_transformer" {
 
   use_fargate_spot = true
 
-  subnets      = var.subnets
+  subnets = var.subnets
+
   max_capacity = local.max_capacity
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
 
   queue_read_policy = module.sierra_transformer_queue.read_policy
 

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -11,9 +11,8 @@ module "sierra_transformer" {
   service_name    = "${local.namespace_hyphen}_sierra_transformer"
   container_image = local.transformer_sierra_image
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -13,9 +13,8 @@ module "batcher" {
   container_image = local.batcher_image
 
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -37,8 +37,13 @@ module "batcher" {
 
   shared_logging_secrets = var.shared_logging_secrets
 
-  subnets           = var.subnets
-  max_capacity      = min(1, local.max_capacity)
+  subnets = var.subnets
+
+  max_capacity = min(1, local.max_capacity)
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.batcher_queue.read_policy
 
   cpu    = 1024

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -56,7 +56,11 @@ module "ingestor_works" {
 
   subnets = var.subnets
 
-  max_capacity      = min(6, local.max_capacity)
+  max_capacity = min(6, local.max_capacity)
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.ingestor_works_queue.read_policy
 
   cpu    = 2048

--- a/pipeline/terraform/stack/service_work_ingestor.tf
+++ b/pipeline/terraform/stack/service_work_ingestor.tf
@@ -21,9 +21,8 @@ module "ingestor_works" {
   service_name    = "${local.namespace_hyphen}_ingestor_works"
   container_image = local.ingestor_works_image
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -46,6 +46,9 @@ module "relation_embedder" {
   # NOTE: limit to avoid >500 concurrent scroll contexts
   max_capacity = min(10, local.max_capacity)
 
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   subnets           = var.subnets
   queue_read_policy = module.relation_embedder_queue.read_policy
 

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -16,9 +16,8 @@ module "relation_embedder" {
   container_image = local.relation_embedder_image
 
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -42,8 +42,13 @@ module "router" {
 
   shared_logging_secrets = var.shared_logging_secrets
 
-  subnets           = var.subnets
-  max_capacity      = min(10, local.max_capacity)
+  subnets = var.subnets
+
+  max_capacity = min(10, local.max_capacity)
+
+  scale_down_adjustment = local.scale_down_adjustment
+  scale_up_adjustment   = local.scale_up_adjustment
+
   queue_read_policy = module.router_queue.read_policy
 
   cpu    = 1024

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -14,9 +14,8 @@ module "router" {
   container_image = local.router_image
 
   security_group_ids = [
-    # TODO: Do we need these?
+    # TODO: Do we need the egress security group?
     aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
   ]
 
   elastic_cloud_vpce_sg_id = var.ec_privatelink_security_group_id


### PR DESCRIPTION
This pipeline includes:

* More tidying of subjects and genres (https://github.com/wellcomecollection/catalogue/pull/1477)
* Better handling of non b numbers in 776 subfield $w (https://github.com/wellcomecollection/catalogue/pull/1479)
* Less repetition of ImageData on image records (https://github.com/wellcomecollection/catalogue/pull/1482)
* Multiple languages in the Calm transformer (https://github.com/wellcomecollection/catalogue/pull/1483)
* A more compact serialisation for IdentifierType (https://github.com/wellcomecollection/catalogue/pull/1486)
* A singular location on holdings (https://github.com/wellcomecollection/catalogue/pull/1487)

Reliability-wise, the hope is that this reindex will give a clean run of the images pipeline post-merger.