### PR TITLE
Add IDs with check digit to the Sierra reporting cluster

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
@@ -22,12 +22,16 @@ trait SierraRecordNumber {
 sealed trait TypedSierraRecordNumber extends SierraRecordNumber {
   val recordType: SierraRecordTypes.Value
 
-  /** Returns the ID with the check digit and prefix. */
+  /** Returns the ID with the check digit and prefix.
+    *
+    * The letter prefixes are taken from
+    * https://documentation.iii.com/sierrahelp/Default.htm#sril/sril_records_numbers.html
+    */
   def withCheckDigit: String = {
     val prefix = recordType match {
       case SierraRecordTypes.bibs     => "b"
       case SierraRecordTypes.items    => "i"
-      case SierraRecordTypes.holdings => "h"
+      case SierraRecordTypes.holdings => "c"  // for "checkin"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
@@ -31,7 +31,7 @@ sealed trait TypedSierraRecordNumber extends SierraRecordNumber {
     val prefix = recordType match {
       case SierraRecordTypes.bibs     => "b"
       case SierraRecordTypes.items    => "i"
-      case SierraRecordTypes.holdings => "c"  // for "checkin"
+      case SierraRecordTypes.holdings => "c" // for "checkin"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/models/IndexerRequest.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/models/IndexerRequest.scala
@@ -24,7 +24,7 @@ object IndexerRequest {
           IndexRequest(
             index = Index(s"${indexPrefix}_${parent.recordType}"),
             id = Some(parent.id.withoutCheckDigit),
-            source = Some(json.remainder.noSpaces)
+            source = Some(json.withId(parent.id).remainder.noSpaces)
           )
       }
     ).flatten

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/models/Parent.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/models/Parent.scala
@@ -7,5 +7,15 @@ import weco.catalogue.source_model.sierra.{
 
 case class Parent(
   recordType: SierraRecordTypes.Value,
-  id: TypedSierraRecordNumber
+  id: TypedSierraRecordNumber,
+  idWithCheckDigit: String
 )
+
+case object Parent {
+  def apply(id: TypedSierraRecordNumber): Parent =
+    Parent(
+      recordType = id.recordType,
+      id = id,
+      idWithCheckDigit = id.withCheckDigit
+    )
+}

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/SierraJsonOps.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/SierraJsonOps.scala
@@ -1,6 +1,7 @@
 package weco.catalogue.sierra_indexer.services
 
 import io.circe.Json
+import weco.catalogue.source_model.sierra.TypedSierraRecordNumber
 
 object SierraJsonOps {
   implicit class JsonOps(j: Json) {
@@ -13,6 +14,11 @@ object SierraJsonOps {
     def remainder: Json =
       j.mapObject {
         _.remove("varFields").remove("fixedFields")
+      }
+
+    def withId(id: TypedSierraRecordNumber): Json =
+      j.mapObject {
+        _.add("idWithCheckDigit", Json.fromString(id.withCheckDigit))
       }
   }
 }

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -5,10 +5,7 @@ import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import io.circe.parser._
 import io.circe.{Json, ParsingFailure}
 import weco.catalogue.sierra_indexer.models.{IndexerRequest, Parent}
-import weco.catalogue.source_model.sierra.{
-  SierraRecordTypes,
-  SierraTransformable
-}
+import weco.catalogue.source_model.sierra.SierraTransformable
 
 // This object splits a SierraTransformable into indexable pieces
 // that can be sent to Elasticsearch.
@@ -43,7 +40,7 @@ class Splitter(indexPrefix: String) {
     val bibData = t.maybeBibRecord match {
       case Some(bibRecord) =>
         Seq(
-          Parent(SierraRecordTypes.bibs, bibRecord.id) ->
+          Parent(bibRecord.id) ->
             parse(bibRecord.data)
               .map { json =>
                 json
@@ -61,13 +58,12 @@ class Splitter(indexPrefix: String) {
 
     val itemData: Seq[(Parent, Either[ParsingFailure, Json])] =
       t.itemRecords.values.map { itemRecord =>
-        Parent(SierraRecordTypes.items, itemRecord.id) -> parse(itemRecord.data)
+        Parent(itemRecord.id) -> parse(itemRecord.data)
       }.toSeq
 
     val holdingsData: Seq[(Parent, Either[ParsingFailure, Json])] =
       t.holdingsRecords.values.map { holdingsRecord =>
-        Parent(SierraRecordTypes.holdings, holdingsRecord.id) -> parse(
-          holdingsRecord.data)
+        Parent(holdingsRecord.id) -> parse(holdingsRecord.data)
       }.toSeq
 
     val data = bibData ++ itemData ++ holdingsData

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -88,8 +88,6 @@ class SierraIndexerFeatureTest
       }.toList,
     )
 
-    println(transformable)
-
     val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
       initialEntries = Map(location -> transformable)
     )

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -129,6 +129,7 @@ class SierraIndexerFeatureTest
             json = s"""
                 |{
                 |  "id" : "$bibId",
+                |  "idWithCheckDigit": "${bibId.withCheckDigit}",
                 |  "updatedDate" : "2013-12-12T13:56:07Z",
                 |  "deleted" : false,
                 |  "itemIds": [$itemIdsList],
@@ -144,7 +145,8 @@ class SierraIndexerFeatureTest
                 |{
                 |  "parent": {
                 |    "recordType": "bibs",
-                |    "id": "${bibId.withoutCheckDigit}"
+                |    "id": "${bibId.withoutCheckDigit}",
+                |    "idWithCheckDigit": "${bibId.withCheckDigit}"
                 |  },
                 |  "position": 0,
                 |  "varField": {
@@ -162,7 +164,8 @@ class SierraIndexerFeatureTest
                 |{
                 |  "parent": {
                 |    "recordType": "bibs",
-                |    "id": "${bibId.withoutCheckDigit}"
+                |    "id": "${bibId.withoutCheckDigit}",
+                |    "idWithCheckDigit": "${bibId.withCheckDigit}"
                 |  },
                 |  "position": 1,
                 |  "varField": {
@@ -188,7 +191,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
-                      |    "id": "${bibId.withoutCheckDigit}"
+                      |    "id": "${bibId.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${bibId.withCheckDigit}"
                       |  },
                       |  "code": "86",
                       |  "fixedField": {
@@ -206,7 +210,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
-                      |    "id": "${bibId.withoutCheckDigit}"
+                      |    "id": "${bibId.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${bibId.withCheckDigit}"
                       |  },
                       |  "code": "265",
                       |  "fixedField": {
@@ -258,6 +263,7 @@ class SierraIndexerFeatureTest
           data = s"""
                     |{
                     |  "id" : "$itemId2",
+                    |  "idWithCheckDigit": "${itemId2.withCheckDigit}",
                     |  "updatedDate" : "2002-02-02T02:02:02Z",
                     |  "deleted" : true,
                     |  "varFields" : [
@@ -309,6 +315,7 @@ class SierraIndexerFeatureTest
             json = s"""
                       |{
                       |  "id" : "$itemId1",
+                      |  "idWithCheckDigit": "${itemId1.withCheckDigit}",
                       |  "updatedDate" : "2001-01-01T01:01:01Z",
                       |  "deleted" : false
                       |}
@@ -321,6 +328,7 @@ class SierraIndexerFeatureTest
             json = s"""
                   |{
                   |  "id" : "$itemId2",
+                  |  "idWithCheckDigit": "${itemId2.withCheckDigit}",
                   |  "updatedDate" : "2002-02-02T02:02:02Z",
                   |  "deleted" : true
                   |}
@@ -334,7 +342,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "items",
-                      |    "id": "${itemId1.withoutCheckDigit}"
+                      |    "id": "${itemId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${itemId1.withCheckDigit}"
                       |  },
                       |  "position": 0,
                       |  "varField": {
@@ -352,7 +361,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "items",
-                      |    "id": "${itemId2.withoutCheckDigit}"
+                      |    "id": "${itemId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${itemId2.withCheckDigit}"
                       |  },
                       |  "position": 0,
                       |  "varField": {
@@ -378,7 +388,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "items",
-                      |    "id": "${itemId1.withoutCheckDigit}"
+                      |    "id": "${itemId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${itemId1.withCheckDigit}"
                       |  },
                       |  "code": "86",
                       |  "fixedField": {
@@ -396,7 +407,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "items",
-                      |    "id": "${itemId2.withoutCheckDigit}"
+                      |    "id": "${itemId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${itemId2.withCheckDigit}"
                       |  },
                       |  "code": "265",
                       |  "fixedField": {
@@ -499,6 +511,7 @@ class SierraIndexerFeatureTest
             json = s"""
                       |{
                       |  "id" : "$holdingsId1",
+                      |  "idWithCheckDigit": "${holdingsId1.withCheckDigit}",
                       |  "updatedDate" : "2001-01-01T01:01:01Z",
                       |  "deleted" : false
                       |}
@@ -511,6 +524,7 @@ class SierraIndexerFeatureTest
             json = s"""
                       |{
                       |  "id" : "$holdingsId2",
+                      |  "idWithCheckDigit": "${holdingsId2.withCheckDigit}",
                       |  "updatedDate" : "2002-02-02T02:02:02Z",
                       |  "deleted" : true
                       |}
@@ -524,7 +538,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "holdings",
-                      |    "id": "${holdingsId1.withoutCheckDigit}"
+                      |    "id": "${holdingsId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${holdingsId1.withCheckDigit}"
                       |  },
                       |  "position": 0,
                       |  "varField": {
@@ -542,7 +557,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "holdings",
-                      |    "id": "${holdingsId2.withoutCheckDigit}"
+                      |    "id": "${holdingsId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${holdingsId2.withCheckDigit}"
                       |  },
                       |  "position": 0,
                       |  "varField": {
@@ -568,7 +584,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "holdings",
-                      |    "id": "${holdingsId1.withoutCheckDigit}"
+                      |    "id": "${holdingsId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${holdingsId1.withCheckDigit}"
                       |  },
                       |  "code": "86",
                       |  "fixedField": {
@@ -586,7 +603,8 @@ class SierraIndexerFeatureTest
                       |{
                       |  "parent": {
                       |    "recordType": "holdings",
-                      |    "id": "${holdingsId2.withoutCheckDigit}"
+                      |    "id": "${holdingsId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${holdingsId2.withCheckDigit}"
                       |  },
                       |  "code": "265",
                       |  "fixedField": {

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/fixtures/IndexerFixtures.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/fixtures/IndexerFixtures.scala
@@ -43,24 +43,24 @@ trait IndexerFixtures
       }
     }
 
+  private def withIndex[R](prefix: String, suffix: String)(
+    testWith: TestWith[Index, R]
+  ): R = {
+    val index = Index(s"${prefix}_$suffix")
+
+    withLocalElasticsearchIndex(NoStrictMapping, index = index) {
+      testWith(_)
+    }
+  }
+
   def withIndices[R](testWith: TestWith[String, R]): R = {
     val indexPrefix = s"sierra_${randomAlphanumeric()}".toLowerCase()
 
-    withLocalElasticsearchIndex(
-      NoStrictMapping,
-      index = Index(s"${indexPrefix}_bibs")) { _ =>
-      withLocalElasticsearchIndex(
-        NoStrictMapping,
-        index = Index(s"${indexPrefix}_items")) { _ =>
-        withLocalElasticsearchIndex(
-          NoStrictMapping,
-          index = Index(s"${indexPrefix}_holdings")) { _ =>
-          withLocalElasticsearchIndex(
-            NoStrictMapping,
-            index = Index(s"${indexPrefix}_varfields")) { _ =>
-            withLocalElasticsearchIndex(
-              NoStrictMapping,
-              index = Index(s"${indexPrefix}_fixedfields")) { _ =>
+    withIndex(indexPrefix, "bibs") { _ =>
+      withIndex(indexPrefix, "items") { _ =>
+        withIndex(indexPrefix, "holdings") { _ =>
+          withIndex(indexPrefix, "varfields") { _ =>
+            withIndex(indexPrefix, "fixedfields") { _ =>
               testWith(indexPrefix)
             }
           }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5105

This was a request from Alexandra.

A quick refresher: Sierra IDs coming in two variants. There's a seven digit variant used by the API (e.g. `1024364`) and an eight digit variant with a prefix letter and check digit (e.g. `b10243641`). Currently, the data in the reporting cluster only uses the seven digit variant, but you can't search for this in the Sierra GUI app.

This patch will add those items to the reporting cluster, by adding a new field `idWithCheckDigit` wherever you see an `id`. Once we reindex, it should be easier to cross reference records in Kibana to Sierra