### PR TITLE
Replace post-filtering & min_doc_count: 0 with global aggregations

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/Aggregation.scala
@@ -2,8 +2,10 @@ package uk.ac.wellcome.platform.api.models
 
 import io.circe.generic.extras.JsonKey
 import io.circe.{Decoder, Json}
+import io.circe.parser._
+import io.circe.optics.JsonPath._
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 // This object maps an aggregation result from Elasticsearch into our
 // Aggregation data type.  The results from ES are of the form:
@@ -24,11 +26,38 @@ import scala.util.Try
 //
 // If the buckets have a subaggregation named "filtered", then we use the
 // count from there; otherwise we use the count from the root of the bucket.
+//
+// Some results will come wrapped in a global aggregation, they will have the
+// above form inside an unknown key:
+//
+//    {
+//      "doc_count": 123,
+//      "some_name": {
+//        "buckets": [
+//          {
+//            "key": "chi",
+//            "doc_count": 4,
+//            "filtered": {
+//              "doc_count": 3
+//            }
+//          },
+//        ...
+//        ],
+//        ...
+//      },
+//      ...
+//    }
 object AggregationMapping {
 
   import uk.ac.wellcome.json.JsonUtil._
 
-  private case class Result(buckets: Seq[Bucket])
+  private case class Result(buckets: Option[Seq[Bucket]])
+
+  // When we use a global aggregation we can't predict the key name of the
+  // resultant sub-aggregation. This optic says,
+  // "for each key of the root object that has a key `buckets`, decode
+  // the value of that field as an array of Buckets"
+  private val globalAggBuckets = root.each.buckets.each.as[Bucket]
 
   private case class Bucket(
     key: Json,
@@ -46,8 +75,16 @@ object AggregationMapping {
 
   def aggregationParser[T: Decoder](jsonString: String): Try[Aggregation[T]] =
     fromJson[Result](jsonString)
-      .map { result =>
-        result.buckets
+      .flatMap {
+        case Result(Some(buckets)) =>
+          Success(buckets)
+        case Result(None) =>
+          parse(jsonString)
+            .map(globalAggBuckets.getAll)
+            .toTry
+      }
+      .map { buckets =>
+        buckets
           .map { b =>
             (b.key.as[T], b.docCount)
           }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilder.scala
@@ -36,11 +36,8 @@ import scala.collection.immutable._
   * constituents of the ES query, this class exposes:
   *
   * - `filteredAggregations`: a list of all the ES query aggregations, where those that need to be filtered
-  *   now have a sub-aggregation of the filter aggregation type, named "filtered".
-  * - `unpairedFilters`: a list of all of the given filters which are not paired to any of
-  *   the given aggregations. These can be used as the ES query filters.
-  * - `pairedFilters`: a list of all of the given filters which are paired to one
-  *   of the given aggregations. These can be used as the ES post-query filters.
+  *   now have a sub-aggregation of the filter aggregation type, named "filtered", and are in the global
+  *   aggregation context so post-filtering of query results is not required.
   */
 trait FiltersAndAggregationsBuilder[Filter, AggregationRequest] {
   val aggregationRequests: List[AggregationRequest]
@@ -50,58 +47,42 @@ trait FiltersAndAggregationsBuilder[Filter, AggregationRequest] {
 
   def pairedAggregationRequests(filter: Filter): List[AggregationRequest]
 
-  lazy val unpairedFilters: List[Filter] =
-    filterSets.getOrElse(FilterCategory.Unpaired, List())
-  lazy val pairedFilters: List[Filter] =
-    filterSets.getOrElse(FilterCategory.Paired, List())
-
   lazy val filteredAggregations: List[AbstractAggregation] =
     aggregationRequests.map { aggReq =>
       val agg = requestToAggregation(aggReq)
-      val subFilters = pairedFilters.filterNot(pairedFilter(aggReq).contains(_))
-      if (subFilters.nonEmpty) {
-        GlobalAggregation(
-          name = agg.name,
-          subaggs = Seq(
+      pairedFilter(aggReq) match {
+        case Some(_) if filters.size == 1 =>
+          GlobalAggregation(
             // We would like to rename the aggregation here to something predictable
             // (eg "global_agg") but because it is an opaque AbstractAggregation we
             // make do with naming it the same as its parent GlobalAggregation, so that
             // the latter can be picked off when parsing in WorkAggregations
-            agg.addSubagg(
-              FilterAggregation(
-                "filtered",
-                boolQuery.filter { subFilters.map(filterToQuery) }
+            name = agg.name,
+            subaggs = Seq(agg)
+          )
+        case Some(paired) if filters.size > 1 =>
+          val subFilters = filters.filterNot(_ == paired)
+          GlobalAggregation(
+            name = agg.name,
+            subaggs = Seq(
+              agg.addSubagg(
+                FilterAggregation(
+                  "filtered",
+                  boolQuery.filter { subFilters.map(filterToQuery) }
+                )
               )
             )
           )
-        )
-      } else {
-        agg
-      }
-    }
-
-  private lazy val filterSets: Map[FilterCategory, List[Filter]] =
-    filters.groupBy {
-      pairedAggregationRequests(_) match {
-        case pairedRequests
-            if aggregationRequests.intersect(pairedRequests).nonEmpty =>
-          FilterCategory.Paired
-        case _ => FilterCategory.Unpaired
+        case _ => agg
       }
     }
 
   private def pairedFilter(
     aggregationRequest: AggregationRequest): Option[Filter] =
-    pairedFilters.find {
-      pairedAggregationRequests(_)
+    filters.find { filter =>
+      pairedAggregationRequests(filter)
         .contains(aggregationRequest)
     }
-
-  private sealed trait FilterCategory
-  private object FilterCategory {
-    case object Unpaired extends FilterCategory
-    case object Paired extends FilterCategory
-  }
 }
 
 class WorkFiltersAndAggregationsBuilder(

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ImagesRequestBuilder.scala
@@ -59,17 +59,14 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
       TermsAggregation("license")
         .size(License.values.size)
         .field("locations.license.id")
-        .minDocCount(0)
     case ImageAggregationRequest.SourceContributorAgents =>
       TermsAggregation("sourceContributorAgents")
         .size(20)
         .field("state.derivedData.sourceContributorAgents")
-        .minDocCount(0)
     case ImageAggregationRequest.SourceGenres =>
       TermsAggregation("sourceGenres")
         .size(20)
         .field("source.canonicalWork.data.genres.label.keyword")
-        .minDocCount(0)
   }
 
   def sortBy(searchOptions: ImageSearchOptions): Seq[Sort] =

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -24,7 +24,6 @@ object WorksRequestBuilder
     search(index)
       .aggs { filteredAggregationBuilder.filteredAggregations }
       .query { filteredQuery }
-      .postFilter { postFilterQuery }
       .sortBy { sortBy }
       .limit { searchOptions.pageSize }
       .from { PaginationQuery.safeGetFrom(searchOptions) }
@@ -108,12 +107,6 @@ object WorksRequestBuilder
       case SortingOrder.Descending => SortOrder.DESC
     }
 
-  private def postFilterQuery(
-    implicit searchOptions: WorkSearchOptions): BoolQuery =
-    boolQuery.filter {
-      filteredAggregationBuilder.pairedFilters.map(buildWorkFilterQuery)
-    }
-
   private def filteredQuery(
     implicit searchOptions: WorkSearchOptions): BoolQuery =
     searchOptions.searchQuery
@@ -123,7 +116,7 @@ object WorksRequestBuilder
       }
       .getOrElse { boolQuery }
       .filter {
-        (VisibleWorkFilter :: filteredAggregationBuilder.unpairedFilters)
+        (VisibleWorkFilter :: searchOptions.filters)
           .map(buildWorkFilterQuery)
       }
 

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -49,6 +49,7 @@ object WorksRequestBuilder
       DateHistogramAggregation("productionDates")
         .calendarInterval(DateHistogramInterval.Year)
         .field("data.production.dates.range.from")
+        .minDocCount(1)
 
     // We don't split genres into concepts, as the data isn't great,
     // and for rendering isn't useful at the moment.

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -44,13 +44,11 @@ object WorksRequestBuilder
       TermsAggregation("format")
         .size(Format.values.size)
         .field("data.format.id")
-        .minDocCount(0)
 
     case WorkAggregationRequest.ProductionDate =>
       DateHistogramAggregation("productionDates")
         .calendarInterval(DateHistogramInterval.Year)
         .field("data.production.dates.range.from")
-        .minDocCount(1)
 
     // We don't split genres into concepts, as the data isn't great,
     // and for rendering isn't useful at the moment.
@@ -59,40 +57,34 @@ object WorksRequestBuilder
       TermsAggregation("genres")
         .size(20)
         .field("data.genres.concepts.label.keyword")
-        .minDocCount(0)
 
     case WorkAggregationRequest.Subject |
         WorkAggregationRequest.SubjectDeprecated =>
       TermsAggregation("subjects")
         .size(20)
         .field("data.subjects.label.keyword")
-        .minDocCount(0)
 
     case WorkAggregationRequest.Contributor |
         WorkAggregationRequest.ContributorDeprecated =>
       TermsAggregation("contributors")
         .size(20)
         .field("state.derivedData.contributorAgents")
-        .minDocCount(0)
 
     case WorkAggregationRequest.Languages =>
       TermsAggregation("languages")
         .size(200)
         .field("data.languages.id")
-        .minDocCount(0)
 
     case WorkAggregationRequest.License |
         WorkAggregationRequest.LicenseDeprecated =>
       TermsAggregation("license")
         .size(License.values.size)
         .field("data.items.locations.license.id")
-        .minDocCount(0)
 
     case WorkAggregationRequest.Availabilities =>
       TermsAggregation("availabilities")
         .size(Availability.values.size)
         .field("state.availabilities.id")
-        .minDocCount(0)
   }
 
   private def sortBy(implicit searchOptions: WorkSearchOptions) =

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/images/ImagesFilteredAggregationsTest.scala
@@ -41,14 +41,13 @@ class ImagesFilteredAggregationsTest extends ApiImagesTestBase {
                       "type" : "AggregationBucket"
                     },
                     {
+                      "data" : ${license(License.OGL)},
+                      "count" : ${oglImages.size},
+                      "type" : "AggregationBucket"
+                    },
+                    {
                       "data" : ${license(License.PDM)},
                       "count" : ${pdmImages.size},
-                      "type" : "AggregationBucket"
-                    }
-                    ,
-                    {
-                      "data" : ${license(License.OGL)},
-                      "count" : 0,
                       "type" : "AggregationBucket"
                     }
                   ]

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/AggregationResultsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/models/AggregationResultsTest.scala
@@ -87,4 +87,40 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
     singleAgg.get.format shouldBe Some(
       Aggregation[Format](List(AggregationBucket(data = Books, count = 1234))))
   }
+
+  it("uses the buckets from the global aggregation when present") {
+    val searchResponse = SearchResponse(
+      took = 1234,
+      isTimedOut = false,
+      isTerminatedEarly = false,
+      suggest = Map(),
+      _shards = Shards(total = 1, failed = 0, successful = 1),
+      scrollId = None,
+      hits = SearchHits(
+        total = Total(0, "potatoes"),
+        maxScore = 0.0,
+        hits = Array()),
+      _aggregationsAsMap = Map(
+        "format" -> Map(
+          "doc_count" -> 12345,
+          "format" -> Map(
+            "doc_count_error_upper_bound" -> 0,
+            "sum_other_doc_count" -> 0,
+            "buckets" -> List(
+              Map(
+                "key" -> "a",
+                "doc_count" -> 393145,
+                "filtered" -> Map(
+                  "doc_count" -> 1234
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    val singleAgg = WorkAggregations(searchResponse)
+    singleAgg.get.format shouldBe Some(
+      Aggregation[Format](List(AggregationBucket(data = Books, count = 1234))))
+  }
 }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/AggregationsTest.scala
@@ -93,28 +93,6 @@ class AggregationsTest
     }
   }
 
-  it("returns empty buckets if they exist") {
-    val formats = Format.values
-    val works = formats.flatMap { format =>
-      (0 to 4).map(_ => indexedWork().format(format))
-    }
-    withLocalWorksIndex { index =>
-      insertIntoElasticsearch(index, works: _*)
-      val searchOptions = createWorksSearchOptionsWith(
-        searchQuery = Some(SearchQuery("anything will give zero results")),
-        aggregations = List(WorkAggregationRequest.Format)
-      )
-      whenReady(aggregationQuery(index, searchOptions)) { aggs =>
-        aggs.format should not be empty
-        val buckets = aggs.format.get.buckets
-        buckets.length shouldBe formats.length
-        buckets.map(_.data.label) should contain theSameElementsAs formats
-          .map(_.label)
-        buckets.map(_.count) should contain only 0
-      }
-    }
-  }
-
   describe("aggregations with filters") {
     val formats = Format.values
     val subjects = (0 to 5).map(_ => createSubject)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -3,7 +3,8 @@ package uk.ac.wellcome.platform.api.services
 import com.sksamuel.elastic4s.requests.searches.aggs.{
   AbstractAggregation,
   Aggregation,
-  FilterAggregation
+  FilterAggregation,
+  GlobalAggregation
 }
 import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
 import org.scalatest.funspec.AnyFunSpec
@@ -72,8 +73,15 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       )
 
       builder.filteredAggregations should have length 2
-      builder.filteredAggregations.head shouldBe a[MockAggregation]
-      val agg = builder.filteredAggregations.head.asInstanceOf[MockAggregation]
+      builder.filteredAggregations.head shouldBe a[GlobalAggregation]
+
+      val topAgg = builder.filteredAggregations.head
+        .asInstanceOf[GlobalAggregation]
+        .subaggs
+        .head
+      topAgg shouldBe a[MockAggregation]
+
+      val agg = topAgg.asInstanceOf[MockAggregation]
       agg.subaggs.head shouldBe a[FilterAggregation]
       agg.request shouldBe WorkAggregationRequest.Format
     }
@@ -108,7 +116,12 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       val formatAgg =
         builder.filteredAggregations.head.asInstanceOf[MockAggregation]
       val languageAgg =
-        builder.filteredAggregations(1).asInstanceOf[MockAggregation]
+        builder
+          .filteredAggregations(1)
+          .asInstanceOf[GlobalAggregation]
+          .subaggs
+          .head
+          .asInstanceOf[MockAggregation]
       formatAgg.subaggs.size shouldBe 0
       languageAgg.subaggs.head
         .asInstanceOf[FilterAggregation]
@@ -133,6 +146,9 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
 
       val agg =
         builder.filteredAggregations.head
+          .asInstanceOf[GlobalAggregation]
+          .subaggs
+          .head
           .asInstanceOf[MockAggregation]
           .subaggs
           .head

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -12,17 +12,33 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
   val quechua = Language(label = "Quechua", id = "que")
   val chechen = Language(label = "Chechen", id = "che")
 
+  /*
+   * | workType     | count |
+   * |--------------|-------|
+   * | a / Books    | 4     |
+   * | d / Journals | 3     |
+   * | i / Audio    | 2     |
+   * | k / Pictures | 1     |
+   *
+   * | language      | count |
+   * |---------------|-------|
+   * | bak / Bashkir | 4     |
+   * | que / Quechua | 3     |
+   * | mar / Marathi  | 2     |
+   * | che / Chechen | 1     |
+   *
+   */
   val works: List[Work.Visible[WorkState.Indexed]] = List(
-    (Books, bashkir),
-    (Journals, marathi),
-    (Pictures, quechua),
-    (Audio, bashkir),
-    (Books, bashkir),
-    (Books, bashkir),
-    (Journals, quechua),
-    (Books, marathi),
-    (Journals, quechua),
-    (Audio, chechen)
+    (Books, bashkir), // a
+    (Journals, marathi), // d
+    (Pictures, quechua), // k
+    (Audio, bashkir), // i
+    (Books, bashkir), // a
+    (Books, bashkir), // a
+    (Journals, quechua), // d
+    (Books, marathi), // a
+    (Journals, quechua), // d
+    (Audio, chechen) // i
   ).map {
     case (format, language) =>
       indexedWork()
@@ -30,20 +46,22 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
         .languages(List(language))
   }
 
-  it(
-    "filters an aggregation with a filter that is not paired to the aggregation") {
-    withWorksApi {
-      case (worksIndex, routes) =>
-        insertIntoElasticsearch(worksIndex, works: _*)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works?workType=a&aggregations=languages") {
-          Status.OK -> s"""
+  describe(
+    "filters aggregation buckets with any filters that are not paired to the aggregation") {
+    it("when those filters do not have a paired aggregation present") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(
+            routes,
+            // We expect to see the language buckets for only the works with workType=a
+            s"/$apiPrefix/works?workType=a&aggregations=languages") {
+            Status.OK -> s"""
             {
               ${resultList(
-                            apiPrefix,
-                            totalResults =
-                              works.count(_.data.format.get == Books))},
+                              apiPrefix,
+                              totalResults =
+                                works.count(_.data.format.get == Books))},
               "aggregations": {
                 "type" : "Aggregations",
                 "languages": {
@@ -63,30 +81,32 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                 }
               },
               "results": [${works
-                            .filter(_.data.format.get == Books)
-                            .sortBy { _.state.canonicalId }
-                            .map(workResponse)
-                            .mkString(",")}]
+                              .filter(_.data.format.get == Books)
+                              .sortBy { _.state.canonicalId }
+                              .map(workResponse)
+                              .mkString(",")}]
             }
           """.stripMargin
-        }
+          }
+      }
     }
-  }
 
-  it(
-    "filters an aggregation with a filter that is paired to another aggregation") {
-    withWorksApi {
-      case (worksIndex, routes) =>
-        insertIntoElasticsearch(worksIndex, works: _*)
-        assertJsonResponse(
-          routes,
-          s"/$apiPrefix/works?workType=a&aggregations=languages,workType") {
-          Status.OK -> s"""
+    it("when those filters do have a paired aggregation present") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(
+            routes,
+            // We expect to see the language buckets for only the works with workType=a
+            // We expect to see the workType buckets for all of the works
+            s"/$apiPrefix/works?workType=a&aggregations=languages,workType"
+          ) {
+            Status.OK -> s"""
             {
               ${resultList(
-                            apiPrefix,
-                            totalResults =
-                              works.count(_.data.format.get == Books))},
+                              apiPrefix,
+                              totalResults =
+                                works.count(_.data.format.get == Books))},
               "aggregations": {
                 "type" : "Aggregations",
                 "languages": {
@@ -98,18 +118,8 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                       "type" : "AggregationBucket"
                     },
                     {
-                      "count" : 0,
-                      "data" : ${language(quechua)},
-                      "type" : "AggregationBucket"
-                    },
-                    {
                       "count" : 1,
                       "data" : ${language(marathi)},
-                      "type" : "AggregationBucket"
-                    },
-                    {
-                      "count" : 0,
-                      "data" : ${language(chechen)},
                       "type" : "AggregationBucket"
                     }
                   ]
@@ -141,13 +151,63 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                 }
               },
               "results": [${works
-                            .filter(_.data.format.get == Books)
-                            .sortBy { _.state.canonicalId }
-                            .map(workResponse)
-                            .mkString(",")}]
+                              .filter(_.data.format.get == Books)
+                              .sortBy { _.state.canonicalId }
+                              .map(workResponse)
+                              .mkString(",")}]
             }
           """.stripMargin
-        }
+          }
+      }
+    }
+
+    it("but still returns empty buckets if their paired filter is present") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          assertJsonResponse(
+            routes,
+            // We expect to see the workType buckets for worktype i/Audio, because that
+            // has the language che/Chechen, and for a/Books, because a filter for it is
+            // present
+            s"/$apiPrefix/works?workType=a&languages=che&aggregations=workType"
+          ) {
+            Status.OK -> s"""
+            {
+              ${resultList(apiPrefix, totalResults = 0, totalPages = 0)},
+              "aggregations": {
+                "type" : "Aggregations",
+                "workType" : {
+                  "type": "Aggregation",
+                  "buckets" : [
+                    {
+                      "count" : 0,
+                      "data" : ${format(Books)},
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 0,
+                      "data" : ${format(Journals)},
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 1,
+                      "data" : ${format(Audio)},
+                      "type" : "AggregationBucket"
+                    },
+                    {
+                      "count" : 0,
+                      "data" : ${format(Pictures)},
+                      "type" : "AggregationBucket"
+                    }
+                  ]
+                }
+              },
+              "results": []
+            }
+          """.stripMargin
+          }
+      }
     }
   }
 

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/works/WorksFilteredAggregationsTest.scala
@@ -58,16 +58,6 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                       "count" : 1,
                       "data" : ${language(marathi)},
                       "type" : "AggregationBucket"
-                    },
-                    {
-                      "count" : 0,
-                      "data" : ${language(chechen)},
-                      "type" : "AggregationBucket"
-                    },
-                    {
-                      "count" : 0,
-                      "data" : ${language(quechua)},
-                      "type" : "AggregationBucket"
                     }
                   ]
                 }


### PR DESCRIPTION
As per the advice in https://github.com/elastic/elasticsearch/issues/62084#issuecomment-689507644

Using the principles in https://github.com/wellcomecollection/docs/blob/master/adr/api_faceting.md I could identify where we did want to return empty buckets and where we didn't - this PR _does_ change some behaviours but I believe that these changes won't hit the UI as the now-removed buckets were already being filtered out. It also turns out there were some inconsistencies between image and works aggregations (oops!) which this fixes.