### PR TITLE
Reduce the batcher wait time when we're not reindexing

### DIFF
--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -38,7 +38,7 @@ module "batcher" {
     # NOTE: SQS in flight limit is 120k
     max_processed_paths = var.is_reindexing ? 100000 : 5000
 
-    max_batch_size      = 40
+    max_batch_size = 40
   }
 
   secret_env_vars = {}


### PR DESCRIPTION
The batcher de-duplicates messages sent to the relation embedder, within a single collection.

e.g. if we send works PP/A, PP/A/1, PP/A/2, and PP/A/3, the batcher will aggregate these into a single message "everything under PP/A" so the relation embedder only has to operate on the complete set once.

The batcher will gather messages until one of the following becomes true:

- 45 minutes have passed
- it's gathered 100,000 messages

and then it sends everything to the relation embedder.

During reindexing, this is massively helpful – it reduces load in the relation embedder and on the pipeline storage cluster.  But when the pipeline is quiet, it's inserting an artificial 45 minute delay into updates appearing on wellcomecollection.org.

This PR makes the batcher return messages faster when it's reindexing.

I think this will only affect works from Calm (works from other sources should bypass the batcher).

A crude fix for https://github.com/wellcomecollection/platform/issues/4938, already applied.