### PR TITLE
Half-bounded dates and descriptive labels

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/PeriodParser.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/parse/PeriodParser.scala
@@ -57,25 +57,33 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
     }) |
       (Start ~ halfBoundedDate ~ End)
 
-  def multiPeriodSeparator[_: P]: P[Unit] =
+  // Any separator between several periods
+  // eg: "25th December 1956; 1957, 1959"
+  private def multiPeriodSeparator[_: P]: P[Unit] =
     ws.? ~ StringIn(";", ",", "and") ~ ws.?
 
-  def timePeriod[_: P]: P[InstantRange] =
+  // Any bounded time period: a range or a single date
+  private def timePeriod[_: P]: P[InstantRange] =
     dateRange |
       singleDate |
       (noopQualifier ~ ws.? ~ singleDate) // Try not to fail for un-spec'd qualifiers
 
-  def halfBoundedDate[_: P]: P[InstantRange] =
-    (leftBoundedDate map InstantRange.after) |
-      (rightBoundedDate map InstantRange.before)
+  // Any half-bounded time period: before or after a date
+  private def halfBoundedDate[_: P]: P[InstantRange] =
+    (afterDate map InstantRange.after) |
+      (beforeDate map InstantRange.before)
 
-  def rightBoundedDate[_: P]: P[InstantRange] =
+  // eg "-1999" or "before 2001"
+  private def beforeDate[_: P]: P[InstantRange] =
     ("-" ~ ws.? ~ singleDate) | ("before" ~ ws.? ~ singleDate)
 
-  def leftBoundedDate[_: P]: P[InstantRange] =
+  // eg "1917-" or "after 1800"
+  private def afterDate[_: P]: P[InstantRange] =
     (singleDate ~ ws.? ~ "-") | ("after" ~ ws.? ~ singleDate)
 
-  def singleDate[_: P]: P[InstantRange] =
+  // Any single date, whether that's an exact date or
+  // a month/year/century/decade/etc
+  private def singleDate[_: P]: P[InstantRange] =
     calendarDate.toInstantRange |
       monthAndYear.toInstantRange |
       yearDivision.toInstantRange |
@@ -87,7 +95,9 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       yearRange.toInstantRange |
       year.toInstantRange
 
-  def dateRange[_: P]: P[InstantRange] =
+  // Any range of dates; effectively a timespan between
+  // 2 single dates (whether these are exact or not)
+  private def dateRange[_: P]: P[InstantRange] =
     calendarDateToDate |
       monthAndYearToDate |
       centuryToDate |
@@ -98,7 +108,8 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       (month to monthAndYear).toInstantRange |
       (day to calendarDate).toInstantRange
 
-  def calendarDateToDate[_: P]: P[InstantRange] =
+  // A range of dates beginning with a calendar date
+  private def calendarDateToDate[_: P]: P[InstantRange] =
     (calendarDate to calendarDate).toInstantRange |
       (calendarDate to year).toInstantRange |
       (calendarDate to qualified(year)).toInstantRange |
@@ -107,14 +118,16 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       (calendarDate to month).toInstantRange |
       (calendarDate to day).toInstantRange
 
-  def monthAndYearToDate[_: P]: P[InstantRange] =
+  // A range of dates dates beginning with a month and year
+  private def monthAndYearToDate[_: P]: P[InstantRange] =
     (monthAndYear to calendarDate).toInstantRange |
       (monthAndYear to monthAndYear).toInstantRange |
       (monthAndYear to monthAndDay).toInstantRange |
       (monthAndYear to month).toInstantRange |
       (monthAndYear to year).toInstantRange
 
-  def centuryToDate[_: P]: P[InstantRange] =
+  // A range of dates beginning with a century
+  private def centuryToDate[_: P]: P[InstantRange] =
     (qualified(century | inferredCentury) to century).toInstantRange |
       ((century | inferredCentury) to qualified(century)).toInstantRange |
       (qualified(century | inferredCentury) to qualified(century)).toInstantRange |
@@ -125,7 +138,8 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       (century to qualified(year)).toInstantRange |
       (qualified(century) to qualified(year)).toInstantRange
 
-  def yearToDate[_: P]: P[InstantRange] =
+  // A range of dates beginning with a year
+  private def yearToDate[_: P]: P[InstantRange] =
     (qualified(year) to calendarDate).toInstantRange |
       (qualified(year) to monthAndYear).toInstantRange |
       (year to calendarDate).toInstantRange |
