### PR TITLE
Fix merging on Works that have electronic items from field 856

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -30,11 +30,10 @@ object WorkPredicates {
   val multiItem: WorkPredicate = work => work.data.items.size > 1
 
   val zeroIdentifiedItems: WorkPredicate =
-    work => work.data.items
-      .collect {
+    work =>
+      work.data.items.collect {
         case it @ Item(IdState.Identified(_, _, _), _, _) => it
-      }
-      .isEmpty
+      }.isEmpty
 
   /**
     * This is the shape in which we expect the works from the transformers.

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -78,7 +78,7 @@ object WorkPredicates {
   val sierraDigaids: WorkPredicate =
     satisfiesAll(sierraWork, hasDigcode("digaids"))
 
-  val sierraElectronicBib: WorkPredicate =
+  val sierraElectronicVideo: WorkPredicate =
     satisfiesAll(zeroItemSierra, format(Format.Videos))
 
   def not(pred: WorkPredicate): WorkPredicate = !pred(_)

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -172,7 +172,7 @@ object PlatformMerger extends Merger {
     works: Seq[Work[Identified]]): Option[Work.Visible[Identified]] =
     works
       .find(WorkPredicates.singlePhysicalItemCalmWork)
-      .orElse(works.find(WorkPredicates.sierraElectronicBib))
+      .orElse(works.find(WorkPredicates.sierraElectronicVideo))
       .orElse(works.find(WorkPredicates.physicalSierra))
       .orElse(works.find(WorkPredicates.sierraWork)) match {
       case Some(target: Work.Visible[Identified]) => Some(target)

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -819,7 +819,8 @@ class PlatformMergerTest
                   url = "http://www.scope.org.uk",
                   locationType = LocationType.OnlineResource,
                   accessConditions = List(
-                    AccessCondition(status = Some(AccessStatus.LicensedResources))
+                    AccessCondition(
+                      status = Some(AccessStatus.LicensedResources))
                   )
                 )
               )
@@ -867,8 +868,9 @@ class PlatformMergerTest
     val invisibleWorks = result.collect { case w: Work.Invisible[Merged] => w }
 
     invisibleWorks shouldBe empty
-    redirectedWorks
-      .map { w => w.state.canonicalId -> w.redirectTarget.canonicalId }
-      .toMap shouldBe Map(metsWork.state.canonicalId -> eVideoWork.state.canonicalId)
+    redirectedWorks.map { w =>
+      w.state.canonicalId -> w.redirectTarget.canonicalId
+    }.toMap shouldBe Map(
+      metsWork.state.canonicalId -> eVideoWork.state.canonicalId)
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -10,11 +10,13 @@ import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.ParentWorks
 import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessStatus,
   DigitalLocation,
   License,
   LocationType
 }
-import weco.catalogue.internal_model.work.{Format, MergeCandidate, Work}
+import weco.catalogue.internal_model.work.{Format, Item, MergeCandidate, Work}
 
 class PlatformMergerTest
     extends AnyFunSpec
@@ -795,5 +797,78 @@ class PlatformMergerTest
     visibleWorks(workForFilmReel.id).data.items shouldBe workForFilmReel.data.items
 
     visibleWorks(workForEbib.id).data.items shouldBe workForMets.data.items
+  }
+
+  it("ignores online resources for physical/digital bib merging rules") {
+    // This test case is based on a real example of three related works that
+    // were being merged incorrectly.  In particular, the METS work (and associated
+    // IIIF manifest) was being merged into the physical video formats, not the
+    // more detailed e-bib that it should have been attached to.
+    //
+    // See https://wellcome.slack.com/archives/C8X9YKM5X/p1617705467131600
+    val eVideoWork =
+      sierraIdentifiedWork()
+        .format(Format.Videos)
+        .items(
+          List(
+            Item(
+              id = IdState.Unidentifiable,
+              title = Some("Scope: UK Disability Charity"),
+              locations = List(
+                DigitalLocation(
+                  url = "http://www.scope.org.uk",
+                  locationType = LocationType.OnlineResource,
+                  accessConditions = List(
+                    AccessCondition(status = Some(AccessStatus.LicensedResources))
+                  )
+                )
+              )
+            )
+          )
+        )
+
+    val physicalVideoWork =
+      sierraIdentifiedWork()
+        .mergeCandidates(
+          List(
+            MergeCandidate(
+              id = IdState.Identified(
+                canonicalId = eVideoWork.state.canonicalId,
+                sourceIdentifier = eVideoWork.sourceIdentifier
+              ),
+              reason = Some("Physical/digitised Sierra work")
+            )
+          )
+        )
+        .format(Format.Videos)
+        .items(List(createIdentifiedPhysicalItem))
+
+    val metsWork =
+      metsIdentifiedWork()
+        .mergeCandidates(
+          List(
+            MergeCandidate(
+              id = IdState.Identified(
+                canonicalId = eVideoWork.state.canonicalId,
+                sourceIdentifier = eVideoWork.sourceIdentifier
+              ),
+              reason = Some("METS work")
+            )
+          )
+        )
+
+    val result = merger
+      .merge(works = Seq(eVideoWork, physicalVideoWork, metsWork))
+      .mergedWorksWithTime(now)
+
+    val redirectedWorks = result.collect {
+      case w: Work.Redirected[Merged] => w
+    }
+    val invisibleWorks = result.collect { case w: Work.Invisible[Merged] => w }
+
+    invisibleWorks shouldBe empty
+    redirectedWorks
+      .map { w => w.state.canonicalId -> w.redirectTarget.canonicalId }
+      .toMap shouldBe Map(metsWork.state.canonicalId -> eVideoWork.state.canonicalId)
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.merger.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import uk.ac.wellcome.models.index.MergedWorkIndexConfig.sourceIdentifier
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.WorkFsm._
 import weco.catalogue.internal_model.image.ParentWork._


### PR DESCRIPTION
It's possible for e-video Works to pick up unidentified items from MARC field 856, which confuses the merger and causes it to attach the IIIF manifest to the wrong Work.  By filtering only for *identified* items (i.e. those that came directly from Sierra), the manifest gets attached to the correct work.

This fixes an issue raised by Harkiran in Slack: https://wellcome.slack.com/archives/C8X9YKM5X/p1617705467131600