### PR TITLE
Add a "Location of duplicates" note for 535 indicator1="2"

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -22,6 +22,8 @@ case class CiteAsNote(content: String) extends Note
 
 case class LocationOfOriginalNote(content: String) extends Note
 
+case class LocationOfDuplicatesNote(content: String) extends Note
+
 case class BindingInformation(content: String) extends Note
 
 case class BiographicalNote(content: String) extends Note

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -53,10 +53,12 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
         case Some((vf, Some(createNote))) => createNote(vf)
       }
 
-  private def createNoteFromContents(createNote: String => Note): VarField => Note =
+  private def createNoteFromContents(
+    createNote: String => Note): VarField => Note =
     (varField: VarField) => {
       val contents =
-        varField.subfieldsWithoutTags(suppressedSubfields.toSeq: _*)
+        varField
+          .subfieldsWithoutTags(suppressedSubfields.toSeq: _*)
           .contents
           .mkString(" ")
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/MarcGenerators.scala
@@ -7,13 +7,14 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
 
 trait MarcGenerators {
   def createVarFieldWith(marcTag: String,
+                         indicator1: Option[String] = None,
                          indicator2: Option[String] = None,
                          subfields: List[MarcSubfield] = List(),
                          content: Option[String] = None): VarField =
     VarField(
       marcTag = Some(marcTag),
       content = content,
-      indicator1 = None,
+      indicator1 = indicator1,
       indicator2 = indicator2,
       subfields = subfields
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -104,12 +104,14 @@ class SierraNotesTest
         createVarFieldWith(
           marcTag = "535",
           indicator1 = Some("1"),
-          subfields = List(MarcSubfield(tag = "a", content = "The originals are in Oman"))
+          subfields =
+            List(MarcSubfield(tag = "a", content = "The originals are in Oman"))
         ),
         createVarFieldWith(
           marcTag = "535",
           indicator1 = Some("2"),
-          subfields = List(MarcSubfield(tag = "a", content = "The duplicates are in Denmark"))
+          subfields = List(
+            MarcSubfield(tag = "a", content = "The duplicates are in Denmark"))
         )
       )
     )
@@ -135,14 +137,16 @@ class SierraNotesTest
     )
 
     val notes = SierraNotes.notesFields.values
-      .map(createNote => createNote(
-        createVarFieldWith(
-          marcTag = "000",
-          subfields = List(
-            MarcSubfield(tag = "a", content = "Main bit.")
-          )
-        )
-      ))
+      .map(
+        createNote =>
+          createNote(
+            createVarFieldWith(
+              marcTag = "000",
+              subfields = List(
+                MarcSubfield(tag = "a", content = "Main bit.")
+              )
+            )
+        ))
       .toList
 
     SierraNotes(bibData) should contain theSameElementsAs notes

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -98,6 +98,28 @@ class SierraNotesTest
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
 
+  it("distinguishes based on the first indicator of 535") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        createVarFieldWith(
+          marcTag = "535",
+          indicator1 = Some("1"),
+          subfields = List(MarcSubfield(tag = "a", content = "The originals are in Oman"))
+        ),
+        createVarFieldWith(
+          marcTag = "535",
+          indicator1 = Some("2"),
+          subfields = List(MarcSubfield(tag = "a", content = "The duplicates are in Denmark"))
+        )
+      )
+    )
+
+    SierraNotes(bibData) shouldBe List(
+      LocationOfOriginalNote("The originals are in Oman"),
+      LocationOfDuplicatesNote("The duplicates are in Denmark")
+    )
+  }
+
   it("suppresses subfield ǂ5 universally") {
     val varFields = SierraNotes.notesFields.keys.map(key => {
       createVarFieldWith(
@@ -113,7 +135,14 @@ class SierraNotesTest
     )
 
     val notes = SierraNotes.notesFields.values
-      .map(notesField => notesField.createNote("Main bit."))
+      .map(createNote => createNote(
+        createVarFieldWith(
+          marcTag = "000",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Main bit.")
+          )
+        )
+      ))
       .toList
 
     SierraNotes(bibData) should contain theSameElementsAs notes


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5051

To tl;dr that ticket and associated discussion: field 535 distinguishes based on the first indicator:

1 = location of originals <br/>
2 = location of duplicates

And we do use both of those fields in the Wellcome catalogue. Currently we present information from 535 2_ as "location of original" in the API and on the website, which is wrong. This patch adds a new note type, and uses that for 535 2_.

This affects >10k works and will need careful coordination with the API (because the current API would be unable to decode any Works with this Note), so I'm going to hold it until the next reindex. It's not an especially urgent change.