### PR TITLE
Add stacks services to catalogue repo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,10 @@ steps:
   - wait
   - command: .buildkite/scripts/run_job.py api
     label: "API"
+  - command: .buildkite/scripts/run_job.py items_api
+    label: "Stacks: Items API"
+  - command: .buildkite/scripts/run_job.py requests_api
+    label: "Stacks: Requests API"
   - command: .buildkite/scripts/run_job.py reindex_worker
     label: "reindex worker"
   - command: .buildkite/scripts/run_job.py ingestor_works

--- a/.sbt_metadata/items_api.json
+++ b/.sbt_metadata/items_api.json
@@ -1,0 +1,7 @@
+{
+  "id" : "items_api",
+  "folder" : "api/stacks/items_api",
+  "dependencyIds" : [
+    "stacks_common"
+  ]
+}

--- a/.sbt_metadata/requests_api.json
+++ b/.sbt_metadata/requests_api.json
@@ -1,0 +1,7 @@
+{
+  "id" : "requests_api",
+  "folder" : "api/stacks/requests_api",
+  "dependencyIds" : [
+    "stacks_common"
+  ]
+}

--- a/.sbt_metadata/stacks_common.json
+++ b/.sbt_metadata/stacks_common.json
@@ -1,0 +1,7 @@
+{
+  "id" : "stacks_common",
+  "folder" : "api/stacks/common",
+  "dependencyIds" : [
+    "display"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ include makefiles/functions.Makefile
 include makefiles/formatting.Makefile
 
 include api/Makefile
+include api/stacks/Makefile
 include common/Makefile
 include pipeline/Makefile
 include reindexer/Makefile

--- a/api/stacks/Makefile
+++ b/api/stacks/Makefile
@@ -1,0 +1,17 @@
+ROOT = $(shell git rev-parse --show-toplevel)
+include $(ROOT)/makefiles/functions.Makefile
+
+STACK_ROOT 	= api/stacks
+
+PROJECT_ID = stacks
+
+SBT_APPS =
+SBT_NO_DOCKER_APPS = items_api requests_api
+
+SBT_DOCKER_LIBRARIES    =
+SBT_NO_DOCKER_LIBRARIES =
+
+PYTHON_APPS =
+LAMBDAS 	=
+
+$(val $(call stack_setup))

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
@@ -1,0 +1,146 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshalling.{Marshal, Marshaller}
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{
+  Authorization,
+  BasicHttpCredentials,
+  OAuth2BearerToken
+}
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+trait AkkaClient {
+
+  sealed trait Response[T] {
+    val content: Option[T]
+  }
+  case class SuccessResponse[T](content: Option[T]) extends Response[T]
+  case class FailureResponse[T](content: Option[T]) extends Response[T]
+
+  implicit val system: ActorSystem
+
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  protected val baseUri: Uri
+
+  import Path._
+
+  protected def buildUri(
+    path: Path,
+    params: Map[String, String] = Map.empty
+  ): Uri =
+    baseUri
+      .withPath(baseUri.path ++ Slash(path))
+      .withQuery(Query(params))
+}
+
+trait AkkaClientGet extends AkkaClient {
+  protected def get[Out](
+    path: Path,
+    params: Map[String, String] = Map.empty,
+    headers: List[HttpHeader] = Nil
+  )(
+    implicit um: Unmarshaller[HttpResponse, Out]
+  ): Future[Response[Out]] =
+    for {
+      response <- Http().singleRequest(
+        HttpRequest(
+          uri = buildUri(path, params),
+          headers = headers
+        )
+      )
+
+      result <- response.entity match {
+        case e if e.isKnownEmpty() => Future.successful(None)
+        case _                     => Unmarshal(response).to[Out].map(Some(_))
+      }
+
+    } yield
+      response.status match {
+        case r if r.isSuccess() => SuccessResponse(result)
+        case _                  => FailureResponse(result)
+      }
+}
+
+trait AkkaClientPost extends AkkaClient {
+  protected def post[In, Out](
+    path: Path,
+    body: Option[In] = None,
+    params: Map[String, String] = Map.empty,
+    headers: List[HttpHeader] = Nil
+  )(
+    implicit
+    um: Unmarshaller[HttpResponse, Out],
+    m: Marshaller[In, RequestEntity]
+  ): Future[Response[Out]] =
+    for {
+      entity <- body match {
+        case Some(body) => Marshal(body).to[RequestEntity]
+        case None       => Future.successful(HttpEntity.Empty)
+      }
+
+      response <- Http().singleRequest(
+        HttpRequest(
+          HttpMethods.POST,
+          uri = buildUri(path, params),
+          headers = headers,
+          entity = entity
+        )
+      )
+
+      result <- response.entity match {
+        case e if e.isKnownEmpty() => Future.successful(None)
+        case _                     => Unmarshal(response).to[Out].map(Some(_))
+      }
+
+    } yield
+      response.status match {
+        case r if r.isSuccess() => SuccessResponse(result)
+        case _                  => FailureResponse(result)
+      }
+}
+
+trait AkkaClientTokenExchange
+    extends AkkaClientPost
+    with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
+
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import io.circe.generic.auto._
+
+  case class AccessToken(access_token: String, expires_in: Int)
+
+  val tokenPath: Path
+
+  protected def getNewToken(
+    credentials: BasicHttpCredentials
+  ): Future[(OAuth2BearerToken, Instant)] =
+    for {
+      response <- post[String, AccessToken](
+        path = tokenPath,
+        headers = List(
+          Authorization(
+            credentials
+          )
+        )
+      )
+
+      result <- response match {
+        case SuccessResponse(Some(AccessToken(access_token, expires_in))) =>
+          Future.successful(
+            (
+              OAuth2BearerToken(access_token),
+              Instant.now().plusSeconds(expires_in))
+          )
+        case _ =>
+          Future.failed(
+            new Exception(s"Failed to get access token.")
+          )
+      }
+    } yield result
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/HttpMetrics.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/HttpMetrics.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCode}
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.monitoring.Metrics
+
+import scala.concurrent.Future
+
+object HttpMetricResults extends Enumeration {
+  type HttpMetricResults = Value
+  val Success, UserError, ServerError, Unrecognised = Value
+}
+
+class HttpMetrics(name: String, metrics: Metrics[Future]) extends Logging {
+
+  def sendMetric(resp: HttpResponse): Future[Unit] =
+    sendMetricForStatus(resp.status)
+
+  // TODO: Can this pattern match on ClientError, ServerError, etc?
+  def sendMetricForStatus(status: StatusCode): Future[Unit] = {
+    val httpMetric = if (status.isSuccess()) {
+      HttpMetricResults.Success
+    } else if (status.isFailure() && status.intValue() < 500) {
+      HttpMetricResults.UserError
+    } else if (status.isFailure()) {
+      HttpMetricResults.ServerError
+    } else {
+      warn(s"Sending unexpected response code: $status")
+      HttpMetricResults.Unrecognised
+    }
+
+    metrics.incrementCount(metricName = s"${name}_HttpResponse_$httpMetric")
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+trait TokenExchange[C, T] {
+  private var cachedToken: Option[(T, Instant)] = None
+
+  // How many seconds before the token expires should we go back and
+  // fetch a new token?
+  protected val expiryGracePeriod: Int = 60
+
+  implicit val ec: ExecutionContext
+
+  protected def getNewToken(credentials: C): Future[(T, Instant)]
+
+  def getToken(credentials: C): Future[T] =
+    cachedToken match {
+      case Some((token, expiryTime))
+          if expiryTime
+            .minusSeconds(expiryGracePeriod)
+            .isAfter(Instant.now()) =>
+        Future.successful(token)
+
+      case _ =>
+        getNewToken(credentials).map {
+          case (token, expiryTime) =>
+            cachedToken = Some((token, expiryTime))
+            token
+        }
+    }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeExceptionHandler.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeExceptionHandler.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import java.net.URL
+
+import akka.http.scaladsl.model.StatusCodes.InternalServerError
+import akka.http.scaladsl.server.ExceptionHandler
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.stacks.common.http.models.InternalServerErrorResponse
+
+trait WellcomeExceptionHandler extends Logging {
+  import akka.http.scaladsl.server.Directives._
+  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+  import uk.ac.wellcome.json.JsonUtil._
+
+  val httpMetrics: HttpMetrics
+  val contextURL: URL
+
+  implicit val exceptionHandler: ExceptionHandler = buildExceptionHandler()
+
+  private def buildExceptionHandler(): ExceptionHandler =
+    ExceptionHandler {
+      case err: Exception =>
+        logger.error(s"Unexpected exception $err")
+        val error = InternalServerErrorResponse(
+          context = contextURL,
+          statusCode = InternalServerError
+        )
+        httpMetrics.sendMetricForStatus(InternalServerError)
+        complete(InternalServerError -> error)
+    }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeHttpApp.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeHttpApp.scala
@@ -1,0 +1,71 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import java.net.URL
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.directives.DebuggingDirectives
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.stacks.common.http.config.models.HTTPServerConfig
+import uk.ac.wellcome.typesafe.Runnable
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WellcomeHttpApp(
+  routes: Route,
+  httpServerConfig: HTTPServerConfig,
+  val httpMetrics: HttpMetrics,
+  val contextURL: URL,
+  val appName: String
+)(
+  implicit
+  val as: ActorSystem,
+  val ec: ExecutionContext
+) extends Runnable
+    with WellcomeExceptionHandler
+    with WellcomeRejectionHandler
+    with Logging {
+
+  private val appId = UUID.randomUUID()
+  val appTag = s"$appName/$appId"
+
+  import akka.http.scaladsl.server.Directives._
+
+  def run(): Future[_] = {
+    val handler = mapResponse { response =>
+      httpMetrics.sendMetric(response)
+
+      response
+    }(routes)
+
+    val logLevel = (appTag, Logging.InfoLevel)
+
+    val loggedHandler = DebuggingDirectives
+      .logRequestResult(logLevel)(handler)
+
+    val binding = Http()
+      .bindAndHandle(
+        handler = loggedHandler,
+        interface = httpServerConfig.host,
+        port = httpServerConfig.port
+      )
+
+    info(
+      s"$appTag - Starting: ${httpServerConfig.host}:${httpServerConfig.port}"
+    )
+
+    for {
+      server <- binding
+      _ = info(
+        s"$appTag - Listening: ${httpServerConfig.host}:${httpServerConfig.port}"
+      )
+      _ <- server.whenTerminated
+      _ = info(
+        s"$appTag - Terminating: ${httpServerConfig.host}:${httpServerConfig.port}"
+      )
+    } yield server
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeRejectionHandler.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/WellcomeRejectionHandler.scala
@@ -1,0 +1,124 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import java.net.URL
+
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.StatusCodes.BadRequest
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.{
+  MalformedRequestContentRejection,
+  RejectionHandler,
+  StandardRoute
+}
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+import io.circe.CursorOp
+import uk.ac.wellcome.platform.stacks.common.http.models.{
+  InternalServerErrorResponse,
+  UserErrorResponse
+}
+
+import scala.concurrent.ExecutionContext
+
+trait WellcomeRejectionHandler {
+  import akka.http.scaladsl.server.Directives._
+  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+  import uk.ac.wellcome.json.JsonUtil._
+
+  val httpMetrics: HttpMetrics
+  val contextURL: URL
+
+  implicit val ec: ExecutionContext
+
+  implicit val rejectionHandler: RejectionHandler = buildRejectionHandler()
+
+  private def buildRejectionHandler(): RejectionHandler =
+    RejectionHandler
+      .newBuilder()
+      .handle {
+        case MalformedRequestContentRejection(_, causes: DecodingFailures) =>
+          handleDecodingFailures(causes)
+      }
+      .result()
+      .seal
+      .mapRejectionResponse {
+        case res @ HttpResponse(
+              statusCode,
+              _,
+              HttpEntity.Strict(contentType, _),
+              _
+            ) if contentType != ContentTypes.`application/json` =>
+          transformToJsonErrorResponse(statusCode, res)
+        case x => x
+      }
+      .mapRejectionResponse { resp: HttpResponse =>
+        httpMetrics.sendMetric(resp)
+        resp
+      }
+
+  private def handleDecodingFailures(
+    causes: DecodingFailures
+  ): StandardRoute = {
+    val message = causes.failures.map { cause =>
+      val path = CursorOp.opsToPath(cause.history)
+
+      // Error messages returned by Circe are somewhat inconsistent and we also return our
+      // own error messages when decoding enums (DisplayIngestType and DisplayStorageProvider).
+      val reason = cause.message match {
+        // "Attempt to decode value on failed cursor" seems to mean in circeworld
+        // that a required field was not present.
+        case s if s.contains("Attempt to decode value on failed cursor") =>
+          "required property not supplied."
+        // These are errors returned by our custom decoders for enum.
+        case s if s.contains("valid values") => s
+        // If a field exists in the JSON but it's of the wrong format
+        // (for example the schema says it should be a String but an object has
+        // been supplied instead), the error message returned by Circe only
+        // contains the expected type.
+        case s => s"should be a $s."
+      }
+
+      s"Invalid value at $path: $reason"
+    }
+
+    complete(
+      BadRequest -> UserErrorResponse(
+        context = contextURL,
+        statusCode = BadRequest,
+        description = message.toList.mkString("\n")
+      )
+    )
+  }
+
+  private def transformToJsonErrorResponse(
+    statusCode: StatusCode,
+    response: HttpResponse
+  ): HttpResponse = {
+
+    val errorResponseMarshallingFlow = Flow[ByteString]
+      .mapAsync(parallelism = 1)(data => {
+        val description = data.utf8String
+        if (statusCode.intValue() >= 500) {
+          val response = InternalServerErrorResponse(
+            context = contextURL,
+            statusCode = statusCode
+          )
+          Marshal(response).to[MessageEntity]
+        } else {
+          val response = UserErrorResponse(
+            context = contextURL,
+            statusCode = statusCode,
+            description = description
+          )
+          Marshal(response).to[MessageEntity]
+        }
+      })
+      .flatMapConcat(_.dataBytes)
+
+    response
+      .transformEntityDataBytes(errorResponseMarshallingFlow)
+      .mapEntity(
+        entity => entity.withContentType(ContentTypes.`application/json`)
+      )
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/config/builders/HTTPServerBuilder.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/config/builders/HTTPServerBuilder.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.stacks.common.http.config.builders
+
+import java.net.URL
+
+import com.typesafe.config.Config
+import uk.ac.wellcome.platform.stacks.common.http.config.models.HTTPServerConfig
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+object HTTPServerBuilder {
+  def buildHTTPServerConfig(config: Config): HTTPServerConfig = {
+    val host = config.requireString("http.host")
+    val port = config.requireInt("http.port")
+    val externalBaseURL = config.requireString("http.externalBaseURL")
+
+    HTTPServerConfig(
+      host = host,
+      port = port,
+      externalBaseURL = externalBaseURL
+    )
+  }
+
+  def buildContextURL(config: Config): URL =
+    new URL(config.requireString("contextURL"))
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/config/models/HTTPServerConfig.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/config/models/HTTPServerConfig.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.platform.stacks.common.http.config.models
+
+case class HTTPServerConfig(
+  host: String,
+  port: Int,
+  externalBaseURL: String
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/models/ErrorResponse.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/models/ErrorResponse.scala
@@ -1,0 +1,44 @@
+package uk.ac.wellcome.platform.stacks.common.http.models
+
+import java.net.URL
+
+import akka.http.scaladsl.model.StatusCode
+import io.circe.generic.extras.JsonKey
+
+case class UserErrorResponse(
+  @JsonKey("@context") context: String,
+  httpStatus: Int,
+  description: String,
+  label: String,
+  `type`: String = "Error"
+)
+
+case object UserErrorResponse {
+  def apply(
+    context: URL,
+    statusCode: StatusCode,
+    description: String
+  ): UserErrorResponse =
+    UserErrorResponse(
+      context = context.toString,
+      httpStatus = statusCode.intValue(),
+      description = description,
+      label = statusCode.reason()
+    )
+}
+
+case class InternalServerErrorResponse(
+  @JsonKey("@context") context: String,
+  httpStatus: Int,
+  label: String,
+  `type`: String = "Error"
+)
+
+case object InternalServerErrorResponse {
+  def apply(context: URL, statusCode: StatusCode): InternalServerErrorResponse =
+    InternalServerErrorResponse(
+      context = context.toString,
+      httpStatus = statusCode.intValue(),
+      label = statusCode.reason()
+    )
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/Identifier.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/Identifier.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+import scala.util.{Failure, Success, Try}
+
+sealed trait Identifier[T] {
+  val value: T
+
+  override def toString: String = value.toString
+}
+
+case class StacksWorkIdentifier(value: String) extends Identifier[String]
+case class StacksUserIdentifier(value: String) extends Identifier[String]
+
+sealed trait ItemIdentifier[T] extends Identifier[T]
+
+case class CatalogueItemIdentifier(value: String) extends ItemIdentifier[String]
+case class SierraItemIdentifier(value: Long) extends ItemIdentifier[Long]
+
+object SierraItemIdentifier {
+  def createFromSierraId(id: String): SierraItemIdentifier =
+    Try {
+      // This value looks like a URI when provided by Sierra
+      // https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/145730
+      id.split("/").last.toLong
+    } match {
+      case Success(v) => SierraItemIdentifier(v)
+      case Failure(e) =>
+        throw new Exception("Failed to create SierraItemIdentifier", e)
+    }
+}
+
+case class StacksItemIdentifier(
+  catalogueId: CatalogueItemIdentifier,
+  sierraId: SierraItemIdentifier
+) extends ItemIdentifier[String] {
+  override val value: String = catalogueId.value
+
+  override def toString: String =
+    s"<StacksItemIdentifier catalogue=$catalogueId, sierra=$sierraId>"
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksHoldRequest.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksHoldRequest.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+case class StacksHoldRequest(
+  itemId: String,
+  userId: String
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksItem.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksItem.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+case class StacksItem(
+  id: StacksItemIdentifier,
+  status: StacksItemStatus
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksItemStatus.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksItemStatus.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+case class StacksItemStatus(id: String, label: String)
+
+object StacksItemStatus {
+  def apply(rawCode: String): StacksItemStatus =
+    rawCode.trim match {
+      case "-"     => StacksItemStatus("available", "Available")
+      case "z"     => StacksItemStatus("cl-returned", "CL Returned")
+      case "o"     => StacksItemStatus("library-use-only", "Library use only")
+      case "n"     => StacksItemStatus("billed-not-paid", "Billed not paid")
+      case "$"     => StacksItemStatus("billed-paid", "Billed paid")
+      case "t"     => StacksItemStatus("in-transit", "In transit")
+      case "!"     => StacksItemStatus("on-holdshelf", "On holdshelf")
+      case "l"     => StacksItemStatus("lost", "Lost")
+      case "m"     => StacksItemStatus("missing", "Missing")
+      case default => StacksItemStatus(default, "Unknown")
+    }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksPickupLocation.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksPickupLocation.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+case class StacksPickupLocation(id: String, label: String)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksUserHolds.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksUserHolds.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+import java.time.Instant
+
+case class StacksUserHolds(
+  userId: String,
+  holds: List[StacksHold]
+)
+
+case class StacksHold(
+  itemId: ItemIdentifier[_],
+  pickup: StacksPickup,
+  status: StacksHoldStatus
+)
+
+case class StacksHoldStatus(
+  id: String,
+  label: String
+)
+
+case class StacksPickup(
+  location: StacksPickupLocation,
+  pickUpBy: Option[Instant]
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksWork.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksWork.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.stacks.common.models
+
+case class StacksWork(id: StacksWorkIdentifier, items: List[StacksItem])

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayItem.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayItem.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.platform.stacks.common.models.display
+
+case class DisplayItem(
+  id: String,
+  status: Option[DisplayItemStatus] = None,
+  `type`: String = "Item"
+)
+
+case class DisplayItemStatus(
+  id: String,
+  label: String,
+  `type`: String = "ItemStatus"
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayResultsList.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayResultsList.scala
@@ -1,0 +1,73 @@
+package uk.ac.wellcome.platform.stacks.common.models.display
+
+import java.time.Instant
+
+import uk.ac.wellcome.platform.stacks.common.models._
+
+object DisplayResultsList {
+  def apply(
+    stacksUserHolds: StacksUserHolds
+  ): DisplayResultsList =
+    DisplayResultsList(
+      results = stacksUserHolds.holds.map(DisplayRequest(_)),
+      totalResults = stacksUserHolds.holds.size
+    )
+}
+
+case class DisplayResultsList(
+  results: List[DisplayRequest],
+  totalResults: Int,
+  `type`: String = "ResultList"
+)
+
+object DisplayRequest {
+  def apply(request: StacksHold): DisplayRequest =
+    DisplayRequest(
+      item = DisplayItem(
+        id = request.itemId.value.toString
+      ),
+      pickupDate = request.pickup.pickUpBy,
+      pickupLocation = DisplayLocationDescription(
+        request.pickup.location
+      ),
+      status = DisplayRequestStatus(
+        request.status
+      )
+    )
+}
+
+case class DisplayRequest(
+  item: DisplayItem,
+  pickupDate: Option[Instant],
+  pickupLocation: DisplayLocationDescription,
+  status: DisplayRequestStatus,
+  `type`: String = "Request"
+)
+
+object DisplayLocationDescription {
+  def apply(location: StacksPickupLocation): DisplayLocationDescription =
+    DisplayLocationDescription(
+      id = location.id,
+      label = location.label
+    )
+}
+
+case class DisplayLocationDescription(
+  id: String,
+  label: String,
+  `type`: String = "LocationDescription"
+)
+
+object DisplayRequestStatus {
+  def apply(holdStatus: StacksHoldStatus): DisplayRequestStatus =
+    DisplayRequestStatus(
+      id = holdStatus.id,
+      label = holdStatus.label
+    )
+}
+
+case class DisplayRequestStatus(
+  id: String,
+  label: String,
+  `type`: String = "RequestStatus"
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayStacksWork.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/display/DisplayStacksWork.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.stacks.common.models.display
+
+import uk.ac.wellcome.platform.stacks.common.models.StacksWork
+
+object DisplayStacksWork {
+  def apply(stacksWork: StacksWork): DisplayStacksWork =
+    DisplayStacksWork(
+      id = stacksWork.id.value,
+      items = stacksWork.items.map { stacksItem =>
+        DisplayItem(
+          id = stacksItem.id.value,
+          status = Some(
+            DisplayItemStatus(
+              id = stacksItem.status.id,
+              label = stacksItem.status.label
+            )
+          )
+        )
+      }
+    )
+}
+
+case class DisplayStacksWork(
+  id: String,
+  items: List[DisplayItem],
+  `type`: String = "Work"
+)

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/CatalogueService.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/CatalogueService.scala
@@ -1,0 +1,90 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import uk.ac.wellcome.platform.stacks.common.models._
+import uk.ac.wellcome.platform.stacks.common.services.source.CatalogueSource
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class CatalogueService(
+  val catalogueSource: CatalogueSource
+)(implicit ec: ExecutionContext) {
+
+  import CatalogueSource._
+
+  private def getSierraItemIdentifier(
+    identifiers: List[IdentifiersStub]
+  ): Option[SierraItemIdentifier] =
+    identifiers filter (_.identifierType.id == "sierra-identifier") match {
+      case List(IdentifiersStub(_, value)) =>
+        Try(value.toLong) match {
+          case Success(l) => Some(SierraItemIdentifier(l))
+          case Failure(_) =>
+            throw new Exception(s"Unable to convert $value to Long!")
+        }
+
+      case Nil => None
+
+      // This would be very unusual and probably points to a problem in the Catalogue API.
+      // We throw a distinct error here so that it's easier to debug if this ever
+      // occurs in practice.
+      case multipleSierraIdentifiers =>
+        throw new Exception(
+          s"Multiple values for sierra-identifier: $multipleSierraIdentifiers"
+        )
+    }
+
+  private def getStacksItems(
+    itemStubs: List[ItemStub]
+  ): List[StacksItemIdentifier] =
+    itemStubs collect {
+      case ItemStub(Some(id), Some(identifiers)) =>
+        (
+          CatalogueItemIdentifier(id),
+          getSierraItemIdentifier(identifiers)
+        )
+    } collect {
+      case (catalogueId, Some(sierraId)) =>
+        StacksItemIdentifier(catalogueId = catalogueId, sierraId = sierraId)
+    }
+
+  def getAllStacksItems(
+    workId: StacksWorkIdentifier
+  ): Future[List[StacksItemIdentifier]] =
+    for {
+      workStub <- catalogueSource.getWorkStub(workId)
+      items = getStacksItems(workStub.items)
+    } yield items
+
+  def getStacksItem(
+    identifier: ItemIdentifier[_]
+  ): Future[Option[StacksItemIdentifier]] =
+    for {
+      searchStub <- catalogueSource.getSearchStub(identifier)
+
+      items = searchStub.results
+        .map(_.items)
+        .flatMap(getStacksItems)
+
+      // Ensure we are only matching items that match the passed id!
+      filteredItems = identifier match {
+        case CatalogueItemIdentifier(id) =>
+          items.filter(_.catalogueId.value == id)
+        case SierraItemIdentifier(id) =>
+          items.filter(_.sierraId.value == id)
+        case _ => items
+      }
+
+      // Items can appear on multiple works in a search result
+      distinctFilteredItems = filteredItems.distinct
+
+    } yield
+      distinctFilteredItems match {
+        case List(item) => Some(item)
+        case Nil        => None
+        case _ =>
+          throw new Exception(
+            s"Found multiple matching items for $identifier in: $distinctFilteredItems"
+          )
+      }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/SierraService.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/SierraService.scala
@@ -1,0 +1,92 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import java.time.Instant
+
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.stacks.common.models._
+import uk.ac.wellcome.platform.stacks.common.services.source.SierraSource
+
+import scala.concurrent.{ExecutionContext, Future}
+
+sealed trait HoldResponse {
+  val lastModified: Instant
+}
+case class HoldAccepted(lastModified: Instant = Instant.now())
+    extends HoldResponse
+case class HoldRejected(lastModified: Instant = Instant.now())
+    extends HoldResponse
+
+class SierraService(
+  sierraSource: SierraSource
+)(implicit ec: ExecutionContext)
+    extends Logging {
+
+  import SierraSource._
+
+  def getItemStatus(
+    sierraId: SierraItemIdentifier
+  ): Future[StacksItemStatus] =
+    sierraSource
+      .getSierraItemStub(sierraId)
+      .map(item => StacksItemStatus(item.status.code))
+
+  def placeHold(
+    userIdentifier: StacksUserIdentifier,
+    sierraItemIdentifier: SierraItemIdentifier,
+    neededBy: Option[Instant]
+  ): Future[HoldResponse] =
+    sierraSource
+      .postHold(
+        userIdentifier,
+        sierraItemIdentifier,
+        neededBy
+      ) map {
+      // This is an "XCirc/Record not available" error
+      // See https://techdocs.iii.com/sierraapi/Content/zReference/errorHandling.htm
+      case Left(SierraErrorCode(132, 2, 500, _, _)) => HoldRejected()
+
+      case Left(result) =>
+        warn(s"Unrecognised hold error: $result")
+        HoldRejected()
+
+      case Right(_) => HoldAccepted()
+    }
+
+  protected def buildStacksHold(
+    entry: SierraUserHoldsEntryStub
+  ): StacksHold = {
+
+    val itemId = SierraItemIdentifier
+      .createFromSierraId(entry.record)
+
+    val pickupLocation = StacksPickupLocation(
+      id = entry.pickupLocation.code,
+      label = entry.pickupLocation.name
+    )
+
+    val pickup = StacksPickup(
+      location = pickupLocation,
+      pickUpBy = entry.pickupByDate
+    )
+
+    val status = StacksHoldStatus(
+      id = entry.status.code,
+      label = entry.status.name
+    )
+
+    StacksHold(itemId, pickup, status)
+  }
+
+  def getStacksUserHolds(
+    userId: StacksUserIdentifier
+  ): Future[StacksUserHolds] = {
+    sierraSource
+      .getSierraUserHoldsStub(userId)
+      .map { hold =>
+        StacksUserHolds(
+          userId = userId.value,
+          holds = hold.entries.map(buildStacksHold)
+        )
+      }
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/StacksService.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/StacksService.scala
@@ -1,0 +1,77 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import java.time.Instant
+
+import cats.instances.future._
+import cats.instances.list._
+import cats.syntax.traverse._
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.stacks.common.models._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class StacksService(
+  catalogueService: CatalogueService,
+  sierraService: SierraService
+)(
+  implicit ec: ExecutionContext
+) extends Logging {
+
+  def requestHoldOnItem(
+    userIdentifier: StacksUserIdentifier,
+    catalogueItemId: CatalogueItemIdentifier,
+    neededBy: Option[Instant]
+  ): Future[HoldResponse] =
+    for {
+      stacksItem <- catalogueService.getStacksItem(catalogueItemId)
+
+      response <- stacksItem match {
+        case Some(id) =>
+          sierraService.placeHold(
+            userIdentifier = userIdentifier,
+            sierraItemIdentifier = id.sierraId,
+            neededBy = neededBy
+          )
+        case None =>
+          Future.failed(
+            new Exception(f"Could not locate item $catalogueItemId!")
+          )
+      }
+
+    } yield response
+
+  def getStacksWork(
+    workId: StacksWorkIdentifier
+  ): Future[StacksWork] =
+    for {
+      stacksItemIds <- catalogueService.getAllStacksItems(workId)
+
+      itemStatuses <- stacksItemIds
+        .map(_.sierraId)
+        .traverse(sierraService.getItemStatus)
+
+      stacksItemsWithStatuses = (stacksItemIds zip itemStatuses) map {
+        case (itemId, status) => StacksItem(itemId, status)
+      }
+
+    } yield StacksWork(workId, stacksItemsWithStatuses)
+
+  def getStacksUserHolds(
+    userId: StacksUserIdentifier
+  ): Future[StacksUserHolds] =
+    for {
+      userHolds <- sierraService.getStacksUserHolds(userId)
+      stacksItemIds <- userHolds.holds
+        .map(_.itemId)
+        .traverse(catalogueService.getStacksItem)
+
+      updatedUserHolds = (userHolds.holds zip stacksItemIds) map {
+        case (hold, Some(stacksItemId)) =>
+          Some(hold.copy(itemId = stacksItemId))
+        case (hold, None) =>
+          error(f"Unable to map $hold to Catalogue Id!")
+          None
+      }
+
+    } yield userHolds.copy(holds = updatedUserHolds.flatten)
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/CatalogueServiceBuilder.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/CatalogueServiceBuilder.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.stacks.common.services.config.builders
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import com.typesafe.config.Config
+import uk.ac.wellcome.platform.stacks.common.services.CatalogueService
+import uk.ac.wellcome.platform.stacks.common.services.source.AkkaCatalogueSource
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+import scala.concurrent.ExecutionContext
+
+object CatalogueServiceBuilder {
+  def build(config: Config)(
+    implicit
+    as: ActorSystem,
+    ec: ExecutionContext
+  ): CatalogueService = {
+    val baseUrl = config.requireString("catalogue.api.baseUrl")
+
+    new CatalogueService(
+      new AkkaCatalogueSource(Uri(baseUrl))
+    )
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/SierraServiceBuilder.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/SierraServiceBuilder.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.stacks.common.services.config.builders
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import com.typesafe.config.Config
+import uk.ac.wellcome.platform.stacks.common.services.SierraService
+import uk.ac.wellcome.platform.stacks.common.services.source.AkkaSierraSource
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+import scala.concurrent.ExecutionContext
+
+object SierraServiceBuilder {
+  def build(config: Config)(
+    implicit
+    as: ActorSystem,
+    ec: ExecutionContext
+  ): SierraService = {
+    val username = config.requireString("sierra.api.key")
+    val password = config.requireString(("sierra.api.secret"))
+    val baseUrl = config.requireString("sierra.api.baseUrl")
+
+    new SierraService(
+      new AkkaSierraSource(
+        baseUri = Uri(baseUrl),
+        credentials = BasicHttpCredentials(
+          username = username,
+          password = password
+        )
+      )
+    )
+  }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/StacksServiceBuilder.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/config/builders/StacksServiceBuilder.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.stacks.common.services.config.builders
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+
+import scala.concurrent.ExecutionContext
+
+object StacksServiceBuilder {
+  def build(config: Config)(
+    implicit
+    as: ActorSystem,
+    ec: ExecutionContext
+  ): StacksService =
+    new StacksService(
+      catalogueService = CatalogueServiceBuilder.build(config),
+      sierraService = SierraServiceBuilder.build(config)
+    )
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/source/CatalogueSource.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/source/CatalogueSource.scala
@@ -1,0 +1,86 @@
+package uk.ac.wellcome.platform.stacks.common.services.source
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+import uk.ac.wellcome.platform.stacks.common.http.AkkaClientGet
+import uk.ac.wellcome.platform.stacks.common.models.{
+  Identifier,
+  StacksWorkIdentifier
+}
+
+import scala.concurrent.Future
+
+trait CatalogueSource {
+  import CatalogueSource._
+
+  def getWorkStub(id: StacksWorkIdentifier): Future[WorkStub]
+  def getSearchStub(identifier: Identifier[_]): Future[SearchStub]
+}
+
+object CatalogueSource {
+  case class TypeStub(
+    id: String,
+    label: String
+  )
+
+  case class IdentifiersStub(
+    identifierType: TypeStub,
+    value: String
+  )
+
+  case class ItemStub(
+    id: Option[String],
+    identifiers: Option[List[IdentifiersStub]]
+  )
+
+  case class WorkStub(
+    id: String,
+    items: List[ItemStub]
+  )
+
+  case class SearchStub(
+    totalResults: Int,
+    results: List[WorkStub]
+  )
+}
+
+class AkkaCatalogueSource(
+  val baseUri: Uri = Uri(
+    "https://api.wellcomecollection.org/catalogue/v2"
+  )
+)(
+  implicit
+  val system: ActorSystem,
+) extends CatalogueSource
+    with AkkaClientGet {
+
+  import CatalogueSource._
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import io.circe.generic.auto._
+
+  // See https://developers.wellcomecollection.org/catalogue/v2/works/getwork
+  def getWorkStub(id: StacksWorkIdentifier): Future[WorkStub] =
+    get[WorkStub](
+      path = Path(s"works/${id.value}"),
+      params = Map(
+        ("include", "items,identifiers")
+      )
+    ) map {
+      case SuccessResponse(Some(workStub)) => workStub
+      case _                               => throw new Exception("Failed to get catalogue work!")
+    }
+
+  // See https://developers.wellcomecollection.org/catalogue/v2/works/getworks
+  def getSearchStub(identifier: Identifier[_]): Future[SearchStub] =
+    get[SearchStub](
+      path = Path("works"),
+      params = Map(
+        ("include", "items,identifiers"),
+        ("query", identifier.value.toString)
+      )
+    ) map {
+      case SuccessResponse(Some(workStub)) => workStub
+      case _                               => throw new Exception("Failed to make catalogue search!")
+    }
+}

--- a/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/source/SierraSource.scala
+++ b/api/stacks/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/source/SierraSource.scala
@@ -1,0 +1,184 @@
+package uk.ac.wellcome.platform.stacks.common.services.source
+
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
+import io.circe.{Encoder, Printer}
+import uk.ac.wellcome.platform.stacks.common.http.{
+  AkkaClientGet,
+  AkkaClientPost,
+  AkkaClientTokenExchange
+}
+import uk.ac.wellcome.platform.stacks.common.models.{
+  SierraItemIdentifier,
+  StacksUserIdentifier
+}
+import uk.ac.wellcome.platform.stacks.common.services.source.SierraSource.{
+  SierraErrorCode,
+  SierraHoldRequestPostBody,
+  SierraItemStub,
+  SierraUserHoldsStub
+}
+
+import scala.concurrent.Future
+
+trait SierraSource {
+
+  import SierraSource._
+
+  def getSierraItemStub(sierraId: SierraItemIdentifier): Future[SierraItemStub]
+  def getSierraUserHoldsStub(
+    userId: StacksUserIdentifier
+  ): Future[SierraUserHoldsStub]
+  def postHold(
+    userIdentifier: StacksUserIdentifier,
+    sierraItemIdentifier: SierraItemIdentifier,
+    neededBy: Option[Instant]
+  ): Future[PostHoldResult]
+}
+
+object SierraSource {
+  type PostHoldResult = Either[SierraErrorCode, Unit]
+
+  case class SierraErrorCode(
+    code: Int,
+    specificCode: Int,
+    httpStatus: Int,
+    name: String,
+    description: Option[String]
+  )
+  case class SierraUserHoldsPickupLocationStub(
+    code: String,
+    name: String
+  )
+  case class SierraUserHoldsStatusStub(
+    code: String,
+    name: String
+  )
+  case class SierraUserHoldsEntryStub(
+    id: String,
+    record: String,
+    pickupLocation: SierraUserHoldsPickupLocationStub,
+    pickupByDate: Option[Instant],
+    status: SierraUserHoldsStatusStub
+  )
+  case class SierraUserHoldsStub(
+    total: Long,
+    entries: List[SierraUserHoldsEntryStub]
+  )
+  case class SierraItemStatusStub(
+    code: String,
+    display: String
+  )
+  case class SierraItemStub(
+    id: String,
+    status: SierraItemStatusStub
+  )
+  case class SierraHoldRequestPostBody(
+    recordType: String,
+    recordNumber: Long,
+    pickupLocation: String,
+    neededBy: Option[Instant]
+  )
+}
+
+class AkkaSierraSource(
+  val baseUri: Uri = Uri(
+    "https://libsys.wellcomelibrary.org/iii/sierra-api"
+  ),
+  credentials: BasicHttpCredentials
+)(
+  implicit
+  val system: ActorSystem
+) extends SierraSource
+    with AkkaClientGet
+    with AkkaClientPost
+    with AkkaClientTokenExchange {
+
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import io.circe.generic.auto._
+  import SierraSource._
+
+  // Sierra will not tolerate null values in optional fields
+  implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
+
+  override val tokenPath = Path("v5/token")
+
+  // See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/items
+  def getSierraItemStub(
+    sierraId: SierraItemIdentifier
+  ): Future[SierraItemStub] =
+    for {
+      token <- getToken(credentials)
+      item <- get[SierraItemStub](
+        path = Path(s"v5/items/${sierraId.value}"),
+        headers = List(Authorization(token))
+      )
+    } yield
+      item match {
+        case SuccessResponse(Some(holds)) => holds
+        case _                            => throw new Exception(s"Failed to get item!")
+      }
+
+  // See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/patrons
+  def getSierraUserHoldsStub(
+    userId: StacksUserIdentifier
+  ): Future[SierraUserHoldsStub] =
+    for {
+      token <- getToken(credentials)
+      response <- get[SierraUserHoldsStub](
+        path = Path(s"v5/patrons/${userId.value}/holds"),
+        params = Map(
+          ("limit", "100"),
+          ("offset", "0")
+        ),
+        headers = List(Authorization(token))
+      )
+    } yield
+      response match {
+        case SuccessResponse(Some(holds)) => holds
+        case _                            => throw new Exception(s"Failed to get user holds!")
+      }
+
+  private val dateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd")
+    .withZone(ZoneId.systemDefault())
+
+  implicit val encodeInstant: Encoder[Instant] =
+    Encoder.encodeString.contramap[Instant](dateTimeFormatter.format)
+
+  // See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/patrons
+  def postHold(
+    userIdentifier: StacksUserIdentifier,
+    sierraItemIdentifier: SierraItemIdentifier,
+    neededBy: Option[Instant]
+  ): Future[PostHoldResult] =
+    for {
+      token <- getToken(credentials)
+      response <- post[SierraHoldRequestPostBody, SierraErrorCode](
+        path = Path(s"v5/patrons/${userIdentifier.value}/holds/requests"),
+        body = Some(
+          SierraHoldRequestPostBody(
+            recordType = "i",
+            recordNumber = sierraItemIdentifier.value,
+            // This field is required non-empty by the Sierra API - but has no effect
+            pickupLocation = "unspecified",
+            neededBy = neededBy
+          )
+        ),
+        headers = List(Authorization(token))
+      )
+    } yield
+      response match {
+        case SuccessResponse(_)                     => Right(())
+        case FailureResponse(Some(sierraErrorCode)) => Left(sierraErrorCode)
+        case _ =>
+          throw new Exception(
+            s"Failed to make hold!"
+          )
+      }
+}

--- a/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-can-search-for-an-identifier/mappings/catalogue_v2_works-55203b5d-258c-4c7c-90bf-3d4e945ddf90.json
+++ b/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-can-search-for-an-identifier/mappings/catalogue_v2_works-55203b5d-258c-4c7c-90bf-3d4e945ddf90.json
@@ -1,0 +1,34 @@
+{
+  "id" : "55203b5d-258c-4c7c-90bf-3d4e945ddf90",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=1093837",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":2,\"results\":[{\"id\":\"aczz5tm3\",\"title\":\"Lacaille : astronomer, traveler with a new translation of his journal\",\"alternativeTitles\":[],\"physicalDescription\":\"320 pages : illustrations, facsimiles, maps, portraits ; 23 cm.\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b10938370\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1093837\",\"type\":\"Identifier\"}],\"items\":[{\"id\":\"qkdy3h58\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i11088953\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1108895\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sghi2\",\"label\":\"Closed stores Hist. 2\",\"type\":\"LocationType\"},\"label\":\"Closed stores Hist. 2\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"},{\"id\":\"ayzrznsz\",\"title\":\"Letters relating to the plague, and other contagious distempers\",\"alternativeTitles\":[],\"physicalDescription\":\"xx, 1 unnumbered leaf, 411 pages 9 pages, [10?] leaves, folded plates ; (8vo)\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b10809569\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1080956\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30511720\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3051172\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b30511720_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"q2knsrhh\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i10938370\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1093837\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sepbb\",\"label\":\"Closed stores EPB / B\",\"type\":\"LocationType\"},\"label\":\"Closed stores EPB / B\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b30511720/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:49:44 GMT",
+      "x-amzn-RequestId" : "63dc7e28-1656-4e38-8be5-0d18e9304005",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "3556",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjxWxFCXjoEFVnQ=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:49:44 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 4bc362c59a07f21706e00e1fe67ba2ff.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C1",
+      "X-Amz-Cf-Id" : "c7woPipruh3Qgn4Sm22T7zo2ZxAWSLydiJwlvNrff5X47DDQARYL8w=="
+    }
+  },
+  "uuid" : "55203b5d-258c-4c7c-90bf-3d4e945ddf90",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-gets-an-individual-work/mappings/catalogue_v2_works_ayzrznsz-1cee8f3d-5c13-4235-9457-de2cae810a40.json
+++ b/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-gets-an-individual-work/mappings/catalogue_v2_works_ayzrznsz-1cee8f3d-5c13-4235-9457-de2cae810a40.json
@@ -1,0 +1,34 @@
+{
+  "id" : "1cee8f3d-5c13-4235-9457-de2cae810a40",
+  "name" : "catalogue_v2_works_ayzrznsz",
+  "request" : {
+    "url" : "/catalogue/v2/works/ayzrznsz?include=items,identifiers",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"ayzrznsz\",\"title\":\"Letters relating to the plague, and other contagious distempers\",\"alternativeTitles\":[],\"physicalDescription\":\"xx, 1 unnumbered leaf, 411 pages 9 pages, [10?] leaves, folded plates ; (8vo)\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b10809569\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1080956\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30511720\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3051172\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b30511720_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"q2knsrhh\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i10938370\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1093837\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sepbb\",\"label\":\"Closed stores EPB / B\",\"type\":\"LocationType\"},\"label\":\"Closed stores EPB / B\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b30511720/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\",\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\"}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:39:11 GMT",
+      "x-amzn-RequestId" : "abbc924e-df7c-433b-803a-18a90c2d19f4",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2323",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "Ijv0AHqdDoEFSFQ=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:39:11 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 1134a22c328d83d656b1bf94245e1dec.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "Tq0QLiRSjaq8eD-8-9bFb4JjvxGR-RorZWX_oNXApFEh46wqAwN7Zw=="
+    }
+  },
+  "uuid" : "1cee8f3d-5c13-4235-9457-de2cae810a40",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-handles-a-work-where-an-item-is-not-identified/mappings/catalogue_v2_works_a227dajt-8030d2e9-0989-4af5-9001-964ae1a0af48.json
+++ b/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-handles-a-work-where-an-item-is-not-identified/mappings/catalogue_v2_works_a227dajt-8030d2e9-0989-4af5-9001-964ae1a0af48.json
@@ -1,0 +1,34 @@
+{
+  "id" : "8030d2e9-0989-4af5-9001-964ae1a0af48",
+  "name" : "catalogue_v2_works_a227dajt",
+  "request" : {
+    "url" : "/catalogue/v2/works/a227dajt?include=items,identifiers",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"a227dajt\",\"title\":\"L'homoeopathie à l'Académie de médecine de Belgique en 1877 : réponse au défi de M. le professeur Crocq\",\"alternativeTitles\":[],\"physicalDescription\":\"93 pages ; 25 cm\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b21053613\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"2105361\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b21053613_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"locations\":[{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b21053613/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"fre\",\"label\":\"French\",\"type\":\"Language\"},\"type\":\"Work\",\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\"}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:42:45 GMT",
+      "x-amzn-RequestId" : "193d476c-da5e-42aa-ac83-03c7f7e6359c",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "1548",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjwVUGL6joEFazg=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:42:45 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 bad4c5c93bbbcff151219f57e6a9b2b5.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR50-C1",
+      "X-Amz-Cf-Id" : "fBf-DTggPDaLid4HLvyaLXC2ml4O-XY0NM0vvutAFnC6CphIgLNojQ=="
+    }
+  },
+  "uuid" : "8030d2e9-0989-4af5-9001-964ae1a0af48",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-handles-a-work-without-any-items/mappings/catalogue_v2_works_a2284uhb-11c8ee7c-7124-42b0-b2f6-809c58bcc3dc.json
+++ b/api/stacks/common/src/test/resources/catalogue/behaves-as-a-cataloguesource-handles-a-work-without-any-items/mappings/catalogue_v2_works_a2284uhb-11c8ee7c-7124-42b0-b2f6-809c58bcc3dc.json
@@ -1,0 +1,34 @@
+{
+  "id" : "11c8ee7c-7124-42b0-b2f6-809c58bcc3dc",
+  "name" : "catalogue_v2_works_a2284uhb",
+  "request" : {
+    "url" : "/catalogue/v2/works/a2284uhb?include=items,identifiers",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"a2284uhb\",\"title\":\"Index locorum in commentario Caesaris Belli gallici descriptorum (Rev: Bonus Accursius)\",\"alternativeTitles\":[],\"physicalDescription\":\"Online resource (v., ill.).\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30948988\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3094898\",\"type\":\"Identifier\"}],\"items\":[],\"language\":{\"id\":\"lat\",\"label\":\"Latin\",\"type\":\"Language\"},\"type\":\"Work\",\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\"}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:41:39 GMT",
+      "x-amzn-RequestId" : "bf99b22d-052a-44b8-8d85-29891187441d",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "699",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjwLFFrcDoEFZzg=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:41:39 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 25206e54d0febe09f3f2edcd0a3fb6cc.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C1",
+      "X-Amz-Cf-Id" : "0BHIrdSRYTmCQA1DTBTlT675sLgIBpKL-cCwiXZ373G9VUph-JWs8Q=="
+    }
+  },
+  "uuid" : "11c8ee7c-7124-42b0-b2f6-809c58bcc3dc",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/items-shows-a-user-the-items-on-a-work/mappings/catalogue_v2_works_cnkv77md-612bd90b-67f8-4b5a-9253-5d601c91e9dd.json
+++ b/api/stacks/common/src/test/resources/catalogue/items-shows-a-user-the-items-on-a-work/mappings/catalogue_v2_works_cnkv77md-612bd90b-67f8-4b5a-9253-5d601c91e9dd.json
@@ -1,0 +1,34 @@
+{
+  "id" : "612bd90b-67f8-4b5a-9253-5d601c91e9dd",
+  "name" : "catalogue_v2_works_cnkv77md",
+  "request" : {
+    "url" : "/catalogue/v2/works/cnkv77md?include=items,identifiers",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\",\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\"}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:03:31 GMT",
+      "x-amzn-RequestId" : "30fdd5f0-7a0f-440e-b8be-9b8f36131fa2",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2480",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqlkHQJjoEFWaw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:03:31 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 7d70f03f40ff914e93ff812c1b366077.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR50-C1",
+      "X-Amz-Cf-Id" : "b30qssoUu30ggWi3hWqAuamOPFCsXYDvXDhmbrQyArehNHyHQwLxbQ=="
+    }
+  },
+  "uuid" : "612bd90b-67f8-4b5a-9253-5d601c91e9dd",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-with-a-pickupdate/mappings/4730ba01-247b-4b94-a81c-357aaca9ff27.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-with-a-pickupdate/mappings/4730ba01-247b-4b94-a81c-357aaca9ff27.json
@@ -1,0 +1,12 @@
+{
+  "id" : "4730ba01-247b-4b94-a81c-357aaca9ff27",
+  "request" : {
+    "method" : "ANY"
+  },
+  "response" : {
+    "status" : 200,
+    "proxyBaseUrl" : "https://api.wellcomecollection.org"
+  },
+  "uuid" : "4730ba01-247b-4b94-a81c-357aaca9ff27",
+  "insertionIndex" : 0
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-with-a-pickupdate/mappings/catalogue_v2_works-bd5c024d-330d-4e63-8532-5b07a298367d.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-with-a-pickupdate/mappings/catalogue_v2_works-bd5c024d-330d-4e63-8532-5b07a298367d.json
@@ -1,0 +1,34 @@
+{
+  "id" : "bd5c024d-330d-4e63-8532-5b07a298367d",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6x",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Fri, 28 Feb 2020 13:43:47 GMT",
+      "x-amzn-RequestId" : "662682d9-e7e6-467f-a4c7-00efb764714f",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "InDbAE6gjoEFm_g=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Fri, 28 Feb 2020 13:43:47 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 001d2c0e1017c442fd79b22841d53218.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "ADwlE7ptEvh0qAcoFu4JMTVZp1xYx-jVU4SRt__L94o5J9qh4HNCpg=="
+    }
+  },
+  "uuid" : "bd5c024d-330d-4e63-8532-5b07a298367d",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-without-a-pickupdate/mappings/aa8f8137-14e9-4432-8988-395308e065aa.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-without-a-pickupdate/mappings/aa8f8137-14e9-4432-8988-395308e065aa.json
@@ -1,0 +1,12 @@
+{
+  "id" : "aa8f8137-14e9-4432-8988-395308e065aa",
+  "request" : {
+    "method" : "ANY"
+  },
+  "response" : {
+    "status" : 200,
+    "proxyBaseUrl" : "https://api.wellcomecollection.org"
+  },
+  "uuid" : "aa8f8137-14e9-4432-8988-395308e065aa",
+  "insertionIndex" : 0
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-without-a-pickupdate/mappings/catalogue_v2_works-e90f7b4a-1e68-4a23-a93f-9d0bcce52ac3.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item-without-a-pickupdate/mappings/catalogue_v2_works-e90f7b4a-1e68-4a23-a93f-9d0bcce52ac3.json
@@ -1,0 +1,34 @@
+{
+  "id" : "e90f7b4a-1e68-4a23-a93f-9d0bcce52ac3",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6x",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Fri, 28 Feb 2020 13:43:47 GMT",
+      "x-amzn-RequestId" : "a4cc6a4f-95ec-4167-8f20-9f25a2c5ef84",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "InDbIHbnjoEFcVw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Fri, 28 Feb 2020 13:43:47 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 81a5a0f348d8c55baa9c088dd6b5ecbd.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "mIIONM0vCMXju4JDKJwlUT5yY0c4NsTrag7Cc_tzXd-3emq9BjXm0w=="
+    }
+  },
+  "uuid" : "e90f7b4a-1e68-4a23-a93f-9d0bcce52ac3",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item/mappings/catalogue_v2_works-3fbf3653-ea1f-4d9b-803d-f49fcb1a67c4.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-accepts-requests-to-place-a-hold-on-an-item/mappings/catalogue_v2_works-3fbf3653-ea1f-4d9b-803d-f49fcb1a67c4.json
@@ -1,0 +1,34 @@
+{
+  "id" : "3fbf3653-ea1f-4d9b-803d-f49fcb1a67c4",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6x",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:15:32 GMT",
+      "x-amzn-RequestId" : "41eae407-5fc4-4247-aa0b-723046bd9e7e",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjsWRFzxDoEFXnw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:15:32 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 bad4c5c93bbbcff151219f57e6a9b2b5.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR50-C1",
+      "X-Amz-Cf-Id" : "r-AtxNfPSabD3jqOiqbNh0OkckxgCu4wRBco3tYvIzWDAEMUfkYJOw=="
+    }
+  },
+  "uuid" : "3fbf3653-ea1f-4d9b-803d-f49fcb1a67c4",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-provides-information-about-a-users--holds/mappings/catalogue_v2_works-7266d44d-781b-4bae-b9d6-ad9eac6094f6.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-provides-information-about-a-users--holds/mappings/catalogue_v2_works-7266d44d-781b-4bae-b9d6-ad9eac6094f6.json
@@ -1,0 +1,34 @@
+{
+  "id" : "7266d44d-781b-4bae-b9d6-ad9eac6094f6",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=1292185",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":2,\"results\":[{\"id\":\"ndfbj5e8\",\"title\":\"Pathology of tropical and extraordinary diseases\",\"alternativeTitles\":[],\"physicalDescription\":\"2 volumes : illustrations ; 27 cm\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"items\":[{\"id\":\"pcku6hmz\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070277\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307027\",\"type\":\"Identifier\"}],\"title\":\"Vol. 2\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"},{\"id\":\"vfjc3dyb\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070265\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307026\",\"type\":\"Identifier\"}],\"title\":\"Vol. 1\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"},{\"id\":\"cjks68s3\",\"title\":\"The whole art and trade of hvsbandry, contained in foure bookes. Viz: I. Of earable-ground, tillage, and pasture. II. Of gardens, orchards, and vvoods. III. Of feeding, breeding, and curing of all manner of cattell. IIII. Of poultrie, fowle, fish, and bees\",\"alternativeTitles\":[],\"physicalDescription\":\"9 pages, [12?], 183 leaves, [1 bl. leaves?] ; (8vo)\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12826078\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1282607\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30334469\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3033446\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b30334469_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"n5v7b4md\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sepbb\",\"label\":\"Closed stores EPB / B\",\"type\":\"LocationType\"},\"label\":\"Closed stores EPB / B\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b30334469/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:15:33 GMT",
+      "x-amzn-RequestId" : "e9fe6ca5-93e9-4341-b634-db1c1ec6ffaf",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "4202",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjsWaGt5DoEF8hw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:15:33 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 0210db6188ed379f1f743c3f6a29a1eb.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR50-C1",
+      "X-Amz-Cf-Id" : "JybvBeMrT507tUQ_SCWS4fo0kQvhnP4HWBK7EwDybT4vrH99QJ13yw=="
+    }
+  },
+  "uuid" : "7266d44d-781b-4bae-b9d6-ad9eac6094f6",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-responds-to-requests-containing-an-weco-sierra-patron-id-header/mappings/catalogue_v2_works-aa1d7007-0826-493b-a05f-9f1b42de6260.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-responds-to-requests-containing-an-weco-sierra-patron-id-header/mappings/catalogue_v2_works-aa1d7007-0826-493b-a05f-9f1b42de6260.json
@@ -1,0 +1,34 @@
+{
+  "id" : "aa1d7007-0826-493b-a05f-9f1b42de6260",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=1292185",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":2,\"results\":[{\"id\":\"ndfbj5e8\",\"title\":\"Pathology of tropical and extraordinary diseases\",\"alternativeTitles\":[],\"physicalDescription\":\"2 volumes : illustrations ; 27 cm\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"items\":[{\"id\":\"pcku6hmz\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070277\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307027\",\"type\":\"Identifier\"}],\"title\":\"Vol. 2\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"},{\"id\":\"vfjc3dyb\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070265\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307026\",\"type\":\"Identifier\"}],\"title\":\"Vol. 1\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"},{\"id\":\"cjks68s3\",\"title\":\"The whole art and trade of hvsbandry, contained in foure bookes. Viz: I. Of earable-ground, tillage, and pasture. II. Of gardens, orchards, and vvoods. III. Of feeding, breeding, and curing of all manner of cattell. IIII. Of poultrie, fowle, fish, and bees\",\"alternativeTitles\":[],\"physicalDescription\":\"9 pages, [12?], 183 leaves, [1 bl. leaves?] ; (8vo)\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12826078\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1282607\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30334469\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3033446\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b30334469_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"n5v7b4md\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sepbb\",\"label\":\"Closed stores EPB / B\",\"type\":\"LocationType\"},\"label\":\"Closed stores EPB / B\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b30334469/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:12:31 GMT",
+      "x-amzn-RequestId" : "c3f84c22-94cc-43f2-a12e-f59d4216b788",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "4202",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "Ijr57GLsjoEFojg=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:12:31 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 fb6fed3e442411d4b881d85e3bbec15a.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C1",
+      "X-Amz-Cf-Id" : "D3Hj0kLpa7VuoWWytFgjWdV7_zQPCzbaMdjYz_TMtlmffUVXKd4tTQ=="
+    }
+  },
+  "uuid" : "aa1d7007-0826-493b-a05f-9f1b42de6260",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/requests-responds-with-a-409-conflict-when-a-hold-is-rejected/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a5.json
+++ b/api/stacks/common/src/test/resources/catalogue/requests-responds-with-a-409-conflict-when-a-hold-is-rejected/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a5.json
@@ -1,0 +1,34 @@
+{
+  "id" : "475ec65d-6106-45bf-a022-b1f33f2805a5",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6y",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6y\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010186\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601018\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "x-amzn-RequestId" : "9923ac77-b3d2-42ca-a62a-5c310d6472eb",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqOOFLjDoEF6Nw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 5e9462d78e1fd171400e24a377935ad0.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "qP0AGgqj0Y0nPaB78-U0wMtKIHPCALlasWS4-5ZPz4TdEu0IojGLyA=="
+    }
+  },
+  "uuid" : "475ec65d-6106-45bf-a022-b1f33f2805a5",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/stacksservice-getstacksuserholdswithstacksitemidentifier-gets-a-stacksuserholds-stacksitemidentifier-/mappings/catalogue_v2_works-ccdb6c85-5522-4f7c-9037-ab8c0f874a0a.json
+++ b/api/stacks/common/src/test/resources/catalogue/stacksservice-getstacksuserholdswithstacksitemidentifier-gets-a-stacksuserholds-stacksitemidentifier-/mappings/catalogue_v2_works-ccdb6c85-5522-4f7c-9037-ab8c0f874a0a.json
@@ -1,0 +1,34 @@
+{
+  "id" : "ccdb6c85-5522-4f7c-9037-ab8c0f874a0a",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=1292185",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":2,\"results\":[{\"id\":\"ndfbj5e8\",\"title\":\"Pathology of tropical and extraordinary diseases\",\"alternativeTitles\":[],\"physicalDescription\":\"2 volumes : illustrations ; 27 cm\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"items\":[{\"id\":\"pcku6hmz\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070277\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307027\",\"type\":\"Identifier\"}],\"title\":\"Vol. 2\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"},{\"id\":\"vfjc3dyb\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i13070265\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1307026\",\"type\":\"Identifier\"}],\"title\":\"Vol. 1\",\"locations\":[{\"locationType\":{\"id\":\"wgmem\",\"label\":\"Medical Collection\",\"type\":\"LocationType\"},\"label\":\"Medical Collection\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"},{\"id\":\"cjks68s3\",\"title\":\"The whole art and trade of hvsbandry, contained in foure bookes. Viz: I. Of earable-ground, tillage, and pasture. II. Of gardens, orchards, and vvoods. III. Of feeding, breeding, and curing of all manner of cattell. IIII. Of poultrie, fowle, fish, and bees\",\"alternativeTitles\":[],\"physicalDescription\":\"9 pages, [12?], 183 leaves, [1 bl. leaves?] ; (8vo)\",\"workType\":{\"id\":\"a\",\"label\":\"Books\",\"type\":\"WorkType\"},\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b12826078\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1282607\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b30334469\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"3033446\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b30334469_0001.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"n5v7b4md\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i12921853\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1292185\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sepbb\",\"label\":\"Closed stores EPB / B\",\"type\":\"LocationType\"},\"label\":\"Closed stores EPB / B\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b30334469/manifest\",\"license\":{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"eng\",\"label\":\"English\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:01:03 GMT",
+      "x-amzn-RequestId" : "411207fd-06f8-48b4-9c64-9b6f5d473007",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "4202",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqOdG9pDoEFZwA=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:01:03 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 63d897654686e9908c8e03c9efa9c27c.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "9nkPvBlpS_S7oLgMVzP62f0hCwMLCsj3z5qpfjJ0kZWTXi7AM6R0ZA=="
+    }
+  },
+  "uuid" : "ccdb6c85-5522-4f7c-9037-ab8c0f874a0a",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/stacksservice-getstackswork-gets-a-stackswork/mappings/catalogue_v2_works_cnkv77md-3496717f-54c4-47c5-b50f-c2fdbfd3c509.json
+++ b/api/stacks/common/src/test/resources/catalogue/stacksservice-getstackswork-gets-a-stackswork/mappings/catalogue_v2_works_cnkv77md-3496717f-54c4-47c5-b50f-c2fdbfd3c509.json
@@ -1,0 +1,34 @@
+{
+  "id" : "3496717f-54c4-47c5-b50f-c2fdbfd3c509",
+  "name" : "catalogue_v2_works_cnkv77md",
+  "request" : {
+    "url" : "/catalogue/v2/works/cnkv77md?include=items,identifiers",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\",\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\"}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:01:03 GMT",
+      "x-amzn-RequestId" : "904025ee-ed01-4531-8e24-ce77ed4f20c9",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2480",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqOXEJdDoEF81Q=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:01:03 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 c727bed829773949471e191d64303113.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "JFfKYnISNhNodklE3KUxRdH5QtpBBsVX2Nbe-omEq1eGG-Am8E773Q=="
+    }
+  },
+  "uuid" : "3496717f-54c4-47c5-b50f-c2fdbfd3c509",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/stacksservice-requestholdonitem-returns-a-rejected-hold-if-sierra-does-the-same/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a5.json
+++ b/api/stacks/common/src/test/resources/catalogue/stacksservice-requestholdonitem-returns-a-rejected-hold-if-sierra-does-the-same/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a5.json
@@ -1,0 +1,34 @@
+{
+  "id" : "475ec65d-6106-45bf-a022-b1f33f2805a5",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6y",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6y\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010186\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601018\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "x-amzn-RequestId" : "9923ac77-b3d2-42ca-a62a-5c310d6472eb",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqOOFLjDoEF6Nw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 5e9462d78e1fd171400e24a377935ad0.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "qP0AGgqj0Y0nPaB78-U0wMtKIHPCALlasWS4-5ZPz4TdEu0IojGLyA=="
+    }
+  },
+  "uuid" : "475ec65d-6106-45bf-a022-b1f33f2805a5",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/catalogue/stacksservice-requestholdonitem-should-request-a-hold-from-the-sierra-api/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a4.json
+++ b/api/stacks/common/src/test/resources/catalogue/stacksservice-requestholdonitem-should-request-a-hold-from-the-sierra-api/mappings/catalogue_v2_works-475ec65d-6106-45bf-a022-b1f33f2805a4.json
@@ -1,0 +1,34 @@
+{
+  "id" : "475ec65d-6106-45bf-a022-b1f33f2805a4",
+  "name" : "catalogue_v2_works",
+  "request" : {
+    "url" : "/catalogue/v2/works?include=items,identifiers&query=ys3ern6x",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\"@context\":\"https://api.wellcomecollection.org/catalogue/v2/context.json\",\"type\":\"ResultList\",\"pageSize\":10,\"totalPages\":1,\"totalResults\":1,\"results\":[{\"id\":\"cnkv77md\",\"title\":\"The sun rising with a yellow condom instead of the sun; representing protection against AIDS. Colour lithograph after M. Kolvenbach and G. Meyer, 199-.\",\"alternativeTitles\":[],\"physicalDescription\":\"1 print : lithograph, printed in colour ; sheet 59.5 x 42 cm\",\"workType\":{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"WorkType\"},\"lettering\":\"Guten Tag. Mach's mit. Bundeszentrale für gesundheitliche Aufklärung, 51101 Köln. Konzept + Gestaltung: Marcel Kolvenbach + Guido Meyer\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"b16656180\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1665618\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"miro-image-number\",\"label\":\"Miro image number\",\"type\":\"IdentifierType\"},\"value\":\"L0053261\",\"type\":\"Identifier\"}],\"thumbnail\":{\"locationType\":{\"id\":\"thumbnail-image\",\"label\":\"Thumbnail Image\",\"type\":\"LocationType\"},\"url\":\"https://dlcs.io/thumbs/wellcome/5/b16656180_l0053261.jp2/full/!200,200/0/default.jpg\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[],\"type\":\"DigitalLocation\"},\"items\":[{\"id\":\"ys3ern6x\",\"identifiers\":[{\"identifierType\":{\"id\":\"sierra-system-number\",\"label\":\"Sierra system number\",\"type\":\"IdentifierType\"},\"value\":\"i16010176\",\"type\":\"Identifier\"},{\"identifierType\":{\"id\":\"sierra-identifier\",\"label\":\"Sierra identifier\",\"type\":\"IdentifierType\"},\"value\":\"1601017\",\"type\":\"Identifier\"}],\"locations\":[{\"locationType\":{\"id\":\"sicon\",\"label\":\"Closed stores Iconographic\",\"type\":\"LocationType\"},\"label\":\"Closed stores Iconographic\",\"accessConditions\":[],\"type\":\"PhysicalLocation\"},{\"locationType\":{\"id\":\"iiif-presentation\",\"label\":\"IIIF Presentation API\",\"type\":\"LocationType\"},\"url\":\"https://wellcomelibrary.org/iiif/b16656180/manifest\",\"license\":{\"id\":\"cc-by-nc\",\"label\":\"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)\",\"url\":\"https://creativecommons.org/licenses/by-nc/4.0/\",\"type\":\"License\"},\"accessConditions\":[{\"status\":{\"id\":\"open\",\"label\":\"Open\",\"type\":\"AccessStatus\"},\"type\":\"AccessCondition\"}],\"type\":\"DigitalLocation\"}],\"type\":\"Item\"}],\"language\":{\"id\":\"ger\",\"label\":\"German\",\"type\":\"Language\"},\"type\":\"Work\"}]}",
+    "headers" : {
+      "Content-Type" : "application/json",
+      "Connection" : "keep-alive",
+      "Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "x-amzn-RequestId" : "9923ac77-b3d2-42ca-a62a-5c310d6472eb",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Headers" : "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type",
+      "x-amzn-Remapped-Content-Length" : "2560",
+      "x-amzn-Remapped-Connection" : "keep-alive",
+      "x-amz-apigw-id" : "IjqOOFLjDoEF6Nw=",
+      "x-amzn-Remapped-Server" : "nginx",
+      "Access-Control-Allow-Methods" : "GET, POST, OPTIONS",
+      "x-amzn-Remapped-Date" : "Thu, 27 Feb 2020 13:01:02 GMT",
+      "Access-Control-Allow-Credentials" : "true",
+      "X-Cache" : "Miss from cloudfront",
+      "Via" : "1.1 5e9462d78e1fd171400e24a377935ad0.cloudfront.net (CloudFront)",
+      "X-Amz-Cf-Pop" : "LHR62-C2",
+      "X-Amz-Cf-Id" : "qP0AGgqj0Y0nPaB78-U0wMtKIHPCALlasWS4-5ZPz4TdEu0IojGLyA=="
+    }
+  },
+  "uuid" : "475ec65d-6106-45bf-a022-b1f33f2805a4",
+  "persistent" : true,
+  "insertionIndex" : 1
+}

--- a/api/stacks/common/src/test/resources/logback-test.xml
+++ b/api/stacks/common/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.jetty" level="INFO"/>
+</configuration>

--- a/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-items-1601017-GDDFo.json
+++ b/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-items-1601017-GDDFo.json
@@ -1,0 +1,19 @@
+{
+  "id": "1601017",
+  "updatedDate": "2009-06-15T14:48:00Z",
+  "createdDate": "2008-05-21T12:47:00Z",
+  "deleted": false,
+  "bibIds": [
+    "1665618"
+  ],
+  "location": {
+    "code": "sicon",
+    "name": "Closed stores Iconographic"
+  },
+  "status": {
+    "code": "-  ",
+    "display": "Available"
+  },
+  "barcode": "D59.14 (Germany file)",
+  "callNumber": "665618i"
+}

--- a/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-patrons-1100189-holds-c8bRb.json
+++ b/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-patrons-1100189-holds-c8bRb.json
@@ -1,0 +1,24 @@
+{
+  "total": 1,
+  "entries": [
+    {
+      "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/holds/145730",
+      "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/items/1292185",
+      "patron": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/1100189",
+      "frozen": false,
+      "placed": "2019-11-19",
+      "notWantedBeforeDate": "2019-11-19",
+      "pickupByDate": "2019-12-03T04:00:00Z",
+      "pickupLocation": {
+        "code": "sepbb",
+        "name": "Rare Materials Room"
+      },
+      "status": {
+        "code": "i",
+        "name": "item hold ready for pickup."
+      },
+      "recordType": "i",
+      "priority": 1
+    }
+  ]
+}

--- a/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-patrons-1100189-holds-requests-500.json
+++ b/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-patrons-1100189-holds-requests-500.json
@@ -1,0 +1,7 @@
+{
+  "code": 132,
+  "specificCode": 2,
+  "httpStatus": 500,
+  "name": "XCirc error",
+  "description": "XCirc error : This record is not available"
+}

--- a/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-token-YvUkU.json
+++ b/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-token-YvUkU.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "dummy_access_token",
+  "token_type": "bearer",
+  "expires_in": 3600
+}

--- a/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-token-mIRgi.json
+++ b/api/stacks/common/src/test/resources/sierra/__files/body-iii-sierra-api-v5-token-mIRgi.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "dummy_access_token",
+  "token_type": "bearer",
+  "expires_in": 3600
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-items-1601017-GDDFo.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-items-1601017-GDDFo.json
@@ -1,0 +1,26 @@
+{
+  "id" : "e4b92ae1-1e2c-3ca3-bc6c-82bc1cc4e1b4",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/items/1601017",
+    "method" : "GET",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer dummy_access_token"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "body-iii-sierra-api-v5-items-1601017-GDDFo.json",
+    "headers" : {
+      "Date" : "Fri, 15 Nov 2019 11:53:06 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding,User-Agent",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api2; path=/iii/patronio", "jcontainerId=.jcontainer-api2; path=/iii/rss", "jcontainerId=.jcontainer-api2; path=/sierra/admin", "jcontainerId=.jcontainer-api2; path=/sierra/dashboard", "jcontainerId=.jcontainer-api2; path=/sierra/shindig", "jcontainerId=.jcontainer-api2; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api2; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api2; path=/iii/sierra-api" ],
+      "Keep-Alive" : "timeout=5, max=100",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "e4b92ae1-1e2c-3ca3-bc6c-82bc1cc4e1b4"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-c8bRb.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-c8bRb.json
@@ -1,0 +1,26 @@
+{
+  "id" : "9057b491-f8c3-3271-a808-c93ab4f8594f",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/patrons/1234567/holds?limit=100&offset=0",
+    "method" : "GET",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer dummy_access_token"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "body-iii-sierra-api-v5-patrons-1100189-holds-c8bRb.json",
+    "headers" : {
+      "Date" : "Tue, 19 Nov 2019 11:54:44 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding,User-Agent",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api2; path=/iii/patronio", "jcontainerId=.jcontainer-api2; path=/iii/rss", "jcontainerId=.jcontainer-api2; path=/sierra/admin", "jcontainerId=.jcontainer-api2; path=/sierra/dashboard", "jcontainerId=.jcontainer-api2; path=/sierra/shindig", "jcontainerId=.jcontainer-api2; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api2; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api2; path=/iii/sierra-api" ],
+      "Keep-Alive" : "timeout=5, max=99",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "9057b491-f8c3-3271-a808-c93ab4f8594f"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vt.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vt.json
@@ -1,0 +1,31 @@
+{
+  "id" : "487e0101-f036-30d7-a955-00f305b77355",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/patrons/1234567/holds/requests",
+    "method" : "POST",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer dummy_access_token"
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"recordType\": \"i\", \"recordNumber\": 1601017, \"pickupLocation\": \"unspecified\", \"neededBy\": \"2020-01-01\" }",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 204,
+    "bodyFileName" : "body-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vt.json",
+    "headers" : {
+      "Date" : "Wed, 20 Nov 2019 13:14:44 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api1; path=/iii/patronio", "jcontainerId=.jcontainer-api1; path=/iii/rss", "jcontainerId=.jcontainer-api1; path=/sierra/admin", "jcontainerId=.jcontainer-api1; path=/sierra/dashboard", "jcontainerId=.jcontainer-api1; path=/sierra/shindig", "jcontainerId=.jcontainer-api1; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api1; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api1; path=/iii/sierra-api" ],
+      "Vary" : "User-Agent",
+      "Keep-Alive" : "timeout=5, max=99",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "487e0101-f036-30d7-a955-00f305b77355"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vu.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vu.json
@@ -1,0 +1,31 @@
+{
+  "id" : "487e0101-f036-30d7-a955-00f305b77356",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/patrons/1234567/holds/requests",
+    "method" : "POST",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer dummy_access_token"
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"recordType\": \"i\", \"recordNumber\": 1601017, \"pickupLocation\": \"unspecified\" }",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 204,
+    "bodyFileName" : "body-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vt.json",
+    "headers" : {
+      "Date" : "Wed, 20 Nov 2019 13:14:44 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api1; path=/iii/patronio", "jcontainerId=.jcontainer-api1; path=/iii/rss", "jcontainerId=.jcontainer-api1; path=/sierra/admin", "jcontainerId=.jcontainer-api1; path=/sierra/dashboard", "jcontainerId=.jcontainer-api1; path=/sierra/shindig", "jcontainerId=.jcontainer-api1; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api1; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api1; path=/iii/sierra-api" ],
+      "Vary" : "User-Agent",
+      "Keep-Alive" : "timeout=5, max=99",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "487e0101-f036-30d7-a955-00f305b77355"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vv.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-patrons-1100189-holds-requests-Pi3Vv.json
@@ -1,0 +1,31 @@
+{
+  "id" : "487e0101-f036-30d7-a955-00f305b77355",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/patrons/1234567/holds/requests",
+    "method" : "POST",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Bearer dummy_access_token"
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"recordType\": \"i\", \"recordNumber\": 1601018, \"pickupLocation\": \"unspecified\" }",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 500,
+    "bodyFileName" : "body-iii-sierra-api-v5-patrons-1100189-holds-requests-500.json",
+    "headers" : {
+      "Date" : "Wed, 20 Nov 2019 13:14:44 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api1; path=/iii/patronio", "jcontainerId=.jcontainer-api1; path=/iii/rss", "jcontainerId=.jcontainer-api1; path=/sierra/admin", "jcontainerId=.jcontainer-api1; path=/sierra/dashboard", "jcontainerId=.jcontainer-api1; path=/sierra/shindig", "jcontainerId=.jcontainer-api1; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api1; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api1; path=/iii/sierra-api" ],
+      "Vary" : "User-Agent",
+      "Keep-Alive" : "timeout=5, max=99",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "487e0101-f036-30d7-a955-00f305b77355"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-YvUkU.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-YvUkU.json
@@ -1,0 +1,26 @@
+{
+  "id" : "49eea99a-bb25-3dec-a95b-4bcda5517729",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/token",
+    "method" : "POST",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "body-iii-sierra-api-v5-token-YvUkU.json",
+    "headers" : {
+      "Date" : "Fri, 15 Nov 2019 11:47:36 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding,User-Agent",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api2; path=/iii/patronio", "jcontainerId=.jcontainer-api2; path=/iii/rss", "jcontainerId=.jcontainer-api2; path=/sierra/admin", "jcontainerId=.jcontainer-api2; path=/sierra/dashboard", "jcontainerId=.jcontainer-api2; path=/sierra/shindig", "jcontainerId=.jcontainer-api2; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api2; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api2; path=/iii/sierra-api" ],
+      "Keep-Alive" : "timeout=5, max=100",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "49eea99a-bb25-3dec-a95b-4bcda5517729"
+}

--- a/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-mIRgi.json
+++ b/api/stacks/common/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-mIRgi.json
@@ -1,0 +1,26 @@
+{
+  "id" : "49eea99a-bb25-3dec-a95b-4bcda5517729",
+  "request" : {
+    "url" : "/iii/sierra-api/v5/token",
+    "method" : "POST",
+    "headers" : {
+      "Authorization" : {
+        "equalTo" : "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "body-iii-sierra-api-v5-token-mIRgi.json",
+    "headers" : {
+      "Date" : "Fri, 15 Nov 2019 11:47:36 GMT",
+      "Server" : "Apache",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Vary" : "Accept-Encoding,User-Agent",
+      "Set-Cookie" : [ "jcontainerId=.jcontainer-api2; path=/iii/patronio", "jcontainerId=.jcontainer-api2; path=/iii/rss", "jcontainerId=.jcontainer-api2; path=/sierra/admin", "jcontainerId=.jcontainer-api2; path=/sierra/dashboard", "jcontainerId=.jcontainer-api2; path=/sierra/shindig", "jcontainerId=.jcontainer-api2; path=/iii/ws/extlink", "jcontainerId=.jcontainer-api2; path=/sierra/ws/summit", "jcontainerId=.jcontainer-api2; path=/iii/sierra-api" ],
+      "Keep-Alive" : "timeout=5, max=100",
+      "Connection" : "Keep-Alive"
+    }
+  },
+  "uuid" : "49eea99a-bb25-3dec-a95b-4bcda5517729"
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/AkkaCatalogueSourceFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/AkkaCatalogueSourceFixture.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import akka.http.scaladsl.model.Uri
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.stacks.common.services.source.AkkaCatalogueSource
+
+trait AkkaCatalogueSourceFixture extends CatalogueWireMockFixture with Akka {
+  def withAkkaCatalogueSource[R](
+    testWith: TestWith[AkkaCatalogueSource, R]
+  ): R =
+    withActorSystem { implicit actorSystem =>
+      withMockCatalogueServer { baseUrl =>
+        testWith(
+          new AkkaCatalogueSource(baseUri = Uri(s"$baseUrl/catalogue/v2"))
+        )
+      }
+    }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueStubGenerators.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueStubGenerators.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import uk.ac.wellcome.platform.stacks.common.services.source.CatalogueSource.{
+  IdentifiersStub,
+  ItemStub,
+  WorkStub
+}
+
+trait CatalogueStubGenerators extends IdentifierGenerators {
+  def createWorkStubWith(items: List[ItemStub]): WorkStub =
+    WorkStub(
+      id = createStacksWorkIdentifier.value,
+      items = items
+    )
+
+  def createItemStubWith(identifiers: List[IdentifiersStub]): ItemStub =
+    ItemStub(
+      id = maybe(createStacksItemIdentifier.value),
+      identifiers = Some(identifiers)
+    )
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
@@ -22,7 +22,8 @@ import uk.ac.wellcome.fixtures.TestWith
   *
   */
 trait CatalogueWireMockFixture extends AnyFunSpec with Logging {
-  val baseRecordingRoot: String = "./api/stacks/common/src/test/resources/catalogue"
+  val baseRecordingRoot: String =
+    "./api/stacks/common/src/test/resources/catalogue"
   var recordingRoot: Path = Paths.get(baseRecordingRoot)
 
   // Each test has a separate set of recordings, in a separate directory,

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
@@ -1,0 +1,95 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import grizzled.slf4j.Logging
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.Outcome
+import uk.ac.wellcome.fixtures.TestWith
+
+/** This is a Wiremock fixture for interacting with the Catalogue API.
+  *
+  * Because the Catalogue API is publicly available and does not require auth,
+  * it will automatically record any API interactions, then save them to the
+  * fixtures folder and replay them in future tests.
+  *
+  * It is inspired by libraries like:
+  *   - vcr (https://rubygems.org/gems/vcr)
+  *   - Betamax (https://pypi.org/project/betamax/)
+  *
+  */
+trait CatalogueWireMockFixture extends AnyFunSpec with Logging {
+  val baseRecordingRoot: String = "./common/src/test/resources/catalogue"
+  var recordingRoot: Path = Paths.get(baseRecordingRoot)
+
+  // Each test has a separate set of recordings, in a separate directory,
+  // so we can see which recording is used by which test.
+  //
+  // This overrides withFixture() to capture the name of the test, and then
+  // turns it into a filesystem-safe name for a directory to keep the
+  // recordings in.
+  //
+  // e.g. recordings for `it("does the right thing")` go to `does-the-right-thing`
+  override def withFixture(test: NoArgTest): Outcome = {
+    val dirname = test.name
+      .replaceAll("[^A-Za-z0-9-]", "-")
+      .toLowerCase
+
+    recordingRoot = Paths.get(baseRecordingRoot, dirname)
+    test()
+  }
+
+  def withMockCatalogueServer[R](
+    testWith: TestWith[String, R]
+  ): R = {
+    val wireMockServer = new WireMockServer(
+      WireMockConfiguration
+        .wireMockConfig()
+        .withRootDirectory(recordingRoot.toString)
+        .dynamicPort()
+    )
+
+    wireMockServer.start()
+
+    // Are there any existing recordings for this test?  If so, we should
+    // configure Wiremock to get new recordings.
+    val shouldRecord: Boolean = !existingRecordingsIn(recordingRoot)
+
+    if (shouldRecord) {
+      info("Recording new Wiremock fixtures for the catalogue API")
+
+      new File(recordingRoot.toString).mkdir()
+      new File(s"$recordingRoot/mappings").mkdir()
+
+      wireMockServer.startRecording("https://api.wellcomecollection.org")
+    } else {
+      info("Using cached Wiremock fixtures")
+    }
+
+    val result = testWith(s"http://localhost:${wireMockServer.port()}")
+
+    if (shouldRecord) {
+      wireMockServer.saveMappings()
+      wireMockServer.stopRecording()
+    }
+
+    wireMockServer.shutdown()
+
+    result
+  }
+
+  private def existingRecordingsIn(p: Path): Boolean = {
+    val mappingsPath = Paths.get(p.toString, "mappings")
+
+    isNonEmpty(mappingsPath)
+  }
+
+  private def exists(p: Path): Boolean =
+    Files.exists(p)
+
+  private def isNonEmpty(dirpath: Path): Boolean =
+    exists(dirpath) && Files.list(dirpath).findAny().isPresent
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/CatalogueWireMockFixture.scala
@@ -22,7 +22,7 @@ import uk.ac.wellcome.fixtures.TestWith
   *
   */
 trait CatalogueWireMockFixture extends AnyFunSpec with Logging {
-  val baseRecordingRoot: String = "./common/src/test/resources/catalogue"
+  val baseRecordingRoot: String = "./api/stacks/common/src/test/resources/catalogue"
   var recordingRoot: Path = Paths.get(baseRecordingRoot)
 
   // Each test has a separate set of recordings, in a separate directory,

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/HttpFixtures.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/HttpFixtures.scala
@@ -1,0 +1,95 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.{GET, POST}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpHeader,
+  HttpRequest,
+  HttpResponse,
+  RequestEntity
+}
+import akka.stream.scaladsl.Sink
+import io.circe.parser._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.stacks.common.http.config.models.HTTPServerConfig
+
+trait HttpFixtures extends Akka with ScalaFutures with Matchers {
+
+  private def whenRequestReady[R](
+    r: HttpRequest
+  )(testWith: TestWith[HttpResponse, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val request = Http().singleRequest(r)
+      whenReady(request) { response: HttpResponse =>
+        testWith(response)
+      }
+    }
+
+  def whenGetRequestReady[R](
+    path: String,
+    headers: List[HttpHeader] = Nil
+  )(testWith: TestWith[HttpResponse, R]): R = {
+
+    val request = HttpRequest(
+      method = GET,
+      uri = s"${externalBaseURL}${path}",
+      headers = headers
+    )
+
+    whenRequestReady(request) { response =>
+      testWith(response)
+    }
+  }
+
+  def createJsonHttpEntityWith(jsonString: String): RequestEntity =
+    HttpEntity(
+      ContentTypes.`application/json`,
+      parse(jsonString).right.get.noSpaces
+    )
+
+  def whenPostRequestReady[R](
+    path: String,
+    entity: RequestEntity,
+    headers: List[HttpHeader] = Nil
+  )(
+    testWith: TestWith[HttpResponse, R]
+  ): R = {
+
+    val request = HttpRequest(
+      method = POST,
+      uri = s"${externalBaseURL}${path}",
+      headers = headers,
+      entity = entity
+    )
+
+    whenRequestReady(request) { response =>
+      testWith(response)
+    }
+  }
+
+  def withStringEntity[R](
+    httpEntity: HttpEntity
+  )(testWith: TestWith[String, R]): R =
+    withMaterializer { implicit mat =>
+      val value =
+        httpEntity.dataBytes.runWith(Sink.fold("") {
+          case (acc, byteString) =>
+            acc + byteString.utf8String
+        })
+      whenReady(value) { string =>
+        testWith(string)
+      }
+    }
+
+  private val port = 1234
+  private val host = "localhost"
+  private val externalBaseURL = s"http://$host:$port"
+
+  val httpServerConfigTest: HTTPServerConfig =
+    HTTPServerConfig(host, port, externalBaseURL)
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/IdentifierGenerators.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/IdentifierGenerators.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import uk.ac.wellcome.platform.stacks.common.models.{
+  CatalogueItemIdentifier,
+  SierraItemIdentifier,
+  StacksItemIdentifier,
+  StacksWorkIdentifier
+}
+
+import scala.util.Random
+
+trait IdentifierGenerators {
+  private def randomAlphanumeric: String =
+    Random.nextString(8)
+
+  def maybe[T](t: T): Option[T] =
+    if (Random.nextBoolean()) Some(t) else None
+
+  def createStacksWorkIdentifier: StacksWorkIdentifier =
+    StacksWorkIdentifier(s"work-$randomAlphanumeric")
+
+  // Sierra identifiers are 7-digit numbers
+  def createSierraItemIdentifier: SierraItemIdentifier =
+    SierraItemIdentifier(
+      (Random.nextFloat * 1000000).toLong
+    )
+
+  def createStacksItemIdentifier: StacksItemIdentifier =
+    StacksItemIdentifier(
+      catalogueId = CatalogueItemIdentifier(s"catalogue-$randomAlphanumeric"),
+      sierraId = createSierraItemIdentifier
+    )
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/ServicesFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/ServicesFixture.scala
@@ -1,0 +1,72 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import com.github.tomakehurst.wiremock.WireMockServer
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.stacks.common.services.source.AkkaSierraSource
+import uk.ac.wellcome.platform.stacks.common.services.{
+  CatalogueService,
+  SierraService,
+  StacksService
+}
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait ServicesFixture
+    extends AkkaCatalogueSourceFixture
+    with SierraWireMockFixture {
+
+  def withCatalogueService[R](
+    testWith: TestWith[CatalogueService, R]
+  ): R =
+    withAkkaCatalogueSource { catalogueSource =>
+      testWith(new CatalogueService(catalogueSource))
+    }
+
+  def withSierraService[R](
+    testWith: TestWith[(SierraService, WireMockServer), R]
+  ): R = {
+    withMockSierraServer {
+      case (sierraApiUrl, wireMockServer) =>
+        withActorSystem { implicit as =>
+          implicit val ec: ExecutionContextExecutor = as.dispatcher
+
+          withMaterializer { _ =>
+            testWith(
+              (
+                new SierraService(
+                  new AkkaSierraSource(
+                    baseUri = Uri(f"$sierraApiUrl/iii/sierra-api"),
+                    credentials = BasicHttpCredentials("username", "password")
+                  )
+                ),
+                wireMockServer
+              )
+            )
+          }
+        }
+    }
+  }
+
+  def withStacksService[R](
+    testWith: TestWith[(StacksService, WireMockServer), R]
+  ): R = {
+    withCatalogueService { catalogueService =>
+      withSierraService {
+        case (sierraService, sierraWireMockSerever) =>
+          withActorSystem { implicit as =>
+            implicit val ec: ExecutionContextExecutor = as.dispatcher
+
+            val stacksService =
+              new StacksService(catalogueService, sierraService)
+
+            testWith(
+              (stacksService, sierraWireMockSerever)
+            )
+          }
+      }
+    }
+  }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
@@ -12,7 +12,8 @@ trait SierraWireMockFixture {
     val wireMockServer = new WireMockServer(
       WireMockConfiguration
         .wireMockConfig()
-        .usingFilesUnderClasspath("./api/stacks/common/src/test/resources/sierra")
+        .usingFilesUnderClasspath(
+          "./api/stacks/common/src/test/resources/sierra")
         .dynamicPort()
     )
 

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.platform.stacks.common.fixtures
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import uk.ac.wellcome.fixtures.TestWith
+
+trait SierraWireMockFixture {
+  def withMockSierraServer[R](
+    testWith: TestWith[(String, WireMockServer), R]
+  ): R = {
+
+    val wireMockServer = new WireMockServer(
+      WireMockConfiguration
+        .wireMockConfig()
+        .usingFilesUnderClasspath("./common/src/test/resources/sierra")
+        .dynamicPort()
+    )
+
+    wireMockServer.start()
+
+    val urlAndServer =
+      (s"http://localhost:${wireMockServer.port()}", wireMockServer)
+    val result = testWith(urlAndServer)
+
+    wireMockServer.shutdown()
+
+    result
+  }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/fixtures/SierraWireMockFixture.scala
@@ -12,7 +12,7 @@ trait SierraWireMockFixture {
     val wireMockServer = new WireMockServer(
       WireMockConfiguration
         .wireMockConfig()
-        .usingFilesUnderClasspath("./common/src/test/resources/sierra")
+        .usingFilesUnderClasspath("./api/stacks/common/src/test/resources/sierra")
         .dynamicPort()
     )
 

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
@@ -1,0 +1,90 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class TokenExchangeTest extends AnyFunSpec with Matchers with ScalaFutures {
+  type Credentials = String
+  type Token = String
+
+  class MemoryTokenExchange(
+    tokens: Seq[(Credentials, Instant)]
+  )(implicit val ec: ExecutionContext)
+      extends TokenExchange[Credentials, Token] {
+    var calls = 0
+    override protected val expiryGracePeriod = 0
+
+    override protected def getNewToken(
+      credentials: Credentials): Future[(Token, Instant)] =
+      synchronized {
+        val index = calls
+        calls += 1
+
+        Future.fromTry(Try(tokens(index)))
+      }
+  }
+
+  val credentials = "password"
+
+  val now = Instant.now()
+
+  it("retrieves a token") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now)
+      )
+    )
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token1"
+    }
+  }
+
+  it("caches a token, and doesn't fetch it again until it expires") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now.plusSeconds(1)),
+        ("token2", now)
+      )
+    )
+
+    // Get the token three times, verify we get the same token each time,
+    // but that the underlying method was only called once.
+    whenReady(exchange.getToken(credentials)) { resp1 =>
+      resp1 shouldBe "token1"
+
+      whenReady(exchange.getToken(credentials)) { resp2 =>
+        resp2 shouldBe "token1"
+
+        whenReady(exchange.getToken(credentials)) { resp3 =>
+          resp3 shouldBe "token1"
+        }
+      }
+    }
+
+    exchange.calls shouldBe 1
+
+    // Now wait for the existing token to expire, and check we can fetch the new token
+    Thread.sleep(1500)
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token2"
+    }
+
+    exchange.calls shouldBe 2
+  }
+
+  it("fails if there is no cached token and the underlying lookup fails") {
+    val brokenExchange = new MemoryTokenExchange(tokens = Seq.empty)
+
+    whenReady(brokenExchange.getToken(credentials).failed) {
+      _ shouldBe a[IndexOutOfBoundsException]
+    }
+  }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/CatalogueServiceTest.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/CatalogueServiceTest.scala
@@ -1,0 +1,343 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.stacks.common.fixtures.CatalogueStubGenerators
+import uk.ac.wellcome.platform.stacks.common.models._
+import uk.ac.wellcome.platform.stacks.common.services.source.CatalogueSource
+import uk.ac.wellcome.platform.stacks.common.services.source.CatalogueSource._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class CatalogueServiceTest
+    extends AnyFunSpec
+    with ScalaFutures
+    with Matchers
+    with CatalogueStubGenerators {
+
+  describe("getAllStacksItems") {
+    class OneWorkCatalogueSource(work: WorkStub) extends CatalogueSource {
+      override def getWorkStub(id: StacksWorkIdentifier): Future[WorkStub] =
+        Future.successful(work)
+
+      override def getSearchStub(
+        identifier: Identifier[_]
+      ): Future[SearchStub] =
+        Future.failed(new Throwable("BOOM!"))
+    }
+
+    it("finds an item on a work") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1234567")))
+      )
+
+      val work = createWorkStubWith(
+        items = List(item)
+      )
+
+      val catalogueSource = new OneWorkCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier)) {
+        _ shouldBe List(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item.id.get),
+            sierraId = SierraItemIdentifier(1234567)
+          )
+        )
+      }
+    }
+
+    it("finds multiple matching items on a work") {
+      val item1 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1234567")))
+      )
+
+      val item2 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1111111")))
+      )
+
+      val work = createWorkStubWith(
+        items = List(item1, item2)
+      )
+
+      val catalogueSource = new OneWorkCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier)) {
+        _ shouldBe List(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item1.id.get),
+            sierraId = SierraItemIdentifier(1234567)
+          ),
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item2.id.get),
+            sierraId = SierraItemIdentifier(1111111)
+          )
+        )
+      }
+    }
+
+    it("ignores items that don't have a sierra-identifier") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(
+          List(
+            IdentifiersStub(
+              identifierType =
+                TypeStub(id = "miro-image-number", label = "Miro image number"),
+              value = "A0001234"
+            )
+          )
+        )
+      )
+
+      val work = createWorkStubWith(
+        items = List(item)
+      )
+
+      val catalogueSource = new OneWorkCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier)) {
+        _ shouldBe empty
+      }
+    }
+
+    it("throws an error if an item has multiple sierra-identifier values") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(
+          List(
+            createSierraIdentifier("1234567"),
+            createSierraIdentifier("1111111")
+          )
+        )
+      )
+
+      val work = createWorkStubWith(
+        items = List(item)
+      )
+
+      val catalogueSource = new OneWorkCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier).failed) {
+        err =>
+          err shouldBe a[Exception]
+          err.getMessage should startWith(
+            "Multiple values for sierra-identifier"
+          )
+      }
+    }
+
+    it("throws an error if it cannot parse the Sierra identifier as a Long") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("Not a Number")))
+      )
+
+      val work = createWorkStubWith(
+        items = List(item)
+      )
+
+      val catalogueSource = new OneWorkCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier).failed) {
+        err =>
+          err shouldBe a[Exception]
+          err.getMessage shouldBe "Unable to convert Not a Number to Long!"
+      }
+    }
+  }
+
+  describe("getStacksItem") {
+    class MockCatalogueSource(works: WorkStub*) extends CatalogueSource {
+      override def getWorkStub(id: StacksWorkIdentifier): Future[WorkStub] =
+        Future.failed(new Throwable("BOOM!"))
+
+      override def getSearchStub(
+        identifier: Identifier[_]
+      ): Future[SearchStub] =
+        Future.successful(
+          SearchStub(totalResults = works.size, results = works.toList)
+        )
+    }
+
+    it("returns an empty list if there are no matching works") {
+      val catalogueSource = new MockCatalogueSource()
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(createStacksItemIdentifier)) {
+        _ shouldBe None
+      }
+    }
+
+    it("gets an item from a work") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1234567")))
+      )
+
+      val work = createWorkStubWith(items = List(item))
+
+      val catalogueSource = new MockCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(CatalogueItemIdentifier(item.id.get))) {
+        _ shouldBe Some(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item.id.get),
+            sierraId = SierraItemIdentifier(1234567)
+          )
+        )
+      }
+    }
+
+    it("filters results by catalogue item identifier") {
+      val item1 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1111111")))
+      )
+
+      val work1 = createWorkStubWith(items = List(item1))
+
+      val item2 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("2222222")))
+      )
+
+      val work2 = createWorkStubWith(items = List(item2))
+
+      val catalogueSource = new MockCatalogueSource(work1, work2)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(CatalogueItemIdentifier(item1.id.get))) {
+        _ shouldBe Some(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item1.id.get),
+            sierraId = SierraItemIdentifier(1111111)
+          )
+        )
+      }
+    }
+
+    it("filters results by Sierra item identifier") {
+      val item1 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1111111")))
+      )
+
+      val work1 = createWorkStubWith(items = List(item1))
+
+      val item2 = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("2222222")))
+      )
+
+      val work2 = createWorkStubWith(items = List(item2))
+
+      val catalogueSource = new MockCatalogueSource(work1, work2)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(SierraItemIdentifier(1111111))) {
+        _ shouldBe Some(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item1.id.get),
+            sierraId = SierraItemIdentifier(1111111)
+          )
+        )
+      }
+    }
+
+    it("de-duplicates results if the same item appears on multiple works") {
+      val item = ItemStub(
+        id = Some(createStacksItemIdentifier.value),
+        identifiers = Some(List(createSierraIdentifier("1111111")))
+      )
+
+      val works = (1 to 5).map { _ =>
+        createWorkStubWith(items = List(item))
+      }
+
+      val catalogueSource = new MockCatalogueSource(works: _*)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(SierraItemIdentifier(1111111))) {
+        _ shouldBe Some(
+          StacksItemIdentifier(
+            catalogueId = CatalogueItemIdentifier(item.id.get),
+            sierraId = SierraItemIdentifier(1111111)
+          )
+        )
+      }
+    }
+
+    it("errors if it finds multiple matching items") {
+      val catalogueId = createStacksItemIdentifier
+
+      val item1 = ItemStub(
+        id = Some(catalogueId.value),
+        identifiers = Some(List(createSierraIdentifier("1111111")))
+      )
+
+      val item2 = ItemStub(
+        id = Some(catalogueId.value),
+        identifiers = Some(List(createSierraIdentifier("22222222")))
+      )
+
+      val work = createWorkStubWith(items = List(item1, item2))
+
+      val catalogueSource = new MockCatalogueSource(work)
+      val service = new CatalogueService(catalogueSource)
+
+      whenReady(service.getStacksItem(catalogueId).failed) { err =>
+        err shouldBe a[Exception]
+        err.getMessage should startWith("Found multiple matching items for")
+      }
+    }
+  }
+
+  describe("handling errors from CatalogueSource") {
+    val getException = new Throwable("BOOM!")
+    val searchException = new Throwable("BANG!")
+
+    class BrokenCatalogueSource extends CatalogueSource {
+      override def getWorkStub(id: StacksWorkIdentifier): Future[WorkStub] =
+        Future.failed(getException)
+
+      override def getSearchStub(
+        identifier: Identifier[_]
+      ): Future[SearchStub] =
+        Future.failed(searchException)
+    }
+
+    val catalogueSource = new BrokenCatalogueSource()
+    val service = new CatalogueService(catalogueSource)
+
+    it("inside getAllStacksItems") {
+      whenReady(service.getAllStacksItems(createStacksWorkIdentifier).failed) {
+        _ shouldBe getException
+      }
+    }
+
+    it("inside getStacksItem") {
+      whenReady(service.getStacksItem(createStacksItemIdentifier).failed) {
+        _ shouldBe searchException
+      }
+    }
+  }
+
+  private def createSierraIdentifier(value: String): IdentifiersStub =
+    IdentifiersStub(
+      identifierType =
+        TypeStub(id = "sierra-identifier", label = "Sierra identifier"),
+      value = value
+    )
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/SierraServiceTest.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/SierraServiceTest.scala
@@ -1,0 +1,147 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import java.time.Instant
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.EitherValues
+import uk.ac.wellcome.platform.stacks.common.fixtures.ServicesFixture
+import uk.ac.wellcome.platform.stacks.common.models._
+import com.github.tomakehurst.wiremock.client.WireMock._
+
+class SierraServiceTest
+    extends AnyFunSpec
+    with ServicesFixture
+    with ScalaFutures
+    with IntegrationPatience
+    with EitherValues
+    with Matchers {
+
+  describe("SierraService") {
+    describe("getItemStatus") {
+      it("gets a StacksItemStatus") {
+        withSierraService {
+          case (sierraService, _) =>
+            val sierraItemIdentifier = SierraItemIdentifier(1601017)
+
+            whenReady(
+              sierraService.getItemStatus(sierraItemIdentifier)
+            ) { stacksItemStatus =>
+              stacksItemStatus shouldBe StacksItemStatus(
+                "available",
+                "Available"
+              )
+            }
+        }
+      }
+    }
+
+    describe("getStacksUserHolds") {
+      it("gets a StacksUserHolds") {
+        withSierraService {
+          case (sierraService, _) =>
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+
+            whenReady(
+              sierraService.getStacksUserHolds(stacksUserIdentifier)
+            ) { stacksUserHolds =>
+              stacksUserHolds shouldBe StacksUserHolds(
+                userId = "1234567",
+                holds = List(
+                  StacksHold(
+                    itemId = SierraItemIdentifier(1292185),
+                    pickup = StacksPickup(
+                      location = StacksPickupLocation(
+                        id = "sepbb",
+                        label = "Rare Materials Room"
+                      ),
+                      pickUpBy = Some(Instant.parse("2019-12-03T04:00:00Z"))
+                    ),
+                    status = StacksHoldStatus(
+                      id = "i",
+                      label = "item hold ready for pickup."
+                    )
+                  )
+                )
+              )
+            }
+        }
+      }
+    }
+
+    describe("placeHold") {
+      it("requests a hold from the Sierra API") {
+        withSierraService {
+          case (sierraService, wireMockServer) =>
+            val sierraItemIdentifier = SierraItemIdentifier(1601017)
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+            val neededBy = Some(
+              Instant.parse("2020-01-01T00:00:00.00Z")
+            )
+
+            whenReady(
+              sierraService.placeHold(
+                userIdentifier = stacksUserIdentifier,
+                sierraItemIdentifier = sierraItemIdentifier,
+                neededBy = neededBy
+              )
+            ) { _ =>
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
+                |{
+                |  "recordType" : "i",
+                |  "recordNumber" : 1601017,
+                |  "pickupLocation" : "unspecified",
+                |  "neededBy" : "2020-01-01"
+                |}
+                |""".stripMargin)
+                )
+              )
+            }
+        }
+      }
+
+      it("rejects a hold when the Sierra API errors indicating such") {
+        withSierraService {
+          case (sierraService, wireMockServer) =>
+            val sierraItemIdentifier = SierraItemIdentifier(1601018)
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+
+            whenReady(
+              sierraService.placeHold(
+                userIdentifier = stacksUserIdentifier,
+                sierraItemIdentifier = sierraItemIdentifier,
+                neededBy = None
+              )
+            ) { response =>
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
+                                |{
+                                |  "recordType" : "i",
+                                |  "recordNumber" : 1601018,
+                                |  "pickupLocation" : "unspecified"
+                                |}
+                                |""".stripMargin)
+                )
+              )
+
+              response shouldBe a[HoldRejected]
+            }
+        }
+      }
+    }
+  }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/StacksServiceTest.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/StacksServiceTest.scala
@@ -1,0 +1,160 @@
+package uk.ac.wellcome.platform.stacks.common.services
+
+import java.time.Instant
+
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlEqualTo
+}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.stacks.common.fixtures.ServicesFixture
+import uk.ac.wellcome.platform.stacks.common.models._
+
+class StacksServiceTest
+    extends AnyFunSpec
+    with ServicesFixture
+    with ScalaFutures
+    with IntegrationPatience
+    with Matchers {
+
+  describe("StacksService") {
+    describe("requestHoldOnItem") {
+      it("requests a hold from the Sierra API") {
+        withStacksService {
+          case (stacksService, wireMockServer) =>
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+            val catalogueItemIdentifier = CatalogueItemIdentifier("ys3ern6x")
+            val neededBy = Some(
+              Instant.parse("2020-01-01T00:00:00.00Z")
+            )
+
+            whenReady(
+              stacksService.requestHoldOnItem(
+                userIdentifier = stacksUserIdentifier,
+                catalogueItemId = catalogueItemIdentifier,
+                neededBy = neededBy
+              )
+            ) { response =>
+              response shouldBe a[HoldAccepted]
+
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
+                      |{
+                      |  "recordType" : "i",
+                      |  "recordNumber" : 1601017,
+                      |  "pickupLocation" : "unspecified",
+                      |  "neededBy" : "2020-01-01"
+                      |}
+                      |""".stripMargin)
+                )
+              )
+            }
+        }
+      }
+
+      it("returns a rejected hold if Sierra does the same") {
+        withStacksService {
+          case (stacksService, wireMockServer) =>
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+            val catalogueItemIdentifier = CatalogueItemIdentifier("ys3ern6y")
+
+            whenReady(
+              stacksService.requestHoldOnItem(
+                userIdentifier = stacksUserIdentifier,
+                catalogueItemId = catalogueItemIdentifier,
+                neededBy = None
+              )
+            ) { response =>
+              response shouldBe a[HoldRejected]
+
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
+                                |{
+                                |  "recordType" : "i",
+                                |  "recordNumber" : 1601018,
+                                |  "pickupLocation" : "unspecified"
+                                |}
+                                |""".stripMargin)
+                )
+              )
+            }
+        }
+      }
+    }
+
+    describe("getStacksWork") {
+      it("gets a StacksWork") {
+        withStacksService {
+          case (stacksService, _) =>
+            val workId = StacksWorkIdentifier("cnkv77md")
+
+            whenReady(
+              stacksService.getStacksWork(workId)
+            ) { stacksWork =>
+              stacksWork shouldBe StacksWork(
+                id = workId,
+                items = List(
+                  StacksItem(
+                    id = StacksItemIdentifier(
+                      catalogueId = CatalogueItemIdentifier("ys3ern6x"),
+                      sierraId = SierraItemIdentifier(1601017)
+                    ),
+                    status = StacksItemStatus("available", "Available")
+                  )
+                )
+              )
+            }
+        }
+      }
+    }
+
+    describe("getStacksUserHoldsWithStacksItemIdentifier") {
+      it("gets a StacksUserHolds[StacksItemIdentifier]") {
+        withStacksService {
+          case (stacksService, _) =>
+            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+
+            whenReady(
+              stacksService.getStacksUserHolds(
+                userId = stacksUserIdentifier
+              )
+            ) { stacksUserHolds =>
+              stacksUserHolds shouldBe StacksUserHolds(
+                userId = "1234567",
+                holds = List(
+                  StacksHold(
+                    itemId = StacksItemIdentifier(
+                      catalogueId = CatalogueItemIdentifier("n5v7b4md"),
+                      sierraId = SierraItemIdentifier(1292185)
+                    ),
+                    pickup = StacksPickup(
+                      location =
+                        StacksPickupLocation("sepbb", "Rare Materials Room"),
+                      pickUpBy = Some(Instant.parse("2019-12-03T04:00:00Z"))
+                    ),
+                    status =
+                      StacksHoldStatus("i", "item hold ready for pickup.")
+                  )
+                )
+              )
+            }
+        }
+      }
+    }
+  }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/source/AkkaCatalogueSourceTest.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/source/AkkaCatalogueSourceTest.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.stacks.common.services.source
+import org.scalatest.concurrent.IntegrationPatience
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.stacks.common.fixtures.AkkaCatalogueSourceFixture
+
+class AkkaCatalogueSourceTest
+    extends CatalogueSourceTestCases[AkkaCatalogueSource]
+    with AkkaCatalogueSourceFixture
+    with IntegrationPatience {
+  override def withCatalogueSource[R](
+    testWith: TestWith[AkkaCatalogueSource, R]
+  ): R =
+    withAkkaCatalogueSource { akkaCatalogueSource =>
+      testWith(akkaCatalogueSource)
+    }
+}

