### PR TITLE
Include 300 subfield $e in the physical description

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
@@ -7,12 +7,18 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 
 // Populate wwork:physicalDescription.
 //
-// We use MARC field 300 and subfields $a, $b and $c.
+// We use MARC field 300 and subfields:
 //
+//    - ǂa = extent
+//    - ǂb = other physical details
+//    - ǂc = dimensions
+//    - ǂe = accompanying material
+//
+// The underlying MARC values should have all the punctuation we need.
 //
 // Notes:
 //
-//  - MARC field 300 and subfield $b are both labelled "R" (repeatable).
+//  - MARC field 300 and subfield ǂb are both labelled "R" (repeatable).
 //    According to Branwen, this field does appear multiple times on some
 //    of our records -- not usually on books, but on some of the moving image
 //    & sound records.
@@ -37,6 +43,7 @@ object SierraPhysicalDescription
         "300" -> "a",
         "300" -> "b",
         "300" -> "c",
+        "300" -> "e",
       )
       .contentString(" ")
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
@@ -26,7 +26,7 @@ class SierraPhysicalDescriptionTest
     SierraPhysicalDescription(bibData(field)) shouldBe None
   }
 
-  it("extracts physical description from MARC field 300 subfield $b") {
+  it("transforms field 300 subfield $b") {
     val description = "Queuing quokkas quarrel about Quirinus Quirrell"
     val field = varField(
       "300",
@@ -36,8 +36,7 @@ class SierraPhysicalDescriptionTest
     SierraPhysicalDescription(bibData(field)) shouldBe Some(description)
   }
 
-  it(
-    "extracts a physical description where there are multiple MARC field 300 $b") {
+  it("transforms multiple instances of field 300 $b") {
     val descriptionA = "The queer quolls quits and quarrels"
     val descriptionB = "A quintessential quadraped is quick"
     val expectedDescription = s"$descriptionA $descriptionB"
@@ -52,8 +51,7 @@ class SierraPhysicalDescriptionTest
     SierraPhysicalDescription(data) shouldBe Some(expectedDescription)
   }
 
-  it(
-    f"extracts a physical description from MARC 300 subfields $$a, $$b and $$c") {
+  it("uses field 300 ǂa, ǂb and ǂc") {
     val descriptionA = "The queer quolls quits and quarrels"
     val descriptionB = "A quintessential quadraped is quick"
     val descriptionC = "The edifying extent of early emus"
@@ -64,6 +62,20 @@ class SierraPhysicalDescriptionTest
       varField("300", MarcSubfield("c", descriptionC)),
     )
     SierraPhysicalDescription(data) shouldBe Some(expectedDescription)
+  }
+
+  it("uses field 300 ǂa, ǂb, ǂc and ǂe") {
+    val extent = "1 photograph :"
+    val otherPhysicalDetails = "photonegative, glass ;"
+    val dimensions = "glass 10.6 x 8 cm +"
+    val accompanyingMaterial = "envelope"
+    val data = bibData(
+      varField("300", MarcSubfield("a", extent)),
+      varField("300", MarcSubfield("b", otherPhysicalDetails)),
+      varField("300", MarcSubfield("c", dimensions)),
+      varField("300", MarcSubfield("e", accompanyingMaterial)),
+    )
+    SierraPhysicalDescription(data) shouldBe Some("1 photograph : photonegative, glass ; glass 10.6 x 8 cm + envelope")
   }
 
   def bibData(varFields: VarField*): SierraBibData =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescriptionTest.scala
@@ -75,7 +75,8 @@ class SierraPhysicalDescriptionTest
       varField("300", MarcSubfield("c", dimensions)),
       varField("300", MarcSubfield("e", accompanyingMaterial)),
     )
-    SierraPhysicalDescription(data) shouldBe Some("1 photograph : photonegative, glass ; glass 10.6 x 8 cm + envelope")
+    SierraPhysicalDescription(data) shouldBe Some(
+      "1 photograph : photonegative, glass ; glass 10.6 x 8 cm + envelope")
   }
 
   def bibData(varFields: VarField*): SierraBibData =


### PR DESCRIPTION
Per a discussion in Slack: https://wellcome.slack.com/archives/C8X9YKM5X/p1615831494080900

This does contain some useful data that we aren't displaying (see spreadsheet of examples in the thread).
