### PR TITLE
Map Copies in Calm to a LocationOfDuplicatesNote

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
@@ -15,7 +15,8 @@ object CalmNotes extends CalmRecordOps {
     ("PubInNote", PublicationsNote(_)),
     ("UserWrapped4", FindingAids(_)),
     ("Copyright", CopyrightNote(_)),
-    ("Arrangement", ArrangementNote(_))
+    ("Arrangement", ArrangementNote(_)),
+    ("Copies", LocationOfDuplicatesNote(_)),
   )
 
   def apply(record: CalmRecord): List[Note] =

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
@@ -17,7 +17,8 @@ class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
       ("PubInNote", "Published in the Public Pamphlet"),
       ("UserWrapped4", "Wrapped in the Worldly Words"),
       ("Copyright", "Copyright the Creative Consortium"),
-      ("Arrangement", "Arranged in an Adorable Alignment")
+      ("Arrangement", "Arranged in an Adorable Alignment"),
+      ("Copies", "A copy is contained in the Circular Church"),
     )
 
     val notes = CalmNotes(record)
@@ -34,7 +35,8 @@ class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
       PublicationsNote("Published in the Public Pamphlet"),
       FindingAids("Wrapped in the Worldly Words"),
       CopyrightNote("Copyright the Creative Consortium"),
-      ArrangementNote("Arranged in an Adorable Alignment")
+      ArrangementNote("Arranged in an Adorable Alignment"),
+      LocationOfDuplicatesNote("A copy is contained in the Circular Church"),
     )
   }
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5051

When the Calm/Sierra harvest happens, the `Copies` field gets mapped to 535 2_. We map the latter as a LocationOfDuplicatesNote, but that gets smooshed when we do a Calm/Sierra merge. This should ensure that data is shown in the API.