### PR TITLE
Use the new IdentifierType model—not magic strings—when matching on identifier type

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -31,7 +31,8 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   // - wellcome-digcode is present to persist digcode identifiers from
   //   Encore records onto Calm target works if they are merged, because
   //   digcode identifiers are used as a tagging/classification system.
-  private val otherIdentifiersTypeAllowList = Set(IdentifierType.WellcomeDigcode)
+  private val otherIdentifiersTypeAllowList = Set(
+    IdentifierType.WellcomeDigcode)
 
   override def merge(
     target: Work.Visible[Identified],

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/OtherIdentifiersRule.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import uk.ac.wellcome.platform.merger.logging.MergerLogging
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 import uk.ac.wellcome.platform.merger.models.Sources.findFirstLinkedDigitisedSierraWorkFor
+import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
 import weco.catalogue.internal_model.work.Work
@@ -30,7 +31,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   // - wellcome-digcode is present to persist digcode identifiers from
   //   Encore records onto Calm target works if they are merged, because
   //   digcode identifiers are used as a tagging/classification system.
-  private val otherIdentifiersTypeAllowList = Set("wellcome-digcode")
+  private val otherIdentifiersTypeAllowList = Set(IdentifierType.WellcomeDigcode)
 
   override def merge(
     target: Work.Visible[Identified],
@@ -60,7 +61,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   private def getAllowedIdentifiersFromSource(
     source: Work[Identified]): List[SourceIdentifier] =
     (source.sourceIdentifier +: source.data.otherIdentifiers.filter { id =>
-      otherIdentifiersTypeAllowList.contains(id.identifierType.id)
+      otherIdentifiersTypeAllowList.exists(_ == id.identifierType)
     }).distinct
 
   private val mergeSingleMiroIntoSingleOrZeroItemSierraTarget =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -9,6 +9,7 @@ import uk.ac.wellcome.platform.merger.rules.WorkPredicates.{
   WorkPredicate,
   WorkPredicateOps
 }
+import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.locations.Location
 import weco.catalogue.internal_model.work.Work
@@ -80,9 +81,9 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
       object MiroIdOrdering extends Ordering[Work[Identified]] {
         def compare(x: Work[Identified], y: Work[Identified]): Int =
           (
-            x.sourceIdentifier.identifierType.id,
-            y.sourceIdentifier.identifierType.id) match {
-            case ("miro-image-number", "miro-image-number") =>
+            x.sourceIdentifier.identifierType,
+            y.sourceIdentifier.identifierType) match {
+            case (IdentifierType.MiroImageNumber, IdentifierType.MiroImageNumber) =>
               x.sourceIdentifier.value compare y.sourceIdentifier.value
             case _ => 0
           }

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ThumbnailRule.scala
@@ -80,10 +80,10 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
 
       object MiroIdOrdering extends Ordering[Work[Identified]] {
         def compare(x: Work[Identified], y: Work[Identified]): Int =
-          (
-            x.sourceIdentifier.identifierType,
-            y.sourceIdentifier.identifierType) match {
-            case (IdentifierType.MiroImageNumber, IdentifierType.MiroImageNumber) =>
+          (x.sourceIdentifier.identifierType, y.sourceIdentifier.identifierType) match {
+            case (
+                IdentifierType.MiroImageNumber,
+                IdentifierType.MiroImageNumber) =>
               x.sourceIdentifier.value compare y.sourceIdentifier.value
             case _ => 0
           }


### PR DESCRIPTION
Spotted while glancing at the merger code.