### PR TITLE
Add alternative spellings to search query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksMultiMatcher.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksMultiMatcher.scala
@@ -14,48 +14,75 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
 import uk.ac.wellcome.models.index.WorksAnalysis.whitespaceAnalyzer
 
 case object WorksMultiMatcher {
+  val titleFields = Seq(
+    "data.title",
+    "data.title.english",
+    "data.title.shingles",
+    "data.alternativeTitles")
+
+  def fieldsWithBoost(boost: Int,
+                      fields: Seq[String]): Seq[FieldWithOptionalBoost] =
+    fields.map(FieldWithOptionalBoost(_, Some(boost.toDouble)))
+
   def apply(q: String): BoolQuery = {
     boolQuery()
       .should(
-        // we're running elasticsearch 7.9 at the moment - upgrading to 7.11 will give us the ability to run case
-        // insensitive prefixQueries, which will solve our "old and new london" problem
-        // (see https://github.com/wellcomecollection/catalogue/issues/1336)
-        prefixQuery("data.title.keyword", q).boost(1000),
         MultiMatchQuery(
           q,
+          queryName = Some("identifiers"),
           `type` = Some(BEST_FIELDS),
           operator = Some(OR),
           analyzer = Some(whitespaceAnalyzer.name),
-          fields = Seq(
-            (Some(1000), "state.canonicalId"),
-            (Some(1000), "state.sourceIdentifier.value"),
-            (Some(1000), "data.otherIdentifiers.value"),
-            (Some(1000), "data.items.id.canonicalId"),
-            (Some(1000), "data.items.id.sourceIdentifier.value"),
-            (Some(1000), "data.items.id.otherIdentifiers.value"),
-            (Some(1000), "data.imageData.id.canonicalId"),
-            (Some(1000), "data.imageData.id.sourceIdentifier.value"),
-            (Some(1000), "data.imageData.id.otherIdentifiers.value"),
-          ).map(f => FieldWithOptionalBoost(f._2, f._1.map(_.toDouble)))
+          fields = fieldsWithBoost(
+            boost = 1000,
+            Seq(
+              "state.canonicalId",
+              "state.sourceIdentifier.value",
+              "data.otherIdentifiers.value",
+              "data.items.id.canonicalId",
+              "data.items.id.sourceIdentifier.value",
+              "data.items.id.otherIdentifiers.value",
+              "data.imageData.id.canonicalId",
+              "data.imageData.id.sourceIdentifier.value",
+              "data.imageData.id.otherIdentifiers.value",
+            )
+          )
         ),
+        /**
+          * This is the different ways we can match on the title fields
+          * - title prefix: An exact match, in order
+          * - title exact spellings: Exact spellings as they have been catalogued
+          * - title alternative spellings: Alternative spellings which people might search for e.g. in transliterations
+          */
+        dismax(
+          queries = Seq(
+            BoolQuery(
+              queryName = Some("title prefix"),
+              boost = Some(1000),
+              must = List(
+                prefixQuery("data.title.keyword", q),
+                matchPhraseQuery("data.title", q)
+              )
+            ),
+            MultiMatchQuery(
+              q,
+              queryName = Some("title exact spellings"),
+              fields = fieldsWithBoost(boost = 100, fields = titleFields),
+              `type` = Some(BEST_FIELDS),
+              operator = Some(AND)
+            ),
+            MultiMatchQuery(
+              q,
+              queryName = Some("title alternative spellings"),
+              fields = fieldsWithBoost(boost = 80, fields = titleFields),
+              `type` = Some(BEST_FIELDS),
+              operator = Some(AND),
+              fuzziness = Some("AUTO")
+            )
+          )),
         MultiMatchQuery(
           q,
-          `type` = Some(BEST_FIELDS),
-          operator = Some(AND),
-          fields = Seq(
-            (Some(100), "data.title"),
-            (Some(100), "data.title.english"),
-            (Some(100), "data.title.shingles"),
-            (Some(100), "data.alternativeTitles"),
-            (None, "data.lettering"),
-          ).map {
-            case (weight, fieldName) =>
-              FieldWithOptionalBoost(fieldName, weight.map(_.toDouble))
-          },
-          fuzziness = Some("AUTO")
-        ),
-        MultiMatchQuery(
-          q,
+          queryName = Some("data"),
           `type` = Some(CROSS_FIELDS),
           operator = Some(AND),
           fields = Seq(
@@ -70,6 +97,7 @@ case object WorksMultiMatcher {
             (None, "data.notes.content"),
             (None, "data.collectionPath.path"),
             (None, "data.collectionPath.label"),
+            (None, "data.lettering"),
           ).map(f => FieldWithOptionalBoost(f._2, f._1.map(_.toDouble)))
         )
       )

--- a/api/api/src/test/resources/WorksMultiMatcherQuery.json
+++ b/api/api/src/test/resources/WorksMultiMatcherQuery.json
@@ -1,0 +1,106 @@
+{
+  "bool": {
+    "minimum_should_match": "1",
+    "should": [
+      {
+        "multi_match": {
+          "_name": "identifiers",
+          "analyzer": "whitespace_analyzer",
+          "fields": [
+            "state.canonicalId^1000.0",
+            "state.sourceIdentifier.value^1000.0",
+            "data.otherIdentifiers.value^1000.0",
+            "data.items.id.canonicalId^1000.0",
+            "data.items.id.sourceIdentifier.value^1000.0",
+            "data.items.id.otherIdentifiers.value^1000.0",
+            "data.imageData.id.canonicalId^1000.0",
+            "data.imageData.id.sourceIdentifier.value^1000.0",
+            "data.imageData.id.otherIdentifiers.value^1000.0"
+          ],
+          "operator": "Or",
+          "query": "{{query}}",
+          "type": "best_fields"
+        }
+      },
+      {
+        "dis_max": {
+          "queries": [
+            {
+              "bool": {
+                "_name": "title prefix",
+                "boost": 1000.0,
+                "must": [
+                  {
+                    "prefix": {
+                      "data.title.keyword": {
+                        "value": "{{query}}"
+                      }
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "data.title": {
+                        "query": "{{query}}"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "multi_match": {
+                "_name": "title exact spellings",
+                "fields": [
+                  "data.title^100.0",
+                  "data.title.english^100.0",
+                  "data.title.shingles^100.0",
+                  "data.alternativeTitles^100.0"
+                ],
+                "operator": "And",
+                "query": "{{query}}",
+                "type": "best_fields"
+              }
+            },
+            {
+              "multi_match": {
+                "_name": "title alternative spellings",
+                "fields": [
+                  "data.title^80.0",
+                  "data.title.english^80.0",
+                  "data.title.shingles^80.0",
+                  "data.alternativeTitles^80.0"
+                ],
+                "fuzziness": "AUTO",
+                "operator": "And",
+                "query": "{{query}}",
+                "type": "best_fields"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "multi_match": {
+          "_name": "data",
+          "fields": [
+            "data.contributors.agent.label^1000.0",
+            "data.subjects.concepts.label^10.0",
+            "data.genres.concepts.label^10.0",
+            "data.production.*.label^10.0",
+            "data.description",
+            "data.physicalDescription",
+            "data.language.label",
+            "data.edition",
+            "data.notes.content",
+            "data.collectionPath.path",
+            "data.collectionPath.label",
+            "data.lettering"
+          ],
+          "operator": "And",
+          "query": "{{query}}",
+          "type": "cross_fields"
+        }
+      }
+    ]
+  }
+}

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksMultiMatcherQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/WorksMultiMatcherQueryTest.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.api.elasticsearch
+
+import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+class WorksMultiMatcherQueryTest
+    extends AnyFunSpec
+    with Matchers
+    with JsonAssertions {
+  it("matches the JSON version of the query") {
+    val fileJson =
+      Source
+        .fromResource("WorksMultiMatcherQuery.json")
+        .getLines
+        .mkString
+
+    val queryJson = QueryBuilderFn(WorksMultiMatcher("{{query}}")).string()
+    assertJsonStringsAreEqual(fileJson, queryJson)
+  }
+}

--- a/docs/search/changelog.md
+++ b/docs/search/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+* 30 March 2020 - Better alternative spelling scoring to matching to query - [Github Issue](https://github.com/wellcomecollection/catalogue/pull/1519)


### PR DESCRIPTION
[Based on the rank eval tests here](https://github.com/wellcomecollection/maat/blob/master/queries/alternative-title-spellings.ts).

Adds better handling of alternative spellings.

We rank the alternative spellings slightly lower, as they can some times bring up irrelevant results for things like `stimming` vs `swimming`.

The alternative spellings are normally quite specialist e.g. `Aṭ-ṭib`, `Aṭ-ṭibb` - so that ranking doesn't really affect us bringing back to the relevant results.

[You can see some examples here](https://rank.wellcomecollection.org/search?query=at-tib&queryId=alternative-title-spellings).

We've added a JSON check as it's easier to read the standard JSON and this ensures that the query created by elastic4s is the one we want as we have had issues with the DSL creating unexpected results previously.