@@ -143,7 +157,8 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       (year to qualified(year)).toInstantRange |
       (qualified(year) to qualified(year)).toInstantRange
 
-  def decadeToDate[_: P]: P[InstantRange] =
+  // A range of dates beginning with a decade
+  private def decadeToDate[_: P]: P[InstantRange] =
     (qualified(decade) to qualified(decade)).toInstantRange |
       (qualified(decade) to decade).toInstantRange |
       (decade to qualified(decade)).toInstantRange |
@@ -153,23 +168,26 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
       (decade to qualified(year)).toInstantRange |
       (decade to year).toInstantRange
 
-  def noopQualifier[_: P]: P[Unit] = Lex.qualifier map (_ => ())
+  // A qualifier which we don't know how to use and so make it a no-op
+  private def noopQualifier[_: P]: P[Unit] = Lex.qualifier map (_ => ())
 
   // We can infer a century intention for some numbers, eg for
   // 14 in the string "14th-15th century"
-  def inferredCentury[_: P]: P[Century] =
+  private def inferredCentury[_: P]: P[Century] =
     P(Lex.int.filter(_ <= 999) ~ Lex.ordinalSuffix.? map { n =>
       Century(n - 1)
     })
 
-  def century[_: P]: P[Century] = Lex.century map Century
+  // eg "1800s"
+  private def century[_: P]: P[Century] = Lex.century map Century
 
