### PR TITLE
Set an explicit time on results sent from the matcher

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.models.matcher
 
+import java.time.Instant
+
 // Represents the output from the matcher.
 //
 // Each entry in the set of works is a collection of identifiers, each of
@@ -16,4 +18,18 @@ package uk.ac.wellcome.models.matcher
 // then the merger should create three works, one from A1-A2-A3, a second
 // from B1-B2, a third from C1-C2-C3.
 //
-case class MatcherResult(works: Set[MatchedIdentifiers])
+case class MatcherResult(
+  works: Set[MatchedIdentifiers],
+  createdTime: Instant
+)
+
+case object MatcherResult {
+  // Note: I could achieve this by putting a default in the case class, but
+  // doing it this way means I can "Find Usages" on this method to find callers
+  // that *don't* explicitly set the correct time.
+  //
+  // This method will only last as long as https://github.com/wellcomecollection/platform/issues/5132,
+  // after which it can be deleted -- all uses should be setting the time explicitly.
+  def apply(works: Set[MatchedIdentifiers]): MatcherResult =
+    MatcherResult(works = works, createdTime = Instant.now())
+}

--- a/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcher.scala
@@ -20,6 +20,7 @@ import uk.ac.wellcome.storage.locking.{
   LockingService
 }
 
+import java.time.Instant
 import java.util.UUID
 
 class WorkMatcher(workGraphStore: WorkGraphStore,
@@ -32,7 +33,10 @@ class WorkMatcher(workGraphStore: WorkGraphStore,
   type Out = Set[MatchedIdentifiers]
 
   def matchWork(links: WorkLinks): Future[MatcherResult] =
-    doMatch(links).map(MatcherResult)
+    doMatch(links)
+      .map { works =>
+        MatcherResult(works = works, createdTime = Instant.now())
+      }
 
   private def doMatch(links: WorkLinks): Future[Out] =
     withLocks(links, links.ids.map(_.toString)) {

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/TimeTestFixture.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/fixtures/TimeTestFixture.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.matcher.fixtures
+
+import java.time.{Duration, Instant}
+
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+
+trait TimeTestFixture extends Matchers {
+  def assertRecent(instant: Instant, recentSeconds: Int = 1): Assertion =
+    Duration
+      .between(instant, Instant.now)
+      .getSeconds should be <= recentSeconds.toLong
+
+  def assertAllRecent(instants: Seq[Instant], recentSeconds: Int = 1): Unit =
+    instants.foreach(i => assertRecent(i, recentSeconds))
+}

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/matcher/WorkMatcherTest.scala
@@ -91,9 +91,10 @@ class WorkMatcherTest
             assertRecent(matcherResult.createdTime)
             matcherResult.works shouldBe
               Set(
-                MatchedIdentifiers(Set(
-                  WorkIdentifier(identifierA.canonicalId, links.version),
-                  WorkIdentifier(identifierB.canonicalId, None))))
+                MatchedIdentifiers(
+                  Set(
+                    WorkIdentifier(identifierA.canonicalId, links.version),
+                    WorkIdentifier(identifierB.canonicalId, None))))
 
             val savedWorkNodes = scan[WorkNode](dynamoClient, graphTable.name)
               .map(_.right.value)

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -40,8 +40,9 @@ class MatcherWorkerServiceTest
     val workLinks = createWorkLinksWith(id = identifierA)
     val expectedWorks =
       Set(
-        MatchedIdentifiers(identifiers =
-          Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
+        MatchedIdentifiers(
+          identifiers =
+            Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
       )
 
     implicit val retriever: MemoryRetriever[WorkLinks] =
@@ -50,9 +51,7 @@ class MatcherWorkerServiceTest
 
     withLocalSqsQueue() { implicit queue =>
       withWorkerService(retriever, queue, messageSender) { _ =>
-        processAndAssertMatchedWorkIs(
-          workLinks,
-          expectedWorks = expectedWorks)
+        processAndAssertMatchedWorkIs(workLinks, expectedWorks = expectedWorks)
       }
     }
   }
@@ -307,7 +306,8 @@ class MatcherWorkerServiceTest
 
             messageSender
               .getMessages[MatcherResult]
-              .last.works shouldBe expectedWorkAv2
+              .last
+              .works shouldBe expectedWorkAv2
           }
         }
     }

