### PR TITLE
Add a type for Canonical ID

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkIdentifier.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.models.matcher
 
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Identified
 
-case class WorkIdentifier(identifier: CanonicalID, version: Option[Int])
+case class WorkIdentifier(identifier: CanonicalId, version: Option[Int])
 
 object WorkIdentifier {
   def apply(work: WorkNode): WorkIdentifier =
@@ -16,6 +16,6 @@ object WorkIdentifier {
       version = Some(work.version)
     )
 
-  def apply(identifier: CanonicalID, version: Int): WorkIdentifier =
+  def apply(identifier: CanonicalId, version: Int): WorkIdentifier =
     WorkIdentifier(identifier, Some(version))
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkIdentifier.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkIdentifier.scala
@@ -1,19 +1,21 @@
 package uk.ac.wellcome.models.matcher
 
+import weco.catalogue.internal_model.identifiers.CanonicalID
 import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.Identified
 
-case class WorkIdentifier(identifier: String, version: Option[Int])
+case class WorkIdentifier(identifier: CanonicalID, version: Option[Int])
 
 object WorkIdentifier {
   def apply(work: WorkNode): WorkIdentifier =
     WorkIdentifier(work.id, work.version)
 
-  def apply(work: Work[_]): WorkIdentifier =
+  def apply(work: Work[Identified]): WorkIdentifier =
     WorkIdentifier(
-      identifier = work.id,
+      identifier = work.state.canonicalId,
       version = Some(work.version)
     )
 
-  def apply(identifier: String, version: Int): WorkIdentifier =
+  def apply(identifier: CanonicalID, version: Int): WorkIdentifier =
     WorkIdentifier(identifier, Some(version))
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkNode.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkNode.scala
@@ -1,16 +1,18 @@
 package uk.ac.wellcome.models.matcher
 
+import weco.catalogue.internal_model.identifiers.CanonicalID
+
 case class WorkNode(
-  id: String,
+  id: CanonicalID,
   version: Option[Int],
-  linkedIds: List[String],
+  linkedIds: List[CanonicalID],
   componentId: String
 )
 
 object WorkNode {
-  def apply(id: String,
+  def apply(id: CanonicalID,
             version: Int,
-            linkedIds: List[String],
+            linkedIds: List[CanonicalID],
             componentId: String): WorkNode =
     WorkNode(id, Some(version), linkedIds, componentId)
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkNode.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/WorkNode.scala
@@ -1,18 +1,18 @@
 package uk.ac.wellcome.models.matcher
 
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 case class WorkNode(
-  id: CanonicalID,
+  id: CanonicalId,
   version: Option[Int],
-  linkedIds: List[CanonicalID],
+  linkedIds: List[CanonicalId],
   componentId: String
 )
 
 object WorkNode {
-  def apply(id: CanonicalID,
+  def apply(id: CanonicalId,
             version: Int,
-            linkedIds: List[CanonicalID],
+            linkedIds: List[CanonicalId],
             componentId: String): WorkNode =
     WorkNode(id, Some(version), linkedIds, componentId)
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
@@ -54,4 +54,3 @@ object CanonicalID {
   implicit val ordering: Ordering[CanonicalID] =
     (x: CanonicalID, y: CanonicalID) => x.underlying.compare(y.underlying)
 }
-

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
@@ -1,0 +1,43 @@
+package weco.catalogue.internal_model.identifiers
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
+import org.scanamo.DynamoFormat
+
+class CanonicalID(val underlying: String) {
+  override def toString: String = underlying
+  // Normally we use case classes for immutable data, which provide these
+  // methods for us.
+  //
+  // We deliberately don't use case classes here so we skip automatic
+  // case class derivation for JSON encoding/DynamoDB in Scanamo,
+  // and force callers to intentionally import the implicits below.
+  def canEqual(a: Any): Boolean = a.isInstanceOf[CanonicalID]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: CanonicalID =>
+        that.canEqual(this) && this.underlying == that.underlying
+      case _ => false
+    }
+
+  override def hashCode: Int = underlying.hashCode
+}
+
+object CanonicalID {
+  def apply(underlying: String): CanonicalID =
+    new CanonicalID(underlying)
+
+  implicit val encoder: Encoder[CanonicalID] =
+    (value: CanonicalID) => Json.fromString(value.toString)
+
+  implicit val decoder: Decoder[CanonicalID] = (cursor: HCursor) =>
+    cursor.value.as[String].map(CanonicalID(_))
+
+  implicit def evidence: DynamoFormat[CanonicalID] =
+    DynamoFormat
+      .iso[CanonicalID, String](
+        CanonicalID(_),
+        _.underlying
+      )
+}
+

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
@@ -5,6 +5,17 @@ import org.scanamo.DynamoFormat
 
 class CanonicalID(val underlying: String) {
   override def toString: String = underlying
+
+  require(
+    !underlying.contains(" "),
+    s"Canonical ID cannot contain whitespace; got $underlying"
+  )
+
+  require(
+    underlying.length == 8,
+    s"Canonical ID should have length 8; got $underlying.  Is this actually a canonical ID?"
+  )
+
   // Normally we use case classes for immutable data, which provide these
   // methods for us.
   //

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalID.scala
@@ -46,9 +46,12 @@ object CanonicalID {
 
   implicit def evidence: DynamoFormat[CanonicalID] =
     DynamoFormat
-      .iso[CanonicalID, String](
+      .coercedXmap[CanonicalID, String, IllegalArgumentException](
         CanonicalID(_),
         _.underlying
       )
+
+  implicit val ordering: Ordering[CanonicalID] =
+    (x: CanonicalID, y: CanonicalID) => x.underlying.compare(y.underlying)
 }
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalId.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/CanonicalId.scala
@@ -3,7 +3,7 @@ package weco.catalogue.internal_model.identifiers
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.scanamo.DynamoFormat
 
-class CanonicalID(val underlying: String) {
+class CanonicalId(val underlying: String) {
   override def toString: String = underlying
 
   require(
@@ -22,11 +22,11 @@ class CanonicalID(val underlying: String) {
   // We deliberately don't use case classes here so we skip automatic
   // case class derivation for JSON encoding/DynamoDB in Scanamo,
   // and force callers to intentionally import the implicits below.
-  def canEqual(a: Any): Boolean = a.isInstanceOf[CanonicalID]
+  def canEqual(a: Any): Boolean = a.isInstanceOf[CanonicalId]
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: CanonicalID =>
+      case that: CanonicalId =>
         that.canEqual(this) && this.underlying == that.underlying
       case _ => false
     }
@@ -34,23 +34,23 @@ class CanonicalID(val underlying: String) {
   override def hashCode: Int = underlying.hashCode
 }
 
-object CanonicalID {
-  def apply(underlying: String): CanonicalID =
-    new CanonicalID(underlying)
+object CanonicalId {
+  def apply(underlying: String): CanonicalId =
+    new CanonicalId(underlying)
 
-  implicit val encoder: Encoder[CanonicalID] =
-    (value: CanonicalID) => Json.fromString(value.toString)
+  implicit val encoder: Encoder[CanonicalId] =
+    (value: CanonicalId) => Json.fromString(value.toString)
 
-  implicit val decoder: Decoder[CanonicalID] = (cursor: HCursor) =>
-    cursor.value.as[String].map(CanonicalID(_))
+  implicit val decoder: Decoder[CanonicalId] = (cursor: HCursor) =>
+    cursor.value.as[String].map(CanonicalId(_))
 
-  implicit def evidence: DynamoFormat[CanonicalID] =
+  implicit def evidence: DynamoFormat[CanonicalId] =
     DynamoFormat
-      .coercedXmap[CanonicalID, String, IllegalArgumentException](
-        CanonicalID(_),
+      .coercedXmap[CanonicalId, String, IllegalArgumentException](
+        CanonicalId(_),
         _.underlying
       )
 
-  implicit val ordering: Ordering[CanonicalID] =
-    (x: CanonicalID, y: CanonicalID) => x.underlying.compare(y.underlying)
+  implicit val ordering: Ordering[CanonicalId] =
+    (x: CanonicalId, y: CanonicalId) => x.underlying.compare(y.underlying)
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -11,7 +11,7 @@ package weco.catalogue.internal_model.identifiers
   *    thus can never have a canonicalId attached
   *  */
 sealed trait IdState {
-  def maybeCanonicalId: Option[String]
+  def maybeCanonicalId: Option[CanonicalID]
   def allSourceIdentifiers: List[SourceIdentifier]
 }
 
@@ -26,7 +26,7 @@ object IdState {
   /** Represents an ID that has been successfully minted, and thus has a
     *  canonicalId assigned. */
   case class Identified(
-    canonicalId: String,
+    canonicalId: CanonicalID,
     sourceIdentifier: SourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
   ) extends Minted {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -11,7 +11,7 @@ package weco.catalogue.internal_model.identifiers
   *    thus can never have a canonicalId attached
   *  */
 sealed trait IdState {
-  def maybeCanonicalId: Option[CanonicalID]
+  def maybeCanonicalId: Option[CanonicalId]
   def allSourceIdentifiers: List[SourceIdentifier]
 }
 
@@ -26,7 +26,7 @@ object IdState {
   /** Represents an ID that has been successfully minted, and thus has a
     *  canonicalId assigned. */
   case class Identified(
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     sourceIdentifier: SourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
   ) extends Minted {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -1,6 +1,10 @@
 package weco.catalogue.internal_model.image
 
-import weco.catalogue.internal_model.identifiers.{HasId, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
+  HasId,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.locations.DigitalLocation
 
 import java.time.Instant
@@ -36,10 +40,10 @@ case class Image[State <: ImageState](
 sealed trait ImageState {
   type TransitionArgs
 
-  val canonicalId: String
+  val canonicalId: CanonicalID
   val sourceIdentifier: SourceIdentifier
 
-  def id: String = canonicalId
+  def id: String = canonicalId.toString
 }
 
 /** ImageState represents the state of the image in the pipeline.
@@ -63,14 +67,14 @@ object ImageState {
 
   case class Initial(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String
+    canonicalId: CanonicalID
   ) extends ImageState {
     type TransitionArgs = Unit
   }
 
   case class Augmented(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     inferredData: Option[InferredData] = None
   ) extends ImageState {
     type TransitionArgs = Option[InferredData]
@@ -78,13 +82,12 @@ object ImageState {
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     inferredData: Option[InferredData] = None,
     derivedData: DerivedImageData
   ) extends ImageState {
     type TransitionArgs = Unit
   }
-
 }
 
 // ImageFsm contains all of the possible transitions between image states

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -1,7 +1,7 @@
 package weco.catalogue.internal_model.image
 
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   HasId,
   SourceIdentifier
 }
@@ -40,7 +40,7 @@ case class Image[State <: ImageState](
 sealed trait ImageState {
   type TransitionArgs
 
-  val canonicalId: CanonicalID
+  val canonicalId: CanonicalId
   val sourceIdentifier: SourceIdentifier
 
   def id: String = canonicalId.toString
@@ -67,14 +67,14 @@ object ImageState {
 
   case class Initial(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID
+    canonicalId: CanonicalId
   ) extends ImageState {
     type TransitionArgs = Unit
   }
 
   case class Augmented(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     inferredData: Option[InferredData] = None
   ) extends ImageState {
     type TransitionArgs = Option[InferredData]
@@ -82,7 +82,7 @@ object ImageState {
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     inferredData: Option[InferredData] = None,
     derivedData: DerivedImageData
   ) extends ImageState {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -70,7 +70,10 @@ object Relation {
       numDescendents = numDescendents,
     )
 
-  def apply[State <: WorkState](work: Work[State], depth: Int, numChildren: Int, numDescendents: Int): Relation =
+  def apply[State <: WorkState](work: Work[State],
+                                depth: Int,
+                                numChildren: Int,
+                                numDescendents: Int): Relation =
     work.state match {
       case state: Indexed =>
         apply(state.canonicalId, work.data, depth, numChildren, numDescendents)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -1,6 +1,7 @@
 package weco.catalogue.internal_model.work
 
 import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
   DataState,
   IdState,
   SourceIdentifier
@@ -163,20 +164,20 @@ object WorkState {
 
   case class Identified(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     modifiedTime: Instant,
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
     type TransitionArgs = Unit
 
-    def id = canonicalId
+    def id = canonicalId.toString
     val relations = Relations.none
   }
 
   case class Merged(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     modifiedTime: Instant,
     availabilities: Set[Availability] = Set.empty,
   ) extends WorkState {
@@ -184,13 +185,13 @@ object WorkState {
     type WorkDataState = DataState.Identified
     type TransitionArgs = Instant
 
-    def id: String = canonicalId
+    def id: String = canonicalId.toString
     val relations: Relations = Relations.none
   }
 
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     modifiedTime: Instant,
     availabilities: Set[Availability],
     relations: Relations = Relations.none
@@ -199,12 +200,12 @@ object WorkState {
     type WorkDataState = DataState.Identified
     type TransitionArgs = (Relations, Set[Availability])
 
-    def id = canonicalId
+    def id = canonicalId.toString
   }
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: String,
+    canonicalId: CanonicalID,
     modifiedTime: Instant,
     availabilities: Set[Availability],
     derivedData: DerivedWorkData,
@@ -214,7 +215,7 @@ object WorkState {
     type WorkDataState = DataState.Identified
     type TransitionArgs = Unit
 
-    def id = canonicalId
+    def id = canonicalId.toString
   }
 }
 
@@ -245,7 +246,7 @@ object WorkFsm {
               modifiedTime: Instant): Merged =
       Merged(
         sourceIdentifier = state.sourceIdentifier,
-        canonicalId = state.id,
+        canonicalId = state.canonicalId,
         modifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data),
       )

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -1,7 +1,7 @@
 package weco.catalogue.internal_model.work
 
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   DataState,
   IdState,
   SourceIdentifier
@@ -164,7 +164,7 @@ object WorkState {
 
   case class Identified(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     modifiedTime: Instant,
   ) extends WorkState {
 
@@ -177,7 +177,7 @@ object WorkState {
 
   case class Merged(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     modifiedTime: Instant,
     availabilities: Set[Availability] = Set.empty,
   ) extends WorkState {
@@ -191,7 +191,7 @@ object WorkState {
 
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     modifiedTime: Instant,
     availabilities: Set[Availability],
     relations: Relations = Relations.none
@@ -205,7 +205,7 @@ object WorkState {
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
-    canonicalId: CanonicalID,
+    canonicalId: CanonicalId,
     modifiedTime: Instant,
     availabilities: Set[Availability],
     derivedData: DerivedWorkData,

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexFixtures.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexFixtures.scala
@@ -68,7 +68,7 @@ trait IndexFixtures extends ElasticsearchFixtures { this: Suite =>
   def assertElasticsearchNeverHasWork(index: Index,
                                       works: Work[Identified]*): Unit = {
     implicit val id: IndexId[Work[Identified]] =
-      (work: Work[Identified]) => work.state.canonicalId
+      (work: Work[Identified]) => work.state.canonicalId.toString
     assertElasticsearchNeverHas(index, works: _*)
   }
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
@@ -14,7 +14,11 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 import weco.catalogue.internal_model.work._
 
@@ -62,6 +66,11 @@ class WorksIndexConfigTest
   implicit val arbitrarySourceIdentifier: Arbitrary[SourceIdentifier] =
     Arbitrary {
       createSourceIdentifier
+    }
+
+  implicit val arbitraryCanonicalId: Arbitrary[CanonicalId] =
+    Arbitrary {
+      createCanonicalId
     }
 
   implicit val badObjectEncoder: Encoder[BadTestObject] = deriveEncoder

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -4,7 +4,11 @@ import weco.catalogue.internal_model.generators.{
   IdentifiersGenerators,
   LocationGenerators
 }
-import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.locations.{
   AccessStatus,
   License,
@@ -16,7 +20,7 @@ import weco.catalogue.internal_model.work.Item
 trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
 
   def createIdentifiedItemWith[I >: IdState.Identified](
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
     locations: List[Location] = List(createDigitalLocation),

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -5,7 +5,7 @@ import weco.catalogue.internal_model.generators.{
   LocationGenerators
 }
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   IdState,
   SourceIdentifier
 }
@@ -20,7 +20,7 @@ import weco.catalogue.internal_model.work.Item
 trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
 
   def createIdentifiedItemWith[I >: IdState.Identified](
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
     locations: List[Location] = List(createDigitalLocation),

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models.work.generators
 import java.time.Instant
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   DataState,
   SourceIdentifier
 }
@@ -37,7 +37,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def mergedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days
   ): Work.Visible[Merged] = {
     val data = initData[DataState.Identified]
@@ -54,7 +54,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def denormalisedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
     relations: Relations = Relations.none
   ): Work.Visible[Denormalised] = {
@@ -74,7 +74,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
@@ -89,7 +89,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def indexedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
     relations: Relations = Relations.none
   ): Work.Visible[Indexed] = {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.models.work.generators
 
 import java.time.Instant
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{DataState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
+  DataState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.image.ImageData
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.Location
@@ -33,7 +37,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def mergedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days
   ): Work.Visible[Merged] = {
     val data = initData[DataState.Identified]
@@ -50,7 +54,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def denormalisedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
     relations: Relations = Relations.none
   ): Work.Visible[Denormalised] = {
@@ -70,7 +74,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
@@ -85,7 +89,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def indexedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     modifiedTime: Instant = instantInLast30Days,
     relations: Relations = Relations.none
   ): Work.Visible[Indexed] = {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -11,7 +11,7 @@ import scala.util.Random
 
 trait IdentifiersGenerators extends RandomGenerators {
   def createCanonicalId: CanonicalID =
-    CanonicalID(randomAlphanumeric(length = 10).toLowerCase())
+    CanonicalID(randomAlphanumeric(length = 8).toLowerCase())
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -2,6 +2,7 @@ package weco.catalogue.internal_model.generators
 
 import uk.ac.wellcome.fixtures.RandomGenerators
 import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
   IdentifierType,
   SourceIdentifier
 }
@@ -9,7 +10,8 @@ import weco.catalogue.internal_model.identifiers.{
 import scala.util.Random
 
 trait IdentifiersGenerators extends RandomGenerators {
-  def createCanonicalId: String = randomAlphanumeric(length = 10).toLowerCase()
+  def createCanonicalId: CanonicalID =
+    CanonicalID(randomAlphanumeric(length = 10).toLowerCase())
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -2,7 +2,7 @@ package weco.catalogue.internal_model.generators
 
 import uk.ac.wellcome.fixtures.RandomGenerators
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   IdentifierType,
   SourceIdentifier
 }
@@ -10,8 +10,8 @@ import weco.catalogue.internal_model.identifiers.{
 import scala.util.Random
 
 trait IdentifiersGenerators extends RandomGenerators {
-  def createCanonicalId: CanonicalID =
-    CanonicalID(randomAlphanumeric(length = 8).toLowerCase())
+  def createCanonicalId: CanonicalId =
+    CanonicalId(randomAlphanumeric(length = 8).toLowerCase())
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -1,7 +1,11 @@
 package weco.catalogue.internal_model.generators
 
 import uk.ac.wellcome.models.work.generators._
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalID,
+  IdState,
+  IdentifierType
+}
 import weco.catalogue.internal_model.image
 import weco.catalogue.internal_model.image.ParentWork._
 import weco.catalogue.internal_model.image.ImageState.{Indexed, Initial}
@@ -72,7 +76,7 @@ trait ImageGenerators
           redirectedWork = redirectedWork)
 
     def toIndexedImageWith(
-      canonicalId: String = createCanonicalId,
+      canonicalId: CanonicalID = createCanonicalId,
       parentWork: Work[WorkState.Identified] = identifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = None,
       inferredData: Option[InferredData] = createInferredData)
@@ -86,7 +90,7 @@ trait ImageGenerators
         )
 
     def toIdentifiedWith(
-      canonicalId: String = createCanonicalId): ImageData[IdState.Identified] =
+      canonicalId: CanonicalID = createCanonicalId): ImageData[IdState.Identified] =
       imageData.copy(
         id = IdState.Identified(
           canonicalId = createCanonicalId,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -89,8 +89,8 @@ trait ImageGenerators
           inferredData = inferredData
         )
 
-    def toIdentifiedWith(
-      canonicalId: CanonicalID = createCanonicalId): ImageData[IdState.Identified] =
+    def toIdentifiedWith(canonicalId: CanonicalID = createCanonicalId)
+      : ImageData[IdState.Identified] =
       imageData.copy(
         id = IdState.Identified(
           canonicalId = createCanonicalId,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -2,7 +2,7 @@ package weco.catalogue.internal_model.generators
 
 import uk.ac.wellcome.models.work.generators._
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalID,
+  CanonicalId,
   IdState,
   IdentifierType
 }
@@ -76,7 +76,7 @@ trait ImageGenerators
           redirectedWork = redirectedWork)
 
     def toIndexedImageWith(
-      canonicalId: CanonicalID = createCanonicalId,
+      canonicalId: CanonicalId = createCanonicalId,
       parentWork: Work[WorkState.Identified] = identifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = None,
       inferredData: Option[InferredData] = createInferredData)
@@ -89,7 +89,7 @@ trait ImageGenerators
           inferredData = inferredData
         )
 
-    def toIdentifiedWith(canonicalId: CanonicalID = createCanonicalId)
+    def toIdentifiedWith(canonicalId: CanonicalId = createCanonicalId)
       : ImageData[IdState.Identified] =
       imageData.copy(
         id = IdState.Identified(

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
@@ -41,14 +41,16 @@ class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
         """
           |"12345678"
           |""".stripMargin
-      fromJson[CanonicalID](jsonString) shouldBe Success(CanonicalID("12345678"))
+      fromJson[CanonicalID](jsonString) shouldBe Success(
+        CanonicalID("12345678"))
     }
   }
 
   describe("DynamoFormat") {
     it("encodes as a string") {
       val id = CanonicalID("12345678")
-      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString("12345678")
+      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString(
+        "12345678")
     }
 
     it("decodes from a string") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
@@ -12,21 +12,21 @@ import scala.util.Success
 class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
   it("checks it's really a canonical ID") {
     intercept[IllegalArgumentException] {
-      CanonicalID("1")
+      CanonicalId("1")
     }
 
     intercept[IllegalArgumentException] {
-      CanonicalID("AStringThatsMoreThanEightCharacters")
+      CanonicalId("AStringThatsMoreThanEightCharacters")
     }
 
     intercept[IllegalArgumentException] {
-      CanonicalID("a string with space")
+      CanonicalId("a string with space")
     }
   }
 
   describe("JSON encoding") {
     it("encodes as a string") {
-      val id = CanonicalID("12345678")
+      val id = CanonicalId("12345678")
 
       assertJsonStringsAreEqual(
         toJson(id).get,
@@ -41,21 +41,21 @@ class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
         """
           |"12345678"
           |""".stripMargin
-      fromJson[CanonicalID](jsonString) shouldBe Success(
-        CanonicalID("12345678"))
+      fromJson[CanonicalId](jsonString) shouldBe Success(
+        CanonicalId("12345678"))
     }
   }
 
   describe("DynamoFormat") {
     it("encodes as a string") {
-      val id = CanonicalID("12345678")
-      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString(
+      val id = CanonicalId("12345678")
+      DynamoFormat[CanonicalId].write(id) shouldBe DynamoValue.fromString(
         "12345678")
     }
 
     it("decodes from a string") {
       val av = AttributeValue.builder().s("12345678").build()
-      DynamoFormat[CanonicalID].read(av) shouldBe Right(CanonicalID("12345678"))
+      DynamoFormat[CanonicalId].read(av) shouldBe Right(CanonicalId("12345678"))
     }
   }
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
@@ -10,14 +10,28 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import scala.util.Success
 
 class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
+  it("checks it's really a canonical ID") {
+    intercept[IllegalArgumentException] {
+      CanonicalID("1")
+    }
+
+    intercept[IllegalArgumentException] {
+      CanonicalID("AStringThatsMoreThanEightCharacters")
+    }
+
+    intercept[IllegalArgumentException] {
+      CanonicalID("a string with space")
+    }
+  }
+
   describe("JSON encoding") {
     it("encodes as a string") {
-      val id = CanonicalID("1234567")
+      val id = CanonicalID("12345678")
 
       assertJsonStringsAreEqual(
         toJson(id).get,
         """
-          |"1234567"
+          |"12345678"
           |""".stripMargin
       )
     }
@@ -25,21 +39,21 @@ class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
     it("decodes from a string") {
       val jsonString =
         """
-          |"1234567"
+          |"12345678"
           |""".stripMargin
-      fromJson[CanonicalID](jsonString) shouldBe Success(CanonicalID("1234567"))
+      fromJson[CanonicalID](jsonString) shouldBe Success(CanonicalID("12345678"))
     }
   }
 
   describe("DynamoFormat") {
     it("encodes as a string") {
-      val id = CanonicalID("1234567")
-      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString("1234567")
+      val id = CanonicalID("12345678")
+      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString("12345678")
     }
 
     it("decodes from a string") {
-      val av = AttributeValue.builder().s("1234567").build()
-      DynamoFormat[CanonicalID].read(av) shouldBe Right(CanonicalID("1234567"))
+      val av = AttributeValue.builder().s("12345678").build()
+      DynamoFormat[CanonicalID].read(av) shouldBe Right(CanonicalID("12345678"))
     }
   }
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/CanonicalIDTest.scala
@@ -1,0 +1,45 @@
+package weco.catalogue.internal_model.identifiers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.{DynamoFormat, DynamoValue}
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+import scala.util.Success
+
+class CanonicalIDTest extends AnyFunSpec with Matchers with JsonAssertions {
+  describe("JSON encoding") {
+    it("encodes as a string") {
+      val id = CanonicalID("1234567")
+
+      assertJsonStringsAreEqual(
+        toJson(id).get,
+        """
+          |"1234567"
+          |""".stripMargin
+      )
+    }
+
+    it("decodes from a string") {
+      val jsonString =
+        """
+          |"1234567"
+          |""".stripMargin
+      fromJson[CanonicalID](jsonString) shouldBe Success(CanonicalID("1234567"))
+    }
+  }
+
+  describe("DynamoFormat") {
+    it("encodes as a string") {
+      val id = CanonicalID("1234567")
+      DynamoFormat[CanonicalID].write(id) shouldBe DynamoValue.fromString("1234567")
+    }
+
+    it("decodes from a string") {
+      val av = AttributeValue.builder().s("1234567").build()
+      DynamoFormat[CanonicalID].read(av) shouldBe Right(CanonicalID("1234567"))
+    }
+  }
+}

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/elastic/ElasticIndexerTest.scala
@@ -164,7 +164,6 @@ class ElasticIndexerTest
           val future = indexer(documents)
 
           whenReady(future) { result =>
-            println(result)
             result.right.get should contain only (documents: _*)
             val hits = eventually {
               val response = elasticClient.execute {

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDao.scala
@@ -97,7 +97,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
   ): Try[InsertResult] =
     Try {
       val values = ids.map(i =>
-        Seq(i.CanonicalId, i.OntologyType, i.SourceSystem, i.SourceId))
+        Seq(i.CanonicalId.toString, i.OntologyType, i.SourceSystem, i.SourceId))
       blocking {
         debug(s"Putting new identifier $ids")
         withSQL {

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/models/Identifier.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/models/Identifier.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.id_minter.models
 
 import scalikejdbc._
-import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
 
 /** Represents a set of identifiers as stored in MySQL */
 case class Identifier(
-  CanonicalId: CanonicalID,
+  CanonicalId: CanonicalId,
   OntologyType: String = "Work",
   SourceSystem: String,
   SourceId: String
@@ -14,13 +14,13 @@ case class Identifier(
 object Identifier {
   def apply(p: SyntaxProvider[Identifier])(rs: WrappedResultSet): Identifier =
     Identifier(
-      CanonicalId = CanonicalID(rs.string(p.resultName.CanonicalId)),
+      CanonicalId = CanonicalId(rs.string(p.resultName.CanonicalId)),
       OntologyType = rs.string(p.resultName.OntologyType),
       SourceSystem = rs.string(p.resultName.SourceSystem),
       SourceId = rs.string(p.resultName.SourceId)
     )
 
-  def apply(canonicalId: CanonicalID,
+  def apply(canonicalId: CanonicalId,
             sourceIdentifier: SourceIdentifier): Identifier =
     Identifier(
       CanonicalId = canonicalId,

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/models/Identifier.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/models/Identifier.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.id_minter.models
 
 import scalikejdbc._
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
+import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
 
 /** Represents a set of identifiers as stored in MySQL */
 case class Identifier(
-  CanonicalId: String,
+  CanonicalId: CanonicalID,
   OntologyType: String = "Work",
   SourceSystem: String,
   SourceId: String
@@ -14,13 +14,13 @@ case class Identifier(
 object Identifier {
   def apply(p: SyntaxProvider[Identifier])(rs: WrappedResultSet): Identifier =
     Identifier(
-      CanonicalId = rs.string(p.resultName.CanonicalId),
+      CanonicalId = CanonicalID(rs.string(p.resultName.CanonicalId)),
       OntologyType = rs.string(p.resultName.OntologyType),
       SourceSystem = rs.string(p.resultName.SourceSystem),
       SourceId = rs.string(p.resultName.SourceId)
     )
 
-  def apply(canonicalId: String,
+  def apply(canonicalId: CanonicalID,
             sourceIdentifier: SourceIdentifier): Identifier =
     Identifier(
       CanonicalId = canonicalId,

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/steps/SourceIdentifierEmbedder.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/steps/SourceIdentifierEmbedder.scala
@@ -7,7 +7,7 @@ import io.circe.optics.JsonOptics._
 import monocle.function.Plated
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.id_minter.models.Identifier
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
+import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
@@ -64,13 +64,13 @@ object SourceIdentifierEmbedder extends Logging {
       .map(getCanonicalId(identifiers))
       .map { canonicalId =>
         root.obj.modify { obj =>
-          ("canonicalId", Json.fromString(canonicalId)) +: obj
+          ("canonicalId", Json.fromString(canonicalId.underlying)) +: obj
         }(node)
       }
       .getOrElse(node)
 
   private def getCanonicalId(identifiers: Map[SourceIdentifier, Identifier])(
-    sourceIdentifier: SourceIdentifier): String =
+    sourceIdentifier: SourceIdentifier): CanonicalID =
     identifiers
       .getOrElse(
         sourceIdentifier,

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/steps/SourceIdentifierEmbedder.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/steps/SourceIdentifierEmbedder.scala
@@ -7,7 +7,7 @@ import io.circe.optics.JsonOptics._
 import monocle.function.Plated
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.platform.id_minter.models.Identifier
-import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
@@ -70,7 +70,7 @@ object SourceIdentifierEmbedder extends Logging {
       .getOrElse(node)
 
   private def getCanonicalId(identifiers: Map[SourceIdentifier, Identifier])(
-    sourceIdentifier: SourceIdentifier): CanonicalID =
+    sourceIdentifier: SourceIdentifier): CanonicalId =
     identifiers
       .getOrElse(
         sourceIdentifier,

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/utils/Identifiable.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/utils/Identifiable.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.id_minter.utils
 
+import weco.catalogue.internal_model.identifiers.CanonicalID
+
 import scala.util.Random
 
 object Identifiable {
@@ -15,16 +17,18 @@ object Identifiable {
   private val firstCharacterSet =
     allowedCharacterSet.filterNot(numberRange.contains)
 
-  def generate: String =
-    (1 to identifierLength).map {
-      // One of the serialization formats of RDF is XML, so for
-      // compatibility, our identifiers have to comply with XML rules.
-      // XML identifiers cannot start with numbers, so we apply the same
-      // rule to the identifiers we generate.
-      //
-      // See: http://stackoverflow.com/a/1077111/1558022
-      case 1 => firstCharacterSet(Random.nextInt(firstCharacterSet.length))
-      case _ =>
-        allowedCharacterSet(Random.nextInt(allowedCharacterSet.length))
-    }.mkString
+  def generate: CanonicalID =
+    CanonicalID(
+      (1 to identifierLength).map {
+        // One of the serialization formats of RDF is XML, so for
+        // compatibility, our identifiers have to comply with XML rules.
+        // XML identifiers cannot start with numbers, so we apply the same
+        // rule to the identifiers we generate.
+        //
+        // See: http://stackoverflow.com/a/1077111/1558022
+        case 1 => firstCharacterSet(Random.nextInt(firstCharacterSet.length))
+        case _ =>
+          allowedCharacterSet(Random.nextInt(allowedCharacterSet.length))
+      }.mkString
+    )
 }

--- a/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/utils/Identifiable.scala
+++ b/pipeline/id_minter/src/main/scala/uk/ac/wellcome/platform/id_minter/utils/Identifiable.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.id_minter.utils
 
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.util.Random
 
@@ -17,8 +17,8 @@ object Identifiable {
   private val firstCharacterSet =
     allowedCharacterSet.filterNot(numberRange.contains)
 
-  def generate: CanonicalID =
-    CanonicalID(
+  def generate: CanonicalId =
+    CanonicalId(
       (1 to identifierLength).map {
         // One of the serialization formats of RDF is XML, so for
         // compatibility, our identifiers have to comply with XML rules.

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import weco.catalogue.internal_model.work.WorkState.Identified
 import uk.ac.wellcome.platform.id_minter.fixtures.WorkerServiceFixture
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
 import weco.catalogue.internal_model.work.Work
 
 import scala.collection.mutable
@@ -52,7 +52,7 @@ class IdMinterFeatureTest
 
           val identifiedWork = outputIndex(sentIds.head)
           identifiedWork.sourceIdentifier shouldBe work.sourceIdentifier
-          identifiedWork.state.canonicalId shouldBe sentIds.head
+          identifiedWork.state.canonicalId shouldBe CanonicalId(sentIds.head)
         }
       }
     }
@@ -84,7 +84,7 @@ class IdMinterFeatureTest
 
           val identifiedWork = outputIndex(sentId)
           identifiedWork.sourceIdentifier shouldBe work.sourceIdentifier
-          identifiedWork.state.canonicalId shouldBe sentId
+          identifiedWork.state.canonicalId shouldBe CanonicalId(sentId)
         }
       }
     }
@@ -119,7 +119,7 @@ class IdMinterFeatureTest
 
           val identifiedWork = outputIndex(sentId)
           identifiedWork.sourceIdentifier shouldBe work.sourceIdentifier
-          identifiedWork.state.canonicalId shouldBe sentId
+          identifiedWork.state.canonicalId shouldBe CanonicalId(sentId)
           identifiedWork
             .asInstanceOf[Work.Redirected[Identified]]
             .redirectTarget

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/IdMinterFeatureTest.scala
@@ -123,7 +123,8 @@ class IdMinterFeatureTest
           identifiedWork
             .asInstanceOf[Work.Redirected[Identified]]
             .redirectTarget
-            .canonicalId shouldNot be(empty)
+            .canonicalId
+            .underlying shouldNot be(empty)
         }
       }
     }

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
@@ -32,7 +32,8 @@ class IdentifiersDaoTest
           val triedLookup = identifiersDao.lookupIds(List(sourceIdentifier))
 
           triedLookup shouldBe a[Success[_]]
-          triedLookup.get.existingIdentifiers shouldBe Map(sourceIdentifier -> identifier)
+          triedLookup.get.existingIdentifiers shouldBe Map(
+            sourceIdentifier -> identifier)
           triedLookup.get.unmintedIdentifiers shouldBe empty
       }
     }
@@ -93,7 +94,7 @@ class IdentifiersDaoTest
       withIdentifiersDao(existingEntries = identifiersMap.values.toSeq) {
         case (identifiersDao, _) =>
           val triedLookup = identifiersDao.lookupIds(
-              identifiersMap.keys.toList ++ unmintedSourceIdentifiers
+            identifiersMap.keys.toList ++ unmintedSourceIdentifiers
           )
 
           triedLookup shouldBe a[Success[_]]
@@ -134,7 +135,9 @@ class IdentifiersDaoTest
               .where
               .eq(identifiersTable.i.SourceSystem, identifier.SourceSystem)
               .and
-              .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId.underlying)
+              .eq(
+                identifiersTable.i.CanonicalId,
+                identifier.CanonicalId.underlying)
           }.map(Identifier(identifiersTable.i)).single.apply()
 
           maybeIdentifier shouldBe defined

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
@@ -5,10 +5,9 @@ import java.sql.BatchUpdateException
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import scalikejdbc._
-import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.id_minter.fixtures
 import uk.ac.wellcome.platform.id_minter.fixtures.SqlIdentifiersGenerators
-import uk.ac.wellcome.platform.id_minter.models.{Identifier, IdentifiersTable}
+import uk.ac.wellcome.platform.id_minter.models.Identifier
 
 import scala.util.{Failure, Success}
 
@@ -19,43 +18,6 @@ class IdentifiersDaoTest
     with SqlIdentifiersGenerators {
 
   implicit val session: DBSession = NamedAutoSession('primary)
-
-  def withIdentifiersDao[R](existingEntries: Seq[Identifier] = Nil)(
-    testWith: TestWith[(IdentifiersDao, IdentifiersTable), R]): R =
-    withIdentifiersTable { identifiersTableConfig =>
-      val identifiersTable = new IdentifiersTable(identifiersTableConfig)
-
-      new TableProvisioner(rdsClientConfig)
-        .provision(
-          database = identifiersTableConfig.database,
-          tableName = identifiersTableConfig.tableName
-        )
-
-      val identifiersDao = new IdentifiersDao(identifiersTable)
-
-      eventuallyTableExists(identifiersTableConfig)
-
-      if (existingEntries.nonEmpty) {
-        NamedDB('primary) localTx { implicit session =>
-          withSQL {
-            insert
-              .into(identifiersTable)
-              .namedValues(
-                identifiersTable.column.CanonicalId -> sqls.?,
-                identifiersTable.column.OntologyType -> sqls.?,
-                identifiersTable.column.SourceSystem -> sqls.?,
-                identifiersTable.column.SourceId -> sqls.?
-              )
-          }.batch {
-            existingEntries.map { id =>
-              Seq(id.CanonicalId, id.OntologyType, id.SourceSystem, id.SourceId)
-            }: _*
-          }.apply()
-        }
-      }
-
-      testWith((identifiersDao, identifiersTable))
-    }
 
   describe("lookupIds") {
 

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/database/IdentifiersDaoTest.scala
@@ -172,7 +172,7 @@ class IdentifiersDaoTest
               .where
               .eq(identifiersTable.i.SourceSystem, identifier.SourceSystem)
               .and
-              .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId)
+              .eq(identifiersTable.i.CanonicalId, identifier.CanonicalId.underlying)
           }.map(Identifier(identifiersTable.i)).single.apply()
 
           maybeIdentifier shouldBe defined

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/SqlIdentifiersGenerators.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/SqlIdentifiersGenerators.scala
@@ -2,11 +2,11 @@ package uk.ac.wellcome.platform.id_minter.fixtures
 
 import uk.ac.wellcome.platform.id_minter.models.Identifier
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
 
 trait SqlIdentifiersGenerators extends IdentifiersGenerators {
   def createSQLIdentifierWith(
-    canonicalId: CanonicalID = createCanonicalId,
+    canonicalId: CanonicalId = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): Identifier =
     Identifier(

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/SqlIdentifiersGenerators.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/SqlIdentifiersGenerators.scala
@@ -2,11 +2,11 @@ package uk.ac.wellcome.platform.id_minter.fixtures
 
 import uk.ac.wellcome.platform.id_minter.models.Identifier
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
+import weco.catalogue.internal_model.identifiers.{CanonicalID, SourceIdentifier}
 
 trait SqlIdentifiersGenerators extends IdentifiersGenerators {
   def createSQLIdentifierWith(
-    canonicalId: String = createCanonicalId,
+    canonicalId: CanonicalID = createCanonicalId,
     sourceIdentifier: SourceIdentifier = createSourceIdentifier
   ): Identifier =
     Identifier(

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/fixtures/WorkerServiceFixture.scala
@@ -58,7 +58,7 @@ trait WorkerServiceFixture
     mergedIndex: Map[String, Json],
     identifiedIndex: mutable.Map[String, Work[Identified]])(
     testWith: TestWith[IdMinterWorkerService[String], R]): R = {
-    Class.forName("com.mysql.jdbc.Driver")
+    Class.forName("com.mysql.cj.jdbc.Driver")
     ConnectionPool.singleton(
       s"jdbc:mysql://$host:$port",
       username,

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
@@ -177,7 +177,7 @@ class IdentifierGeneratorTest
         )
 
         val id = triedId.get.values.head.CanonicalId
-        id should not be empty
+        id.underlying should not be empty
 
         val i = identifiersTable.i
         val maybeIdentifier = withSQL {

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/steps/IdentifierGeneratorTest.scala
@@ -26,22 +26,25 @@ class IdentifierGeneratorTest
                                    None,
                                  existingDaoEntries: Seq[Identifier] = Nil)(
     testWith: TestWith[(IdentifierGenerator, IdentifiersTable), R]): R =
-    withIdentifiersDao(existingDaoEntries) { case (identifiersDao, table) =>
-      val identifierGenerator = maybeIdentifiersDao match {
-        case Some(dao) => new IdentifierGenerator(dao)
-        case None      => new IdentifierGenerator(identifiersDao)
-      }
+    withIdentifiersDao(existingDaoEntries) {
+      case (identifiersDao, table) =>
+        val identifierGenerator = maybeIdentifiersDao match {
+          case Some(dao) => new IdentifierGenerator(dao)
+          case None      => new IdentifierGenerator(identifiersDao)
+        }
 
-      testWith((identifierGenerator, table))
+        testWith((identifierGenerator, table))
     }
 
   it("queries the database and returns matching canonical IDs") {
     val sourceIdentifiers = (1 to 5).map(_ => createSourceIdentifier).toList
     val canonicalIds = (1 to 5).map(_ => createCanonicalId).toList
     val existingEntries = (sourceIdentifiers zip canonicalIds).map {
-      case (sourceId, canonicalId) => Identifier(
-        canonicalId, sourceId
-      )
+      case (sourceId, canonicalId) =>
+        Identifier(
+          canonicalId,
+          sourceId
+        )
     }
     withIdentifierGenerator(existingDaoEntries = existingEntries) {
       case (identifierGenerator, _) =>
@@ -98,8 +101,7 @@ class IdentifierGeneratorTest
     val identifiersDao = new IdentifiersDao(
       identifiers = new IdentifiersTable(config)
     ) {
-      override def lookupIds(
-        sourceIdentifiers: Seq[SourceIdentifier])(
+      override def lookupIds(sourceIdentifiers: Seq[SourceIdentifier])(
         implicit session: DBSession
       ): Try[IdentifiersDao.LookupResult] =
         Success(
@@ -109,8 +111,7 @@ class IdentifierGeneratorTest
           )
         )
 
-      override def saveIdentifiers(
-        ids: List[Identifier])(
+      override def saveIdentifiers(ids: List[Identifier])(
         implicit session: DBSession
       ): Try[IdentifiersDao.InsertResult] =
         Failure(

--- a/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/utils/IdentifiableTest.scala
+++ b/pipeline/id_minter/src/test/scala/uk/ac/wellcome/platform/id_minter/utils/IdentifiableTest.scala
@@ -7,7 +7,7 @@ class IdentifiableTest extends AnyFunSpec with Matchers {
 
   it("generates an 8-char string, with no ambiguous characters") {
     (1 to 100).map { _ =>
-      val id = Identifiable.generate
+      val id = Identifiable.generate.underlying
       id should have size 8
       id.toCharArray should contain noneOf ('0', 'o', 'i', 'l', '1')
       id should fullyMatch regex "[0-9|a-z&&[^oil10]]{8}"
@@ -16,7 +16,7 @@ class IdentifiableTest extends AnyFunSpec with Matchers {
 
   it("never generates an identifier that starts with a number") {
     (1 to 100).map { _ =>
-      Identifiable.generate should not(startWith regex "[0-9]")
+      Identifiable.generate.underlying should not(startWith regex "[0-9]")
     }
   }
 }

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/integration/ManagerInferrerIntegrationTest.scala
@@ -71,7 +71,7 @@ class ManagerInferrerIntegrationTest
 
           inside(augmentedImage.state) {
             case Augmented(_, id, Some(inferredData)) =>
-              id should be(image.id)
+              id should be(image.state.canonicalId)
               inside(inferredData) {
                 case InferredData(
                     features1,

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -44,7 +44,7 @@ class InferenceManagerWorkerServiceTest
     "reads image messages, augments them with the inferrers, and sends them to SNS") {
     val images = (1 to 5)
       .map(_ => createImageData.toInitialImage)
-      .map(image => image.id -> image)
+      .map(image => image.state.canonicalId -> image)
       .toMap
     withResponsesAndFixtures(
       images.values.toList,

--- a/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/uk/ac/wellcome/platform/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -66,7 +66,7 @@ class InferenceManagerWorkerServiceTest
           case None =>
             warn(s"Unable to find matching image for request $req")
             None
-        },
+      },
       images = _ => Some(Responses.image)
     ) {
       case (QueuePair(queue, dlq), messageSender, augmentedImages, _, _) =>

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -35,7 +35,7 @@ class WorkMatcher(workGraphStore: WorkGraphStore,
     doMatch(links).map(MatcherResult)
 
   private def doMatch(links: WorkLinks): Future[Out] =
-    withLocks(links, links.ids) {
+    withLocks(links, links.ids.map(_.toString)) {
       for {
         beforeGraph <- workGraphStore.findAffectedWorks(links)
         afterGraph = WorkGraphUpdater.update(links, beforeGraph)

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.matcher.models
 
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Identified
 
-case class WorkLinks(workId: CanonicalID,
+case class WorkLinks(workId: CanonicalId,
                      version: Int,
-                     referencedWorkIds: Set[CanonicalID]) {
-  lazy val ids: Set[CanonicalID] = referencedWorkIds + workId
+                     referencedWorkIds: Set[CanonicalId]) {
+  lazy val ids: Set[CanonicalId] = referencedWorkIds + workId
 }
 
 case object WorkLinks {

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/models/WorkLinks.scala
@@ -1,17 +1,18 @@
 package uk.ac.wellcome.platform.matcher.models
 
+import weco.catalogue.internal_model.identifiers.CanonicalID
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Identified
 
-case class WorkLinks(workId: String,
+case class WorkLinks(workId: CanonicalID,
                      version: Int,
-                     referencedWorkIds: Set[String]) {
-  lazy val ids: Set[String] = referencedWorkIds + workId
+                     referencedWorkIds: Set[CanonicalID]) {
+  lazy val ids: Set[CanonicalID] = referencedWorkIds + workId
 }
 
 case object WorkLinks {
   def apply(work: Work[Identified]): WorkLinks = {
-    val id = work.id
+    val id = work.state.canonicalId
     val referencedWorkIds = work.data.mergeCandidates
       .map { mergeCandidate =>
         mergeCandidate.id.canonicalId

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.storage.dynamo.DynamoBatchWriter
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,7 +34,7 @@ class WorkNodeDao(dynamoClient: DynamoDbClient, dynamoConfig: DynamoConfig)(
           throw MatcherException(exception)
       }
 
-  def get(ids: Set[String]): Future[Set[WorkNode]] =
+  def get(ids: Set[CanonicalID]): Future[Set[WorkNode]] =
     Future {
       scanamo
         .exec { nodes.getAll("id" in ids) }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDao.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.storage.dynamo.DynamoBatchWriter
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -34,7 +34,7 @@ class WorkNodeDao(dynamoClient: DynamoDbClient, dynamoConfig: DynamoConfig)(
           throw MatcherException(exception)
       }
 
-  def get(ids: Set[CanonicalID]): Future[Set[WorkNode]] =
+  def get(ids: Set[CanonicalId]): Future[Set[WorkNode]] =
     Future {
       scanamo
         .exec { nodes.getAll("id" in ids) }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.pipeline_storage.elastic.ElasticRetriever
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalID, IdState}
 import weco.catalogue.internal_model.work.MergeCandidate
 
 import scala.concurrent.ExecutionContext
@@ -48,7 +48,7 @@ class ElasticWorkLinksRetriever(val client: ElasticClient, val index: Index)(
       )
     }
 
-  private case class StateStub(canonicalId: String)
+  private case class StateStub(canonicalId: CanonicalID)
   private case class DataStub(
     mergeCandidates: List[MergeCandidate[IdState.Identified]])
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetriever.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.pipeline_storage.elastic.ElasticRetriever
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
-import weco.catalogue.internal_model.identifiers.{CanonicalID, IdState}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
 import weco.catalogue.internal_model.work.MergeCandidate
 
 import scala.concurrent.ExecutionContext
@@ -48,7 +48,7 @@ class ElasticWorkLinksRetriever(val client: ElasticClient, val index: Index)(
       )
     }
 
-  private case class StateStub(canonicalId: CanonicalID)
+  private case class StateStub(canonicalId: CanonicalId)
   private case class DataStub(
     mergeCandidates: List[MergeCandidate[IdState.Identified]])
 

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.platform.matcher.models.{
   WorkGraph,
   WorkLinks
 }
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 object WorkGraphUpdater extends Logging {
   def update(links: WorkLinks, existingGraph: WorkGraph): WorkGraph = {
@@ -60,7 +61,7 @@ object WorkGraphUpdater extends Logging {
     //
     // Every work in the existing graph will be in this list.
     //
-    val workVersions: Map[String, Int] =
+    val workVersions: Map[CanonicalID, Int] =
       linkedWorks.collect {
         case WorkNode(id, Some(version), _, _) => (id, version)
       }.toMap + (workLinks.workId -> workLinks.version)
@@ -106,7 +107,7 @@ object WorkGraphUpdater extends Logging {
     //
     // In this example, linkedWorkIds(B) = {C, D}
     //
-    def linkedWorkIds(n: g.NodeT): List[String] =
+    def linkedWorkIds(n: g.NodeT): List[CanonicalID] =
       n.diSuccessors.map(_.value).toList.sorted
 
     // Go through the components of the graph, and turn each of them into
@@ -145,6 +146,6 @@ object WorkGraphUpdater extends Logging {
     * TODO: Does this need to be a SHA-256 value?
     * Could we just concatenate all the IDs?
     */
-  private def componentIdentifier(nodeIds: List[String]): String =
-    DigestUtils.sha256Hex(nodeIds.sorted.mkString("+"))
+  private def componentIdentifier(nodeIds: List[CanonicalID]): String =
+    DigestUtils.sha256Hex(nodeIds.sorted.map(_.underlying).mkString("+"))
 }

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdater.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.matcher.models.{
   WorkGraph,
   WorkLinks
 }
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 object WorkGraphUpdater extends Logging {
   def update(links: WorkLinks, existingGraph: WorkGraph): WorkGraph = {
@@ -61,7 +61,7 @@ object WorkGraphUpdater extends Logging {
     //
     // Every work in the existing graph will be in this list.
     //
-    val workVersions: Map[CanonicalID, Int] =
+    val workVersions: Map[CanonicalId, Int] =
       linkedWorks.collect {
         case WorkNode(id, Some(version), _, _) => (id, version)
       }.toMap + (workLinks.workId -> workLinks.version)
@@ -107,7 +107,7 @@ object WorkGraphUpdater extends Logging {
     //
     // In this example, linkedWorkIds(B) = {C, D}
     //
-    def linkedWorkIds(n: g.NodeT): List[CanonicalID] =
+    def linkedWorkIds(n: g.NodeT): List[CanonicalId] =
       n.diSuccessors.map(_.value).toList.sorted
 
     // Go through the components of the graph, and turn each of them into
@@ -146,6 +146,6 @@ object WorkGraphUpdater extends Logging {
     * TODO: Does this need to be a SHA-256 value?
     * Could we just concatenate all the IDs?
     */
-  private def componentIdentifier(nodeIds: List[CanonicalID]): String =
+  private def componentIdentifier(nodeIds: List[CanonicalId]): String =
     DigestUtils.sha256Hex(nodeIds.sorted.map(_.underlying).mkString("+"))
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/MatcherFeatureTest.scala
@@ -73,7 +73,7 @@ class MatcherFeatureTest
               id = linksV1.workId,
               version = Some(existingWorkVersion),
               linkedIds = Nil,
-              componentId = linksV1.workId
+              componentId = ciHash(linksV1.workId)
             )
             put(dynamoClient, graphTable.name)(nodeV2)
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -31,7 +31,7 @@ import uk.ac.wellcome.storage.locking.memory.{
   MemoryLockDao,
   MemoryLockingService
 }
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -133,7 +133,7 @@ trait MatcherFixtures
     sendNotificationToSQS(queue, body = links.workId.toString)
   }
 
-  def ciHash(ids: CanonicalID*): String =
+  def ciHash(ids: CanonicalId*): String =
     DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
 
   def get[T](dynamoClient: DynamoDbClient, tableName: String)(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/MatcherFixtures.scala
@@ -31,6 +31,7 @@ import uk.ac.wellcome.storage.locking.memory.{
   MemoryLockDao,
   MemoryLockingService
 }
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -128,12 +129,12 @@ trait MatcherFixtures
     retriever: MemoryRetriever[WorkLinks],
     queue: SQS.Queue
   ): Any = {
-    retriever.index ++= Map(links.workId -> links)
-    sendNotificationToSQS(queue, body = links.workId)
+    retriever.index ++= Map(links.workId.toString -> links)
+    sendNotificationToSQS(queue, body = links.workId.toString)
   }
 
-  def ciHash(ids: String*): String =
-    DigestUtils.sha256Hex(ids.sorted.mkString("+"))
+  def ciHash(ids: CanonicalID*): String =
+    DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
 
   def get[T](dynamoClient: DynamoDbClient, tableName: String)(
     key: UniqueKey[_])(

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -8,7 +8,8 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
   def createIdentifier(canonicalId: CanonicalID): IdState.Identified =
     IdState.Identified(
       canonicalId = canonicalId,
-      sourceIdentifier = createSourceIdentifierWith(value = canonicalId.toString)
+      sourceIdentifier =
+        createSourceIdentifierWith(value = canonicalId.toString)
     )
 
   def createIdentifier(canonicalId: String): IdState.Identified =

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -2,17 +2,20 @@ package uk.ac.wellcome.platform.matcher.generators
 
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalID, IdState}
 
 trait WorkLinksGenerators extends IdentifiersGenerators {
-  def createIdentifier(id: String): IdState.Identified =
+  def createIdentifier(canonicalId: CanonicalID): IdState.Identified =
     IdState.Identified(
-      canonicalId = id,
-      sourceIdentifier = createSourceIdentifierWith(value = id)
+      canonicalId = canonicalId,
+      sourceIdentifier = createSourceIdentifierWith(value = canonicalId.toString)
     )
 
+  def createIdentifier(canonicalId: String): IdState.Identified =
+    createIdentifier(canonicalId = CanonicalID(canonicalId))
+
   def createWorkLinksWith(
-    id: IdState.Identified = createIdentifier(randomAlphanumeric()),
+    id: IdState.Identified = createIdentifier(canonicalId = createCanonicalId),
     version: Int = randomInt(from = 1, to = 10),
     referencedIds: Set[IdState.Identified] = Set.empty
   ): WorkLinks =
@@ -25,7 +28,7 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
   def createWorkLinks: WorkLinks =
     createWorkLinksWith(
       referencedIds = collectionOf(min = 0) {
-        createIdentifier(randomAlphanumeric())
+        createIdentifier(canonicalId = createCanonicalId)
       }.toSet
     )
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/generators/WorkLinksGenerators.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.platform.matcher.generators
 
 import uk.ac.wellcome.platform.matcher.models.WorkLinks
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalID, IdState}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
 
 trait WorkLinksGenerators extends IdentifiersGenerators {
-  def createIdentifier(canonicalId: CanonicalID): IdState.Identified =
+  def createIdentifier(canonicalId: CanonicalId): IdState.Identified =
     IdState.Identified(
       canonicalId = canonicalId,
       sourceIdentifier =
@@ -13,7 +13,7 @@ trait WorkLinksGenerators extends IdentifiersGenerators {
     )
 
   def createIdentifier(canonicalId: String): IdState.Identified =
-    createIdentifier(canonicalId = CanonicalID(canonicalId))
+    createIdentifier(canonicalId = CanonicalId(canonicalId))
 
   def createWorkLinksWith(
     id: IdState.Identified = createIdentifier(canonicalId = createCanonicalId),

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -32,8 +32,8 @@ class WorkMatcherConcurrencyTest
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
         val workMatcher = new WorkMatcher(workGraphStore, lockingService)
-        val identifierA = createIdentifier(id = "A")
-        val identifierB = createIdentifier(id = "B")
+        val identifierA = createIdentifier(canonicalId = "AAAAAAAA")
+        val identifierB = createIdentifier(canonicalId = "BBBBBBBB")
 
         val linksA = createWorkLinksWith(
           id = identifierA,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -38,9 +38,9 @@ class WorkMatcherTest
     with EitherValues
     with WorkLinksGenerators {
 
-  private val identifierA = createIdentifier("A")
-  private val identifierB = createIdentifier("B")
-  private val identifierC = createIdentifier("C")
+  private val identifierA = createIdentifier("AAAAAAAA")
+  private val identifierB = createIdentifier("BBBBBBBB")
+  private val identifierC = createIdentifier("CCCCCCCC")
 
   it(
     "matches a work with no linked identifiers to itself only A and saves the updated graph A") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -28,9 +28,9 @@ class MatcherWorkerServiceTest
     with MatcherFixtures
     with WorkLinksGenerators {
 
-  private val identifierA = createIdentifier("A")
-  private val identifierB = createIdentifier("B")
-  private val identifierC = createIdentifier("C")
+  private val identifierA = createIdentifier("AAAAAAAA")
+  private val identifierB = createIdentifier("BBBBBBBB")
+  private val identifierC = createIdentifier("CCCCCCCC")
 
   it("matches a Work which doesn't reference any other Works") {
     val workLinks = createWorkLinksWith(id = identifierA)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 class WorkGraphStoreTest
     extends AnyFunSpec
@@ -18,9 +18,9 @@ class WorkGraphStoreTest
     with MatcherFixtures
     with IdentifiersGenerators {
 
-  val idA = CanonicalID("AAAAAAAA")
-  val idB = CanonicalID("BBBBBBBB")
-  val idC = CanonicalID("CCCCCCCC")
+  val idA = CanonicalId("AAAAAAAA")
+  val idB = CanonicalId("BBBBBBBB")
+  val idC = CanonicalId("CCCCCCCC")
 
   describe("Get graph of linked works") {
     it("returns nothing if there are no matching graphs") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -42,7 +42,6 @@ class WorkGraphStoreTest
       "returns a WorkNode if it has no links and it's the only node in the setId") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-
           val work =
             WorkNode(
               id = idA,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkGraphStoreTest.scala
@@ -8,16 +8,19 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models.{WorkGraph, WorkLinks}
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 class WorkGraphStoreTest
     extends AnyFunSpec
     with Matchers
     with ScalaFutures
-    with MatcherFixtures {
+    with MatcherFixtures
+    with IdentifiersGenerators {
 
-  val idA = "A"
-  val idB = "B"
-  val idC = "C"
+  val idA = CanonicalID("AAAAAAAA")
+  val idB = CanonicalID("BBBBBBBB")
+  val idC = CanonicalID("CCCCCCCC")
 
   describe("Get graph of linked works") {
     it("returns nothing if there are no matching graphs") {
@@ -26,7 +29,7 @@ class WorkGraphStoreTest
           whenReady(
             workGraphStore.findAffectedWorks(
               WorkLinks(
-                "Not-there",
+                createCanonicalId,
                 version = 0,
                 referencedWorkIds = Set.empty))) { workGraph =>
             workGraph shouldBe WorkGraph(Set.empty)
@@ -39,6 +42,7 @@ class WorkGraphStoreTest
       "returns a WorkNode if it has no links and it's the only node in the setId") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
+
           val work =
             WorkNode(
               id = idA,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -22,6 +22,8 @@ import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 import scala.language.higherKinds
 
@@ -30,16 +32,17 @@ class WorkNodeDaoTest
     with Matchers
     with MockitoSugar
     with ScalaFutures
-    with MatcherFixtures {
+    with MatcherFixtures
+    with IdentifiersGenerators {
 
-  val idA = "A"
-  val idB = "B"
+  val idA = CanonicalID("AAAAAAAA")
+  val idB = CanonicalID("BBBBBBBB")
 
   describe("Get from dynamo") {
     it("returns nothing if ids are not in dynamo") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          whenReady(workNodeDao.get(Set("Not-there"))) { workNodeSet =>
+          whenReady(workNodeDao.get(Set(createCanonicalId))) { workNodeSet =>
             workNodeSet shouldBe Set.empty
           }
         }
@@ -196,7 +199,7 @@ class WorkNodeDaoTest
     it("returns an error if Scanamo fails during a getByComponentIds") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: String, componentId: String, version: String)
+          case class BadRecord(id: CanonicalID, componentId: String, version: String)
           val badRecord: BadRecord =
             BadRecord(
               id = idA,
@@ -233,7 +236,7 @@ class WorkNodeDaoTest
     it("returns an error if Scanamo fails to put a record") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: String, version: String)
+          case class BadRecord(id: CanonicalID, version: String)
           val badRecord: BadRecord = BadRecord(id = idA, version = "six")
           put(dynamoClient, table.name)(badRecord)
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -199,7 +199,9 @@ class WorkNodeDaoTest
     it("returns an error if Scanamo fails during a getByComponentIds") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: CanonicalID, componentId: String, version: String)
+          case class BadRecord(id: CanonicalID,
+                               componentId: String,
+                               version: String)
           val badRecord: BadRecord =
             BadRecord(
               id = idA,

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/WorkNodeDaoTest.scala
@@ -23,7 +23,7 @@ import uk.ac.wellcome.platform.matcher.exceptions.MatcherException
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.language.higherKinds
 
@@ -35,8 +35,8 @@ class WorkNodeDaoTest
     with MatcherFixtures
     with IdentifiersGenerators {
 
-  val idA = CanonicalID("AAAAAAAA")
-  val idB = CanonicalID("BBBBBBBB")
+  val idA = CanonicalId("AAAAAAAA")
+  val idB = CanonicalId("BBBBBBBB")
 
   describe("Get from dynamo") {
     it("returns nothing if ids are not in dynamo") {
@@ -199,7 +199,7 @@ class WorkNodeDaoTest
     it("returns an error if Scanamo fails during a getByComponentIds") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: CanonicalID,
+          case class BadRecord(id: CanonicalId,
                                componentId: String,
                                version: String)
           val badRecord: BadRecord =
@@ -238,7 +238,7 @@ class WorkNodeDaoTest
     it("returns an error if Scanamo fails to put a record") {
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
-          case class BadRecord(id: CanonicalID, version: String)
+          case class BadRecord(id: CanonicalId, version: String)
           val badRecord: BadRecord = BadRecord(id = idA, version = "six")
           put(dynamoClient, table.name)(badRecord)
 

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
@@ -61,5 +61,5 @@ class ElasticWorkLinksRetrieverTest
   override def createT: WorkLinks = createWorkLinks
 
   override implicit val id: IndexId[WorkLinks] =
-    (links: WorkLinks) => links.workId
+    (links: WorkLinks) => links.workId.underlying
 }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -5,16 +5,17 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models._
+import weco.catalogue.internal_model.identifiers.CanonicalID
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
     with Matchers
     with MatcherFixtures {
 
-  val idA = "A"
-  val idB = "B"
-  val idC = "C"
-  val idD = "D"
+  val idA = CanonicalID("AAAAAAAA")
+  val idB = CanonicalID("BBBBBBBB")
+  val idC = CanonicalID("CCCCCCCC")
+  val idD = CanonicalID("DDDDDDDD")
 
   describe("Adding links without existing works") {
     it("updating nothing with A gives A:A") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -5,17 +5,17 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.matcher.WorkNode
 import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
 import uk.ac.wellcome.platform.matcher.models._
-import weco.catalogue.internal_model.identifiers.CanonicalID
+import weco.catalogue.internal_model.identifiers.CanonicalId
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
     with Matchers
     with MatcherFixtures {
 
-  val idA = CanonicalID("AAAAAAAA")
-  val idB = CanonicalID("BBBBBBBB")
-  val idC = CanonicalID("CCCCCCCC")
-  val idD = CanonicalID("DDDDDDDD")
+  val idA = CanonicalId("AAAAAAAA")
+  val idB = CanonicalId("BBBBBBBB")
+  val idC = CanonicalId("CCCCCCCC")
+  val idD = CanonicalId("DDDDDDDD")
 
   describe("Adding links without existing works") {
     it("updating nothing with A gives A:A") {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -357,7 +357,7 @@ class WorkGraphUpdaterTest
                   componentId = ciHash(idA))))
           )
       }
-      thrown.message shouldBe "update failed, work:A v1 is not newer than existing work v3"
+      thrown.message shouldBe s"update failed, work:$idA v1 is not newer than existing work v3"
     }
 
     it(
@@ -418,7 +418,7 @@ class WorkGraphUpdaterTest
                   componentId = ciHash(idA, idB))))
           )
       }
-      thrown.getMessage shouldBe "update failed, work:A v2 already exists with different content! update-ids:Set(A) != existing-ids:Set(B)"
+      thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idA) != existing-ids:Set($idB)"
     }
   }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookup.scala
@@ -18,7 +18,7 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
 
     val workIds = workIdentifiers
       .collect {
-        case WorkIdentifier(identifier, Some(_)) => identifier
+        case WorkIdentifier(identifier, Some(_)) => identifier.toString
       }
 
     // If none of the work identifiers had a version, we'll discard anything
@@ -37,7 +37,7 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
               .map {
                 case WorkIdentifier(_, None) => None
                 case WorkIdentifier(id, Some(version)) =>
-                  val work = works(id)
+                  val work = works(id.toString)
                   // We only want to get the exact versions of the works specified
                   // by the matcher.
                   //

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -101,7 +101,7 @@ trait Merger extends MergerLogging {
 
           val redirectedIdentifiers =
             redirectedSources.map { s =>
-              IdState.Identified(s.id, s.sourceIdentifier)
+              IdState.Identified(s.state.canonicalId, s.sourceIdentifier)
             }.toSeq
 
           val targetWork: Work.Visible[Identified] =

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -212,7 +212,7 @@ class MergerFeatureTest
             List(
               MergeCandidate(
                 id = IdState.Identified(
-                  canonicalId = workWithPhysicalVideoFormats.id,
+                  canonicalId = workWithPhysicalVideoFormats.state.canonicalId,
                   sourceIdentifier =
                     workWithPhysicalVideoFormats.sourceIdentifier
                 ),
@@ -228,7 +228,7 @@ class MergerFeatureTest
             List(
               MergeCandidate(
                 id = IdState.Identified(
-                  canonicalId = workForEbib.id,
+                  canonicalId = workForEbib.state.canonicalId,
                   sourceIdentifier = workForEbib.sourceIdentifier
                 ),
                 reason = Some("METS work")

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/IdentifiedWorkLookupTest.scala
@@ -43,7 +43,7 @@ class IdentifiedWorkLookupTest
 
   it("returns None if asked to fetch a Work without a version") {
     val work = identifiedWork().withVersion(0)
-    val workId = WorkIdentifier(work.sourceIdentifier.toString, version = None)
+    val workId = WorkIdentifier(work.state.canonicalId, version = None)
 
     val retriever = new MemoryRetriever[Work[Identified]](
       index = mutable.Map(work.id -> work)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerTest.scala
@@ -117,7 +117,7 @@ class MergerTest
 
     mergedWork.redirectSources should contain theSameElementsAs
       inputWorks.tail.tail.map { w =>
-        IdState.Identified(w.id, w.sourceIdentifier)
+        IdState.Identified(w.state.canonicalId, w.sourceIdentifier)
       }
   }
 
@@ -161,7 +161,7 @@ class MergerTest
     mergedWork.redirectSources should contain allElementsOf existingRedirectSources
     mergedWork.redirectSources should contain allElementsOf
       sourceWorks.tail.map { w =>
-        IdState.Identified(w.id, w.sourceIdentifier)
+        IdState.Identified(w.state.canonicalId, w.sourceIdentifier)
       }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -21,7 +21,7 @@ import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.WorkFsm._
 import uk.ac.wellcome.models.work.generators.MiroWorkGenerators
 import uk.ac.wellcome.pipeline_storage.MemoryRetriever
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
 import weco.catalogue.internal_model.work.{MergeCandidate, Work}
 
 class MergerWorkerServiceTest
@@ -291,9 +291,9 @@ class MergerWorkerServiceTest
           mergedWorks should have size 1
           mergedWorks.head.sourceIdentifier shouldBe physicalWork.sourceIdentifier
 
-          imagesSent.head shouldBe miroWork.data.imageData.head.id.canonicalId
+          CanonicalId(imagesSent.head) shouldBe miroWork.data.imageData.head.id.canonicalId
           images should have size 1
-          images.head.id shouldBe miroWork.data.imageData.head.id.canonicalId
+          CanonicalId(images.head.id) shouldBe miroWork.data.imageData.head.id.canonicalId
         }
     }
   }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -154,7 +154,7 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -204,7 +204,7 @@ class PlatformMergerTest
       ),
       state = zeroItemSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -263,7 +263,7 @@ class PlatformMergerTest
       ),
       state = sierraDigitalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -309,7 +309,7 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.id, miroWork.sourceIdentifier)
+        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -345,7 +345,7 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -415,7 +415,7 @@ class PlatformMergerTest
       ),
       state = sierraPictureWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -475,10 +475,10 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
-        IdState.Identified(miroWork.id, miroWork.sourceIdentifier),
+        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
+        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier),
         IdState.Identified(
-          sierraDigitisedWork.id,
+          sierraDigitisedWork.state.canonicalId,
           sierraDigitisedWork.sourceIdentifier),
       )
     )
@@ -556,7 +556,7 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier)
+        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -598,9 +598,9 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.id, metsWork.sourceIdentifier),
+        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
         IdState.Identified(
-          sierraDigitisedWork.id,
+          sierraDigitisedWork.state.canonicalId,
           sierraDigitisedWork.sourceIdentifier)
       )
     )
@@ -715,7 +715,7 @@ class PlatformMergerTest
           List(
             MergeCandidate(
               id = IdState.Identified(
-                canonicalId = workWithPhysicalVideoFormats.id,
+                canonicalId = workWithPhysicalVideoFormats.state.canonicalId,
                 sourceIdentifier = workWithPhysicalVideoFormats.sourceIdentifier
               ),
               reason = Some("Physical/digitised Sierra work")
@@ -730,7 +730,7 @@ class PlatformMergerTest
           List(
             MergeCandidate(
               id = IdState.Identified(
-                canonicalId = workForEbib.id,
+                canonicalId = workForEbib.state.canonicalId,
                 sourceIdentifier = workForEbib.sourceIdentifier
               ),
               reason = Some("METS work")
@@ -747,7 +747,7 @@ class PlatformMergerTest
           List(
             MergeCandidate(
               id = IdState.Identified(
-                canonicalId = workForEbib.id,
+                canonicalId = workForEbib.state.canonicalId,
                 sourceIdentifier = workForEbib.sourceIdentifier
               ),
               reason = Some("Physical/digitised Sierra work")
@@ -780,7 +780,7 @@ class PlatformMergerTest
 
     // Now check that the METS work redirects into the e-bib specifically
     val redirectedWork = redirectedWorks.head
-    redirectedWork.redirectTarget.canonicalId shouldBe workForEbib.id
+    redirectedWork.redirectTarget.canonicalId shouldBe workForEbib.state.canonicalId
 
     visibleWorks(workWithPhysicalVideoFormats.id).data.items shouldBe workWithPhysicalVideoFormats.data.items
     visibleWorks(workForFilmReel.id).data.items shouldBe workForFilmReel.data.items

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -154,7 +154,8 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
+        IdState
+          .Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -204,7 +205,8 @@ class PlatformMergerTest
       ),
       state = zeroItemSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
+        IdState
+          .Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -263,7 +265,8 @@ class PlatformMergerTest
       ),
       state = sierraDigitalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
+        IdState
+          .Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -309,7 +312,8 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
+        IdState
+          .Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier)
       )
     )
 
@@ -345,7 +349,8 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
+        IdState
+          .Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -415,7 +420,8 @@ class PlatformMergerTest
       ),
       state = sierraPictureWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
+        IdState
+          .Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -475,8 +481,10 @@ class PlatformMergerTest
       ),
       state = sierraPhysicalWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
-        IdState.Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier),
+        IdState
+          .Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
+        IdState
+          .Identified(miroWork.state.canonicalId, miroWork.sourceIdentifier),
         IdState.Identified(
           sierraDigitisedWork.state.canonicalId,
           sierraDigitisedWork.sourceIdentifier),
@@ -556,7 +564,8 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
+        IdState
+          .Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier)
       )
     )
 
@@ -598,7 +607,8 @@ class PlatformMergerTest
       ),
       state = multipleItemsSierraWork.transition[Merged](now).state,
       redirectSources = Seq(
-        IdState.Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
+        IdState
+          .Identified(metsWork.state.canonicalId, metsWork.sourceIdentifier),
         IdState.Identified(
           sierraDigitisedWork.state.canonicalId,
           sierraDigitisedWork.sourceIdentifier)

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationWork.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/uk/ac/wellcome/relation_embedder/RelationWork.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.relation_embedder
 
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work._
 
 /** Contains the minimal set of fields on a Work needed for generating a
@@ -23,7 +24,7 @@ case class RelationWork(
 }
 
 case class RelationWorkState(
-  canonicalId: String,
+  canonicalId: CanonicalId,
   availabilities: Set[Availability],
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -203,7 +203,8 @@ object CatalogueDependencies {
       ExternalDependencies.parseDependencies ++
       ExternalDependencies.scalacheckDependencies ++
       ExternalDependencies.enumeratumDependencies ++
-      ExternalDependencies.scalaXmlDependencies
+      ExternalDependencies.scalaXmlDependencies ++
+      WellcomeDependencies.storageLibrary
 
   val displayModelDependencies =
     WellcomeDependencies.internalModel ++


### PR DESCRIPTION
A persistent source of confusion (for me, at least) is the number of things in the catalogue codebase called "identifier" or "id" with type `String`. This patch adds a new `CanonicalID` type, which looks like a string externally (in JSON/Dynamo serialisations), but gives a human a bit more of a hint that they really are dealing with the canonical IDs we see in API URLs and the like.

Follows https://github.com/wellcomecollection/catalogue/pull/1503, part of wellcomecollection/platform#3659