### PR TITLE
Try to fix the ordering of results in this test

### DIFF
--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -74,12 +74,14 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
         val baguetteImage = createImageData.toIndexedImageWith(
           canonicalId = "a",
           parentWork = identifiedWork()
-            .title("Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread")
+            .title(
+              "Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread")
         )
         val focacciaImage = createImageData.toIndexedImageWith(
           canonicalId = "b",
           parentWork = identifiedWork()
-            .title("A Ligurian style of bread, Focaccia is a flat Italian bread")
+            .title(
+              "A Ligurian style of bread, Focaccia is a flat Italian bread")
         )
         val mantouImage = createImageData.toIndexedImageWith(
           canonicalId = "c",

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesTest.scala
@@ -74,12 +74,12 @@ class ImagesTest extends ApiImagesTestBase with SierraWorkGenerators {
         val baguetteImage = createImageData.toIndexedImageWith(
           canonicalId = "a",
           parentWork = identifiedWork()
-            .title("Baguette is a French bread style")
+            .title("Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread")
         )
         val focacciaImage = createImageData.toIndexedImageWith(
           canonicalId = "b",
           parentWork = identifiedWork()
-            .title("A Ligurian style of bread, Focaccia")
+            .title("A Ligurian style of bread, Focaccia is a flat Italian bread")
         )
         val mantouImage = createImageData.toIndexedImageWith(
           canonicalId = "c",


### PR DESCRIPTION
CI is flaky because sometimes these images are returned in a different order.  By doubling/tripling up the search query, I'm hoping we can get more stable search results.