--- a/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/uk/ac/wellcome/platform/matcher/services/MatcherWorkerServiceTest.scala
@@ -12,7 +12,10 @@ import uk.ac.wellcome.models.matcher.{
   MatcherResult,
   WorkIdentifier
 }
-import uk.ac.wellcome.platform.matcher.fixtures.MatcherFixtures
+import uk.ac.wellcome.platform.matcher.fixtures.{
+  MatcherFixtures,
+  TimeTestFixture
+}
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.pipeline_storage.MemoryRetriever
 import uk.ac.wellcome.platform.matcher.generators.WorkLinksGenerators
@@ -26,7 +29,8 @@ class MatcherWorkerServiceTest
     with Eventually
     with IntegrationPatience
     with MatcherFixtures
-    with WorkLinksGenerators {
+    with WorkLinksGenerators
+    with TimeTestFixture {
 
   private val identifierA = createIdentifier("AAAAAAAA")
   private val identifierB = createIdentifier("BBBBBBBB")
@@ -34,12 +38,10 @@ class MatcherWorkerServiceTest
 
   it("matches a Work which doesn't reference any other Works") {
     val workLinks = createWorkLinksWith(id = identifierA)
-    val expectedResult =
-      MatcherResult(
-        Set(
-          MatchedIdentifiers(identifiers =
-            Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
-        )
+    val expectedWorks =
+      Set(
+        MatchedIdentifiers(identifiers =
+          Set(WorkIdentifier(workLinks.workId, version = workLinks.version)))
       )
 
     implicit val retriever: MemoryRetriever[WorkLinks] =
@@ -50,7 +52,7 @@ class MatcherWorkerServiceTest
       withWorkerService(retriever, queue, messageSender) { _ =>
         processAndAssertMatchedWorkIs(
           workLinks,
-          expectedResult = expectedResult)
+          expectedWorks = expectedWorks)
       }
     }
   }
@@ -66,7 +68,7 @@ class MatcherWorkerServiceTest
     // Work Av1 matched to B (before B exists hence version is None)
     // need to match to works that do not exist to support
     // bi-directionally matched works without deadlocking (A->B, B->A)
-    val expectedMatchedWorks = MatcherResult(
+    val expectedWorks =
       Set(
         MatchedIdentifiers(
           identifiers = Set(
@@ -75,7 +77,6 @@ class MatcherWorkerServiceTest
           )
         )
       )
-    )
 
     implicit val retriever: MemoryRetriever[WorkLinks] =
       new MemoryRetriever[WorkLinks]()
@@ -85,7 +86,7 @@ class MatcherWorkerServiceTest
       withWorkerService(retriever, queue, messageSender) { _ =>
         processAndAssertMatchedWorkIs(
           workLinksAv1,
-          expectedResult = expectedMatchedWorks)
+          expectedWorks = expectedWorks)
       }
     }
   }
@@ -97,14 +98,13 @@ class MatcherWorkerServiceTest
       version = 1
     )
 
-    val expectedMatchedWorksAv1 = MatcherResult(
+    val expectedWorksAv1 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierA.canonicalId, version = 1))
         )
       )
-    )
 
     // Work Bv1
     val workLinksBv1 = createWorkLinksWith(
@@ -112,14 +112,13 @@ class MatcherWorkerServiceTest
       version = 1
     )
 
-    val expectedMatchedWorksBv1 = MatcherResult(
+    val expectedWorksBv1 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierB.canonicalId, version = 1))
         )
       )
-    )
 
     // Work Av2 matched to B
     val workLinksAv2 = createWorkLinksWith(
@@ -128,7 +127,7 @@ class MatcherWorkerServiceTest
       referencedIds = Set(identifierB)
     )
 
-    val expectedMatchedWorksAv2 = MatcherResult(
+    val expectedWorksAv2 =
       Set(
         MatchedIdentifiers(
           identifiers = Set(
@@ -137,7 +136,6 @@ class MatcherWorkerServiceTest
           )
         )
       )
-    )
 
     // Work Cv1
     val workLinksCv1 = createWorkLinksWith(
@@ -145,13 +143,11 @@ class MatcherWorkerServiceTest
       version = 1
     )
 