-  def decade[_: P]: P[CenturyAndDecade] = Lex.decade map { year =>
+  // eg "1920s"
+  private def decade[_: P]: P[CenturyAndDecade] = Lex.decade map { year =>
     CenturyAndDecade(century = year / 100, decade = (year % 100) / 10)
   }
 
   // A year range is a string like 1994-5 or 1066-90
-  def yearRange[_: P]: P[FuzzyDateRange[Year, Year]] =
+  private def yearRange[_: P]: P[FuzzyDateRange[Year, Year]] =
     P(year ~ ws.? ~ "-" ~ ws.? ~ digitRep(1, 2) map {
       case (year @ Year(y), n) if n < 10 =>
         FuzzyDateRange(year, Year(y - (y % 10) + n))
@@ -177,47 +195,62 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
         FuzzyDateRange(year, Year(y - (y % 100) + n))
     })
 
-  def monthAndDay[_: P]: P[MonthAndDay] =
+  // eg "January 12th" or "15th May"
+  private def monthAndDay[_: P]: P[MonthAndDay] =
     dayFollowedByMonth | monthFollowedByDay
 
-  def dayFollowedByMonth[_: P]: P[MonthAndDay] =
+  // eg "11th May"
+  private def dayFollowedByMonth[_: P]: P[MonthAndDay] =
     P(writtenDay ~ ws ~ writtenMonth map { case (d, m) => MonthAndDay(m, d) })
 
-  def monthFollowedByDay[_: P]: P[MonthAndDay] =
+  // eg "December 24th"
+  private def monthFollowedByDay[_: P]: P[MonthAndDay] =
     P(writtenMonth ~ ws ~ writtenDay map MonthAndDay.tupled)
 
-  def yearDivision[_: P]: P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
+  // A standardised section of a year, for example a season
+  private def yearDivision[_: P]
+    : P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
     seasonYear | lawTermYear
 
-  def calendarDate[_: P]: P[CalendarDate] =
+  // Any specified day/date/month
+  private def calendarDate[_: P]: P[CalendarDate] =
     numericDate | dayMonthYear | monthDayYear | yearMonthDay
 
-  def numericDate[_: P]: P[CalendarDate] =
+  // eg "31/12/2013"
+  private def numericDate[_: P]: P[CalendarDate] =
     (dayDigits ~ "/" ~ monthDigits ~ "/" ~ yearDigits)
       .map { case (d, m, y) => CalendarDate(d, m, y) }
 
-  def dayMonthYear[_: P]: P[CalendarDate] =
+  // eg "12th December 1992" or "12th 3 1888"
+  private def dayMonthYear[_: P]: P[CalendarDate] =
     (writtenDay ~ ws ~ (writtenMonth | monthDigits) ~ ",".? ~ ws ~ yearDigits)
       .map { case (d, m, y) => CalendarDate(d, m, y) }
 
-  def monthDayYear[_: P]: P[CalendarDate] =
+  // eg "January 12th 1567"
+  private def monthDayYear[_: P]: P[CalendarDate] =
     (writtenMonth ~ ws ~ writtenDay ~ ",".? ~ ws ~ yearDigits)
       .map { case (m, d, y) => CalendarDate(d, m, y) }
 
-  def yearMonthDay[_: P]: P[CalendarDate] =
+  // eg "1801 March 19th"
+  private def yearMonthDay[_: P]: P[CalendarDate] =
     (yearDigits ~ ws ~ (writtenMonth | monthDigits) ~ ws ~ writtenDay).map {
       case (y, m, d) => CalendarDate(d, m, y)
     }
 
-  def monthAndYear[_: P]: P[MonthAndYear] =
+  // eg "January 2012" or "2013 December"
+  private def monthAndYear[_: P]: P[MonthAndYear] =
     (monthFollowedByYear | yearFollowedByMonth)
       .map { case (m, y) => MonthAndYear(m, y) }
 
-  def month[_: P]: P[Month] = writtenMonth map Month
+  // eg "June"
+  private def month[_: P]: P[Month] = writtenMonth map Month
 
-  def day[_: P]: P[Day] = writtenDay map Day
+  // An ordinal which we can use as a day-of-month
+  // eg "31st"
+  private def day[_: P]: P[Day] = writtenDay map Day
 
-  def seasonYear[_: P]: P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
+  // eg "spring"
+  private def seasonYear[_: P]: P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
     P((Lex.season map {
       case "spring" => (3, 5)
       case "summer" => (6, 8)
@@ -233,7 +266,8 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
         )
     })
 
-  def lawTermYear[_: P]: P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
+  // eg "michaelmas"
+  private def lawTermYear[_: P]: P[FuzzyDateRange[MonthAndYear, MonthAndYear]] =
     P((Lex.lawTerm map {
       case "michaelmas" => (10, 11)
       case "hilary"     => (1, 2)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
@@ -39,14 +39,16 @@ object InstantRange {
       label
     )
 
-  val positiveInfinity = LocalDate
+  // We use the year 9999 here because it's the same convention
+  // used by Sierra and in MARC 008 codes
+  private val positiveInfinity = LocalDate
     .of(9999, 12, 31)
     .atStartOfDay()
     .plusDays(1)
     .minusNanos(1)
     .toInstant(ZoneOffset.UTC)
 
-  val negativeInfinity = LocalDate
+  private val negativeInfinity = LocalDate
     .of(-9999, 1, 1)
     .atStartOfDay()
     .toInstant(ZoneOffset.UTC)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
@@ -39,6 +39,30 @@ object InstantRange {
       label
     )
 
+  val positiveInfinity = LocalDate
+    .of(9999, 12, 31)
+    .atStartOfDay()
+    .plusDays(1)
+    .minusNanos(1)
+    .toInstant(ZoneOffset.UTC)
+
+  val negativeInfinity = LocalDate
+    .of(-9999, 1, 1)
+    .atStartOfDay()
+    .toInstant(ZoneOffset.UTC)
+
+  def after(start: InstantRange): InstantRange = InstantRange(
+    from = start.from,
+    to = positiveInfinity,
+    label = start.label
+  )
+
+  def before(end: InstantRange): InstantRange = InstantRange(
+    from = negativeInfinity,
+    to = end.to,
+    label = end.label
+  )
+
   def parse(label: String)(
     implicit parser: Parser[InstantRange]): Option[InstantRange] =
     parser(label)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/parse/PeriodParserTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/parse/PeriodParserTest.scala
@@ -402,6 +402,11 @@ class PeriodParserTest extends AnyFunSpec with Matchers with Inspectors {
           LocalDate of (1897, 1, 1),
           LocalDate of (9999, 12, 31),
           "1897-"))
+      PeriodParser("after 1897") shouldBe Some(
+        InstantRange(
+          LocalDate of (1897, 1, 1),
+          LocalDate of (9999, 12, 31),
+          "after 1897"))
     }
 
     it("handles right-bounded intervals") {
@@ -410,6 +415,11 @@ class PeriodParserTest extends AnyFunSpec with Matchers with Inspectors {
           LocalDate of (-9999, 1, 1),
           LocalDate of (1897, 12, 31),
           "-1897"))
+      PeriodParser("before 1897") shouldBe Some(
+        InstantRange(
+          LocalDate of (-9999, 1, 1),
+          LocalDate of (1897, 12, 31),
+          "before 1897"))
     }
 
     it("parses and combines multiple periods") {

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/parse/PeriodParserTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/parse/PeriodParserTest.scala
@@ -396,6 +396,22 @@ class PeriodParserTest extends AnyFunSpec with Matchers with Inspectors {
           "2000s-2020s"))
     }
 
