### PR TITLE
Move some stuff out of internal_model

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
@@ -6,17 +6,6 @@ import WorksAnalysis._
 /** Mixin for common fields used within an IndexConfig in our internal models.
   */
 trait IndexConfigFields {
-  // `textWithKeyword` and `keywordWithText` are slightly different in the semantics and their use case.
-  // If the intended field type is keyword, but you would like to search it textually, use `keywordWithText` and
-  // visa versa.
-
-  // This encodes how someone would expect the field to work, but allow querying it in other ways.
-  def textWithKeyword(name: String) =
-    textField(name).fields(keywordField("keyword"))
-
-  def keywordWithText(name: String) =
-    keywordField(name).fields(textField("text"))
-
   def englishTextKeywordField(name: String) =
     textField(name).fields(
       keywordField("keyword"),
@@ -50,7 +39,8 @@ trait IndexConfigFields {
     keywordField(name).normalizer(lowercaseNormalizer.name)
 
   def asciifoldingTextFieldWithKeyword(name: String) =
-    textWithKeyword(name)
+    textField(name)
+      .fields(keywordField("keyword"))
       .analyzer(asciifoldingAnalyzer.name)
 
   val label = asciifoldingTextFieldWithKeyword("label")

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/text/TextNormalisation.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/text/TextNormalisation.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.work.text
+package weco.catalogue.internal_model.text
 
 import scala.util.matching.Regex
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -1,7 +1,7 @@
 package weco.catalogue.internal_model.work
 
 import uk.ac.wellcome.models.parse.parsers.DateParser
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.{HasId, IdState}
 
 sealed trait AbstractRootConcept[+State] extends HasId[State] {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/text/TextNormalisationTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/text/TextNormalisationTest.scala
@@ -1,9 +1,9 @@
-package uk.ac.wellcome.models.work.internal.text
+package weco.catalogue.internal_model.text
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import TextNormalisation._
 
 class TextNormalisationTest extends AnyFunSpec with Matchers {
   describe("trimTrailing") {

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.calm
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.models.work.internal.result._
 import uk.ac.wellcome.platform.transformer.calm.models.{
   CalmSourceData,
   CalmTransformerException
@@ -14,6 +13,7 @@ import uk.ac.wellcome.platform.transformer.calm.transformers.{
 }
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.catalogue.transformer.Transformer
+import weco.catalogue.transformer.result._
 import weco.catalogue.internal_model.work.WorkState.Source
 import uk.ac.wellcome.models.parse.PeriodParser
 import weco.catalogue.internal_model.identifiers.{

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmItems.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmItems.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.transformer.calm.transformers
 
-import uk.ac.wellcome.models.work.internal.result._
 import uk.ac.wellcome.platform.transformer.calm.CalmRecordOps
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.{
@@ -11,6 +10,7 @@ import weco.catalogue.internal_model.locations.{
 }
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.calm.CalmRecord
+import weco.catalogue.transformer.result._
 
 object CalmItems extends CalmRecordOps {
   def apply(record: CalmRecord): Result[List[Item[IdState.Unminted]]] =

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/Transformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/Transformer.scala
@@ -1,8 +1,8 @@
 package weco.catalogue.transformer
 
 import weco.catalogue.internal_model.work.WorkState.Source
-import uk.ac.wellcome.models.work.internal.result.Result
 import weco.catalogue.internal_model.work.Work
+import weco.catalogue.transformer.result.Result
 
 trait Transformer[SourceData] {
   def apply(sourceData: SourceData, version: Int): Result[Work[Source]] = ???

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/result/result.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/catalogue/transformer/result/result.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.work.internal
+package weco.catalogue.transformer
 
 package object result {
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.transformer.mets.transformer
 
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.Identified
-import uk.ac.wellcome.models.work.internal.result.Result
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import weco.catalogue.internal_model.work.{Work, WorkState}
 import weco.catalogue.source_model.mets.{
@@ -11,6 +10,7 @@ import weco.catalogue.source_model.mets.{
   MetsSourceData
 }
 import weco.catalogue.transformer.Transformer
+import weco.catalogue.transformer.result.Result
 
 class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     extends Transformer[MetsSourceData] {

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.mets.transformer
 import java.time.Instant
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.models.work.internal.result.Result
 import uk.ac.wellcome.platform.transformer.mets.fixtures.{
   LocalResources,
   MetsGenerators
@@ -12,6 +11,7 @@ import uk.ac.wellcome.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.memory.MemoryStore
 import weco.catalogue.internal_model.locations.License
 import weco.catalogue.source_model.mets.{DeletedMetsFile, MetsFileWithImages}
+import weco.catalogue.transformer.result.Result
 
 class MetsXmlTransformerTest
     extends AnyFunSpec

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import uk.ac.wellcome.platform.transformer.miro.transformers._
 import weco.catalogue.internal_model.work.WorkState.Source
-import uk.ac.wellcome.models.work.internal.result.Result
 import weco.catalogue.internal_model.identifiers.{
   DataState,
   IdentifierType,
@@ -22,6 +21,7 @@ import weco.catalogue.internal_model.work.DeletedReason.SuppressedFromSource
 import weco.catalogue.internal_model.work.InvisibilityReason.UnableToTransform
 import weco.catalogue.internal_model.work.{Work, WorkData}
 import weco.catalogue.transformer.Transformer
+import weco.catalogue.transformer.result.Result
 
 class MiroRecordTransformer
     extends MiroContributors

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroGenres.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Genre}
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroSubjects.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroSubjects.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Subject}
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorker.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/services/SierraTransformerWorker.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.transformer.sierra.services
 
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.models.work.internal.result
 import weco.catalogue.internal_model.work.WorkState.Source
 import uk.ac.wellcome.pipeline_storage.{PipelineStorageStream, Retriever}
 import uk.ac.wellcome.platform.transformer.sierra.SierraTransformer
@@ -14,6 +13,7 @@ import weco.catalogue.internal_model.work.Work
 import weco.catalogue.source_model.SierraSourcePayload
 import weco.catalogue.source_model.sierra.SierraTransformable
 import weco.catalogue.transformer.{Transformer, TransformerWorker}
+import weco.catalogue.transformer.result
 
 import scala.concurrent.ExecutionContext
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraQueryOps,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
 import uk.ac.wellcome.platform.transformer.sierra.source._
-import uk.ac.wellcome.models.parse.Marc008Parser
+import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.Marc008Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.sierra.SierraBibNumber

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParser.scala
@@ -1,8 +1,9 @@
-package uk.ac.wellcome.models.parse
+package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
-import DateParserImplicits._
+import uk.ac.wellcome.models.parse.DateParserImplicits._
+import uk.ac.wellcome.models.parse._
 import weco.catalogue.internal_model.work.InstantRange
 
 /**

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008Parser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008Parser.scala
@@ -1,7 +1,8 @@
-package uk.ac.wellcome.models.parse
+package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
+import uk.ac.wellcome.models.parse.Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Period, ProductionEvent}
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MarcPlaceParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/MarcPlaceParser.scala
@@ -1,7 +1,8 @@
-package uk.ac.wellcome.models.parse
+package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
+import uk.ac.wellcome.models.parse.Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Place
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   VarField

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraQueryOps,
   VarField
 }
-import uk.ac.wellcome.models.work.text.TextNormalisation._
+import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
 import weco.catalogue.source_model.sierra.SierraBibNumber

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParserTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParserTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.parse
+package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
 import org.scalatest.matchers.should.Matchers
 import java.time.LocalDate

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.models.parse
+package uk.ac.wellcome.platform.transformer.sierra.transformers.parsers
 
 import org.scalatest.matchers.should.Matchers
 import java.time.LocalDate


### PR DESCRIPTION
Because internal_model is such a load-bearing library, we don't really want stuff in there that doesn't need to be shared across every service. This PR splits out two pieces that didn't belong in internal_model:

* The `Result[T] = Either[Throwable, T]` type, which is only used in the transformers
* The parsers for MARC field 008, which are only used in the Sierra transformer

Plus binning a couple of helpers we no longer use.