-    val expectedMatcherWorksCv1 =
-      MatcherResult(
-        Set(
-          MatchedIdentifiers(
-            identifiers =
-              Set(WorkIdentifier(identifierC.canonicalId, version = 1))
-          )
+    val expectedWorksCv1 =
+      Set(
+        MatchedIdentifiers(
+          identifiers =
+            Set(WorkIdentifier(identifierC.canonicalId, version = 1))
         )
       )
 
@@ -162,15 +158,13 @@ class MatcherWorkerServiceTest
       referencedIds = Set(identifierC)
     )
 
-    val expectedMatchedWorksBv2 =
-      MatcherResult(
-        Set(
-          MatchedIdentifiers(
-            identifiers = Set(
-              WorkIdentifier(identifierA.canonicalId, version = 2),
-              WorkIdentifier(identifierB.canonicalId, version = 2),
-              WorkIdentifier(identifierC.canonicalId, version = 1)
-            )
+    val expectedWorksBv2 =
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(
+            WorkIdentifier(identifierA.canonicalId, version = 2),
+            WorkIdentifier(identifierB.canonicalId, version = 2),
+            WorkIdentifier(identifierC.canonicalId, version = 1)
           )
         )
       )
@@ -181,11 +175,11 @@ class MatcherWorkerServiceTest
 
     withLocalSqsQueue() { implicit queue =>
       withWorkerService(retriever, queue, messageSender) { _ =>
-        processAndAssertMatchedWorkIs(workLinksAv1, expectedMatchedWorksAv1)
-        processAndAssertMatchedWorkIs(workLinksBv1, expectedMatchedWorksBv1)
-        processAndAssertMatchedWorkIs(workLinksAv2, expectedMatchedWorksAv2)
-        processAndAssertMatchedWorkIs(workLinksCv1, expectedMatcherWorksCv1)
-        processAndAssertMatchedWorkIs(workLinksBv2, expectedMatchedWorksBv2)
+        processAndAssertMatchedWorkIs(workLinksAv1, expectedWorksAv1)
+        processAndAssertMatchedWorkIs(workLinksBv1, expectedWorksBv1)
+        processAndAssertMatchedWorkIs(workLinksAv2, expectedWorksAv2)
+        processAndAssertMatchedWorkIs(workLinksCv1, expectedWorksCv1)
+        processAndAssertMatchedWorkIs(workLinksBv2, expectedWorksBv2)
       }
     }
   }
@@ -197,14 +191,13 @@ class MatcherWorkerServiceTest
       version = 1
     )
 
-    val expectedMatchedWorksAv1 = MatcherResult(
+    val expectedWorksAv1 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierA.canonicalId, version = 1))
         )
       )
-    )
 
     // Work Bv1
     val workLinksBv1 = createWorkLinksWith(
@@ -212,14 +205,13 @@ class MatcherWorkerServiceTest
       version = 1
     )
 
-    val expectedMatchedWorksBv1 = MatcherResult(
+    val expectedWorksBv1 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierB.canonicalId, version = 1))
         )
       )
-    )
 
     // Match Work A to Work B
     val workLinksAv2MatchedToB =
@@ -229,14 +221,12 @@ class MatcherWorkerServiceTest
         referencedIds = Set(identifierB)
       )
 
-    val expectedMatchedWorksAv2MatchedToB =
-      MatcherResult(
-        Set(
-          MatchedIdentifiers(
-            identifiers = Set(
-              WorkIdentifier(identifierA.canonicalId, version = 2),
-              WorkIdentifier(identifierB.canonicalId, version = 1)
-            )
+    val expectedWorksAv2MatchedToB =
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(
+            WorkIdentifier(identifierA.canonicalId, version = 2),
+            WorkIdentifier(identifierB.canonicalId, version = 1)
           )
         )
       )
@@ -248,17 +238,15 @@ class MatcherWorkerServiceTest
         version = 3
       )
 
