### PR TITLE
Implement a basic form of lazy indexing in the Sierra indexer

### DIFF
--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -1,29 +1,64 @@
 package weco.catalogue.sierra_indexer.services
 
+import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.delete.DeleteByQueryRequest
+import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
+import grizzled.slf4j.Logging
 import io.circe.parser._
 import io.circe.{Json, ParsingFailure}
 import weco.catalogue.sierra_indexer.models.{IndexerRequest, Parent}
 import weco.catalogue.source_model.sierra.SierraTransformable
 
+import scala.concurrent.{ExecutionContext, Future}
+
 // This object splits a SierraTransformable into indexable pieces
 // that can be sent to Elasticsearch.
-class Splitter(indexPrefix: String) {
-  def split(t: SierraTransformable)
-    : Either[Seq[(Parent, ParsingFailure)],
-             (Seq[IndexRequest], Seq[DeleteByQueryRequest])] = {
+class Splitter(indexPrefix: String)(
+  implicit
+  client: ElasticClient,
+  ec: ExecutionContext
+) extends Logging {
+  import weco.catalogue.sierra_indexer.services.SierraJsonOps._
+
+  def split(t: SierraTransformable): Future[(Seq[IndexRequest], Seq[DeleteByQueryRequest])] = {
     for {
       apiData <- getSierraApiData(t)
 
-      mainRecords = IndexerRequest.mainRecords(indexPrefix, apiData)
-      varFields = IndexerRequest.varFields(indexPrefix, apiData)
-      fixedFields = IndexerRequest.fixedFields(indexPrefix, apiData)
+      // This is an attempt to reduce the pressure on the Elasticsearch cluster.
+      //
+      // We look at the main record for this bib/item/holdings, and compare it to what's
+      // already stored.  We assume the modified/deletedDate will change when the record
+      // changes (including fixedFields and varFields).
+      //
+      // If you wanted to go one step further, you could diff individual
+      // varFields/fixedFields, but that adds more complexity.
+      //
+      // I'm hoping this is a quick fix that makes the indexer performance "good enough"
+      // without us having to pour money into the reporting cluster.
+      stored <- getStored(apiData)
+      modifiedApiData =
+        stored
+          .filter {
+            case (parent, json, Some(getResponse)) if jsonStringsMatch(json.withId(parent.id).remainder, getResponse.sourceAsString) =>
+              debug(s"Not indexing ${parent.id.withCheckDigit}; it is already indexed")
+              false
 
-      varFieldDeletions = IndexerRequest.varFieldDeletions(indexPrefix, apiData)
+            case (parent, _, _) =>
+              debug(s"Indexing ${parent.id.withCheckDigit}")
+              true
+          }
+          .map { case (parent, json, _) => (parent, json) }
+
+      mainRecords = IndexerRequest.mainRecords(indexPrefix, modifiedApiData)
+      varFields = IndexerRequest.varFields(indexPrefix, modifiedApiData)
+      fixedFields = IndexerRequest.fixedFields(indexPrefix, modifiedApiData)
+
+      varFieldDeletions = IndexerRequest.varFieldDeletions(indexPrefix, modifiedApiData)
       fixedFieldDeletions = IndexerRequest.fixedFieldDeletions(
         indexPrefix,
-        apiData)
+        modifiedApiData)
     } yield
       (
         mainRecords ++ varFields ++ fixedFields,
@@ -31,8 +66,26 @@ class Splitter(indexPrefix: String) {
       )
   }
 
-  private def getSierraApiData(t: SierraTransformable)
-    : Either[Seq[(Parent, ParsingFailure)], Seq[(Parent, Json)]] = {
+  private def jsonStringsMatch(j1: Json, j2: String): Boolean =
+    parse(j2) match {
+      case Right(value) => value == j1
+      case _ => false
+    }
+
+  private def getStored(apiData: Seq[(Parent, Json)]): Future[Seq[(Parent, Json, Option[GetResponse])]] =
+    Future.sequence(
+      apiData.map { case (parent, json) =>
+        val resp = client.execute(
+          get(Index(s"${indexPrefix}_${parent.recordType}"), id = parent.id.withoutCheckDigit)
+        )
+
+        resp.map { r =>
+          (parent, json, if (r.isSuccess) Some(r.result) else None)
+        }
+      }
+    )
+
+  private def getSierraApiData(t: SierraTransformable): Future[Seq[(Parent, Json)]] = {
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =
       t.holdingsRecords.keys.map { _.withoutCheckDigit }.toList.sorted
@@ -73,6 +126,10 @@ class Splitter(indexPrefix: String) {
     }
     val failures = data.collect { case (parent, Left(err)) => (parent, err) }
 
-    Either.cond(failures.isEmpty, successes, failures)
+    if (failures.isEmpty) {
+      Future.successful(successes)
+    } else {
+      Future.failed(new Throwable(s"Could not parse all records: $failures"))
+    }
   }
 }

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -30,7 +30,8 @@ class Splitter(indexPrefix: String)(
       //
       // We look at the main record for this bib/item/holdings, and compare it to what's
       // already stored.  We assume the modified/deletedDate will change when the record
-      // changes (including fixedFields and varFields).
+      // changes (including fixedFields and varFields) – this is one of the fields in
+      // the JSON of a Sierra record, so if the date changes, so will the JSON.
       //
       // If you wanted to go one step further, you could diff individual
       // varFields/fixedFields, but that adds more complexity.
@@ -81,7 +82,7 @@ class Splitter(indexPrefix: String)(
       apiData.zip(resp.result.items)
     }
   }
-  
+
   private def getSierraApiData(t: SierraTransformable): Future[Seq[(Parent, Json)]] = {
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -73,7 +73,7 @@ class Splitter(indexPrefix: String)(
     }
 
   private def getStored(apiData: Seq[(Parent, Json)]): Future[Seq[((Parent, Json), GetResponse)]] = {
-    val gets = apiData.map { case (parent, json) =>
+    val gets = apiData.map { case (parent, _) =>
       get(Index(s"${indexPrefix}_${parent.recordType}"), id = parent.id.withoutCheckDigit)
     }
 
@@ -81,7 +81,7 @@ class Splitter(indexPrefix: String)(
       apiData.zip(resp.result.items)
     }
   }
-
+  
   private def getSierraApiData(t: SierraTransformable): Future[Seq[(Parent, Json)]] = {
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -29,9 +29,13 @@ class Splitter(indexPrefix: String)(
       // This is an attempt to reduce the pressure on the Elasticsearch cluster.
       //
       // We look at the main record for this bib/item/holdings, and compare it to what's
-      // already stored.  We assume the modified/deletedDate will change when the record
-      // changes (including fixedFields and varFields) – this is one of the fields in
-      // the JSON of a Sierra record, so if the date changes, so will the JSON.
+      // already stored.  Note that these records include the modifiedDate/deletedDate, e.g
+      //
+      //    {"id": "1234567", "modifiedDate": "2001-01-01T01:01:01Z", …}
+      //
+      // and we assume that this value will change when the record is modified.
+      // Because the modified/deletedDate is part of the JSON, it is sufficient to compare
+      // the JSON strings without extracting the dates directly.
       //
       // If you wanted to go one step further, you could diff individual
       // varFields/fixedFields, but that adds more complexity.

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
@@ -38,8 +38,9 @@ class Worker(
         )
 
         transformable <- sierraReadable.get(payload.location) match {
-          case Right(Identified(_, transformable)) => Future.successful(transformable)
-          case Left(err)                           => Future.failed(err.e)
+          case Right(Identified(_, transformable)) =>
+            Future.successful(transformable)
+          case Left(err) => Future.failed(err.e)
         }
 
         ops <- splitter.split(transformable)

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -299,20 +299,21 @@ class SierraIndexerFeatureTest
     )
 
     withIndices { indexPrefix =>
-      withLocalSqsQueuePair(visibilityTimeout = 5) { case QueuePair(queue, dlq) =>
-        withWorker(queue, store, indexPrefix) { _ =>
-          sendNotificationToSQS(
-            queue,
-            SierraSourcePayload(
-              id = bibId.withoutCheckDigit,
-              location = location1,
-              version = 1)
-          )
+      withLocalSqsQueuePair(visibilityTimeout = 5) {
+        case QueuePair(queue, dlq) =>
+          withWorker(queue, store, indexPrefix) { _ =>
+            sendNotificationToSQS(
+              queue,
+              SierraSourcePayload(
+                id = bibId.withoutCheckDigit,
+                location = location1,
+                version = 1)
+            )
 
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_bibs"),
-            id = bibId.withoutCheckDigit,
-            json = s"""
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_bibs"),
+              id = bibId.withoutCheckDigit,
+              json = s"""
                       |{
                       |  "id" : "$bibId",
                       |  "idWithCheckDigit": "${bibId.withCheckDigit}",
@@ -322,12 +323,12 @@ class SierraIndexerFeatureTest
                       |  "holdingsIds": []
                       |}
                       |""".stripMargin
-          )
+            )
 
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_varfields"),
-            id = s"bibs-${bibId.withoutCheckDigit}-0",
-            json = s"""
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_varfields"),
+              id = s"bibs-${bibId.withoutCheckDigit}-0",
+              json = s"""
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
@@ -341,12 +342,12 @@ class SierraIndexerFeatureTest
                       |  }
                       |}
                       |""".stripMargin
-          )
+            )
 
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_fixedfields"),
-            id = s"bibs-${bibId.withoutCheckDigit}-86",
-            json = s"""
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_fixedfields"),
+              id = s"bibs-${bibId.withoutCheckDigit}-86",
+              json = s"""
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
@@ -360,40 +361,40 @@ class SierraIndexerFeatureTest
                       |  }
                       |}
                       |""".stripMargin
-          )
+            )
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
-          }
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueEmpty(dlq)
+            }
 
-          // Now re-send the same notification, and check the queue clears
-          sendNotificationToSQS(
-            queue,
-            SierraSourcePayload(
+            // Now re-send the same notification, and check the queue clears
+            sendNotificationToSQS(
+              queue,
+              SierraSourcePayload(
+                id = bibId.withoutCheckDigit,
+                location = location1,
+                version = 1)
+            )
+
+            eventually {
+              assertQueueEmpty(queue)
+              assertQueueEmpty(dlq)
+            }
+
+            // Now send the new notification, and check the record gets updated
+            sendNotificationToSQS(
+              queue,
+              SierraSourcePayload(
+                id = bibId.withoutCheckDigit,
+                location = location2,
+                version = 2)
+            )
+
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_bibs"),
               id = bibId.withoutCheckDigit,
-              location = location1,
-              version = 1)
-          )
-
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueEmpty(dlq)
-          }
-
-          // Now send the new notification, and check the record gets updated
-          sendNotificationToSQS(
-            queue,
-            SierraSourcePayload(
-              id = bibId.withoutCheckDigit,
-              location = location2,
-              version = 2)
-          )
-
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_bibs"),
-            id = bibId.withoutCheckDigit,
-            json = s"""
+              json = s"""
                       |{
                       |  "id" : "$bibId",
                       |  "idWithCheckDigit": "${bibId.withCheckDigit}",
@@ -403,12 +404,12 @@ class SierraIndexerFeatureTest
                       |  "holdingsIds": []
                       |}
                       |""".stripMargin
-          )
+            )
 
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_varfields"),
-            id = s"bibs-${bibId.withoutCheckDigit}-0",
-            json = s"""
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_varfields"),
+              id = s"bibs-${bibId.withoutCheckDigit}-0",
+              json = s"""
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
@@ -422,12 +423,12 @@ class SierraIndexerFeatureTest
                       |  }
                       |}
                       |""".stripMargin
-          )
+            )
 
-          assertElasticsearchEventuallyHas(
-            index = Index(s"${indexPrefix}_fixedfields"),
-            id = s"bibs-${bibId.withoutCheckDigit}-86",
-            json = s"""
+            assertElasticsearchEventuallyHas(
+              index = Index(s"${indexPrefix}_fixedfields"),
+              id = s"bibs-${bibId.withoutCheckDigit}-86",
+              json = s"""
                       |{
                       |  "parent": {
                       |    "recordType": "bibs",
@@ -441,8 +442,8 @@ class SierraIndexerFeatureTest
                       |  }
                       |}
                       |""".stripMargin
-          )
-        }
+            )
+          }
       }
     }
   }


### PR DESCRIPTION
The Sierra indexer has a queue that will, at current processing rates, clear in 70 days. A large pile of stuff landed on the queue about four days ago, and it can't keep up.

We could increase the CPU in the reporting cluster, but the next step up is $400/mo, and the next step up again is an extra $800/mo on top of that. That's not great. We're also burning money on Fargate tasks.

This is an attempt at a quick fix – we look up the top-level record, and if it matches what's already stored we'll skip indexing it again (assuming the varFields and fixedFields are similarly the same). This won't fix the problem fully, but I'm hoping it releases some of the pressure, and gets it "good enough" until we have time to look at this properly.