### PR TITLE
Try to make WorksIndexConfigTest less flaky

### DIFF
--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
@@ -43,7 +43,7 @@ class WorksIndexConfigTest
   // We could just import the library, but I might wait until we need more
   // Taken from here:
   // https://github.com/rallyhealth/scalacheck-ops/blob/master/core/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
-  implicit val arbInstant: Arbitrary[Instant] = {
+  implicit val arbInstant: Arbitrary[Instant] =
     Arbitrary {
       for {
         millis <- chooseNum(
@@ -54,7 +54,6 @@ class WorksIndexConfigTest
         Instant.ofEpochMilli(millis).plusNanos(nanos)
       }
     }
-  }
 
   implicit val badObjectEncoder: Encoder[BadTestObject] = deriveEncoder
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 import weco.catalogue.internal_model.work._
 
@@ -53,6 +53,15 @@ class WorksIndexConfigTest
       } yield {
         Instant.ofEpochMilli(millis).plusNanos(nanos)
       }
+    }
+
+  // We have a rule that says SourceIdentifier isn't allowed to contain whitespace,
+  // but sometimes scalacheck will happen to generate such a string, which breaks
+  // tests in CI.  This generator is meant to create SourceIdentifiers that
+  // don't contain whitespace.
+  implicit val arbitrarySourceIdentifier: Arbitrary[SourceIdentifier] =
+    Arbitrary {
+      createSourceIdentifier
     }
 
   implicit val badObjectEncoder: Encoder[BadTestObject] = deriveEncoder


### PR DESCRIPTION
This test has been pretty flaky for me in CI, but it usually clears up on a restart. This is an attempt to make it less flaky.

A quick recap: this test is meant to validate our Elasticsearch mapping. It uses Scalacheck to generate random instances of the Work model, and tries to put them into an index that uses our mapping. If they index – great, the mapping is accurate. If they don't – oh no, flag it for us to investigate.

Unfortunately, Scalacheck knows very little about our models. For example, it sees:

```scala
case class SourceIdentifier(value: String, …)
```

and assumes that _any_ randomly generated String will work there.

This used to be true, but we now have an assertion that prevents you from creating a SourceIdentifier with whitespace in the value. If Scalacheck happens to create a string with whitespace, the test will fail even if the mapping is fine.

This patch tries to control the SourceIdentifier generation, so Scalacheck won't put strings with whitespace here. It means we lose some of the nice shrinking behaviour, but that's not something we use in these tests anyway.