### PR TITLE
API faceting consistency updates

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -69,13 +69,13 @@ object DisplayWorkAggregations {
         aggregationRequests,
         WorkAggregationRequest.GenreDeprecated)(
         displayAggregation[Genre[Minted], DisplayGenre](
-          aggs.genres,
+          aggs.genresLabel,
           DisplayGenre(_, includesIdentifiers = false))
       ),
       `genres.label` =
         whenRequestPresent(aggregationRequests, WorkAggregationRequest.Genre)(
           displayAggregation[Genre[Minted], DisplayGenre](
-            aggs.genres,
+            aggs.genresLabel,
             DisplayGenre(_, includesIdentifiers = false))
         ),
       languages = displayAggregation(aggs.languages, DisplayLanguage.apply),
@@ -83,20 +83,20 @@ object DisplayWorkAggregations {
         aggregationRequests,
         WorkAggregationRequest.SubjectDeprecated)(
         displayAggregation[Subject[Minted], DisplaySubject](
-          aggs.subjects,
+          aggs.subjectsLabel,
           subject => DisplaySubject(subject, includesIdentifiers = false)
         )),
       `subjects.label` =
         whenRequestPresent(aggregationRequests, WorkAggregationRequest.Subject)(
           displayAggregation[Subject[Minted], DisplaySubject](
-            aggs.subjects,
+            aggs.subjectsLabel,
             subject => DisplaySubject(subject, includesIdentifiers = false)
           )),
       contributors = whenRequestPresent(
         aggregationRequests,
         WorkAggregationRequest.ContributorDeprecated)(
         displayAggregation[Contributor[Minted], DisplayContributor](
-          aggs.contributors,
+          aggs.contributorsAgentsLabel,
           contributor =>
             DisplayContributor(contributor, includesIdentifiers = false)
         )),
@@ -104,18 +104,18 @@ object DisplayWorkAggregations {
         aggregationRequests,
         WorkAggregationRequest.Contributor)(
         displayAggregation[Contributor[Minted], DisplayContributor](
-          aggs.contributors,
+          aggs.contributorsAgentsLabel,
           contributor =>
             DisplayContributor(contributor, includesIdentifiers = false)
         )),
       license = whenRequestPresent(
         aggregationRequests,
         WorkAggregationRequest.LicenseDeprecated)(
-        displayAggregation(aggs.license, DisplayLicense.apply)
+        displayAggregation(aggs.itemsLocationsLicense, DisplayLicense.apply)
       ),
       `items.locations.license` =
         whenRequestPresent(aggregationRequests, WorkAggregationRequest.License)(
-          displayAggregation(aggs.license, DisplayLicense.apply)
+          displayAggregation(aggs.itemsLocationsLicense, DisplayLicense.apply)
         ),
       availabilities =
         displayAggregation(aggs.availabilities, DisplayAvailability.apply)

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -38,7 +38,8 @@ case class DisplayWorkAggregations(
   ) contributors: Option[DisplayAggregation[DisplayContributor]],
   @Schema(
     description = "Contributor aggregation on a set of results."
-  ) `contributors.agent.label`: Option[DisplayAggregation[DisplayContributor]],
+  ) `contributors.agent.label`: Option[
+    DisplayAggregation[DisplayAbstractAgent]],
   @Schema(
     description = "Language aggregation on a set of results."
   ) languages: Option[DisplayAggregation[DisplayLanguage]],
