### PR TITLE
add relations.ancestors.collectionPath to IndexedWorkIndexConfig

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.7.4"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -56,7 +56,7 @@ object IdentifiedWorkIndexConfig extends WorksIndexConfig {
   val fields =
     Seq(
       objectField("data").fields(
-        objectField("otherIdentifiers").fields(lowercaseKeyword("value")),
+        objectField("otherIdentifiers").fields(lowercaseKeyword("value"))
       ),
       objectField("state")
         .fields(sourceIdentifier)
@@ -90,7 +90,7 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       englishTextKeywordField("physicalDescription"),
       multilingualField("lettering"),
       objectField("contributors").fields(
-        objectField("agent").fields(label),
+        objectField("agent").fields(label)
       ),
       objectField("subjects").fields(
         label,
@@ -107,7 +107,7 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
           objectField("license").fields(keywordField("id")),
           objectField("accessConditions").fields(
             objectField("status").fields(keywordField("type"))
-          ),
+          )
         ),
         objectField("id").fields(
           canonicalId,
@@ -151,7 +151,15 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       objectField("availabilities").fields(keywordField("id")),
       objectField("relations")
         .fields(
-          objectField("ancestors").fields(lowercaseKeyword("id"))
+          objectField("ancestors").fields(
+            lowercaseKeyword("id"),
+            objectField("collectionPath").fields(
+              label,
+              textField("path")
+                .analyzer(pathAnalyzer.name)
+                .fields(keywordField("keyword"))
+            )
+          )
         )
         .dynamic("false"),
       objectField("derivedData")


### PR DESCRIPTION
ref https://github.com/wellcomecollection/platform/issues/5123

We need to be able to query on the ancestors label to be able to retrieve **all works that are children of a collection**.

This adds the mappings to make the data queryable.

We will then add to the [current query](https://github.com/wellcomecollection/catalogue/blob/master/api/api/src/test/resources/WorksMultiMatcherQuery.json) to satisfy this data need.

Example of what the query might look like.

```JSON
{
    "bool": {
      "should": [
        {
          "term": {
            "state.relations.ancestors.collectionPath.label": {
              "value": "WA/HMM"
            }
          }
        }
      ]
    }
  }
```