### PR TITLE
Apply search query to global aggregation filters

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksRequestBuilder.scala
@@ -35,7 +35,8 @@ object WorksRequestBuilder
       aggregationRequests = searchOptions.aggregations,
       filters = searchOptions.filters,
       requestToAggregation = toAggregation,
-      filterToQuery = buildWorkFilterQuery
+      filterToQuery = buildWorkFilterQuery,
+      searchQuery = searchQuery
     )
 
   private def toAggregation(aggReq: WorkAggregationRequest) = aggReq match {
@@ -107,7 +108,7 @@ object WorksRequestBuilder
       case SortingOrder.Descending => SortOrder.DESC
     }
 
-  private def filteredQuery(
+  private def searchQuery(
     implicit searchOptions: WorkSearchOptions): BoolQuery =
     searchOptions.searchQuery
       .map {
@@ -115,6 +116,10 @@ object WorksRequestBuilder
           queryType.toEsQuery(query)
       }
       .getOrElse { boolQuery }
+
+  private def filteredQuery(
+    implicit searchOptions: WorkSearchOptions): BoolQuery =
+    searchQuery
       .filter {
         (VisibleWorkFilter :: searchOptions.filters)
           .map(buildWorkFilterQuery)

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/services/FiltersAndAggregationsBuilderTest.scala
@@ -23,7 +23,8 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
           List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages),
         filters = List(formatFilter, languagesFilter),
         requestToAggregation = requestToAggregation,
-        filterToQuery = filterToQuery
+        filterToQuery = filterToQuery,
+        searchQuery = MockSearchQuery
       )
 
       builder.filteredAggregations should have length 2
@@ -46,7 +47,8 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
         aggregationRequests = List(WorkAggregationRequest.Format),
         filters = List(languagesFilter),
         requestToAggregation = requestToAggregation,
-        filterToQuery = filterToQuery
+        filterToQuery = filterToQuery,
+        searchQuery = MockSearchQuery
       )
 
       builder.filteredAggregations should have length 1
@@ -63,7 +65,8 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
           List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages),
         filters = List(formatFilter),
         requestToAggregation = requestToAggregation,
-        filterToQuery = filterToQuery
+        filterToQuery = filterToQuery,
+        searchQuery = MockSearchQuery
       )
 
       builder.filteredAggregations should have length 2
@@ -73,7 +76,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
         .subaggs
         .head
         .asInstanceOf[MockAggregation]
-        .subaggs should have length 0
+        .subaggs should have length 1
 
       builder.filteredAggregations(1) shouldBe a[MockAggregation]
       builder
@@ -93,7 +96,8 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
           WorkAggregationRequest.Genre),
         filters = List(formatFilter, languagesFilter, genreFilter),
         requestToAggregation = requestToAggregation,
-        filterToQuery = filterToQuery
+        filterToQuery = filterToQuery,
+        searchQuery = MockSearchQuery
       )
 
       val agg =
@@ -108,8 +112,9 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
       agg.query shouldBe a[BoolQuery]
       val query = agg.query.asInstanceOf[BoolQuery]
       query.filters should not contain MockQuery(formatFilter)
-      query.filters should contain only (MockQuery(languagesFilter), MockQuery(
-        genreFilter))
+      query.filters should contain only (
+        MockSearchQuery, MockQuery(languagesFilter), MockQuery(genreFilter)
+      )
     }
   }
 
@@ -120,6 +125,7 @@ class FiltersAndAggregationsBuilderTest extends AnyFunSpec with Matchers {
   private def filterToQuery(filter: WorkFilter): Query = MockQuery(filter)
 
   private case class MockQuery(filter: WorkFilter) extends Query
+  private case object MockSearchQuery extends Query
 
   private case class MockAggregation(name: String,
                                      request: WorkAggregationRequest,


### PR DESCRIPTION
I had neglected to realise that the `global` aggregations need to be filtered from scratch - including the search query!

This makes me less convinced of the approach, since it requires a complete duplicate of the search query in the aggregations (although as I understand ES caching means that it won't actually be performing it twice), but I would still like to try it out given the recommendation. I'll keep an eye on performance and roll back if it's detrimental.