### PR TITLE
Use the matcher result time for works after the merger

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/matcher/MatcherResult.scala
@@ -22,14 +22,3 @@ case class MatcherResult(
   works: Set[MatchedIdentifiers],
   createdTime: Instant
 )
-
-case object MatcherResult {
-  // Note: I could achieve this by putting a default in the case class, but
-  // doing it this way means I can "Find Usages" on this method to find callers
-  // that *don't* explicitly set the correct time.
-  //
-  // This method will only last as long as https://github.com/wellcomecollection/platform/issues/5132,
-  // after which it can be deleted -- all uses should be setting the time explicitly.
-  def apply(works: Set[MatchedIdentifiers]): MatcherResult =
-    MatcherResult(works = works, createdTime = Instant.now())
-}

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -1,11 +1,13 @@
 package uk.ac.wellcome.pipeline_storage
 
+import grizzled.slf4j.Logging
+
 import scala.collection.mutable
 import scala.concurrent.Future
 
 class MemoryIndexer[T: Indexable](
   val index: mutable.Map[String, T] = mutable.Map[String, T]())
-    extends Indexer[T] {
+    extends Indexer[T] with Logging {
 
   def init(): Future[Unit] =
     Future.successful(())
@@ -15,6 +17,8 @@ class MemoryIndexer[T: Indexable](
       index.get(indexable.id(doc)) match {
         case Some(storedDoc)
             if indexable.version(storedDoc) > indexable.version(doc) =>
+          info(
+            s"Skipping ${indexable.id(doc)} because already indexed item has a higher version")
           ()
         case _ => index.put(indexable.id(doc), doc)
       }

--- a/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
+++ b/common/pipeline_storage/src/main/scala/uk/ac/wellcome/pipeline_storage/MemoryIndexer.scala
@@ -7,7 +7,8 @@ import scala.concurrent.Future
 
 class MemoryIndexer[T: Indexable](
   val index: mutable.Map[String, T] = mutable.Map[String, T]())
-    extends Indexer[T] with Logging {
+    extends Indexer[T]
+    with Logging {
 
   def init(): Future[Unit] =
     Future.successful(())

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -67,25 +67,24 @@ class MergerWorkerService[WorkDestination, ImageDestination](
         fromJson[MatcherResult](message.body)
       )
 
-      workSets <-
-        getWorkSets(matcherResult)
-          .map(workSets => workSets.filter(_.flatten.nonEmpty))
+      workSets <- getWorkSets(matcherResult)
+        .map(workSets => workSets.filter(_.flatten.nonEmpty))
 
       result = workSets match {
         case Nil => Nil
         case workSets =>
-          workSets.flatMap(ws =>
-            // We use the matcher result time as the "modified" time on
-            // the merged works, because it reflects the last time the
-            // matcher inspected the connections between these works.
-            //
-            // We *cannot* rely on the modified times of the individual
-            // works -- this may cause us to drop updates if works
-            // get unlinked.
-            //
-            // See https://github.com/wellcomecollection/docs/tree/8d83d75aba89ead23559584db2533e95ceb09200/rfcs/038-matcher-versioning
-            applyMerge(ws, matcherResult.createdTime)
-          )
+          workSets.flatMap(
+            ws =>
+              // We use the matcher result time as the "modified" time on
+              // the merged works, because it reflects the last time the
+              // matcher inspected the connections between these works.
+              //
+              // We *cannot* rely on the modified times of the individual
+              // works -- this may cause us to drop updates if works
+              // get unlinked.
+              //
+              // See https://github.com/wellcomecollection/docs/tree/8d83d75aba89ead23559584db2533e95ceb09200/rfcs/038-matcher-versioning
+              applyMerge(ws, matcherResult.createdTime))
       }
     } yield result
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerService.scala
@@ -74,8 +74,18 @@ class MergerWorkerService[WorkDestination, ImageDestination](
       result = workSets match {
         case Nil => Nil
         case workSets =>
-          val lastUpdated = getLastUpdated(workSets)
-          workSets.flatMap(workSet => applyMerge(workSet, lastUpdated))
+          workSets.flatMap(ws =>
+            // We use the matcher result time as the "modified" time on
+            // the merged works, because it reflects the last time the
+            // matcher inspected the connections between these works.
+            //
+            // We *cannot* rely on the modified times of the individual
+            // works -- this may cause us to drop updates if works
+            // get unlinked.
+            //
+            // See https://github.com/wellcomecollection/docs/tree/8d83d75aba89ead23559584db2533e95ceb09200/rfcs/038-matcher-versioning
+            applyMerge(ws, matcherResult.createdTime)
+          )
       }
     } yield result
 
@@ -87,19 +97,14 @@ class MergerWorkerService[WorkDestination, ImageDestination](
     }
 
   private def applyMerge(workSet: WorkSet,
-                         lastUpdated: Instant): Seq[WorkOrImage] =
+                         matcherResultTime: Instant): Seq[WorkOrImage] =
     mergerManager
       .applyMerge(maybeWorks = workSet)
-      .mergedWorksAndImagesWithTime(lastUpdated)
+      .mergedWorksAndImagesWithTime(matcherResultTime)
 
   private def sendWorkOrImage(workOrImage: WorkOrImage): Try[Unit] =
     workOrImage match {
       case Left(work)   => workMsgSender.send(workIndexable.id(work))
       case Right(image) => imageMsgSender.send(imageIndexable.id(image))
     }
-
-  private def getLastUpdated(workSets: List[WorkSet]): Instant =
-    workSets
-      .flatMap(_.flatten.map(work => work.state.modifiedTime))
-      .max
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -1,256 +1,76 @@
 package uk.ac.wellcome.platform.merger
 
-import org.scalatest.GivenWhenThen
-import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
-import uk.ac.wellcome.platform.merger.fixtures.FeatureTestSugar
-import uk.ac.wellcome.platform.merger.services.PlatformMerger
-import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{Format, MergeCandidate}
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.pipeline_storage.MemoryRetriever
+import uk.ac.wellcome.platform.merger.fixtures.WorkerServiceFixture
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 
-class MergerFeatureTest
-    extends AnyFeatureSpec
-    with GivenWhenThen
-    with Matchers
-    with FeatureTestSugar
-    with SourceWorkGenerators {
-  val merger = PlatformMerger
+import java.time.Instant
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
 
-  /*
-   * We test field-level behaviour in the rule tests, and have to replicate it
-   * in the PlatformMergerTest. This obscures the top-level merging behaviour
-   * which has led to confusion about intended/desired/actual behaviour.
-   *
-   * These feature tests are intended to be simple smoke tests of merging
-   * behaviour which are most valuable as documentation of our intentions.
-   */
-  Feature("Top-level merging") {
-    Scenario("One Sierra and multiple Miro works are matched") {
-      Given("a Sierra work and 3 Miro works")
-      val sierra = sierraPhysicalIdentifiedWork()
-      val miro1 = miroIdentifiedWork()
-      val miro2 = miroIdentifiedWork()
-      val miro3 = miroIdentifiedWork()
+class MergerFeatureTest extends AnyFunSpec with Matchers with WorkGenerators with WorkerServiceFixture {
+  it("switches how a pair of works care matched") {
+    // This test case is based on a real example of four Works that were
+    // being matched correctly.  In particular, we had some Sanskrit manuscripts
+    // where the METS work and e-bib were paired incorrectly.
+    //
+    // This led us to tweak how the merger assigns the "modifiedDate"
+    // on the Works it creates.
+    //
+    // This is a feature test rather than a scenario test because we have
+    // to simulate an exact sequence of actions around SQS ordering.
+    //
+    // This is based on the worked example described in RFC 038:
+    // https://github.com/wellcomecollection/docs/tree/8d83d75aba89ead23559584db2533e95ceb09200/rfcs/038-matcher-versioning#the-problem-a-worked-example
 
-      When("the works are merged")
-      val outcome = merger.merge(Seq(sierra, miro1, miro2, miro3))
+    val idA = id('A')
+    val idB = id('B')
+    val idC = id('C')
+    val idD = id('D')
 
-      Then("the Miro works are redirected to the Sierra work")
-      outcome.getMerged(miro1) should beRedirectedTo(sierra)
-      outcome.getMerged(miro2) should beRedirectedTo(sierra)
-      outcome.getMerged(miro3) should beRedirectedTo(sierra)
+    // 1) Start with four works, all created at time t = 0.  Assume further that
+    // they have already been processed by the matcher/merger at time t = 0.
+    val workA_t0 = identifiedWork(canonicalId = idA, modifiedTime = time(t = 0))
+    val workB_t0 = identifiedWork(canonicalId = idB, modifiedTime = time(t = 0))
+    val workC_t0 = identifiedWork(canonicalId = idC, modifiedTime = time(t = 0))
+    val workD_t0 = identifiedWork(canonicalId = idD, modifiedTime = time(t = 0))
 
-      And("images are created from the Miro works")
-      outcome.imageData should contain(miro1.singleImage)
-      outcome.imageData should contain(miro2.singleImage)
-      outcome.imageData should contain(miro3.singleImage)
+    val index = mutable.Map[String, WorkOrImage](
+      idA.underlying -> Left(workA_t0.transition[Merged](time(t = 0))),
+      idB.underlying -> Left(workB_t0.transition[Merged](time(t = 0))),
+      idC.underlying -> Left(workC_t0.transition[Merged](time(t = 0))),
+      idD.underlying -> Left(workD_t0.transition[Merged](time(t = 0))),
+    )
 
-      And("the merged Sierra work's images contain all of the images")
-      val mergedImages = outcome.getMerged(sierra).data.imageData
-      mergedImages should contain(miro1.singleImage)
-      mergedImages should contain(miro2.singleImage)
-      mergedImages should contain(miro3.singleImage)
-    }
+    // TODO: Can we use a CanonicalId in the retriever?
+    val retriever = new MemoryRetriever[Work[Identified]](
+      index = mutable.Map[String, Work[Identified]](
+        idA.underlying -> workA_t0,
+        idB.underlying -> workB_t0,
+        idC.underlying -> workC_t0,
+        idD.underlying -> workD_t0,
+      )
+    )
 
-    Scenario("One Sierra and one Miro work are matched") {
-      Given("a Sierra work and a Miro work")
-      val sierra = sierraPhysicalIdentifiedWork()
-      val miro = miroIdentifiedWork()
+    val workSender = new MemoryMessageSender
 
-      When("the works are merged")
-      val outcome = merger.merge(Seq(sierra, miro))
-
-      Then("the Miro work is redirected to the Sierra work")
-      outcome.getMerged(miro) should beRedirectedTo(sierra)
-
-      And("an image is created from the Miro work")
-      outcome.imageData should contain only miro.singleImage
-
-      And("the merged Sierra work contains the image")
-      outcome
-        .getMerged(sierra)
-        .data
-        .imageData should contain only miro.singleImage
-    }
-
-    Scenario("A Sierra picture or ephemera work and METS work are matched") {
-      Given("a Sierra picture or ephemera work and a METS work")
-      val sierraPicture = sierraIdentifiedWork()
-        .items(List(createIdentifiedPhysicalItem))
-        .format(Format.Pictures)
-      val sierraEphemera = sierraIdentifiedWork()
-        .items(List(createIdentifiedPhysicalItem))
-        .format(Format.Ephemera)
-      val mets = metsIdentifiedWork()
-
-      When("the works are merged")
-      val pictureOutcome = merger.merge(Seq(sierraPicture, mets))
-      val ephemeraOutcome = merger.merge(Seq(sierraEphemera, mets))
-
-      Then("the METS work is redirected to the Sierra work")
-      pictureOutcome.getMerged(mets) should beRedirectedTo(sierraPicture)
-      ephemeraOutcome.getMerged(mets) should beRedirectedTo(sierraEphemera)
-
-      And("an image is created from the METS work")
-      pictureOutcome.imageData should contain only mets.singleImage
-      ephemeraOutcome.imageData should contain only mets.singleImage
-
-      And("the merged Sierra work contains the image")
-      pictureOutcome
-        .getMerged(sierraPicture)
-        .data
-        .imageData should contain only mets.singleImage
-      ephemeraOutcome
-        .getMerged(sierraEphemera)
-        .data
-        .imageData should contain only mets.singleImage
-    }
-
-    Scenario("An AIDS poster Sierra picture, a METS and a Miro are matched") {
-      Given(
-        "a Sierra picture with digcode `digaids`, a METS work and a Miro work")
-      val sierraDigaidsPicture = sierraIdentifiedWork()
-        .items(List(createIdentifiedPhysicalItem))
-        .format(Format.Pictures)
-        .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
-      val mets = metsIdentifiedWork()
-      val miro = miroIdentifiedWork()
-
-      When("the works are merged")
-      val outcome = merger.merge(Seq(sierraDigaidsPicture, mets, miro))
-
-      Then("the METS work and the Miro work are redirected to the Sierra work")
-      outcome.getMerged(mets) should beRedirectedTo(sierraDigaidsPicture)
-      outcome.getMerged(miro) should beRedirectedTo(sierraDigaidsPicture)
-
-      And("the Sierra work contains only the METS images")
-      outcome
-        .getMerged(sierraDigaidsPicture)
-        .data
-        .imageData should contain only mets.singleImage
-    }
-
-    Scenario("A physical and a digital Sierra work are matched") {
-      Given("a pair of a physical Sierra work and a digital Sierra work")
-      val (digitalSierra, physicalSierra) = sierraIdentifiedWorkPair()
-
-      When("the works are merged")
-      val outcome = merger.merge(Seq(physicalSierra, digitalSierra))
-
-      Then("the digital work is redirected to the physical work")
-      outcome.getMerged(digitalSierra) should beRedirectedTo(physicalSierra)
-
-      And("the physical work contains the digitised work's identifiers")
-      val physicalIdentifiers = outcome.getMerged(physicalSierra).identifiers
-      physicalIdentifiers should contain allElementsOf digitalSierra.identifiers
-    }
-
-    Scenario("Audiovisual Sierra works are not merged") {
-      Given("a physical Sierra AV work and its digitised counterpart")
-      val digitisedVideo =
-        sierraDigitalIdentifiedWork().format(Format.EVideos)
-
-      val physicalVideo =
-        sierraPhysicalIdentifiedWork()
-          .format(Format.Videos)
-          .mergeCandidates(
-            List(
-              MergeCandidate(
-                id = IdState.Identified(
-                  sourceIdentifier = digitisedVideo.sourceIdentifier,
-                  canonicalId = digitisedVideo.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
-              )
-            )
-          )
-
-      When("the works are merged")
-      val outcome = merger.merge(Seq(physicalVideo, digitisedVideo))
-
-      Then("both original works are preserved")
-      outcome.resultWorks should contain theSameElementsAs Seq(
-        physicalVideo,
-        digitisedVideo)
-    }
-
-    Scenario("A Calm work and a Sierra work are matched") {
-      Given("a Sierra work and a Calm work")
-      val sierra = sierraPhysicalIdentifiedWork()
-      val calm = calmIdentifiedWork()
-
-      When("the works are merged")
-      val outcome = merger.merge(Seq(sierra, calm))
-
-      Then("the Sierra work is redirected to the Calm work")
-      outcome.getMerged(sierra) should beRedirectedTo(calm)
-
-      And("the Calm work contains the Sierra item ID")
-      val calmItem = outcome.getMerged(calm).data.items.head
-      calmItem.id shouldBe sierra.data.items.head.id
-    }
-
-    Scenario("A digitised video with Sierra physical records and e-bibs") {
-      // This test case is based on a real example of four related works that
-      // were being merged incorrectly.  In particular, the METS work (and associated
-      // IIIF manifest) was being merged into the physical video formats, not the
-      // more detailed e-bib that it should have been attached to.
-      //
-      // See https://wellcome.slack.com/archives/C3TQSF63C/p1615474389063800
-      Given("a Sierra physical record, an e-bib, and a METS work")
-      val workWithPhysicalVideoFormats =
-        sierraIdentifiedWork()
-          .title("A work with physical video formats, e.g. DVD or digibeta")
-          .format(Format.Film)
-          .items(List(createIdentifiedPhysicalItem))
-
-      val workForEbib =
-        sierraIdentifiedWork()
-          .title("A work for an e-bib")
-          .format(Format.Videos)
-          .mergeCandidates(
-            List(
-              MergeCandidate(
-                id = IdState.Identified(
-                  canonicalId = workWithPhysicalVideoFormats.state.canonicalId,
-                  sourceIdentifier =
-                    workWithPhysicalVideoFormats.sourceIdentifier
-                ),
-                reason = Some("Physical/digitised Sierra work")
-              )
-            )
-          )
-
-      val workForMets =
-        identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
-          .title("A METS work")
-          .mergeCandidates(
-            List(
-              MergeCandidate(
-                id = IdState.Identified(
-                  canonicalId = workForEbib.state.canonicalId,
-                  sourceIdentifier = workForEbib.sourceIdentifier
-                ),
-                reason = Some("METS work")
-              )
-            )
-          )
-          .items(List(createDigitalItem))
-          .invisible()
-
-      When("the works are merged")
-      val sierraWorks = List(workWithPhysicalVideoFormats, workForEbib)
-      val works = sierraWorks :+ workForMets
-      val outcome = merger.merge(works)
-
-      Then("the METS work is redirected to the Sierra e-bib")
-      outcome.getMerged(workForMets) should beRedirectedTo(workForEbib)
-
-      And("the Sierra e-bib gets the items from the METS work")
-      outcome.getMerged(workForEbib).data.items shouldBe workForMets.data.items
-
-      And("the Sierra physical work is unaffected")
-      outcome.getMerged(workWithPhysicalVideoFormats) shouldBe workWithPhysicalVideoFormats
+    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+      withWorkerService(retriever, queue, workSender, index = index) { _ =>
+        true shouldBe true
+      }
     }
   }
+
+  private def id(c: Char): CanonicalId =
+    CanonicalId(c.toString * 8)
+
+  private def time(t: Int): Instant =
+    Instant.ofEpochSecond(t)
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -121,7 +121,7 @@ class MergerFeatureTest
 
         val storedTimes_t5 = getModifiedTimes(index)
         existingTimes_t5.foreach { case (id, time) =>
-          storedTimes_t5(id) shouldBe >=(time)
+          storedTimes_t5(id) shouldBe >(time)
         }
 
         index(idD.underlying).left.value.data.title shouldBe Some("I was updated at t = 4")
@@ -157,7 +157,7 @@ class MergerFeatureTest
 
         val storedTimes_t6 = getModifiedTimes(index)
         existingTimes_t6.foreach { case (id, time) =>
-          storedTimes_t6(id) shouldBe >=(time)
+          storedTimes_t6(id) shouldBe >(time)
         }
 
         index(idA.underlying).left.value.data.title shouldBe Some("I was updated at t = 1")
@@ -183,8 +183,8 @@ class MergerFeatureTest
         storedTimes_t7(idA) shouldBe existingTimes_t7(idA)
         storedTimes_t7(idD) shouldBe existingTimes_t7(idD)
 
-        storedTimes_t7(idB) shouldBe >=(existingTimes_t7(idB))
-        storedTimes_t7(idC) shouldBe >=(existingTimes_t7(idC))
+        storedTimes_t7(idB) shouldBe >(existingTimes_t7(idB))
+        storedTimes_t7(idC) shouldBe >(existingTimes_t7(idC))
 
         index(idB.underlying).left.value.data.title shouldBe Some("I was updated at t = 2")
       }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -28,7 +28,7 @@ class MergerFeatureTest
     with Eventually
     with EitherValues
     with IntegrationPatience {
-  it("switches how a pair of works care matched") {
+  it("switches how a pair of works are matched") {
     // This test case is based on a real example of four Works that were
     // being matched correctly.  In particular, we had some Sanskrit manuscripts
     // where the METS work and e-bib were paired incorrectly.
@@ -181,7 +181,7 @@ class MergerFeatureTest
 
         val storedTimes_t7 = getModifiedTimes(index)
         storedTimes_t7(idA) shouldBe existingTimes_t7(idA)
-        storedTimes_t7(idC) shouldBe existingTimes_t7(idC)
+        storedTimes_t7(idD) shouldBe existingTimes_t7(idD)
 
         storedTimes_t7(idB) shouldBe >=(existingTimes_t7(idB))
         storedTimes_t7(idC) shouldBe >=(existingTimes_t7(idC))

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.pipeline_storage.MemoryRetriever
-import uk.ac.wellcome.platform.merger.fixtures.{MatcherResultFixture, WorkerServiceFixture}
+import uk.ac.wellcome.platform.merger.fixtures.{
+  MatcherResultFixture,
+  WorkerServiceFixture
+}
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
@@ -20,7 +23,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MergerFeatureTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with WorkGenerators
     with WorkerServiceFixture
@@ -78,116 +81,129 @@ class MergerFeatureTest
 
     val workSender = new MemoryMessageSender
 
-    withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-      withWorkerService(retriever, queue, workSender, index = index) { _ =>
+    withLocalSqsQueuePair() {
+      case QueuePair(queue, dlq) =>
+        withWorkerService(retriever, queue, workSender, index = index) { _ =>
+          // 2) Now we update all four works at times t=1, t=2, t=3 and t=4.
+          // However, due to best-effort ordering, we don't process these updates
+          // in the correct order.
+          val workA_t1 =
+            identifiedWork(canonicalId = idA, modifiedTime = time(t = 1))
+              .title("I was updated at t = 1")
+          val workB_t2 =
+            identifiedWork(canonicalId = idB, modifiedTime = time(t = 2))
+              .title("I was updated at t = 2")
+          val workC_t3 =
+            identifiedWork(canonicalId = idC, modifiedTime = time(t = 3))
+              .title("I was updated at t = 3")
+          val workD_t4 =
+            identifiedWork(canonicalId = idD, modifiedTime = time(t = 4))
+              .title("I was updated at t = 4")
 
-        // 2) Now we update all four works at times t=1, t=2, t=3 and t=4.
-        // However, due to best-effort ordering, we don't process these updates
-        // in the correct order.
-        val workA_t1 = identifiedWork(canonicalId = idA, modifiedTime = time(t = 1))
-          .title("I was updated at t = 1")
-        val workB_t2 = identifiedWork(canonicalId = idB, modifiedTime = time(t = 2))
-          .title("I was updated at t = 2")
-        val workC_t3 = identifiedWork(canonicalId = idC, modifiedTime = time(t = 3))
-          .title("I was updated at t = 3")
-        val workD_t4 = identifiedWork(canonicalId = idD, modifiedTime = time(t = 4))
-          .title("I was updated at t = 4")
+          // 3) Suppose the update to D gets processed by the matcher at
+          // time t=5, and it matches all four works together.
+          //
+          //      A ---> B
+          //      ^
+          //      |
+          //      v
+          //      D <--- C
+          //
+          // Send the corresponding matcher result to SQS.  Check that all four works
+          // get updated.
+          retriever.index(idD.underlying) = workD_t4
 
-        // 3) Suppose the update to D gets processed by the matcher at
-        // time t=5, and it matches all four works together.
-        //
-        //      A ---> B
-        //      ^
-        //      |
-        //      v
-        //      D <--- C
-        //
-        // Send the corresponding matcher result to SQS.  Check that all four works
-        // get updated.
-        retriever.index(idD.underlying) = workD_t4
+          val matcherResult_t5 = MatcherResult(
+            works =
+              Set(matchedIdentifiers(workA_t0, workB_t0, workC_t0, workD_t4)),
+            createdTime = time(t = 5)
+          )
 
-        val matcherResult_t5 = MatcherResult(
-          works = Set(matchedIdentifiers(workA_t0, workB_t0, workC_t0, workD_t4)),
-          createdTime = time(t = 5)
-        )
+          val existingTimes_t5 = getModifiedTimes(index)
+          sendNotificationToSQS(queue, matcherResult_t5)
 
-        val existingTimes_t5 = getModifiedTimes(index)
-        sendNotificationToSQS(queue, matcherResult_t5)
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+          }
 
-        eventually {
-          assertQueueEmpty(queue)
-          assertQueueEmpty(dlq)
+          val storedTimes_t5 = getModifiedTimes(index)
+          existingTimes_t5.foreach {
+            case (id, time) =>
+              storedTimes_t5(id) shouldBe >(time)
+          }
+
+          index(idD.underlying).left.value.data.title shouldBe Some(
+            "I was updated at t = 4")
+
+          true shouldBe true
+
+          // 4) Now suppose the updates to A and C get processed by the matcher
+          // at time t = 6.
+          //
+          //      A      B
+          //      ^      ^
+          //      |      |
+          //      v      v
+          //      D      C
+          //
+          // As before, send the matcher result to SQS and check that all four works
+          // get updated.
+          retriever.index(idA.underlying) = workA_t1
+          retriever.index(idC.underlying) = workC_t3
+
+          val matcherResult_t6 = MatcherResult(
+            works = Set(
+              matchedIdentifiers(workA_t1, workD_t4),
+              matchedIdentifiers(workB_t0, workC_t3)),
+            createdTime = time(t = 6)
+          )
+
+          val existingTimes_t6 = getModifiedTimes(index)
+          sendNotificationToSQS(queue, matcherResult_t6)
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+          }
+
+          val storedTimes_t6 = getModifiedTimes(index)
+          existingTimes_t6.foreach {
+            case (id, time) =>
+              storedTimes_t6(id) shouldBe >(time)
+          }
+
+          index(idA.underlying).left.value.data.title shouldBe Some(
+            "I was updated at t = 1")
+          index(idC.underlying).left.value.data.title shouldBe Some(
+            "I was updated at t = 3")
+
+          // 5) Now suppose we finally process the update to B at time t=7.
+          retriever.index(idB.underlying) = workB_t2
+
+          val matcherResult_t7 = MatcherResult(
+            works = Set(matchedIdentifiers(workB_t2, workC_t3)),
+            createdTime = time(t = 7)
+          )
+
+          val existingTimes_t7 = getModifiedTimes(index)
+          sendNotificationToSQS(queue, matcherResult_t7)
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueEmpty(dlq)
+          }
+
+          val storedTimes_t7 = getModifiedTimes(index)
+          storedTimes_t7(idA) shouldBe existingTimes_t7(idA)
+          storedTimes_t7(idD) shouldBe existingTimes_t7(idD)
+
+          storedTimes_t7(idB) shouldBe >(existingTimes_t7(idB))
+          storedTimes_t7(idC) shouldBe >(existingTimes_t7(idC))
+
+          index(idB.underlying).left.value.data.title shouldBe Some(
+            "I was updated at t = 2")
         }
-
-        val storedTimes_t5 = getModifiedTimes(index)
-        existingTimes_t5.foreach { case (id, time) =>
-          storedTimes_t5(id) shouldBe >(time)
-        }
-
-        index(idD.underlying).left.value.data.title shouldBe Some("I was updated at t = 4")
-
-        true shouldBe true
-
-        // 4) Now suppose the updates to A and C get processed by the matcher
-        // at time t = 6.
-        //
-        //      A      B
-        //      ^      ^
-        //      |      |
-        //      v      v
-        //      D      C
-        //
-        // As before, send the matcher result to SQS and check that all four works
-        // get updated.
-        retriever.index(idA.underlying) = workA_t1
-        retriever.index(idC.underlying) = workC_t3
-
-        val matcherResult_t6 = MatcherResult(
-          works = Set(matchedIdentifiers(workA_t1, workD_t4), matchedIdentifiers(workB_t0, workC_t3)),
-          createdTime = time(t = 6)
-        )
-
-        val existingTimes_t6 = getModifiedTimes(index)
-        sendNotificationToSQS(queue, matcherResult_t6)
-
-        eventually {
-          assertQueueEmpty(queue)
-          assertQueueEmpty(dlq)
-        }
-
-        val storedTimes_t6 = getModifiedTimes(index)
-        existingTimes_t6.foreach { case (id, time) =>
-          storedTimes_t6(id) shouldBe >(time)
-        }
-
-        index(idA.underlying).left.value.data.title shouldBe Some("I was updated at t = 1")
-        index(idC.underlying).left.value.data.title shouldBe Some("I was updated at t = 3")
-
-        // 5) Now suppose we finally process the update to B at time t=7.
-        retriever.index(idB.underlying) = workB_t2
-
-        val matcherResult_t7 = MatcherResult(
-          works = Set(matchedIdentifiers(workB_t2, workC_t3)),
-          createdTime = time(t = 7)
-        )
-
-        val existingTimes_t7 = getModifiedTimes(index)
-        sendNotificationToSQS(queue, matcherResult_t7)
-
-        eventually {
-          assertQueueEmpty(queue)
-          assertQueueEmpty(dlq)
-        }
-
-        val storedTimes_t7 = getModifiedTimes(index)
-        storedTimes_t7(idA) shouldBe existingTimes_t7(idA)
-        storedTimes_t7(idD) shouldBe existingTimes_t7(idD)
-
-        storedTimes_t7(idB) shouldBe >(existingTimes_t7(idB))
-        storedTimes_t7(idC) shouldBe >(existingTimes_t7(idC))
-
-        index(idB.underlying).left.value.data.title shouldBe Some("I was updated at t = 2")
-      }
     }
   }
 
@@ -200,7 +216,8 @@ class MergerFeatureTest
   private def matchedIdentifiers(works: Work[Identified]*): MatchedIdentifiers =
     MatchedIdentifiers(worksToWorkIdentifiers(works))
 
-  private def getModifiedTimes(index: mutable.Map[String, WorkOrImage]): Map[CanonicalId, Instant] =
+  private def getModifiedTimes(
+    index: mutable.Map[String, WorkOrImage]): Map[CanonicalId, Instant] =
     index.values.collect {
       case Left(work) => work.state.canonicalId -> work.state.modifiedTime
     }.toMap

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
@@ -1,0 +1,256 @@
+package uk.ac.wellcome.platform.merger
+
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
+import uk.ac.wellcome.platform.merger.fixtures.FeatureTestSugar
+import uk.ac.wellcome.platform.merger.services.PlatformMerger
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{Format, MergeCandidate}
+
+class MergerScenarioTest
+    extends AnyFeatureSpec
+    with GivenWhenThen
+    with Matchers
+    with FeatureTestSugar
+    with SourceWorkGenerators {
+  val merger = PlatformMerger
+
+  /*
+   * We test field-level behaviour in the rule tests, and have to replicate it
+   * in the PlatformMergerTest. This obscures the top-level merging behaviour
+   * which has led to confusion about intended/desired/actual behaviour.
+   *
+   * These feature tests are intended to be simple smoke tests of merging
+   * behaviour which are most valuable as documentation of our intentions.
+   */
+  Feature("Top-level merging") {
+    Scenario("One Sierra and multiple Miro works are matched") {
+      Given("a Sierra work and 3 Miro works")
+      val sierra = sierraPhysicalIdentifiedWork()
+      val miro1 = miroIdentifiedWork()
+      val miro2 = miroIdentifiedWork()
+      val miro3 = miroIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierra, miro1, miro2, miro3))
+
+      Then("the Miro works are redirected to the Sierra work")
+      outcome.getMerged(miro1) should beRedirectedTo(sierra)
+      outcome.getMerged(miro2) should beRedirectedTo(sierra)
+      outcome.getMerged(miro3) should beRedirectedTo(sierra)
+
+      And("images are created from the Miro works")
+      outcome.imageData should contain(miro1.singleImage)
+      outcome.imageData should contain(miro2.singleImage)
+      outcome.imageData should contain(miro3.singleImage)
+
+      And("the merged Sierra work's images contain all of the images")
+      val mergedImages = outcome.getMerged(sierra).data.imageData
+      mergedImages should contain(miro1.singleImage)
+      mergedImages should contain(miro2.singleImage)
+      mergedImages should contain(miro3.singleImage)
+    }
+
+    Scenario("One Sierra and one Miro work are matched") {
+      Given("a Sierra work and a Miro work")
+      val sierra = sierraPhysicalIdentifiedWork()
+      val miro = miroIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierra, miro))
+
+      Then("the Miro work is redirected to the Sierra work")
+      outcome.getMerged(miro) should beRedirectedTo(sierra)
+
+      And("an image is created from the Miro work")
+      outcome.imageData should contain only miro.singleImage
+
+      And("the merged Sierra work contains the image")
+      outcome
+        .getMerged(sierra)
+        .data
+        .imageData should contain only miro.singleImage
+    }
+
+    Scenario("A Sierra picture or ephemera work and METS work are matched") {
+      Given("a Sierra picture or ephemera work and a METS work")
+      val sierraPicture = sierraIdentifiedWork()
+        .items(List(createIdentifiedPhysicalItem))
+        .format(Format.Pictures)
+      val sierraEphemera = sierraIdentifiedWork()
+        .items(List(createIdentifiedPhysicalItem))
+        .format(Format.Ephemera)
+      val mets = metsIdentifiedWork()
+
+      When("the works are merged")
+      val pictureOutcome = merger.merge(Seq(sierraPicture, mets))
+      val ephemeraOutcome = merger.merge(Seq(sierraEphemera, mets))
+
+      Then("the METS work is redirected to the Sierra work")
+      pictureOutcome.getMerged(mets) should beRedirectedTo(sierraPicture)
+      ephemeraOutcome.getMerged(mets) should beRedirectedTo(sierraEphemera)
+
+      And("an image is created from the METS work")
+      pictureOutcome.imageData should contain only mets.singleImage
+      ephemeraOutcome.imageData should contain only mets.singleImage
+
+      And("the merged Sierra work contains the image")
+      pictureOutcome
+        .getMerged(sierraPicture)
+        .data
+        .imageData should contain only mets.singleImage
+      ephemeraOutcome
+        .getMerged(sierraEphemera)
+        .data
+        .imageData should contain only mets.singleImage
+    }
+
+    Scenario("An AIDS poster Sierra picture, a METS and a Miro are matched") {
+      Given(
+        "a Sierra picture with digcode `digaids`, a METS work and a Miro work")
+      val sierraDigaidsPicture = sierraIdentifiedWork()
+        .items(List(createIdentifiedPhysicalItem))
+        .format(Format.Pictures)
+        .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
+      val mets = metsIdentifiedWork()
+      val miro = miroIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierraDigaidsPicture, mets, miro))
+
+      Then("the METS work and the Miro work are redirected to the Sierra work")
+      outcome.getMerged(mets) should beRedirectedTo(sierraDigaidsPicture)
+      outcome.getMerged(miro) should beRedirectedTo(sierraDigaidsPicture)
+
+      And("the Sierra work contains only the METS images")
+      outcome
+        .getMerged(sierraDigaidsPicture)
+        .data
+        .imageData should contain only mets.singleImage
+    }
+
+    Scenario("A physical and a digital Sierra work are matched") {
+      Given("a pair of a physical Sierra work and a digital Sierra work")
+      val (digitalSierra, physicalSierra) = sierraIdentifiedWorkPair()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(physicalSierra, digitalSierra))
+
+      Then("the digital work is redirected to the physical work")
+      outcome.getMerged(digitalSierra) should beRedirectedTo(physicalSierra)
+
+      And("the physical work contains the digitised work's identifiers")
+      val physicalIdentifiers = outcome.getMerged(physicalSierra).identifiers
+      physicalIdentifiers should contain allElementsOf digitalSierra.identifiers
+    }
+
+    Scenario("Audiovisual Sierra works are not merged") {
+      Given("a physical Sierra AV work and its digitised counterpart")
+      val digitisedVideo =
+        sierraDigitalIdentifiedWork().format(Format.EVideos)
+
+      val physicalVideo =
+        sierraPhysicalIdentifiedWork()
+          .format(Format.Videos)
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = digitisedVideo.sourceIdentifier,
+                  canonicalId = digitisedVideo.state.canonicalId),
+                reason = Some("Physical/digitised Sierra work")
+              )
+            )
+          )
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(physicalVideo, digitisedVideo))
+
+      Then("both original works are preserved")
+      outcome.resultWorks should contain theSameElementsAs Seq(
+        physicalVideo,
+        digitisedVideo)
+    }
+
+    Scenario("A Calm work and a Sierra work are matched") {
+      Given("a Sierra work and a Calm work")
+      val sierra = sierraPhysicalIdentifiedWork()
+      val calm = calmIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierra, calm))
+
+      Then("the Sierra work is redirected to the Calm work")
+      outcome.getMerged(sierra) should beRedirectedTo(calm)
+
+      And("the Calm work contains the Sierra item ID")
+      val calmItem = outcome.getMerged(calm).data.items.head
+      calmItem.id shouldBe sierra.data.items.head.id
+    }
+
+    Scenario("A digitised video with Sierra physical records and e-bibs") {
+      // This test case is based on a real example of four related works that
+      // were being merged incorrectly.  In particular, the METS work (and associated
+      // IIIF manifest) was being merged into the physical video formats, not the
+      // more detailed e-bib that it should have been attached to.
+      //
+      // See https://wellcome.slack.com/archives/C3TQSF63C/p1615474389063800
+      Given("a Sierra physical record, an e-bib, and a METS work")
+      val workWithPhysicalVideoFormats =
+        sierraIdentifiedWork()
+          .title("A work with physical video formats, e.g. DVD or digibeta")
+          .format(Format.Film)
+          .items(List(createIdentifiedPhysicalItem))
+
+      val workForEbib =
+        sierraIdentifiedWork()
+          .title("A work for an e-bib")
+          .format(Format.Videos)
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  canonicalId = workWithPhysicalVideoFormats.state.canonicalId,
+                  sourceIdentifier =
+                    workWithPhysicalVideoFormats.sourceIdentifier
+                ),
+                reason = Some("Physical/digitised Sierra work")
+              )
+            )
+          )
+
+      val workForMets =
+        identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+          .title("A METS work")
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  canonicalId = workForEbib.state.canonicalId,
+                  sourceIdentifier = workForEbib.sourceIdentifier
+                ),
+                reason = Some("METS work")
+              )
+            )
+          )
+          .items(List(createDigitalItem))
+          .invisible()
+
+      When("the works are merged")
+      val sierraWorks = List(workWithPhysicalVideoFormats, workForEbib)
+      val works = sierraWorks :+ workForMets
+      val outcome = merger.merge(works)
+
+      Then("the METS work is redirected to the Sierra e-bib")
+      outcome.getMerged(workForMets) should beRedirectedTo(workForEbib)
+
+      And("the Sierra e-bib gets the items from the METS work")
+      outcome.getMerged(workForEbib).data.items shouldBe workForMets.data.items
+
+      And("the Sierra physical work is unaffected")
+      outcome.getMerged(workWithPhysicalVideoFormats) shouldBe workWithPhysicalVideoFormats
+    }
+  }
+}

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/MatcherResultFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/MatcherResultFixture.scala
@@ -9,7 +9,7 @@ import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work.Work
 
 trait MatcherResultFixture {
-  def matcherResultWith(matchedEntries: Set[Set[Work[Identified]]]) =
+  def createMatcherResultWith(matchedEntries: Set[Set[Work[Identified]]]) =
     MatcherResult(
       matchedEntries.map { works =>
         MatchedIdentifiers(worksToWorkIdentifiers(works))

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/MatcherResultFixture.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/fixtures/MatcherResultFixture.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.merger.fixtures
 
+import uk.ac.wellcome.fixtures.RandomGenerators
 import uk.ac.wellcome.models.matcher.{
   MatchedIdentifiers,
   MatcherResult,
@@ -8,12 +9,13 @@ import uk.ac.wellcome.models.matcher.{
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work.Work
 
-trait MatcherResultFixture {
+trait MatcherResultFixture extends RandomGenerators {
   def createMatcherResultWith(matchedEntries: Set[Set[Work[Identified]]]) =
     MatcherResult(
-      matchedEntries.map { works =>
+      works = matchedEntries.map { works =>
         MatchedIdentifiers(worksToWorkIdentifiers(works))
-      }
+      },
+      createdTime = randomInstant
     )
 
   def worksToWorkIdentifiers(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.models.Implicits._
-import uk.ac.wellcome.models.matcher.{MatchedIdentifiers, MatcherResult}
 import uk.ac.wellcome.monitoring.memory.MemoryMetrics
 import uk.ac.wellcome.platform.merger.fixtures.{
   MatcherResultFixture,
@@ -202,11 +201,7 @@ class MergerWorkerServiceTest
           physicalWork.id -> physicalWork,
           digitisedWork.id -> digitisedWork)
 
-        val matcherResult = MatcherResult(
-          Set(
-            MatchedIdentifiers(worksToWorkIdentifiers(works))
-          )
-        )
+        val matcherResult = createMatcherResultWith(Set(works.toSet))
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 
@@ -250,11 +245,7 @@ class MergerWorkerServiceTest
           digitisedWork.id -> digitisedWork,
           miroWork.id -> miroWork)
 
-        val matcherResult = MatcherResult(
-          Set(
-            MatchedIdentifiers(worksToWorkIdentifiers(works))
-          )
-        )
+        val matcherResult = createMatcherResultWith(Set(works.toSet))
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 
@@ -312,11 +303,12 @@ class MergerWorkerServiceTest
           digitisedWork2.id -> digitisedWork2
         )
 
-        val matcherResult = MatcherResult(
+        val matcherResult = createMatcherResultWith(
           Set(
-            MatchedIdentifiers(worksToWorkIdentifiers(workPair1)),
-            MatchedIdentifiers(worksToWorkIdentifiers(workPair2))
-          ))
+            workPair1.toSet,
+            workPair2.toSet
+          )
+        )
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 
@@ -360,11 +352,9 @@ class MergerWorkerServiceTest
           deletedWork.id -> deletedWork
         )
 
-        val matcherResult = MatcherResult(
-          Set(
-            MatchedIdentifiers(
-              worksToWorkIdentifiers(List(visibleWork, deletedWork)))
-          ))
+        val matcherResult = createMatcherResultWith(
+          Set(Set(visibleWork, deletedWork))
+        )
 
         sendNotificationToSQS(queue = queue, message = matcherResult)
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -42,7 +42,7 @@ class MergerWorkerServiceTest
         val work3 = identifiedWork(modifiedTime = latestUpdate - (2 days))
 
         val matcherResult =
-          matcherResultWith(Set(Set(work3), Set(work1, work2)))
+          createMatcherResultWith(Set(Set(work3), Set(work1, work2)))
 
         retriever.index ++= Map(
           work1.id -> work1,
@@ -82,7 +82,7 @@ class MergerWorkerServiceTest
       case (retriever, QueuePair(queue, dlq), senders, metrics, index) =>
         val work = identifiedWork().invisible()
 
-        val matcherResult = matcherResultWith(Set(Set(work)))
+        val matcherResult = createMatcherResultWith(Set(Set(work)))
 
         retriever.index ++= Map(work.id -> work)
 
@@ -111,7 +111,7 @@ class MergerWorkerServiceTest
       case (_, QueuePair(queue, dlq), senders, metrics, _) =>
         val work = identifiedWork()
 
-        val matcherResult = matcherResultWith(Set(Set(work)))
+        val matcherResult = createMatcherResultWith(Set(Set(work)))
 
         sendNotificationToSQS(
           queue = queue,
@@ -139,7 +139,7 @@ class MergerWorkerServiceTest
           identifiedWork(canonicalId = olderWork.state.canonicalId)
             .withVersion(olderWork.version + 1)
 
-        val matcherResult = matcherResultWith(Set(Set(work, olderWork)))
+        val matcherResult = createMatcherResultWith(Set(Set(work, olderWork)))
 
         retriever.index ++= Map(work.id -> work, newerWork.id -> newerWork)
 
@@ -169,7 +169,7 @@ class MergerWorkerServiceTest
           identifiedWork(canonicalId = versionZeroWork.state.canonicalId)
             .withVersion(1)
 
-        val matcherResult = matcherResultWith(Set(Set(work, versionZeroWork)))
+        val matcherResult = createMatcherResultWith(Set(Set(work, versionZeroWork)))
 
         retriever.index ++= Map(work.id -> work)
 
@@ -409,7 +409,7 @@ class MergerWorkerServiceTest
         val work0 = identifiedWork().withVersion(0)
         val work1 = identifiedWork(canonicalId = work0.state.canonicalId)
           .withVersion(1)
-        val matcherResult = matcherResultWith(Set(Set(work0)))
+        val matcherResult = createMatcherResultWith(Set(Set(work0)))
         retriever.index ++= Map(work1.id -> work1)
 
         sendNotificationToSQS(

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerWorkerServiceTest.scala
@@ -63,9 +63,12 @@ class MergerWorkerServiceTest
           )
 
           index shouldBe Map(
-            work1.id -> Left(work1.transition[Merged](matcherResult.createdTime)),
-            work2.id -> Left(work2.transition[Merged](matcherResult.createdTime)),
-            work3.id -> Left(work3.transition[Merged](matcherResult.createdTime))
+            work1.id -> Left(
+              work1.transition[Merged](matcherResult.createdTime)),
+            work2.id -> Left(
+              work2.transition[Merged](matcherResult.createdTime)),
+            work3.id -> Left(
+              work3.transition[Merged](matcherResult.createdTime))
           )
 
           metrics.incrementedCounts.length should be >= 1
@@ -166,7 +169,8 @@ class MergerWorkerServiceTest
           identifiedWork(canonicalId = versionZeroWork.state.canonicalId)
             .withVersion(1)
 
-        val matcherResult = createMatcherResultWith(Set(Set(work, versionZeroWork)))
+        val matcherResult =
+          createMatcherResultWith(Set(Set(work, versionZeroWork)))
 
         retriever.index ++= Map(work.id -> work)
 


### PR DESCRIPTION
The second half of https://github.com/wellcomecollection/platform/issues/5132

This PR implements the merger versioning scheme described in [RFC 038](https://github.com/wellcomecollection/docs/tree/master/rfcs/038-matcher-versioning). I've already deployed a matcher that sends messages with a `createdTime`; this PR updates the merger to pay attention to it.

Previously: the merger would use `max(w.modifiedTime for w in works)` as the modifiedTime when it created works and images. This caused some weird edge cases when works get unlinked and the pipeline became unable to update them because it "remembers" what they used to be linked to.

Now: the merger uses the time when the matcher processed these works.

I've included a feature test that reproduces the worked example from the RFC, and confirmed that it fails without this patch.