### PR TITLE
Use the generic label for "Closed stores" in the Calm transformer

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmItems.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmItems.scala
@@ -29,7 +29,7 @@ object CalmItems extends CalmRecordOps {
                                status: Option[AccessStatus]): PhysicalLocation =
     PhysicalLocation(
       locationType = LocationType.ClosedStores,
-      label = "Closed stores Arch. & MSS",
+      label = LocationType.ClosedStores.label,
       accessConditions = accessCondition(record, status).filterEmpty.toList
     )
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -65,7 +65,7 @@ class CalmTransformerTest
               locations = List(
                 PhysicalLocation(
                   locationType = LocationType.ClosedStores,
-                  label = "Closed stores Arch. & MSS",
+                  label = "Closed stores",
                   accessConditions = Nil
                 )
               )


### PR DESCRIPTION
Elsewhere in the catalogue, we no longer expose the name of individual closed stores in the API.  We didn't change it when we were doing the Calm transformer, but we should be consistent here.