### PR TITLE
Add API environment to APM config

### DIFF
--- a/api/api/src/main/resources/application.conf
+++ b/api/api/src/main/resources/application.conf
@@ -7,3 +7,4 @@ api.host=${?api_host}
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
+apm.environment=${?apm_environment}

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/Tracing.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/Tracing.scala
@@ -37,6 +37,9 @@ object Tracing {
         "service_name" -> config
           .getStringOption("apm.service.name")
           .getOrElse("catalogue-api"),
+        "environment" -> config
+          .getStringOption("apm.environment")
+          .getOrElse(""),
         "server_urls" -> config
           .getStringOption("apm.server.url")
           .getOrElse("http://localhost:9200"),

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticsearchService.scala
@@ -55,7 +55,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
         .map(_.toEither)
         .map { responseOrError =>
           responseOrError.map { res =>
-            transaction.addLabel("elasticTook", res.took)
+            transaction.setLabel("elasticTook", res.took)
             res
           }
         }
@@ -83,7 +83,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
                 case None =>
                   val responses = results.collect { case Right(resp) => resp }.toList
                   val took = responses.map(_.took).sum
-                  transaction.addLabel("elasticTook", took)
+                  transaction.setLabel("elasticTook", took)
                   Right(responses)
               }
           }
@@ -93,16 +93,16 @@ class ElasticsearchService(elasticClient: ElasticClient)(
   implicit class EnhancedTransaction(transaction: Transaction) {
     def addQueryOptionLabels(
       searchOptions: SearchOptions[_, _, _]): Transaction = {
-      transaction.addLabel("pageSize", searchOptions.pageSize)
-      transaction.addLabel("pageNumber", searchOptions.pageNumber)
-      transaction.addLabel("sortOrder", searchOptions.sortOrder.toString)
-      transaction.addLabel(
+      transaction.setLabel("pageSize", searchOptions.pageSize)
+      transaction.setLabel("pageNumber", searchOptions.pageNumber)
+      transaction.setLabel("sortOrder", searchOptions.sortOrder.toString)
+      transaction.setLabel(
         "sortBy",
         searchOptions.sortBy.map { _.toString }.mkString(","))
-      transaction.addLabel(
+      transaction.setLabel(
         "filters",
         searchOptions.filters.map { _.toString }.mkString(","))
-      transaction.addLabel(
+      transaction.setLabel(
         "aggregations",
         searchOptions.aggregations.map { _.toString }.mkString(","))
     }

--- a/api/terraform/modules/stack/main.tf
+++ b/api/terraform/modules/stack/main.tf
@@ -38,6 +38,7 @@ module "service" {
   environment = {
     api_host         = "api.wellcomecollection.org"
     apm_service_name = var.namespace
+    apm_environment  = var.environment
   }
 
   secrets = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,7 +92,7 @@ object ExternalDependencies {
     val scalacheckShapeless = "1.1.6"
     val scalacsv = "1.3.5"
     val scalaGraph = "1.12.5"
-    val apm = "1.12.0"
+    val apm = "1.22.0"
     val enumeratum = "1.6.1"
     val enumeratumScalacheck = "1.6.1"
     val jsoup = "1.13.1"


### PR DESCRIPTION
We used to use service_names to distinguish but that got lost in some terraform changes and now the APM UI (which is much improved) has its own way of distinguishing application environments