### PR TITLE
Get a no-op plan in Terraform for Cognito + identity pieces

### DIFF
--- a/infrastructure/shared/.terraform.lock.hcl
+++ b/infrastructure/shared/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+  ]
+}

--- a/infrastructure/shared/identity/cognito.tf
+++ b/infrastructure/shared/identity/cognito.tf
@@ -1,8 +1,7 @@
 # Route 53
 provider "aws" {
-  region  = "eu-west-1"
-  alias   = "dns"
-  version = "~> 2.35"
+  region = "eu-west-1"
+  alias  = "dns"
 
   assume_role {
     role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
@@ -10,9 +9,8 @@ provider "aws" {
 }
 
 provider "aws" {
-  region  = "us-east-1"
-  alias   = "us_east_1"
-  version = "~> 2.35"
+  region = "us-east-1"
+  alias  = "us_east_1"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"

--- a/infrastructure/shared/identity/cognito.tf
+++ b/infrastructure/shared/identity/cognito.tf
@@ -33,24 +33,32 @@ data "aws_route53_zone" "weco_zone" {
   private_zone = false
 }
 
-resource "aws_route53_record" "cert_validation" {
+/*resource "aws_route53_record" "cert_validation" {
   provider = aws.dns
 
   name    = aws_acm_certificate.id.domain_validation_options[0].resource_record_name
   type    = aws_acm_certificate.id.domain_validation_options[0].resource_record_type
   zone_id = data.aws_route53_zone.weco_zone.id
-  records = [aws_acm_certificate.id.domain_validation_options[0].resource_record_value]
+  records = [
+    aws_acm_certificate.id.domain_validation_options[0].resource_record_value
+  ]
   ttl     = 60
-}
+}*/
 
 resource "aws_acm_certificate_validation" "id_cert" {
   provider = aws.us_east_1
 
   certificate_arn         = aws_acm_certificate.id.arn
-  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
+  validation_record_fqdns = [
+    # This is temporarily hard-coded to match what's currently deployed,
+    # but if we decide to keep this we should come back and deploy
+    # it properly.
+    "_4471fcd7032a27a3594fb572e9c5bcff.id.wellcomecollection.org",
+    #aws_route53_record.cert_validation.fqdn,
+  ]
 }
 
-resource "aws_route53_record" "cognito_cloudfront_distribution" {
+/*resource "aws_route53_record" "cognito_cloudfront_distribution" {
   provider = aws.dns
 
   name    = "id.wellcomecollection.org"
@@ -62,7 +70,7 @@ resource "aws_route53_record" "cognito_cloudfront_distribution" {
     zone_id                = "Z2FDTNDATAQYW2"
     evaluate_target_health = true
   }
-}
+}*/
 
 # Cognito
 resource "aws_cognito_user_pool" "pool" {
@@ -147,13 +155,17 @@ resource "aws_cognito_user_pool_client" "web_auth_test" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = concat(["openid", "email"], aws_cognito_resource_server.stacks_api.scope_identifiers)
-  explicit_auth_flows                  = ["USER_PASSWORD_AUTH"]
+  explicit_auth_flows                  = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_PASSWORD_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+  ]
 
   user_pool_id    = aws_cognito_user_pool.pool.id
   generate_secret = false
 
   callback_urls                = ["http://localhost:3000/works/auth-code"]
-  default_redirect_uri         = "http://localhost:3000/works/auth-code"
-  logout_urls                  = ["http://localhost:3000/logout"]
+  logout_urls                  = ["http://localhost:3000/works/logout"]
   supported_identity_providers = ["COGNITO"]
 }

--- a/infrastructure/shared/identity/cognito.tf
+++ b/infrastructure/shared/identity/cognito.tf
@@ -46,7 +46,7 @@ data "aws_route53_zone" "weco_zone" {
 resource "aws_acm_certificate_validation" "id_cert" {
   provider = aws.us_east_1
 
-  certificate_arn         = aws_acm_certificate.id.arn
+  certificate_arn = aws_acm_certificate.id.arn
   validation_record_fqdns = [
     # This is temporarily hard-coded to match what's currently deployed,
     # but if we decide to keep this we should come back and deploy
@@ -153,7 +153,7 @@ resource "aws_cognito_user_pool_client" "web_auth_test" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = concat(["openid", "email"], aws_cognito_resource_server.stacks_api.scope_identifiers)
-  explicit_auth_flows                  = [
+  explicit_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
     "ALLOW_REFRESH_TOKEN_AUTH",
     "ALLOW_USER_PASSWORD_AUTH",

--- a/infrastructure/shared/terraform.tf
+++ b/infrastructure/shared/terraform.tf
@@ -12,8 +12,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "eu-west-1"
-  version = "~> 2.35"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"

--- a/infrastructure/shared/versions.tf
+++ b/infrastructure/shared/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
So the Terraform reflects what's currently deployed.

I'm tempted to restore the Route 53 records, but I'd like a second opinion.

Part of https://github.com/wellcomecollection/stacks-service/issues/93 – I want the details of the Cognito user pool in the stacks-service Terraform, which means yanking on this particular configuration.

Next steps, for separate PRs:

- ? Restore the Route 53 records
- Move all this Terraform into the stacks-service repo
- Export details of the Cognito distribution / create some app clients with items-read_only