### PR TITLE
Fix an issue with the Swagger model for DisplayWorkAggregations

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWorkAggregations.scala
@@ -18,16 +18,20 @@ case class DisplayWorkAggregations(
     description = "Format aggregation on a set of results."
   ) workType: Option[DisplayAggregation[DisplayFormat]],
   @Schema(
+    name = "production.dates",
     description = "Date aggregation on a set of results."
-  ) @JsonKey("production.dates") productionDates: Option[
+  ) @JsonKey("production.dates") `production.dates`: Option[
     DisplayAggregation[DisplayPeriod]],
   @Schema(
+    name = "genres.label",
     description = "Genre aggregation on a set of results."
   ) `genres.label`: Option[DisplayAggregation[DisplayGenre]],
   @Schema(
+    name = "subjects.label",
     description = "Subject aggregation on a set of results."
   ) `subjects.label`: Option[DisplayAggregation[DisplaySubject]],
   @Schema(
+    name = "contributors.agent.label",
     description = "Contributor aggregation on a set of results."
   ) `contributors.agent.label`: Option[
     DisplayAggregation[DisplayAbstractAgent]],
@@ -35,6 +39,7 @@ case class DisplayWorkAggregations(
     description = "Language aggregation on a set of results."
   ) languages: Option[DisplayAggregation[DisplayLanguage]],
   @Schema(
+    name = "items.locations.license",
     description = "License aggregation on a set of results."
   ) `items.locations.license`: Option[DisplayAggregation[DisplayLicense]],
   @Schema(
@@ -52,7 +57,7 @@ object DisplayWorkAggregations {
     aggregationRequests: Seq[WorkAggregationRequest]): DisplayWorkAggregations =
     DisplayWorkAggregations(
       workType = displayAggregation(aggs.format, DisplayFormat.apply),
-      productionDates =
+      `production.dates` =
         displayAggregation(aggs.productionDates, DisplayPeriod.apply),
       `genres.label` =
         whenRequestPresent(aggregationRequests, WorkAggregationRequest.Genre)(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -326,14 +326,10 @@ class ApiSwaggerTest
   it("lists the properties on the Aggregations model") {
     checkSwaggerJson { json =>
       val schemas =
-        getKey(json, "components")
-          .flatMap { getKey(_, "schemas") }
-          .get
+        getKey(json, "components").flatMap { getKey(_, "schemas") }.get
 
       val aggregationsProperties =
-        getKey(schemas, "Aggregations")
-          .flatMap { getKey(_, "properties") }
-          .get
+        getKey(schemas, "Aggregations").flatMap { getKey(_, "properties") }.get
 
       getKeys(aggregationsProperties) should contain("type")
       val displayFields = getKeys(aggregationsProperties)
@@ -341,7 +337,7 @@ class ApiSwaggerTest
 
       getFields[DisplayWorkAggregations] should contain("ontologyType")
       val internalFields = getFields[DisplayWorkAggregations]
-        .filterNot { _ == "ontologyType"}
+        .filterNot { _ == "ontologyType" }
 
       displayFields should contain theSameElementsAs internalFields
     }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -6,7 +6,11 @@ import io.circe.Json
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.display.models.{SingleImageIncludes, WorksIncludes}
 import uk.ac.wellcome.platform.api.fixtures.ReflectionHelpers
-import uk.ac.wellcome.platform.api.models.{SearchQueryType, WorkAggregations}
+import uk.ac.wellcome.platform.api.models.{
+  DisplayWorkAggregations,
+  SearchQueryType,
+  WorkAggregations
+}
 import uk.ac.wellcome.platform.api.rest._
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 
@@ -316,6 +320,30 @@ class ApiSwaggerTest
         getKey(schema, key = "type").flatMap { _.asString } shouldBe Some(
           "integer")
       }
+    }
+  }
+
+  it("lists the properties on the Aggregations model") {
+    checkSwaggerJson { json =>
+      val schemas =
+        getKey(json, "components")
+          .flatMap { getKey(_, "schemas") }
+          .get
+
+      val aggregationsProperties =
+        getKey(schemas, "Aggregations")
+          .flatMap { getKey(_, "properties") }
+          .get
+
+      getKeys(aggregationsProperties) should contain("type")
+      val displayFields = getKeys(aggregationsProperties)
+        .filterNot { _ == "type" }
+
+      getFields[DisplayWorkAggregations] should contain("ontologyType")
+      val internalFields = getFields[DisplayWorkAggregations]
+        .filterNot { _ == "ontologyType"}
+
+      displayFields should contain theSameElementsAs internalFields
     }
   }
 


### PR DESCRIPTION
Previously, Swagger was serialising the field names with the slightly ugly `$u002E` in the name (a Unicode full stop), e.g.

```json
"Aggregations": {
  "type": "object",
  "properties": {
    "genres$u002Elabel": {
      "$ref": "#/components/schemas/GenreAggregation"
    },
    "genres.label": {
      "$ref": "#/components/schemas/GenreAggregation"
    },
    ...
  },
  "description": "A map containing the requested aggregations."
}
```

This is clearly wrong -- setting the `name` parameter in the `@Schema()` annotation means we see the properties as they actually appear in the serialised JSON.

This is the only currently visible model in the Swagger that displays this issue.