--- a/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/source/CatalogueSourceTestCases.scala
+++ b/api/stacks/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/source/CatalogueSourceTestCases.scala
@@ -1,0 +1,151 @@
+package uk.ac.wellcome.platform.stacks.common.services.source
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.stacks.common.models.{
+  SierraItemIdentifier,
+  StacksWorkIdentifier
+}
+import uk.ac.wellcome.platform.stacks.common.services.source.CatalogueSource._
+
+trait CatalogueSourceTestCases[CatalogueSourceImpl <: CatalogueSource]
+    extends AnyFunSpec
+    with Matchers
+    with ScalaFutures {
+  def withCatalogueSource[R](testWith: TestWith[CatalogueSourceImpl, R]): R
+
+  describe("behaves as a CatalogueSource") {
+    it("gets an individual work") {
+      withCatalogueSource { catalogueSource =>
+        val future =
+          catalogueSource.getWorkStub(id = StacksWorkIdentifier("ayzrznsz"))
+
+        val expectedWork = WorkStub(
+          id = "ayzrznsz",
+          items = List(
+            ItemStub(
+              id = Some("q2knsrhh"),
+              identifiers = Some(
+                List(
+                  IdentifiersStub(
+                    identifierType = TypeStub(
+                      id = "sierra-system-number",
+                      label = "Sierra system number"
+                    ),
+                    value = "i10938370"
+                  ),
+                  IdentifiersStub(
+                    identifierType = TypeStub(
+                      id = "sierra-identifier",
+                      label = "Sierra identifier"
+                    ),
+                    value = "1093837"
+                  )
+                )
+              )
+            )
+          )
+        )
+
+        whenReady(future) { _ shouldBe expectedWork }
+      }
+    }
+
+    it("handles a work without any items") {
+      withCatalogueSource { catalogueSource =>
+        val future =
+          catalogueSource.getWorkStub(id = StacksWorkIdentifier("a2284uhb"))
+
+        val expectedWork = WorkStub(id = "a2284uhb", items = List.empty)
+
+        whenReady(future) { _ shouldBe expectedWork }
+      }
+    }
+
+    it("handles a work where an item is not identified") {
+      withCatalogueSource { catalogueSource =>
+        val future =
+          catalogueSource.getWorkStub(id = StacksWorkIdentifier("a227dajt"))
+
+        val expectedWork = WorkStub(
+          id = "a227dajt",
+          items = List(
+            ItemStub(id = None, identifiers = None)
+          )
+        )
+
+        whenReady(future) { _ shouldBe expectedWork }
+      }
+    }
+
+    it("can search for an identifier") {
+      withCatalogueSource { catalogueSource =>
+        val future = catalogueSource.getSearchStub(
+          identifier = SierraItemIdentifier(1093837)
+        )
+
+        val expectedSearch = SearchStub(
+          totalResults = 2,
+          results = List(
+            WorkStub(
+              id = "aczz5tm3",
+              items = List(
+                ItemStub(
+                  id = Some("qkdy3h58"),
+                  identifiers = Some(
+                    List(
+                      IdentifiersStub(
+                        identifierType = TypeStub(
+                          id = "sierra-system-number",
+                          label = "Sierra system number"
+                        ),
+                        value = "i11088953"
+                      ),
+                      IdentifiersStub(
+                        identifierType = TypeStub(
+                          id = "sierra-identifier",
+                          label = "Sierra identifier"
+                        ),
+                        value = "1108895"
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            WorkStub(
+              id = "ayzrznsz",
+              items = List(
+                ItemStub(
+                  id = Some("q2knsrhh"),
+                  identifiers = Some(
+                    List(
+                      IdentifiersStub(
+                        identifierType = TypeStub(
+                          id = "sierra-system-number",
+                          label = "Sierra system number"
+                        ),
+                        value = "i10938370"
+                      ),
+                      IdentifiersStub(
+                        identifierType = TypeStub(
+                          id = "sierra-identifier",
+                          label = "Sierra identifier"
+                        ),
+                        value = "1093837"
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+
+        whenReady(future) { _ shouldBe expectedSearch }
+      }
+    }
+  }
+}

--- a/api/stacks/items_api/Dockerfile
+++ b/api/stacks/items_api/Dockerfile
@@ -1,0 +1,4 @@
+FROM wellcome/typesafe_config_base:edge
+ADD target/universal/stage /opt/docker
+
+ENV PROJECT=items_api

--- a/api/stacks/items_api/src/main/resources/application.conf
+++ b/api/stacks/items_api/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+http.externalBaseURL=${?app_base_url}
+http.host="0.0.0.0"
+http.port=9001
+contextURL=${?context_url}
+aws.metrics.namespace=${?metrics_namespace}
+sierra.api.key=${?sierra_api_key}
+sierra.api.secret=${?sierra_api_secret}
+catalogue.api.baseUrl=${?catalogue_base_url}
+sierra.api.baseUrl=${?sierra_base_url}

--- a/api/stacks/items_api/src/main/resources/logback.xml
+++ b/api/stacks/items_api/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+</configuration>

--- a/api/stacks/items_api/src/main/scala/uk/ac/wellcome/platform/stacks/items/api/ItemsApi.scala
+++ b/api/stacks/items_api/src/main/scala/uk/ac/wellcome/platform/stacks/items/api/ItemsApi.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.platform.stacks.items.api
+
+import akka.http.scaladsl.server.Route
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.stacks.common.models.display.DisplayStacksWork
+import uk.ac.wellcome.platform.stacks.common.models.{
+  StacksWork,
+  StacksWorkIdentifier
+}
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+trait ItemsApi extends Logging with FailFastCirceSupport {
+
+  import akka.http.scaladsl.server.Directives._
+  import io.circe.generic.auto._
+
+  implicit val ec: ExecutionContext
+  implicit val stacksWorkService: StacksService
+
+  val routes: Route = concat(
+    pathPrefix("works") {
+      path(Segment) { id: String =>
+        get {
+          val result: Future[StacksWork] =
+            stacksWorkService.getStacksWork(
+              StacksWorkIdentifier(id)
+            )
+
+          onComplete(result) {
+            case Success(value) => complete(DisplayStacksWork(value))
+            case Failure(err)   => failWith(err)
+          }
+        }
+      }
+    }
+  )
+}

--- a/api/stacks/items_api/src/main/scala/uk/ac/wellcome/platform/stacks/items/api/Main.scala
+++ b/api/stacks/items_api/src/main/scala/uk/ac/wellcome/platform/stacks/items/api/Main.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.stacks.items.api
+
+import java.net.URL
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
+import uk.ac.wellcome.platform.stacks.common.http.config.builders.HTTPServerBuilder
+import uk.ac.wellcome.platform.stacks.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+import uk.ac.wellcome.platform.stacks.common.services.config.builders.StacksServiceBuilder
+import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
+import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+
+import scala.concurrent.ExecutionContext
+
+object Main extends WellcomeTypesafeApp {
+  runWithConfig { config: Config =>
+    implicit val asMain: ActorSystem =
+      AkkaBuilder.buildActorSystem()
+
+    implicit val ecMain: ExecutionContext =
+      AkkaBuilder.buildExecutionContext()
+
+    val workService: StacksService = StacksServiceBuilder.build(config)
+
+    val router: ItemsApi = new ItemsApi {
+      override implicit val ec: ExecutionContext = ecMain
+      override implicit val stacksWorkService: StacksService = workService
+    }
+
+    val appName = "ItemsApi"
+
+    new WellcomeHttpApp(
+      routes = router.routes,
+      httpMetrics = new HttpMetrics(
+        name = appName,
+        metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
+      ),
+      httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),
+      contextURL =
+        new URL("https://api.wellcomecollection.org/stacks/v1/context.json"),
+      appName = appName
+    )
+  }
+}

--- a/api/stacks/items_api/src/test/resources/logback-test.xml
+++ b/api/stacks/items_api/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.jetty" level="INFO"/>
+</configuration>

--- a/api/stacks/items_api/src/test/scala/uk/ac/wellcome/platform/stacks/items/api/ItemsApiFeatureTest.scala
+++ b/api/stacks/items_api/src/test/scala/uk/ac/wellcome/platform/stacks/items/api/ItemsApiFeatureTest.scala
@@ -1,0 +1,50 @@
+package uk.ac.wellcome.platform.stacks.items.api
+
+import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.platform.stacks.items.api.fixtures.ItemsApiFixture
+
+class ItemsApiFeatureTest
+    extends AnyFunSpec
+    with Matchers
+    with ItemsApiFixture
+    with JsonAssertions
+    with IntegrationPatience {
+
+  describe("items") {
+    it("shows a user the items on a work") {
+      withApp { _ =>
+        val path = "/works/cnkv77md"
+
+        val expectedJson =
+          s"""
+             |{
+             |  "id" : "cnkv77md",
+             |  "items" : [
+             |    {
+             |      "id" : "ys3ern6x",
+             |      "status" : {
+             |        "id" : "available",
+             |        "label" : "Available",
+             |        "type": "ItemStatus"
+             |      },
+             |      "type": "Item"
+             |    }
+             |  ],
+             |  "type": "Work"
+             |}""".stripMargin
+
+        whenGetRequestReady(path) { response =>
+          response.status shouldBe StatusCodes.OK
+
+          withStringEntity(response.entity) { actualJson =>
+            assertJsonStringsAreEqual(actualJson, expectedJson)
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/stacks/items_api/src/test/scala/uk/ac/wellcome/platform/stacks/items/api/fixtures/ItemsApiFixture.scala
+++ b/api/stacks/items_api/src/test/scala/uk/ac/wellcome/platform/stacks/items/api/fixtures/ItemsApiFixture.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.stacks.items.api.fixtures
+
+import com.github.tomakehurst.wiremock.WireMockServer
+
+import java.net.URL
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.monitoring.memory.MemoryMetrics
+import uk.ac.wellcome.platform.stacks.common.fixtures.{
+  HttpFixtures,
+  ServicesFixture
+}
+import uk.ac.wellcome.platform.stacks.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+import uk.ac.wellcome.platform.stacks.items.api.ItemsApi
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait ItemsApiFixture extends ServicesFixture with HttpFixtures {
+
+  val metricsName = "ItemsApiFixture"
+
+  val contextURLTest = new URL(
+    "http://api.wellcomecollection.org/stacks/v1/context.json"
+  )
+
+  def withApp[R](testWith: TestWith[WireMockServer, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val httpMetrics = new HttpMetrics(
+        name = metricsName,
+        metrics = new MemoryMetrics()
+      )
+
+      withStacksService {
+        case (stacksService, server) =>
+          val router: ItemsApi = new ItemsApi {
+            override implicit val ec: ExecutionContext = global
+            override implicit val stacksWorkService: StacksService =
+              stacksService
+          }
+
+          val app = new WellcomeHttpApp(
+            routes = router.routes,
+            httpMetrics = httpMetrics,
+            httpServerConfig = httpServerConfigTest,
+            contextURL = contextURLTest,
+            appName = metricsName
+          )
+
+          app.run()
+
+          testWith(server)
+      }
+    }
+}

--- a/api/stacks/requests_api/Dockerfile
+++ b/api/stacks/requests_api/Dockerfile
@@ -1,0 +1,4 @@
+FROM wellcome/typesafe_config_base:edge
+ADD target/universal/stage /opt/docker
+
+ENV PROJECT=requests_api

--- a/api/stacks/requests_api/src/main/resources/application.conf
+++ b/api/stacks/requests_api/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+http.externalBaseURL=${?app_base_url}
+http.host="0.0.0.0"
+http.port=9001
+contextURL=${?context_url}
+aws.metrics.namespace=${?metrics_namespace}
+sierra.api.key=${?sierra_api_key}
+sierra.api.secret=${?sierra_api_secret}
+catalogue.api.baseUrl=${?catalogue_base_url}
+sierra.api.baseUrl=${?sierra_base_url}

--- a/api/stacks/requests_api/src/main/resources/logback.xml
+++ b/api/stacks/requests_api/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="LOGSTASH"/>
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="WARN"/>
+</configuration>

--- a/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/Main.scala
+++ b/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/Main.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.stacks.requests.api
+
+import java.net.URL
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
+import uk.ac.wellcome.platform.stacks.common.http.config.builders.HTTPServerBuilder
+import uk.ac.wellcome.platform.stacks.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+import uk.ac.wellcome.platform.stacks.common.services.config.builders.StacksServiceBuilder
+import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
+import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+
+import scala.concurrent.ExecutionContext
+
+object Main extends WellcomeTypesafeApp {
+  runWithConfig { config: Config =>
+    implicit val asMain: ActorSystem =
+      AkkaBuilder.buildActorSystem()
+
+    implicit val ecMain: ExecutionContext =
+      AkkaBuilder.buildExecutionContext()
+
+    val workService: StacksService = StacksServiceBuilder.build(config)
+
+    val router: RequestsApi = new RequestsApi {
+      override implicit val ec: ExecutionContext = ecMain
+      override implicit val stacksWorkService: StacksService = workService
+    }
+
+    val appName = "RequestsApi"
+
+    new WellcomeHttpApp(
+      routes = router.routes,
+      httpMetrics = new HttpMetrics(
+        name = appName,
+        metrics = CloudWatchBuilder.buildCloudWatchMetrics(config)
+      ),
+      httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),
+      contextURL =
+        new URL("https://api.wellcomecollection.org/stacks/v1/context.json"),
+      appName = appName
+    )
+  }
+}

--- a/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
+++ b/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
@@ -1,0 +1,76 @@
+package uk.ac.wellcome.platform.stacks.requests.api
+
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Route
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import grizzled.slf4j.Logging
+import io.circe.Printer
+import uk.ac.wellcome.platform.stacks.common.models.display.DisplayResultsList
+import uk.ac.wellcome.platform.stacks.common.models.{
+  CatalogueItemIdentifier,
+  StacksUserIdentifier
+}
+import uk.ac.wellcome.platform.stacks.common.services.{
+  HoldAccepted,
+  HoldRejected,
+  StacksService
+}
+import uk.ac.wellcome.platform.stacks.requests.api.models.Request
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+trait RequestsApi extends Logging with FailFastCirceSupport {
+
+  import akka.http.scaladsl.server.Directives._
+  import io.circe.generic.auto._
+
+  implicit val ec: ExecutionContext
+  implicit val stacksWorkService: StacksService
+
+  // Omit optional fields in response to clients
+  implicit val printer: Printer =
+    Printer.noSpaces.copy(dropNullValues = true)
+
+  val routes: Route = concat(
+    pathPrefix("requests") {
+      headerValueByName("Weco-Sierra-Patron-Id") {
+        sierraPatronId =>
+          val userIdentifier = StacksUserIdentifier(sierraPatronId)
+
+          post {
+            entity(as[Request]) {
+              requestItemHold: Request =>
+                val catalogueItemId =
+                  CatalogueItemIdentifier(requestItemHold.item.id)
+
+                val result = stacksWorkService.requestHoldOnItem(
+                  userIdentifier = userIdentifier,
+                  catalogueItemId = catalogueItemId,
+                  neededBy = requestItemHold.pickupDate
+                )
+
+                val accepted = (StatusCodes.Accepted, HttpEntity.Empty)
+                val conflict = (StatusCodes.Conflict, HttpEntity.Empty)
+
+                onComplete(result) {
+                  case Success(HoldAccepted(_)) => complete(accepted)
+                  case Success(HoldRejected(_)) => complete(conflict)
+                  case Failure(err)             => failWith(err)
+                }
+            }
+          } ~ get {
+
+            val result = stacksWorkService.getStacksUserHolds(
+              StacksUserIdentifier(sierraPatronId)
+            )
+
+            onComplete(result) {
+              case Success(value) => complete(DisplayResultsList(value))
+              case Failure(err)   => failWith(err)
+            }
+          }
+      }
+    }
+  )
+}

--- a/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/models/Request.scala
+++ b/api/stacks/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/models/Request.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.stacks.requests.api.models
+
+import java.time.Instant
+
+case class RequestItem(
+  id: String,
+  `type`: String
+)
+
+case class Request(
+  item: RequestItem,
+  pickupDate: Option[Instant],
+  `type`: String
+)

--- a/api/stacks/requests_api/src/test/resources/logback-test.xml
+++ b/api/stacks/requests_api/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.jetty" level="INFO"/>
+</configuration>

--- a/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
+++ b/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
@@ -146,22 +146,21 @@ class RequestsApiFeatureTest
     }
 
     it("responds with a 409 Conflict when a hold is rejected") {
-      withMaterializer { implicit mat =>
-        withApp { wireMockServer =>
-          val path = "/requests"
+      withApp { wireMockServer =>
+        val path = "/requests"
 
-          val headers = List(
-            HttpHeader
-              .parse(
-                name = "Weco-Sierra-Patron-Id",
-                value = "1234567"
-              )
-              .asInstanceOf[ParsingResult.Ok]
-              .header
-          )
+        val headers = List(
+          HttpHeader
+            .parse(
+              name = "Weco-Sierra-Patron-Id",
+              value = "1234567"
+            )
+            .asInstanceOf[ParsingResult.Ok]
+            .header
+        )
 
-          val entity = createJsonHttpEntityWith(
-            """
+        val entity = createJsonHttpEntityWith(
+          """
               |{
               |  "item": {
               |    "id": "ys3ern6y",
@@ -170,29 +169,28 @@ class RequestsApiFeatureTest
               |  "type": "Request"
               |}
               |""".stripMargin
-          )
+        )
 
-          whenPostRequestReady(path, entity, headers) { response =>
-            response.status shouldBe StatusCodes.Conflict
+        whenPostRequestReady(path, entity, headers) { response =>
+          response.status shouldBe StatusCodes.Conflict
 
-            wireMockServer.verify(
-              1,
-              postRequestedFor(
-                urlEqualTo(
-                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-                )
-              ).withRequestBody(
-                equalToJson("""
+          wireMockServer.verify(
+            1,
+            postRequestedFor(
+              urlEqualTo(
+                "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+              )
+            ).withRequestBody(
+              equalToJson("""
                     |{
                     |  "recordType" : "i",
                     |  "recordNumber" : 1601018,
                     |  "pickupLocation" : "unspecified"
                     |}
                     |""".stripMargin)
-              )
             )
+          )
 
-          }
         }
       }
     }

--- a/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
+++ b/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
@@ -1,0 +1,251 @@
+package uk.ac.wellcome.platform.stacks.requests.api
+
+import akka.http.scaladsl.model.HttpHeader.ParsingResult
+import akka.http.scaladsl.model.{HttpHeader, StatusCodes}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlEqualTo
+}
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.platform.stacks.requests.api.fixtures.RequestsApiFixture
+
+class RequestsApiFeatureTest
+    extends AnyFunSpec
+    with Matchers
+    with RequestsApiFixture
+    with JsonAssertions
+    with IntegrationPatience {
+
+  describe("requests") {
+    it("responds to requests containing an Weco-Sierra-Patron-Id header") {
+      withApp { _ =>
+        val path = "/requests"
+
+        val headers = List(
+          HttpHeader
+            .parse(
+              name = "Weco-Sierra-Patron-Id",
+              value = "1234567"
+            )
+            .asInstanceOf[ParsingResult.Ok]
+            .header
+        )
+
+        whenGetRequestReady(path, headers) { response =>
+          response.status shouldBe StatusCodes.OK
+        }
+      }
+    }
+
+    it("accepts requests to place a hold on an item with a pickupDate") {
+      withApp { wireMockServer =>
+        val path = "/requests"
+
+        val headers = List(
+          HttpHeader
+            .parse(
+              name = "Weco-Sierra-Patron-Id",
+              value = "1234567"
+            )
+            .asInstanceOf[ParsingResult.Ok]
+            .header
+        )
+
+        val entity = createJsonHttpEntityWith(
+          """
+            |{
+            |  "item": {
+            |    "id": "ys3ern6x",
+            |    "type": "Item"
+            |  },
+            |  "pickupDate": "2020-01-01T00:00:00Z",
+            |  "type": "Request"
+            |}
+            |""".stripMargin
+        )
+
+        whenPostRequestReady(path, entity, headers) { response =>
+          response.status shouldBe StatusCodes.Accepted
+
+          wireMockServer.verify(
+            1,
+            postRequestedFor(
+              urlEqualTo(
+                "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+              )
+            ).withRequestBody(
+              equalToJson("""
+                  |{
+                  |  "recordType" : "i",
+                  |  "recordNumber" : 1601017,
+                  |  "pickupLocation" : "unspecified",
+                  |  "neededBy" : "2020-01-01"
+                  |}
+                  |""".stripMargin)
+            )
+          )
+
+          response.entity.isKnownEmpty() shouldBe true
+        }
+      }
+    }
+
+    it("accepts requests to place a hold on an item without a pickupDate") {
+      withApp { wireMockServer =>
+        val path = "/requests"
+
+        val headers = List(
+          HttpHeader
+            .parse(
+              name = "Weco-Sierra-Patron-Id",
+              value = "1234567"
+            )
+            .asInstanceOf[ParsingResult.Ok]
+            .header
+        )
+
+        val entity = createJsonHttpEntityWith(
+          """
+            |{
+            |  "item": {
+            |    "id": "ys3ern6x",
+            |    "type": "Item"
+            |  },
+            |  "type": "Request"
+            |}
+            |""".stripMargin
+        )
+
+        whenPostRequestReady(path, entity, headers) { response =>
+          response.status shouldBe StatusCodes.Accepted
+
+          wireMockServer.verify(
+            1,
+            postRequestedFor(
+              urlEqualTo(
+                "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+              )
+            ).withRequestBody(
+              equalToJson("""
+                  |{
+                  |  "recordType" : "i",
+                  |  "recordNumber" : 1601017,
+                  |  "pickupLocation" : "unspecified"
+                  |}
+                  |""".stripMargin)
+            )
+          )
+
+          response.entity.isKnownEmpty() shouldBe true
+        }
+      }
+    }
+
+    it("responds with a 409 Conflict when a hold is rejected") {
+      withMaterializer { implicit mat =>
+        withApp { wireMockServer =>
+          val path = "/requests"
+
+          val headers = List(
+            HttpHeader
+              .parse(
+                name = "Weco-Sierra-Patron-Id",
+                value = "1234567"
+              )
+              .asInstanceOf[ParsingResult.Ok]
+              .header
+          )
+
+          val entity = createJsonHttpEntityWith(
+            """
+              |{
+              |  "item": {
+              |    "id": "ys3ern6y",
+              |    "type": "Item"
+              |  },
+              |  "type": "Request"
+              |}
+              |""".stripMargin
+          )
+
+          whenPostRequestReady(path, entity, headers) { response =>
+            response.status shouldBe StatusCodes.Conflict
+
+            wireMockServer.verify(
+              1,
+              postRequestedFor(
+                urlEqualTo(
+                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                )
+              ).withRequestBody(
+                equalToJson("""
+                    |{
+                    |  "recordType" : "i",
+                    |  "recordNumber" : 1601018,
+                    |  "pickupLocation" : "unspecified"
+                    |}
+                    |""".stripMargin)
+              )
+            )
+
+          }
+        }
+      }
+    }
+
+    it("provides information about a users' holds") {
+      withApp { _ =>
+        val path = "/requests"
+
+        val headers = List(
+          HttpHeader
+            .parse(
+              name = "Weco-Sierra-Patron-Id",
+              value = "1234567"
+            )
+            .asInstanceOf[ParsingResult.Ok]
+            .header
+        )
+
+        val expectedJson =
+          s"""
+             |{
+             |  "results" : [
+             |    {
+             |      "item" : {
+             |        "id" : "n5v7b4md",
+             |        "type" : "Item"
+             |      },
+             |      "pickupDate" : "2019-12-03T04:00:00Z",
+             |      "pickupLocation" : {
+             |        "id" : "sepbb",
+             |        "label" : "Rare Materials Room",
+             |        "type" : "LocationDescription"
+             |      },
+             |      "status" : {
+             |        "id" : "i",
+             |        "label" : "item hold ready for pickup.",
+             |        "type" : "RequestStatus"
+             |      },
+             |      "type" : "Request"
+             |    }
+             |  ],
+             |  "totalResults" : 1,
+             |  "type" : "ResultList"
+             |}""".stripMargin
+
+        whenGetRequestReady(path, headers) { response =>
+          response.status shouldBe StatusCodes.OK
+
+          withStringEntity(response.entity) { actualJson =>
+            assertJsonStringsAreEqual(actualJson, expectedJson)
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/fixtures/RequestsApiFixture.scala
+++ b/api/stacks/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/fixtures/RequestsApiFixture.scala
@@ -1,0 +1,55 @@
+package uk.ac.wellcome.platform.stacks.requests.api.fixtures
+
+import com.github.tomakehurst.wiremock.WireMockServer
+
+import java.net.URL
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.monitoring.memory.MemoryMetrics
+import uk.ac.wellcome.platform.stacks.common.fixtures.{
+  HttpFixtures,
+  ServicesFixture
+}
+import uk.ac.wellcome.platform.stacks.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.stacks.common.services.StacksService
+import uk.ac.wellcome.platform.stacks.requests.api.RequestsApi
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
+
+  val metricsName = "RequestsApiFixture"
+
+  val contextURLTest = new URL(
+    "http://api.wellcomecollection.org/requests/v1/context.json"
+  )
+
+  def withApp[R](testWith: TestWith[WireMockServer, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val httpMetrics = new HttpMetrics(
+        name = metricsName,
+        metrics = new MemoryMetrics
+      )
+
+      withStacksService {
+        case (stacksService, server) =>
+          val router: RequestsApi = new RequestsApi {
+            override implicit val ec: ExecutionContext = global
+            override implicit val stacksWorkService: StacksService =
+              stacksService
+          }
+
+          val app = new WellcomeHttpApp(
+            routes = router.routes,
+            httpMetrics = httpMetrics,
+            httpServerConfig = httpServerConfigTest,
+            contextURL = contextURLTest,
+            appName = metricsName
+          )
+
+          app.run()
+
+          testWith(server)
+      }
+    }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,27 @@ lazy val api = setupProject(
   externalDependencies = CatalogueDependencies.apiDependencies
 )
 
+lazy val stacks_common = setupProject(
+  project,
+  "api/stacks/common",
+  localDependencies = Seq(display),
+  externalDependencies = CatalogueDependencies.stacksDependencies
+)
+
+lazy val items_api = setupProject(
+  project,
+  "api/stacks/items_api",
+  localDependencies = Seq(stacks_common),
+  externalDependencies = CatalogueDependencies.stacksDependencies
+)
+
+lazy val requests_api = setupProject(
+  project,
+  "api/stacks/requests_api",
+  localDependencies = Seq(stacks_common),
+  externalDependencies = CatalogueDependencies.stacksDependencies
+)
+
 lazy val id_minter = setupProject(
   project,
   "pipeline/id_minter",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -247,6 +247,15 @@ object CatalogueDependencies {
       WellcomeDependencies.elasticsearchTypesafeLibrary ++
       WellcomeDependencies.typesafeLibrary
 
+  val stacksDependencies: Seq[ModuleID] =
+    ExternalDependencies.akkaHttpDependencies ++
+      ExternalDependencies.scalatestDependencies ++
+      ExternalDependencies.wireMockDependencies ++
+      WellcomeDependencies.jsonLibrary ++
+      WellcomeDependencies.monitoringLibrary ++
+      WellcomeDependencies.typesafeLibrary ++
+      WellcomeDependencies.monitoringLibrary
+
   val idminterDependencies: Seq[ModuleID] =
     ExternalDependencies.mySqlDependencies ++
       ExternalDependencies.circeOpticsDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,6 +49,11 @@ object WellcomeDependencies {
     version = versions.monitoring
   )
 
+  val monitoringTypesafeLibrary: Seq[ModuleID] = monitoringLibrary ++ library(
+    name = "monitoring_typesafe",
+    version = versions.monitoring
+  )
+
   val storageLibrary: Seq[ModuleID] = library(
     name = "storage",
     version = versions.storage
@@ -252,7 +257,7 @@ object CatalogueDependencies {
       ExternalDependencies.scalatestDependencies ++
       ExternalDependencies.wireMockDependencies ++
       WellcomeDependencies.jsonLibrary ++
-      WellcomeDependencies.monitoringLibrary ++
+      WellcomeDependencies.monitoringTypesafeLibrary ++
       WellcomeDependencies.typesafeLibrary ++
       WellcomeDependencies.monitoringLibrary
 


### PR DESCRIPTION
Adding the stacks code to the catalogue repo in preparation for consuming catalogue models / logic.

This change just adds the code / verifies it will compile & pass tests.

Future PRs will address infrastructure and deployment.