@@ -103,10 +104,10 @@ object DisplayWorkAggregations {
       `contributors.agent.label` = whenRequestPresent(
         aggregationRequests,
         WorkAggregationRequest.Contributor)(
-        displayAggregation[Contributor[Minted], DisplayContributor](
+        displayAggregation[Contributor[Minted], DisplayAbstractAgent](
           aggs.contributorsAgentsLabel,
           contributor =>
-            DisplayContributor(contributor, includesIdentifiers = false)
+            DisplayAbstractAgent(contributor.agent, includesIdentifiers = false)
         )),
       license = whenRequestPresent(
         aggregationRequests,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -31,6 +31,9 @@ case class DisplayWorkAggregations(
     description = "Subject aggregation on a set of results."
   ) subjects: Option[DisplayAggregation[DisplaySubject]],
   @Schema(
+    description = "Subject aggregation on a set of results."
+  ) `subjects.label`: Option[DisplayAggregation[DisplaySubject]],
+  @Schema(
     description = "Contributor aggregation on a set of results."
   ) contributors: Option[DisplayAggregation[DisplayContributor]],
   @Schema(
@@ -73,10 +76,19 @@ object DisplayWorkAggregations {
             DisplayGenre(_, includesIdentifiers = false))
         ),
       languages = displayAggregation(aggs.languages, DisplayLanguage.apply),
-      subjects = displayAggregation[Subject[Minted], DisplaySubject](
-        aggs.subjects,
-        subject => DisplaySubject(subject, includesIdentifiers = false)
-      ),
+      subjects = whenRequestPresent(
+        aggregationRequests,
+        WorkAggregationRequest.SubjectDeprecated)(
+        displayAggregation[Subject[Minted], DisplaySubject](
+          aggs.subjects,
+          subject => DisplaySubject(subject, includesIdentifiers = false)
+        )),
+      `subjects.label` =
+        whenRequestPresent(aggregationRequests, WorkAggregationRequest.Subject)(
+          displayAggregation[Subject[Minted], DisplaySubject](
+            aggs.subjects,
+            subject => DisplaySubject(subject, includesIdentifiers = false)
+          )),
       contributors =
         displayAggregation[Contributor[Minted], DisplayContributor](
           aggs.contributors,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -37,6 +37,9 @@ case class DisplayWorkAggregations(
     description = "Contributor aggregation on a set of results."
   ) contributors: Option[DisplayAggregation[DisplayContributor]],
   @Schema(
+    description = "Contributor aggregation on a set of results."
+  ) `contributors.agent.label`: Option[DisplayAggregation[DisplayContributor]],
+  @Schema(
     description = "Language aggregation on a set of results."
   ) languages: Option[DisplayAggregation[DisplayLanguage]],
   @Schema(
@@ -89,12 +92,22 @@ object DisplayWorkAggregations {
             aggs.subjects,
             subject => DisplaySubject(subject, includesIdentifiers = false)
           )),
-      contributors =
+      contributors = whenRequestPresent(
+        aggregationRequests,
+        WorkAggregationRequest.ContributorDeprecated)(
         displayAggregation[Contributor[Minted], DisplayContributor](
           aggs.contributors,
           contributor =>
             DisplayContributor(contributor, includesIdentifiers = false)
-        ),
+        )),
+      `contributors.agent.label` = whenRequestPresent(
+        aggregationRequests,
+        WorkAggregationRequest.Contributor)(
+        displayAggregation[Contributor[Minted], DisplayContributor](
+          aggs.contributors,
+          contributor =>
+            DisplayContributor(contributor, includesIdentifiers = false)
+        )),
       license = whenRequestPresent(
         aggregationRequests,
         WorkAggregationRequest.LicenseDeprecated)(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
@@ -12,12 +12,11 @@ import scala.util.Try
 
 case class WorkAggregations(
   format: Option[Aggregation[Format]] = None,
-  genres: Option[Aggregation[Genre[Minted]]] = None,
+  genresLabel: Option[Aggregation[Genre[Minted]]] = None,
   productionDates: Option[Aggregation[Period[Minted]]] = None,
   languages: Option[Aggregation[Language]] = None,
-  subjects: Option[Aggregation[Subject[Minted]]] = None,
-  contributors: Option[Aggregation[Contributor[Minted]]] = None,
-  license: Option[Aggregation[License]] = None,
+  subjectsLabel: Option[Aggregation[Subject[Minted]]] = None,
+  contributorsAgentsLabel: Option[Aggregation[Contributor[Minted]]] = None,
   itemsLocationsLicense: Option[Aggregation[License]] = None,
   availabilities: Option[Aggregation[Availability]] = None,
 )
@@ -30,15 +29,14 @@ object WorkAggregations extends ElasticAggregations {
       Some(
         WorkAggregations(
           format = e4sAggregations.decodeAgg[Format]("format"),
-          genres = e4sAggregations.decodeAgg[Genre[Minted]]("genres"),
+          genresLabel = e4sAggregations.decodeAgg[Genre[Minted]]("genres"),
           productionDates = e4sAggregations
             .decodeAgg[Period[Minted]]("productionDates"),
           languages = e4sAggregations.decodeAgg[Language]("languages"),
-          subjects = e4sAggregations
+          subjectsLabel = e4sAggregations
             .decodeAgg[Subject[Minted]]("subjects"),
-          contributors = e4sAggregations
+          contributorsAgentsLabel = e4sAggregations
             .decodeAgg[Contributor[Minted]]("contributors"),
-          license = e4sAggregations.decodeAgg[License]("license"),
           itemsLocationsLicense = e4sAggregations.decodeAgg[License]("license"),
           availabilities =
             e4sAggregations.decodeAgg[Availability]("availabilities")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
@@ -18,6 +18,7 @@ case class WorkAggregations(
   subjects: Option[Aggregation[Subject[Minted]]] = None,
   contributors: Option[Aggregation[Contributor[Minted]]] = None,
   license: Option[Aggregation[License]] = None,
+  itemsLocationsLicense: Option[Aggregation[License]] = None,
   availabilities: Option[Aggregation[Availability]] = None,
 )
 
@@ -38,6 +39,7 @@ object WorkAggregations extends ElasticAggregations {
           contributors = e4sAggregations
             .decodeAgg[Contributor[Minted]]("contributors"),
           license = e4sAggregations.decodeAgg[License]("license"),
+          itemsLocationsLicense = e4sAggregations.decodeAgg[License]("license"),
           availabilities =
             e4sAggregations.decodeAgg[Availability]("availabilities")
         ))

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorkAggregations.scala
@@ -35,6 +35,7 @@ object WorkAggregations extends ElasticAggregations {
           languages = e4sAggregations.decodeAgg[Language]("languages"),
           subjectsLabel = e4sAggregations
             .decodeAgg[Subject[Minted]]("subjects"),
+          // TODO decode only agents here once `contributors` is removed
           contributorsAgentsLabel = e4sAggregations
             .decodeAgg[Contributor[Minted]]("contributors"),
           itemsLocationsLicense = e4sAggregations.decodeAgg[License]("license"),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/Responses.scala
@@ -56,7 +56,7 @@ object DisplayResultList {
 
   def apply(
     resultList: ResultList[Work.Visible[WorkState.Indexed], WorkAggregations],
-    searchOptions: SearchOptions[_, _, _],
+    searchOptions: SearchOptions[_, WorkAggregationRequest, _],
     includes: WorksIncludes,
     requestUri: Uri,
     contextUri: String)
@@ -71,8 +71,9 @@ object DisplayResultList {
           results = resultList.results.map(DisplayWork(_, includes)),
           prevPage = prevPage,
           nextPage = nextPage,
-          aggregations =
-            resultList.aggregations.map(DisplayWorkAggregations.apply)
+          aggregations = resultList.aggregations.map(
+            DisplayWorkAggregations.apply(_, searchOptions.aggregations)
+          )
         )
     }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -259,7 +259,9 @@ object MultipleWorksParams extends QueryParamsUtils {
       "subjects" -> WorkAggregationRequest.Subject,
       "languages" -> WorkAggregationRequest.Languages,
       "contributors" -> WorkAggregationRequest.Contributor,
-      "license" -> WorkAggregationRequest.License,
+      // TODO remove license in favour of items.locations.license
+      "license" -> WorkAggregationRequest.LicenseDeprecated,
+      "items.locations.license" -> WorkAggregationRequest.License,
       "availabilities" -> WorkAggregationRequest.Availabilities
     )
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -262,7 +262,9 @@ object MultipleWorksParams extends QueryParamsUtils {
       "subjects" -> WorkAggregationRequest.SubjectDeprecated,
       "subjects.label" -> WorkAggregationRequest.Subject,
       "languages" -> WorkAggregationRequest.Languages,
-      "contributors" -> WorkAggregationRequest.Contributor,
+      // TODO remove contributors in favour of contributors.agent.label
+      "contributors" -> WorkAggregationRequest.ContributorDeprecated,
+      "contributors.agent.label" -> WorkAggregationRequest.Contributor,
       // TODO remove license in favour of items.locations.license
       "license" -> WorkAggregationRequest.LicenseDeprecated,
       "items.locations.license" -> WorkAggregationRequest.License,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -258,7 +258,9 @@ object MultipleWorksParams extends QueryParamsUtils {
       // TODO remove genres in favour of genres.label
       "genres.label" -> WorkAggregationRequest.Genre,
       "production.dates" -> WorkAggregationRequest.ProductionDate,
-      "subjects" -> WorkAggregationRequest.Subject,
+      // TODO remove subjects in favour of subjects.label
+      "subjects" -> WorkAggregationRequest.SubjectDeprecated,
+      "subjects.label" -> WorkAggregationRequest.Subject,
       "languages" -> WorkAggregationRequest.Languages,
       "contributors" -> WorkAggregationRequest.Contributor,
       // TODO remove license in favour of items.locations.license

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/rest/WorksParams.scala
@@ -254,7 +254,9 @@ object MultipleWorksParams extends QueryParamsUtils {
   implicit val aggregationsDecoder: Decoder[List[WorkAggregationRequest]] =
     decodeOneOfCommaSeparated(
       "workType" -> WorkAggregationRequest.Format,
-      "genres" -> WorkAggregationRequest.Genre,
+      "genres" -> WorkAggregationRequest.GenreDeprecated,
+      // TODO remove genres in favour of genres.label
+      "genres.label" -> WorkAggregationRequest.Genre,
       "production.dates" -> WorkAggregationRequest.ProductionDate,
       "subjects" -> WorkAggregationRequest.Subject,
       "languages" -> WorkAggregationRequest.Languages,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -104,9 +104,12 @@ class WorkFiltersAndAggregationsBuilder(
   override def pairedAggregationRequests(
     filter: WorkFilter): List[WorkAggregationRequest] =
     filter match {
-      case _: FormatFilter       => List(WorkAggregationRequest.Format)
-      case _: LanguagesFilter    => List(WorkAggregationRequest.Languages)
-      case _: GenreFilter        => List(WorkAggregationRequest.Genre)
+      case _: FormatFilter    => List(WorkAggregationRequest.Format)
+      case _: LanguagesFilter => List(WorkAggregationRequest.Languages)
+      case _: GenreFilter =>
+        List(
+          WorkAggregationRequest.Genre,
+          WorkAggregationRequest.GenreDeprecated)
       case _: SubjectFilter      => List(WorkAggregationRequest.Subject)
       case _: ContributorsFilter => List(WorkAggregationRequest.Contributor)
       case _: LicenseFilter =>

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -114,7 +114,10 @@ class WorkFiltersAndAggregationsBuilder(
         List(
           WorkAggregationRequest.Subject,
           WorkAggregationRequest.SubjectDeprecated)
-      case _: ContributorsFilter => List(WorkAggregationRequest.Contributor)
+      case _: ContributorsFilter =>
+        List(
+          WorkAggregationRequest.Contributor,
+          WorkAggregationRequest.ContributorDeprecated)
       case _: LicenseFilter =>
         List(
           WorkAggregationRequest.License,

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -110,7 +110,10 @@ class WorkFiltersAndAggregationsBuilder(
         List(
           WorkAggregationRequest.Genre,
           WorkAggregationRequest.GenreDeprecated)
-      case _: SubjectFilter      => List(WorkAggregationRequest.Subject)
+      case _: SubjectFilter =>
+        List(
+          WorkAggregationRequest.Subject,
+          WorkAggregationRequest.SubjectDeprecated)
       case _: ContributorsFilter => List(WorkAggregationRequest.Contributor)
       case _: LicenseFilter =>
         List(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -78,7 +78,8 @@ object WorksRequestBuilder
         .field("data.languages.id")
         .minDocCount(0)
 
-    case WorkAggregationRequest.License =>
+    case WorkAggregationRequest.License |
+        WorkAggregationRequest.LicenseDeprecated =>
       TermsAggregation("license")
         .size(License.values.size)
         .field("data.items.locations.license.id")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -68,7 +68,8 @@ object WorksRequestBuilder
         .field("data.subjects.label.keyword")
         .minDocCount(0)
 
-    case WorkAggregationRequest.Contributor =>
+    case WorkAggregationRequest.Contributor |
+        WorkAggregationRequest.ContributorDeprecated =>
       TermsAggregation("contributors")
         .size(20)
         .field("state.derivedData.contributorAgents")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -61,7 +61,8 @@ object WorksRequestBuilder
         .field("data.genres.concepts.label.keyword")
         .minDocCount(0)
 
-    case WorkAggregationRequest.Subject =>
+    case WorkAggregationRequest.Subject |
+        WorkAggregationRequest.SubjectDeprecated =>
       TermsAggregation("subjects")
         .size(20)
         .field("data.subjects.label.keyword")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -54,7 +54,8 @@ object WorksRequestBuilder
 
     // We don't split genres into concepts, as the data isn't great,
     // and for rendering isn't useful at the moment.
-    case WorkAggregationRequest.Genre =>
+    case WorkAggregationRequest.Genre |
+        WorkAggregationRequest.GenreDeprecated =>
       TermsAggregation("genres")
         .size(20)
         .field("data.genres.concepts.label.keyword")

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -500,6 +500,20 @@ trait MultipleWorksSwagger {
         required = false
       ),
       new Parameter(
+        name = "items.locations.license",
+        in = ParameterIn.QUERY,
+        description = "Filter the work by license.",
+        schema = new Schema(
+          allowableValues = Array(
+            "cc-by",
+            "cc-by-nc",
+            "cc-by-nc-nd",
+            "cc-0",
+            "pdm",
+            "copyright-not-cleared")),
+        required = false
+      ),
+      new Parameter(
         name = "sort",
         in = ParameterIn.QUERY,
         description = "Which field to sort the results on",

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -424,6 +424,7 @@ trait MultipleWorksSwagger {
             "subjects",
             "contributors",
             "license",
+            "items.locations.license",
             "languages",
             "availabilities")),
         required = false

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -420,13 +420,17 @@ trait MultipleWorksSwagger {
           allowableValues = Array(
             "workType",
             "genres",
+            "genres.label",
             "production.dates",
             "subjects",
+            "subjects.label",
             "contributors",
+            "contributors.agent.label",
             "license",
             "items.locations.license",
             "languages",
-            "availabilities")),
+            "availabilities"
+          )),
         required = false
       ),
       new Parameter(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerScalaModelConverter.scala
@@ -81,6 +81,7 @@ class SwaggerScalaModelConverter extends AbstractModelConverter(Json.mapper()) {
     else if (cls == classOf[DisplaySubject]) "Subject"
     else if (cls == classOf[DisplayLanguage]) "Language"
     else if (cls == classOf[DisplayContributor]) "Contributor"
+    else if (cls == classOf[DisplayAbstractAgent]) "Agent"
     else if (cls == classOf[DisplayLicense]) "License"
     else if (cls == classOf[DisplayAvailability]) "Availability"
     else throw new IllegalArgumentException(s"Unknown class $cls")

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -190,7 +190,8 @@ class ApiSwaggerTest
     val swaggerParams = getEnumValues(aggregationsParam)
 
     // TODO remove aliases
-    val aliasedAggregations = List("subjects", "genres", "contributors")
+    val aliasedAggregations =
+      List("subjects", "genres", "contributors", "license")
     val aggregationParams = getFields[WorkAggregations] ++ aliasedAggregations
 
     assert(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -88,7 +88,10 @@ class ApiSwaggerTest
     it("multiple works endpoint") {
       val swaggerParams = getParameterNames(multipleWorksEndpoint)
 
-      val queryParams = getFields[MultipleWorksParams]
+      // TODO remove aliases
+      // "license" is added here as it is a deprecated filter
+      // which aliases `items.locations.license`
+      val queryParams = getFields[MultipleWorksParams] :+ "license"
 
       assert(
         swaggerParams.length == queryParams.length,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -189,7 +189,9 @@ class ApiSwaggerTest
 
     val swaggerParams = getEnumValues(aggregationsParam)
 
-    val aggregationParams = getFields[WorkAggregations]
+    // TODO remove aliases
+    val aliasedAggregations = List("subjects", "genres", "contributors")
+    val aggregationParams = getFields[WorkAggregations] ++ aliasedAggregations
 
     assert(
       swaggerParams.length == aggregationParams.length,

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -42,7 +42,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
   }
 
   val aggregationsString =
-    "['workType', 'genres', 'production.dates', 'subjects', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
+    "['workType', 'genres', 'genres.label', 'production.dates', 'subjects', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
 
   describe(
     "returns a 400 Bad Request for errors in the ?aggregations parameter") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -42,7 +42,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
   }
 
   val aggregationsString =
-    "['workType', 'genres', 'production.dates', 'subjects', 'languages', 'contributors', 'license', 'availabilities']"
+    "['workType', 'genres', 'production.dates', 'subjects', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
 
   describe(
     "returns a 400 Bad Request for errors in the ?aggregations parameter") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -42,7 +42,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
   }
 
   val aggregationsString =
-    "['workType', 'genres', 'genres.label', 'production.dates', 'subjects', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
+    "['workType', 'genres', 'genres.label', 'production.dates', 'subjects', 'subjects.label', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
 
   describe(
     "returns a 400 Bad Request for errors in the ?aggregations parameter") {

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksErrorsTest.scala
@@ -42,7 +42,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
   }
 
   val aggregationsString =
-    "['workType', 'genres', 'genres.label', 'production.dates', 'subjects', 'subjects.label', 'languages', 'contributors', 'license', 'items.locations.license', 'availabilities']"
+    "['workType', 'genres', 'genres.label', 'production.dates', 'subjects', 'subjects.label', 'languages', 'contributors', 'contributors.agent.label', 'license', 'items.locations.license', 'availabilities']"
 
   describe(
     "returns a 400 Bad Request for errors in the ?aggregations parameter") {

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
@@ -13,6 +13,8 @@ object WorkAggregationRequest {
 
   case object Subject extends WorkAggregationRequest
 
+  case object SubjectDeprecated extends WorkAggregationRequest
+
   case object Contributor extends WorkAggregationRequest
 
   case object Languages extends WorkAggregationRequest

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
@@ -9,6 +9,8 @@ object WorkAggregationRequest {
 
   case object Genre extends WorkAggregationRequest
 
+  case object GenreDeprecated extends WorkAggregationRequest
+
   case object Subject extends WorkAggregationRequest
 
   case object Contributor extends WorkAggregationRequest

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
@@ -17,6 +17,8 @@ object WorkAggregationRequest {
 
   case object Contributor extends WorkAggregationRequest
 
+  case object ContributorDeprecated extends WorkAggregationRequest
+
   case object Languages extends WorkAggregationRequest
 
   case object License extends WorkAggregationRequest

--- a/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
+++ b/common/display/src/main/scala/uk/ac/wellcome/display/models/WorkAggregationRequest.scala
@@ -17,5 +17,7 @@ object WorkAggregationRequest {
 
   case object License extends WorkAggregationRequest
 
+  case object LicenseDeprecated extends WorkAggregationRequest
+
   case object Availabilities extends WorkAggregationRequest
 }


### PR DESCRIPTION
This _adds_ aggregations and filters to make the API comply with https://github.com/wellcomecollection/docs/blob/master/adr/api_faceting.md.

That means that there are no breaking changes - a later PR will remove the old, non-compliant behaviours. Because of this there's plenty of duplication in here as I want to be able to rip stuff out easily.

The changes are:
- Add an `items.locations.license` filter (deprecate `license`)
- Add an `items.locations.license` aggregation (deprecate `license`)
- Add a `subjects.label` aggregation (deprecate `subjects`)
- Add a `genres.label` aggregation (deprecate `genres`)
- Add a `contributors.agent.label` aggregation (deprecate `contributors`)
- Make the return type of `contributors.agent.label` an `agent`, not a `contributor`

The `production.dates.to`, `production.dates.from`, and `identifiers` filters still don't comply and they were deemed out of scope for this. The problems that remain there are:
- The dates (`to`/`from`) are never exposed in the display model, only their labels
- Identifiers implicitly use the `value` field rather than `id`, to avoid `id.id`-type constructions