-    val expectedMatchedWorksAv3 =
-      MatcherResult(
-        Set(
-          MatchedIdentifiers(
-            identifiers =
-              Set(WorkIdentifier(identifierA.canonicalId, version = 3))
-          ),
-          MatchedIdentifiers(
-            identifiers =
-              Set(WorkIdentifier(identifierB.canonicalId, version = 1))
-          )
+    val expectedWorksAv3 =
+      Set(
+        MatchedIdentifiers(
+          identifiers =
+            Set(WorkIdentifier(identifierA.canonicalId, version = 3))
+        ),
+        MatchedIdentifiers(
+          identifiers =
+            Set(WorkIdentifier(identifierB.canonicalId, version = 1))
         )
       )
 
@@ -268,14 +256,14 @@ class MatcherWorkerServiceTest
 
     withLocalSqsQueue() { implicit queue =>
       withWorkerService(retriever, queue, messageSender) { _ =>
-        processAndAssertMatchedWorkIs(workLinksAv1, expectedMatchedWorksAv1)
-        processAndAssertMatchedWorkIs(workLinksBv1, expectedMatchedWorksBv1)
+        processAndAssertMatchedWorkIs(workLinksAv1, expectedWorksAv1)
+        processAndAssertMatchedWorkIs(workLinksBv1, expectedWorksBv1)
         processAndAssertMatchedWorkIs(
           workLinksAv2MatchedToB,
-          expectedMatchedWorksAv2MatchedToB)
+          expectedWorksAv2MatchedToB)
         processAndAssertMatchedWorkIs(
           workLinksAv3WithNoMatchingWorks,
-          expectedMatchedWorksAv3)
+          expectedWorksAv3)
       }
     }
   }
@@ -286,14 +274,13 @@ class MatcherWorkerServiceTest
       version = 2
     )
 
-    val expectedMatchedWorkAv2 = MatcherResult(
+    val expectedWorkAv2 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierA.canonicalId, version = 2))
         )
       )
-    )
 
     implicit val retriever: MemoryRetriever[WorkLinks] =
       new MemoryRetriever[WorkLinks]()
@@ -304,7 +291,7 @@ class MatcherWorkerServiceTest
         implicit val q: SQS.Queue = queue
 
         withWorkerService(retriever, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(workLinksAv2, expectedMatchedWorkAv2)
+          processAndAssertMatchedWorkIs(workLinksAv2, expectedWorkAv2)
 
           // Work V1 is sent but not matched
           val workLinksAv1 =
@@ -320,7 +307,7 @@ class MatcherWorkerServiceTest
 
             messageSender
               .getMessages[MatcherResult]
-              .last shouldBe expectedMatchedWorkAv2
+              .last.works shouldBe expectedWorkAv2
           }
         }
     }
@@ -332,14 +319,13 @@ class MatcherWorkerServiceTest
       version = 2
     )
 
-    val expectedMatchedWorkAv2 = MatcherResult(
+    val expectedWorkAv2 =
       Set(
         MatchedIdentifiers(
           identifiers =
             Set(WorkIdentifier(identifierA.canonicalId, version = 2))
         )
       )
-    )
 
     implicit val retriever: MemoryRetriever[WorkLinks] =
       new MemoryRetriever[WorkLinks]()
@@ -350,7 +336,7 @@ class MatcherWorkerServiceTest
         implicit val q: SQS.Queue = queue
 
         withWorkerService(retriever, queue, messageSender) { _ =>
-          processAndAssertMatchedWorkIs(workLinksAv2, expectedMatchedWorkAv2)
+          processAndAssertMatchedWorkIs(workLinksAv2, expectedWorkAv2)
 
           // Work V1 is sent but not matched
           val differentWorkLinksAv2 =
@@ -369,15 +355,20 @@ class MatcherWorkerServiceTest
     }
   }
 
-  private def processAndAssertMatchedWorkIs(links: WorkLinks,
-                                            expectedResult: MatcherResult)(
+  private def processAndAssertMatchedWorkIs(
+    links: WorkLinks,
+    expectedWorks: Set[MatchedIdentifiers])(
     implicit
     retriever: MemoryRetriever[WorkLinks],
     queue: SQS.Queue,
-    messageSender: MemoryMessageSender): Assertion = {
+    messageSender: MemoryMessageSender
+  ): Assertion = {
     sendWork(links, retriever, queue)
     eventually {
-      messageSender.getMessages[MatcherResult].last shouldBe expectedResult
+      val result = messageSender.getMessages[MatcherResult].last
+
+      result.works shouldBe expectedWorks
+      assertRecent(result.createdTime)
     }
   }
 }


### PR DESCRIPTION
This is the first part of a change to how matcher versioning works (https://github.com/wellcomecollection/platform/issues/5132).

This patch just adds the time in the matcher, but the value is ignored by the versioner.  I'll deploy this first, let any messages in the old format get processed by the merger, wait for the matcher to exclusively send messages with the new format, then update the merger to read this value separately.