+    it("handles left-bounded intervals") {
+      PeriodParser("1897-") shouldBe Some(
+        InstantRange(
+          LocalDate of (1897, 1, 1),
+          LocalDate of (9999, 12, 31),
+          "1897-"))
+    }
+
+    it("handles right-bounded intervals") {
+      PeriodParser("-1897") shouldBe Some(
+        InstantRange(
+          LocalDate of (-9999, 1, 1),
+          LocalDate of (1897, 12, 31),
+          "-1897"))
+    }
+
     it("parses and combines multiple periods") {
       PeriodParser("1952, 1953, 1955, 1957-1960") shouldBe Some(
         InstantRange(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -24,7 +24,8 @@ object SierraProduction
   //
   // If 260/264 are available but can't be parsed into dates, we fill in
   // the first ProductionEvent with date information from 008 (which is what the
-  // 008 field should refer to according to the cataloguing rules).
+  // 008 field should refer to according to the cataloguing rules), but use the
+  // 260/264 field contents for the date labels.
   //
   // It is theoretically possible for a bib record to have both 260 and 264,
   // but it would be a cataloguing error -- we should reject it, and flag it
@@ -55,7 +56,13 @@ object SierraProduction
           ProductionEvent(_, _, _, marc008dates, _) :: _
           )
           if firstEvent.dates.forall(_.range.isEmpty) && marc008dates.nonEmpty =>
-        firstEvent.copy(dates = marc008dates) :: otherEvents
+        // There is only ever 1 date in an 008 production event
+        val productionLabelledDate = marc008dates.head.copy(
+          label = firstEvent.dates.headOption
+            .map(_.label)
+            .getOrElse(marc008dates.head.label)
+        )
+        firstEvent.copy(dates = List(productionLabelledDate)) :: otherEvents
       case (Nil, _) => marc008productionEvents
       case _        => productionEvents
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/parsers/Marc008DateParser.scala
@@ -46,22 +46,18 @@ object Marc008DateParser extends Parser[InstantRange] with DateParserUtils {
   def continuingResourceCeasedPublication[_: P] =
     ("d" ~ year ~ year) map { case (from, to) => FuzzyDateRange(from, to) }
 
-  // TODO : InstantRange should have optional start / end rather than 9999
   def continuingResourceCurrentlyPublished[_: P] =
     ("c" ~ year ~ "9999") map (FuzzyDateRange(_, Year(9999)))
 
-  // TODO : InstantRange should have optional start / end rather than 9999
   def continuingResourceStatusUnknown[_: P] =
     ("u" ~ year ~ "uuuu") map (FuzzyDateRange(_, Year(9999)))
 
-  // TODO : should these dates be marked as inferred?
   def questionableDate[_: P] =
     ("q" ~ year ~ year) map { case (from, to) => FuzzyDateRange(from, to) }
 
   def differingReleaseAndProduction[_: P] =
     ("p" ~ year ~ year) map { case (release, production) => release }
 
-  // TODO : should century / century and decade be marked inferred
   def partialYear[_: P] =
     year.toInstantRange |
       century.toInstantRange |

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProductionTest.scala
@@ -647,7 +647,8 @@ class SierraProductionTest
 
     // Example is from b28533306, with the 264 field modified so it's never parseable
     // and so this test is predictable.
-    it("uses date information from 008 if 260/264 cannot be parsed") {
+    it(
+      "uses date information from 008 but labels from 260/4 if the latter cannot be parsed") {
       val varFields = List(
         createVarFieldWith(
           marcTag = "008",
@@ -672,7 +673,9 @@ class SierraProductionTest
           "[Netherne, Surrey], B̷A̴D̸ ̴U̶N̸P̵A̸R̸S̷E̷A̶B̵L̶E̸ ̵N̴O̴N̶S̵E̷N̷S̴E̴",
         places = List(Place("[Netherne, Surrey],")),
         agents = Nil,
-        dates = List(Period("1972")),
+        dates = List(
+          Period("1972").copy(
+            label = "B̷A̴D̸ ̴U̶N̸P̵A̸R̸S̷E̷A̶B̵L̶E̸ ̵N̴O̴N̶S̵E̷N̷S̴E̴")),
         function = Some(Concept("Production"))
       )
     }


### PR DESCRIPTION
This adds support for half bounded dates (eg `1990-`) and also makes it so that when we can't parse a 260/4 date field, we still use it as a label (they're usually much more descriptive than the 008 codes)