### PR TITLE
Handle a Sierra record with no "name" in the source language

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.source
 
-import io.circe.{Decoder, DecodingFailure, HCursor}
+import io.circe.Decoder
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.{
   SierraSourceCountry,
   SierraSourceLanguage,
@@ -49,12 +49,8 @@ object SierraBibData {
   // so we use a custom decoder to achieve that
   implicit def d(implicit dec: Decoder[Option[SierraSourceLanguage]])
     : Decoder[Option[SierraSourceLanguage]] =
-    dec.handleErrorWith { err: DecodingFailure =>
-      Decoder.instance { hcursor: HCursor =>
-        hcursor.downField("code").as[String].flatMap {
-          case c if c.trim.isEmpty => Right(None)
-          case _                   => Left(err)
-        }
-      }
+    dec.map {
+      case Some(SierraSourceLanguage(code, _)) if code.trim.isEmpty => None
+      case other => other
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibData.scala
@@ -51,6 +51,6 @@ object SierraBibData {
     : Decoder[Option[SierraSourceLanguage]] =
     dec.map {
       case Some(SierraSourceLanguage(code, _)) if code.trim.isEmpty => None
-      case other => other
+      case other                                                    => other
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/sierra/SierraSourceLanguage.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/sierra/SierraSourceLanguage.scala
@@ -2,4 +2,12 @@ package uk.ac.wellcome.platform.transformer.sierra.source.sierra
 
 // Represents a Language object, as returned by the Sierra API.
 // https://techdocs.iii.com/sierraapi/Content/zReference/objects/bibObjectDescription.htm?Highlight=language
-case class SierraSourceLanguage(code: String, name: String)
+case class SierraSourceLanguage(
+  code: String,
+  name: Option[String]
+)
+
+case object SierraSourceLanguage {
+  def apply(code: String, name: String): SierraSourceLanguage =
+    SierraSourceLanguage(code = code, name = Some(name))
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraBibDataTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.json.exceptions.JsonDecodingError
 import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLanguage
 
 class SierraBibDataTest extends AnyFunSpec with Matchers {
-  it("should decode a bibData with language") {
+  it("decodes a bibData with language") {
     val bibDataJson =
       s"""
          |{
@@ -22,7 +22,7 @@ class SierraBibDataTest extends AnyFunSpec with Matchers {
       lang = Some(SierraSourceLanguage("eng", "English")))
   }
 
-  it("should decode a bibData with language with empty code as None") {
+  it("decodes a language with empty code as None") {
     val bibDataJson =
       s"""
          |{
@@ -33,7 +33,7 @@ class SierraBibDataTest extends AnyFunSpec with Matchers {
 
     fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData()
   }
-  it("should fail decoding a bibData without name and non-empty code") {
+  it("fails to decode a bibData without name and non-empty code") {
     val bibDataJson =
       s"""
          |{

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -189,6 +189,14 @@ class SierraLanguagesTest
     )
   }
 
+  it("skips a language with no name and an unidentifiable code") {
+    val bibData = createSierraBibDataWith(
+      lang = Some(SierraSourceLanguage(code = "idk", name = None))
+    )
+
+    getLanguages(bibData) shouldBe empty
+  }
+
   private def getLanguages(bibData: SierraBibData): List[Language] =
     SierraLanguages(bibId = createSierraBibNumber, bibData = bibData)
 }


### PR DESCRIPTION
Previously we assumed that the language on a Sierra bib record would always have a `code` and a `name`, e.g.

    {"code": "tgl", "name": "Tagalog"}

but today's pipeline has some records with just a code, e.g.

    {"code": "tgl"}

The `name` is mostly irrelevant for our transformer – we look up the code against our own copy of the MARC language code list, and only if it's unrecognised do we fall back to the name on the source record. As such, its absence definitely shouldn't cause a record to fail (=DLQ).

This patch modifies the transformer to tolerate the absence of a `name` on Sierra languages.