### PR TITLE
Add support for order records to the Sierra adapter

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/Implicits.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/Implicits.scala
@@ -25,11 +25,17 @@ object Implicits {
   implicit val holdingsNumberKeyEncoder: KeyEncoder[SierraHoldingsNumber] =
     (key: SierraHoldingsNumber) => key.withoutCheckDigit
 
+  implicit val orderNumberKeyEncoder: KeyEncoder[SierraOrderNumber] =
+    (key: SierraOrderNumber) => key.withoutCheckDigit
+
   implicit val itemNumberKeyDecoder: KeyDecoder[SierraItemNumber] =
     (key: String) => Some(new SierraItemNumber(key))
 
   implicit val holdingsNumberKeyDecoder: KeyDecoder[SierraHoldingsNumber] =
     (key: String) => Some(new SierraHoldingsNumber(key))
+
+  implicit val orderNumberKeyDecoder: KeyDecoder[SierraOrderNumber] =
+    (key: String) => Some(new SierraOrderNumber(key))
 
   // We have Sierra record numbers stored in three formats:
   //
@@ -72,6 +78,9 @@ object Implicits {
   implicit val bibNumberDecoder: Decoder[SierraBibNumber] =
     createDecoder(new SierraBibNumber(_))
 
+  implicit val orderNumberDecoder: Decoder[SierraOrderNumber] =
+    createDecoder(new SierraOrderNumber(_))
+
   implicit val typedSierraRecordNumberEncoder
     : Encoder[TypedSierraRecordNumber] =
     (number: TypedSierraRecordNumber) =>
@@ -86,13 +95,18 @@ object Implicits {
   implicit val bibNumberEncoder: Encoder[SierraBibNumber] =
     (number: SierraBibNumber) => Json.fromString(number.withoutCheckDigit)
 
+  implicit val orderNumberEncoder: Encoder[SierraOrderNumber] =
+    (number: SierraOrderNumber) => Json.fromString(number.withoutCheckDigit)
+
   implicit val _dec01: Decoder[SierraItemRecord] = deriveConfiguredDecoder
   implicit val _dec02: Decoder[SierraHoldingsRecord] = deriveConfiguredDecoder
   implicit val _dec03: Decoder[SierraBibRecord] = deriveConfiguredDecoder
-  implicit val _dec04: Decoder[SierraTransformable] = deriveConfiguredDecoder
+  implicit val _dec04: Decoder[SierraOrderRecord] = deriveConfiguredDecoder
+  implicit val _dec05: Decoder[SierraTransformable] = deriveConfiguredDecoder
 
   implicit val _enc01: Encoder[SierraItemRecord] = deriveConfiguredEncoder
   implicit val _enc02: Encoder[SierraHoldingsRecord] = deriveConfiguredEncoder
   implicit val _enc03: Encoder[SierraBibRecord] = deriveConfiguredEncoder
-  implicit val _enc04: Encoder[SierraTransformable] = deriveConfiguredEncoder
+  implicit val _enc04: Encoder[SierraOrderRecord] = deriveConfiguredEncoder
+  implicit val _enc05: Encoder[SierraTransformable] = deriveConfiguredEncoder
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraOrderRecord.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraOrderRecord.scala
@@ -1,0 +1,47 @@
+package weco.catalogue.source_model.sierra
+
+import java.time.Instant
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.util.{Failure, Success}
+
+case class SierraOrderRecord(
+  id: SierraOrderNumber,
+  data: String,
+  modifiedDate: Instant,
+  bibIds: List[SierraBibNumber],
+  unlinkedBibIds: List[SierraBibNumber] = List()
+) extends AbstractSierraRecord[SierraOrderNumber]
+
+case object SierraOrderRecord {
+  private case class SierraAPIData(bibs: List[String])
+
+  /** This apply method is for parsing JSON bodies that come from the
+   * Sierra API.
+   */
+  def apply(id: String,
+            data: String,
+            modifiedDate: Instant): SierraOrderRecord = {
+    val bibIds = fromJson[SierraAPIData](data) match {
+      // The Sierra API returns bibs on orders as a list of URLs,
+      // e.g. https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1459609
+      //
+      // For now, just split on slashes and take the final part.
+      case Success(apiData) =>
+        apiData.bibs.map { url =>
+          assert(url.startsWith("https://libsys.wellcomelibrary.org/iii/sierra-api"))
+          SierraBibNumber(url.split("/").last)
+        }
+      case Failure(e) =>
+        throw new IllegalArgumentException(
+          s"Error parsing bibIds from JSON <<$data>> ($e)")
+    }
+
+    SierraOrderRecord(
+      id = SierraOrderNumber(id),
+      data = data,
+      modifiedDate = modifiedDate,
+      bibIds = bibIds
+    )
+  }
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraOrderRecord.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraOrderRecord.scala
@@ -17,8 +17,8 @@ case object SierraOrderRecord {
   private case class SierraAPIData(bibs: List[String])
 
   /** This apply method is for parsing JSON bodies that come from the
-   * Sierra API.
-   */
+    * Sierra API.
+    */
   def apply(id: String,
             data: String,
             modifiedDate: Instant): SierraOrderRecord = {
@@ -29,7 +29,8 @@ case object SierraOrderRecord {
       // For now, just split on slashes and take the final part.
       case Success(apiData) =>
         apiData.bibs.map { url =>
-          assert(url.startsWith("https://libsys.wellcomelibrary.org/iii/sierra-api"))
+          assert(
+            url.startsWith("https://libsys.wellcomelibrary.org/iii/sierra-api"))
           SierraBibNumber(url.split("/").last)
         }
       case Failure(e) =>

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
@@ -135,7 +135,7 @@ object SierraHoldingsNumber {
 }
 
 class SierraOrderNumber(val recordNumber: String)
-  extends TypedSierraRecordNumber {
+    extends TypedSierraRecordNumber {
   val recordType: SierraRecordTypes.Value = SierraRecordTypes.orders
 }
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraRecordNumber.scala
@@ -1,7 +1,7 @@
 package weco.catalogue.source_model.sierra
 
 object SierraRecordTypes extends Enumeration {
-  val bibs, items, holdings = Value
+  val bibs, items, holdings, orders = Value
 }
 
 trait SierraRecordNumber {
@@ -32,6 +32,7 @@ sealed trait TypedSierraRecordNumber extends SierraRecordNumber {
       case SierraRecordTypes.bibs     => "b"
       case SierraRecordTypes.items    => "i"
       case SierraRecordTypes.holdings => "c" // for "checkin"
+      case SierraRecordTypes.orders   => "o"
       case _ =>
         throw new RuntimeException(
           s"Received unrecognised record type: $recordType"
@@ -131,4 +132,13 @@ class SierraHoldingsNumber(val recordNumber: String)
 
 object SierraHoldingsNumber {
   def apply(number: String) = new SierraHoldingsNumber(number)
+}
+
+class SierraOrderNumber(val recordNumber: String)
+  extends TypedSierraRecordNumber {
+  val recordType: SierraRecordTypes.Value = SierraRecordTypes.orders
+}
+
+object SierraOrderNumber {
+  def apply(number: String) = new SierraOrderNumber(number)
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -4,7 +4,8 @@ case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,
   itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map(),
-  holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map()
+  holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map(),
+  orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map()
 )
 
 object SierraTransformable {
@@ -12,5 +13,4 @@ object SierraTransformable {
     SierraTransformable(
       sierraId = bibRecord.id,
       maybeBibRecord = Some(bibRecord))
-
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
@@ -154,7 +154,9 @@ trait SierraGenerators extends RandomGenerators {
                                modifiedDate: Instant,
                                bibIds: List[SierraBibNumber]): String = {
     val urls =
-      bibIds.map { id => s"https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/$id" }
+      bibIds.map { id =>
+        s"https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/$id"
+      }
 
     s"""
        |{

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
@@ -133,8 +133,8 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraTransformableWith(
     sierraId: SierraBibNumber = createSierraBibNumber,
     maybeBibRecord: Option[SierraBibRecord] = Some(createSierraBibRecord),
-    itemRecords: List[SierraItemRecord] = List(),
-    holdingsRecords: List[SierraHoldingsRecord] = List()
+    itemRecords: Seq[SierraItemRecord] = List(),
+    holdingsRecords: Seq[SierraHoldingsRecord] = List()
   ): SierraTransformable =
     SierraTransformable(
       sierraId = sierraId,

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
@@ -33,6 +33,9 @@ trait SierraGenerators extends RandomGenerators {
   def createSierraHoldingsNumber: SierraHoldingsNumber =
     SierraHoldingsNumber(createSierraRecordNumberString)
 
+  def createSierraOrderNumber: SierraOrderNumber =
+    SierraOrderNumber(createSierraRecordNumberString)
+
   protected def createTitleVarfield(
     title: String = s"title-${randomAlphanumeric()}"): String =
     s"""
@@ -106,6 +109,25 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
+  def createSierraOrderRecordWith(
+    id: SierraOrderNumber = createSierraOrderNumber,
+    data: (SierraOrderNumber, Instant, List[SierraBibNumber]) => String =
+      defaultOrderData,
+    modifiedDate: Instant = Instant.now,
+    bibIds: List[SierraBibNumber] = List(),
+    unlinkedBibIds: List[SierraBibNumber] = List()
+  ): SierraOrderRecord = {
+    val recordData = data(id, modifiedDate, bibIds)
+
+    SierraOrderRecord(
+      id = id,
+      data = recordData,
+      modifiedDate = modifiedDate,
+      bibIds = bibIds,
+      unlinkedBibIds = unlinkedBibIds
+    )
+  }
+
   private def defaultItemData(id: SierraItemNumber,
                               modifiedDate: Instant,
                               bibIds: List[SierraBibNumber]): String =
@@ -128,13 +150,29 @@ trait SierraGenerators extends RandomGenerators {
        |}
        |""".stripMargin
 
+  private def defaultOrderData(id: SierraOrderNumber,
+                               modifiedDate: Instant,
+                               bibIds: List[SierraBibNumber]): String = {
+    val urls =
+      bibIds.map { id => s"https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/$id" }
+
+    s"""
+       |{
+       |  "id": $id,
+       |  "updatedDate": "${modifiedDate.toString}",
+       |  "bibs": ${toJson(urls).get}
+       |}
+       |""".stripMargin
+  }
+
   def createSierraItemRecord: SierraItemRecord = createSierraItemRecordWith()
 
   def createSierraTransformableWith(
     sierraId: SierraBibNumber = createSierraBibNumber,
     maybeBibRecord: Option[SierraBibRecord] = Some(createSierraBibRecord),
     itemRecords: Seq[SierraItemRecord] = List(),
-    holdingsRecords: Seq[SierraHoldingsRecord] = List()
+    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
+    orderRecords: Seq[SierraOrderRecord] = List()
   ): SierraTransformable =
     SierraTransformable(
       sierraId = sierraId,
@@ -143,6 +181,9 @@ trait SierraGenerators extends RandomGenerators {
         record.id -> record
       }.toMap,
       holdingsRecords = holdingsRecords.map { record =>
+        record.id -> record
+      }.toMap,
+      orderRecords = orderRecords.map { record =>
         record.id -> record
       }.toMap
     )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraOrderRecordTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraOrderRecordTest.scala
@@ -1,0 +1,44 @@
+package weco.catalogue.source_model.sierra
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class SierraOrderRecordTest extends AnyFunSpec with Matchers {
+  it("gets the bib IDs from Sierra JSON") {
+    val jsonString =
+      """
+        |{
+        |  "accountingUnit": 0,
+        |  "bibs": [
+        |    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/2000002",
+        |    "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/3000003"
+        |  ],
+        |  "chargedFunds": [],
+        |  "createdDate": "2000-03-07T14:07:14Z",
+        |  "estimatedPrice": 18.95,
+        |  "fixedFields": {},
+        |  "id": 1000002,
+        |  "orderDate": "2000-03-07T00:00:00Z",
+        |  "suppressed": false,
+        |  "updatedDate": "2010-03-16T19:23:48Z",
+        |  "varFields": [],
+        |  "vendorRecordCode": "c"
+        |}
+        |""".stripMargin
+
+    val record = SierraOrderRecord(
+      id = "1000002",
+      data = jsonString,
+      modifiedDate = Instant.parse("2010-03-16T19:23:48Z")
+    )
+
+    record shouldBe SierraOrderRecord(
+      id = SierraOrderNumber("1000002"),
+      data = jsonString,
+      modifiedDate = Instant.parse("2010-03-16T19:23:48Z"),
+      bibIds = List(SierraBibNumber("2000002"), SierraBibNumber("3000003"))
+    )
+  }
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
@@ -23,7 +23,7 @@ class SierraTransformableTest
   it("allows looking up items by ID") {
     val itemRecords = (0 to 3).map { _ =>
       createSierraItemRecord
-    }.toList
+    }
     val transformable = createSierraTransformableWith(
       itemRecords = itemRecords
     )

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -119,10 +119,9 @@ class Splitter(indexPrefix: String)(
                     _.add("holdingsIds", Json.fromValues(holdingsIds.map {
                       Json.fromString
                     })))
-                  .mapObject(
-                    _.add("orderIds", Json.fromValues(orderIds.map {
-                      Json.fromString
-                    })))
+                  .mapObject(_.add("orderIds", Json.fromValues(orderIds.map {
+                    Json.fromString
+                  })))
               }
         )
       case None => Seq()

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -102,6 +102,8 @@ class Splitter(indexPrefix: String)(
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =
       t.holdingsRecords.keys.map { _.withoutCheckDigit }.toList.sorted
+    val orderIds =
+      t.orderRecords.keys.map { _.withoutCheckDigit }.toList.sorted
 
     val bibData = t.maybeBibRecord match {
       case Some(bibRecord) =>
@@ -115,6 +117,10 @@ class Splitter(indexPrefix: String)(
                   })))
                   .mapObject(
                     _.add("holdingsIds", Json.fromValues(holdingsIds.map {
+                      Json.fromString
+                    })))
+                  .mapObject(
+                    _.add("orderIds", Json.fromValues(orderIds.map {
                       Json.fromString
                     })))
               }
@@ -132,7 +138,12 @@ class Splitter(indexPrefix: String)(
         Parent(holdingsRecord.id) -> parse(holdingsRecord.data)
       }.toSeq
 
-    val data = bibData ++ itemData ++ holdingsData
+    val orderData: Seq[(Parent, Either[ParsingFailure, Json])] =
+      t.orderRecords.values.map { orderRecord =>
+        Parent(orderRecord.id) -> parse(orderRecord.data)
+      }.toSeq
+
+    val data = bibData ++ itemData ++ holdingsData ++ orderData
 
     val successes = data.collect {
       case (parent, Right(json)) => (parent, json)

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -83,10 +83,10 @@ class SierraIndexerFeatureTest
       ),
       itemRecords = itemIds.map { id =>
         createSierraItemRecordWith(id = id)
-      }.toList,
+      },
       holdingsRecords = holdingsIds.map { id =>
         createSierraHoldingsRecordWith(id = id)
-      }.toList,
+      }
     )
 
     val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -16,6 +16,7 @@ import weco.catalogue.source_model.sierra.Implicits._
 import weco.catalogue.source_model.sierra.{
   SierraHoldingsRecord,
   SierraItemRecord,
+  SierraOrderRecord,
   SierraTransformable
 }
 
@@ -38,6 +39,9 @@ class SierraIndexerFeatureTest
     }
     val holdingsIds = (1 to 4).map { _ =>
       createSierraHoldingsNumber
+    }
+    val orderIds = (1 to 4).map { _ =>
+      createSierraOrderNumber
     }
 
     val transformable = createSierraTransformableWith(
@@ -86,6 +90,9 @@ class SierraIndexerFeatureTest
       },
       holdingsRecords = holdingsIds.map { id =>
         createSierraHoldingsRecordWith(id = id)
+      },
+      orderRecords = orderIds.map { id =>
+        createSierraOrderRecordWith(id = id)
       }
     )
 
@@ -124,6 +131,16 @@ class SierraIndexerFeatureTest
               .sorted
               .mkString(",")
 
+          val orderIdsList =
+            orderIds
+              .map { id =>
+                s"""
+                   |"${id.withoutCheckDigit}"
+                   |""".stripMargin
+              }
+              .sorted
+              .mkString(",")
+
           assertElasticsearchEventuallyHas(
             index = Index(s"${indexPrefix}_bibs"),
             id = bibId.withoutCheckDigit,
@@ -134,7 +151,8 @@ class SierraIndexerFeatureTest
                 |  "updatedDate" : "2013-12-12T13:56:07Z",
                 |  "deleted" : false,
                 |  "itemIds": [$itemIdsList],
-                |  "holdingsIds": [$holdingsIdsList]
+                |  "holdingsIds": [$holdingsIdsList],
+                |  "orderIds": [$orderIdsList]
                 |}
                 |""".stripMargin
           )
@@ -320,7 +338,8 @@ class SierraIndexerFeatureTest
                       |  "updatedDate" : "2001-01-01T01:01:01Z",
                       |  "deleted" : false,
                       |  "itemIds": [],
-                      |  "holdingsIds": []
+                      |  "holdingsIds": [],
+                      |  "orderIds": []
                       |}
                       |""".stripMargin
             )
@@ -401,7 +420,8 @@ class SierraIndexerFeatureTest
                       |  "updatedDate" : "2002-02-02T02:02:02Z",
                       |  "deleted" : false,
                       |  "itemIds": [],
-                      |  "holdingsIds": []
+                      |  "holdingsIds": [],
+                      |  "orderIds": []
                       |}
                       |""".stripMargin
             )
@@ -827,6 +847,202 @@ class SierraIndexerFeatureTest
                       |    "recordType": "holdings",
                       |    "id": "${holdingsId2.withoutCheckDigit}",
                       |    "idWithCheckDigit": "${holdingsId2.withCheckDigit}"
+                      |  },
+                      |  "code": "265",
+                      |  "fixedField": {
+                      |    "label" : "Inherit Location",
+                      |    "value" : false
+                      |  }
+                      |}
+                      |""".stripMargin
+          )
+        }
+      }
+    }
+  }
+
+  it("indexes order records and their varFields/fixedFields") {
+    val location = createS3ObjectLocation
+
+    val orderId1 = createSierraOrderNumber
+    val orderId2 = createSierraOrderNumber
+
+    val transformable = createSierraTransformableWith(
+      orderRecords = List(
+        SierraOrderRecord(
+          id = orderId1,
+          data = s"""
+                    |{
+                    |  "id" : "$orderId1",
+                    |  "updatedDate" : "2001-01-01T01:01:01Z",
+                    |  "deleted" : false,
+                    |  "varFields" : [
+                    |    {
+                    |      "fieldTag" : "b",
+                    |      "content" : "22501328220"
+                    |    }
+                    |  ],
+                    |  "fixedFields": {
+                    |    "86": {
+                    |      "label" : "AGENCY",
+                    |       "value" : "1"
+                    |    }
+                    |  }
+                    |}
+                    |""".stripMargin,
+          modifiedDate = Instant.now(),
+          bibIds = List()
+        ),
+        SierraOrderRecord(
+          id = orderId2,
+          data = s"""
+                    |{
+                    |  "id" : "$orderId2",
+                    |  "updatedDate" : "2002-02-02T02:02:02Z",
+                    |  "deleted" : true,
+                    |  "varFields" : [
+                    |    {
+                    |      "fieldTag" : "c",
+                    |      "marcTag" : "949",
+                    |      "ind1" : " ",
+                    |      "ind2" : " ",
+                    |      "subfields" : [
+                    |        {
+                    |          "tag" : "a",
+                    |          "content" : "/RHO"
+                    |        }
+                    |      ]
+                    |    }
+                    |  ],
+                    |  "fixedFields": {
+                    |    "265": {
+                    |      "label" : "Inherit Location",
+                    |      "value" : false
+                    |    }
+                    |  }
+                    |}
+                    |""".stripMargin,
+          modifiedDate = Instant.now(),
+          bibIds = List()
+        )
+      )
+    )
+    val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
+      initialEntries = Map(location -> transformable)
+    )
+
+    withIndices { indexPrefix =>
+      withLocalSqsQueue() { queue =>
+        withWorker(queue, store, indexPrefix) { _ =>
+          sendNotificationToSQS(
+            queue,
+            SierraSourcePayload(
+              id = transformable.sierraId.withoutCheckDigit,
+              location = location,
+              version = 1
+            )
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_orders"),
+            id = orderId1.withoutCheckDigit,
+            json = s"""
+                      |{
+                      |  "id" : "$orderId1",
+                      |  "idWithCheckDigit": "${orderId1.withCheckDigit}",
+                      |  "updatedDate" : "2001-01-01T01:01:01Z",
+                      |  "deleted" : false
+                      |}
+                      |""".stripMargin
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_orders"),
+            id = orderId2.withoutCheckDigit,
+            json = s"""
+                      |{
+                      |  "id" : "$orderId2",
+                      |  "idWithCheckDigit": "${orderId2.withCheckDigit}",
+                      |  "updatedDate" : "2002-02-02T02:02:02Z",
+                      |  "deleted" : true
+                      |}
+                      |""".stripMargin
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_varfields"),
+            id = s"orders-${orderId1.withoutCheckDigit}-0",
+            json = s"""
+                      |{
+                      |  "parent": {
+                      |    "recordType": "orders",
+                      |    "id": "${orderId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${orderId1.withCheckDigit}"
+                      |  },
+                      |  "position": 0,
+                      |  "varField": {
+                      |    "fieldTag" : "b",
+                      |    "content" : "22501328220"
+                      |  }
+                      |}
+                      |""".stripMargin
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_varfields"),
+            id = s"orders-${orderId2.withoutCheckDigit}-0",
+            json = s"""
+                      |{
+                      |  "parent": {
+                      |    "recordType": "orders",
+                      |    "id": "${orderId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${orderId2.withCheckDigit}"
+                      |  },
+                      |  "position": 0,
+                      |  "varField": {
+                      |    "fieldTag" : "c",
+                      |    "marcTag" : "949",
+                      |    "ind1" : " ",
+                      |    "ind2" : " ",
+                      |    "subfields" : [
+                      |      {
+                      |        "tag" : "a",
+                      |        "content" : "/RHO"
+                      |      }
+                      |    ]
+                      |  }
+                      |}
+                      |""".stripMargin
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_fixedfields"),
+            id = s"orders-${orderId1.withoutCheckDigit}-86",
+            json = s"""
+                      |{
+                      |  "parent": {
+                      |    "recordType": "orders",
+                      |    "id": "${orderId1.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${orderId1.withCheckDigit}"
+                      |  },
+                      |  "code": "86",
+                      |  "fixedField": {
+                      |    "label" : "AGENCY",
+                      |    "value" : "1"
+                      |  }
+                      |}
+                      |""".stripMargin
+          )
+
+          assertElasticsearchEventuallyHas(
+            index = Index(s"${indexPrefix}_fixedfields"),
+            id = s"orders-${orderId2.withoutCheckDigit}-265",
+            json = s"""
+                      |{
+                      |  "parent": {
+                      |    "recordType": "orders",
+                      |    "id": "${orderId2.withoutCheckDigit}",
+                      |    "idWithCheckDigit": "${orderId2.withCheckDigit}"
                       |  },
                       |  "code": "265",
                       |  "fixedField": {

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/Link.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/Link.scala
@@ -3,7 +3,8 @@ package weco.catalogue.sierra_linker.models
 import weco.catalogue.source_model.sierra.{
   SierraBibNumber,
   SierraHoldingsRecord,
-  SierraItemRecord
+  SierraItemRecord,
+  SierraOrderRecord
 }
 
 import java.time.Instant
@@ -27,5 +28,12 @@ case object Link {
       bibIds = holdingsRecord.bibIds,
       unlinkedBibIds = holdingsRecord.unlinkedBibIds,
       modifiedDate = holdingsRecord.modifiedDate
+    )
+
+  def apply(orderRecord: SierraOrderRecord): Link =
+    Link(
+      bibIds = orderRecord.bibIds,
+      unlinkedBibIds = orderRecord.unlinkedBibIds,
+      modifiedDate = orderRecord.modifiedDate
     )
 }

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/LinkOps.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/LinkOps.scala
@@ -95,7 +95,8 @@ object LinkOps {
   }
 
   implicit val orderLinkOps = new LinkOps[SierraOrderRecord] {
-    override def getBibIds(orderRecord: SierraOrderRecord): List[SierraBibNumber] =
+    override def getBibIds(
+      orderRecord: SierraOrderRecord): List[SierraBibNumber] =
       orderRecord.bibIds
 
     override def createLink(orderRecord: SierraOrderRecord): Link =

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/LinkOps.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/models/LinkOps.scala
@@ -5,7 +5,8 @@ import weco.catalogue.source_model.sierra.{
   AbstractSierraRecord,
   SierraBibNumber,
   SierraHoldingsRecord,
-  SierraItemRecord
+  SierraItemRecord,
+  SierraOrderRecord
 }
 
 trait LinkOps[Record <: AbstractSierraRecord[_]] extends Logging {
@@ -91,5 +92,18 @@ object LinkOps {
       link: Link,
       holdingsRecord: SierraHoldingsRecord): SierraHoldingsRecord =
       holdingsRecord.copy(unlinkedBibIds = link.unlinkedBibIds)
+  }
+
+  implicit val orderLinkOps = new LinkOps[SierraOrderRecord] {
+    override def getBibIds(orderRecord: SierraOrderRecord): List[SierraBibNumber] =
+      orderRecord.bibIds
+
+    override def createLink(orderRecord: SierraOrderRecord): Link =
+      Link(orderRecord)
+
+    override def copyUnlinkedBibIds(
+      link: Link,
+      orderRecord: SierraOrderRecord): SierraOrderRecord =
+      orderRecord.copy(unlinkedBibIds = link.unlinkedBibIds)
   }
 }

--- a/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
+++ b/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
@@ -96,13 +96,12 @@ trait WorkerFixture extends SQS with Akka {
   def withOrderWorker[R](
     queue: Queue,
     store: MemoryVersionedStore[SierraOrderNumber, Link] =
-      MemoryVersionedStore[SierraOrderNumber, Link](
-        initialEntries = Map.empty),
+      MemoryVersionedStore[SierraOrderNumber, Link](initialEntries = Map.empty),
     metrics: Metrics[Future] = new MemoryMetrics(),
     messageSender: MemoryMessageSender = new MemoryMessageSender
   )(testWith: TestWith[
-    SierraLinkerWorker[SierraOrderNumber, SierraOrderRecord, String],
-    R]): R =
+      SierraLinkerWorker[SierraOrderNumber, SierraOrderRecord, String],
+      R]): R =
     withWorker[SierraOrderNumber, SierraOrderRecord, R](
       queue,
       store,

--- a/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
+++ b/sierra_adapter/sierra_linker/src/test/scala/weco/catalogue/sierra_linker/fixtures/WorkerFixture.scala
@@ -19,6 +19,8 @@ import weco.catalogue.source_model.sierra.{
   SierraHoldingsRecord,
   SierraItemNumber,
   SierraItemRecord,
+  SierraOrderNumber,
+  SierraOrderRecord,
   TypedSierraRecordNumber
 }
 
@@ -84,6 +86,24 @@ trait WorkerFixture extends SQS with Akka {
       SierraLinkerWorker[SierraHoldingsNumber, SierraHoldingsRecord, String],
       R]): R =
     withWorker[SierraHoldingsNumber, SierraHoldingsRecord, R](
+      queue,
+      store,
+      metrics,
+      messageSender) { worker =>
+      testWith(worker)
+    }
+
+  def withOrderWorker[R](
+    queue: Queue,
+    store: MemoryVersionedStore[SierraOrderNumber, Link] =
+      MemoryVersionedStore[SierraOrderNumber, Link](
+        initialEntries = Map.empty),
+    metrics: Metrics[Future] = new MemoryMetrics(),
+    messageSender: MemoryMessageSender = new MemoryMessageSender
+  )(testWith: TestWith[
+    SierraLinkerWorker[SierraOrderNumber, SierraOrderRecord, String],
+    R]): R =
+    withWorker[SierraOrderNumber, SierraOrderRecord, R](
       queue,
       store,
       metrics,

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
@@ -55,7 +55,8 @@ object RecordOps {
     override def getBibIds(r: SierraOrderRecord): List[SierraBibNumber] =
       r.bibIds
 
-    override def getUnlinkedBibIds(r: SierraOrderRecord): List[SierraBibNumber] =
+    override def getUnlinkedBibIds(
+      r: SierraOrderRecord): List[SierraBibNumber] =
       r.unlinkedBibIds
   }
 }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/RecordOps.scala
@@ -6,7 +6,8 @@ import weco.catalogue.source_model.sierra.{
   SierraBibNumber,
   SierraBibRecord,
   SierraHoldingsRecord,
-  SierraItemRecord
+  SierraItemRecord,
+  SierraOrderRecord
 }
 
 trait RecordOps[Record <: AbstractSierraRecord[_]] extends Logging {
@@ -47,6 +48,14 @@ object RecordOps {
 
     override def getUnlinkedBibIds(
       r: SierraHoldingsRecord): List[SierraBibNumber] =
+      r.unlinkedBibIds
+  }
+
+  implicit val orderRecordOps = new RecordOps[SierraOrderRecord] {
+    override def getBibIds(r: SierraOrderRecord): List[SierraBibNumber] =
+      r.bibIds
+
+    override def getUnlinkedBibIds(r: SierraOrderRecord): List[SierraBibNumber] =
       r.unlinkedBibIds
   }
 }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/TransformableOps.scala
@@ -73,13 +73,17 @@ object TransformableOps {
         s"We should never be removing a bib record from a SierraTransformable (${transformable.sierraId})")
   }
 
-  trait SubrecordTransformableOps[Id <: TypedSierraRecordNumber, Record <: AbstractSierraRecord[Id]] extends TransformableOps[Record] {
+  trait SubrecordTransformableOps[
+    Id <: TypedSierraRecordNumber, Record <: AbstractSierraRecord[Id]]
+      extends TransformableOps[Record] {
     implicit val recordOps: RecordOps[Record]
 
     def getRecords(t: SierraTransformable): Map[Id, Record]
-    def setRecords(t: SierraTransformable, records: Map[Id, Record]): SierraTransformable
+    def setRecords(t: SierraTransformable,
+                   records: Map[Id, Record]): SierraTransformable
 
-    override def create(sierraId: SierraBibNumber, record: Record): SierraTransformable = {
+    override def create(sierraId: SierraBibNumber,
+                        record: Record): SierraTransformable = {
       val t = SierraTransformable(sierraId = sierraId)
       val newRecords = Map(record.id -> record)
 
@@ -118,7 +122,8 @@ object TransformableOps {
       }
     }
 
-    override def remove(t: SierraTransformable, record: Record): Option[SierraTransformable] = {
+    override def remove(t: SierraTransformable,
+                        record: Record): Option[SierraTransformable] = {
       if (!recordOps.getUnlinkedBibIds(record).contains(t.sierraId)) {
         throw new RuntimeException(
           s"Non-matching bib id ${t.sierraId} in ${recordOps.getUnlinkedBibIds(record)}")
@@ -145,33 +150,51 @@ object TransformableOps {
     }
   }
 
-  implicit val itemTransformableOps = new SubrecordTransformableOps[SierraItemNumber, SierraItemRecord] {
-    override implicit val recordOps: RecordOps[SierraItemRecord] = RecordOps.itemRecordOps
+  implicit val itemTransformableOps =
+    new SubrecordTransformableOps[SierraItemNumber, SierraItemRecord] {
+      override implicit val recordOps: RecordOps[SierraItemRecord] =
+        RecordOps.itemRecordOps
 
-    override def getRecords(t: SierraTransformable): Map[SierraItemNumber, SierraItemRecord] =
-      t.itemRecords
+      override def getRecords(
+        t: SierraTransformable): Map[SierraItemNumber, SierraItemRecord] =
+        t.itemRecords
 
-    override def setRecords(t: SierraTransformable, itemRecords: Map[SierraItemNumber, SierraItemRecord]): SierraTransformable =
-      t.copy(itemRecords = itemRecords)
-  }
+      override def setRecords(
+        t: SierraTransformable,
+        itemRecords: Map[SierraItemNumber, SierraItemRecord])
+        : SierraTransformable =
+        t.copy(itemRecords = itemRecords)
+    }
 
-  implicit val holdingsTransformableOps = new SubrecordTransformableOps[SierraHoldingsNumber, SierraHoldingsRecord] {
-    override implicit val recordOps: RecordOps[SierraHoldingsRecord] = RecordOps.holdingsRecordOps
+  implicit val holdingsTransformableOps =
+    new SubrecordTransformableOps[SierraHoldingsNumber, SierraHoldingsRecord] {
+      override implicit val recordOps: RecordOps[SierraHoldingsRecord] =
+        RecordOps.holdingsRecordOps
 
-    override def getRecords(t: SierraTransformable): Map[SierraHoldingsNumber, SierraHoldingsRecord] =
-      t.holdingsRecords
+      override def getRecords(t: SierraTransformable)
+        : Map[SierraHoldingsNumber, SierraHoldingsRecord] =
+        t.holdingsRecords
 
-    override def setRecords(t: SierraTransformable, holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord]): SierraTransformable =
-      t.copy(holdingsRecords = holdingsRecords)
-  }
+      override def setRecords(
+        t: SierraTransformable,
+        holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord])
+        : SierraTransformable =
+        t.copy(holdingsRecords = holdingsRecords)
+    }
 
-  implicit val orderTransformableOps = new SubrecordTransformableOps[SierraOrderNumber, SierraOrderRecord] {
-    override implicit val recordOps: RecordOps[SierraOrderRecord] = RecordOps.orderRecordOps
+  implicit val orderTransformableOps =
+    new SubrecordTransformableOps[SierraOrderNumber, SierraOrderRecord] {
+      override implicit val recordOps: RecordOps[SierraOrderRecord] =
+        RecordOps.orderRecordOps
 
-    override def getRecords(t: SierraTransformable): Map[SierraOrderNumber, SierraOrderRecord] =
-      t.orderRecords
+      override def getRecords(
+        t: SierraTransformable): Map[SierraOrderNumber, SierraOrderRecord] =
+        t.orderRecords
 
-    override def setRecords(t: SierraTransformable, orderRecords: Map[SierraOrderNumber, SierraOrderRecord]): SierraTransformable =
-      t.copy(orderRecords = orderRecords)
-  }
+      override def setRecords(
+        t: SierraTransformable,
+        orderRecords: Map[SierraOrderNumber, SierraOrderRecord])
+        : SierraTransformable =
+        t.copy(orderRecords = orderRecords)
+    }
 }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/models/TransformableOps.scala
@@ -4,9 +4,14 @@ import weco.catalogue.source_model.sierra.{
   AbstractSierraRecord,
   SierraBibNumber,
   SierraBibRecord,
+  SierraHoldingsNumber,
   SierraHoldingsRecord,
+  SierraItemNumber,
   SierraItemRecord,
-  SierraTransformable
+  SierraOrderNumber,
+  SierraOrderRecord,
+  SierraTransformable,
+  TypedSierraRecordNumber
 }
 
 trait TransformableOps[Record <: AbstractSierraRecord[_]] {
@@ -68,20 +73,24 @@ object TransformableOps {
         s"We should never be removing a bib record from a SierraTransformable (${transformable.sierraId})")
   }
 
-  implicit val itemTransformableOps = new TransformableOps[SierraItemRecord] {
-    override def create(sierraId: SierraBibNumber,
-                        itemRecord: SierraItemRecord): SierraTransformable =
-      SierraTransformable(
-        sierraId = sierraId,
-        itemRecords = Map(itemRecord.id -> itemRecord)
-      )
+  trait SubrecordTransformableOps[Id <: TypedSierraRecordNumber, Record <: AbstractSierraRecord[Id]] extends TransformableOps[Record] {
+    implicit val recordOps: RecordOps[Record]
 
-    override def add(
-      sierraTransformable: SierraTransformable,
-      itemRecord: SierraItemRecord): Option[SierraTransformable] = {
-      if (!itemRecord.bibIds.contains(sierraTransformable.sierraId)) {
+    def getRecords(t: SierraTransformable): Map[Id, Record]
+    def setRecords(t: SierraTransformable, records: Map[Id, Record]): SierraTransformable
+
+    override def create(sierraId: SierraBibNumber, record: Record): SierraTransformable = {
+      val t = SierraTransformable(sierraId = sierraId)
+      val newRecords = Map(record.id -> record)
+
+      setRecords(t, newRecords)
+    }
+
+    override def add(t: SierraTransformable,
+                     record: Record): Option[SierraTransformable] = {
+      if (!recordOps.getBibIds(record).contains(t.sierraId)) {
         throw new RuntimeException(
-          s"Non-matching bib id ${sierraTransformable.sierraId} in item bib ${itemRecord.bibIds}")
+          s"Non-matching bib id ${t.sierraId} in ${recordOps.getBibIds(record)}")
       }
 
       // We can decide whether to insert the new data in two steps:
@@ -92,123 +101,77 @@ object TransformableOps {
       //    just received?  If the existing data is older, we need to merge the
       //    new record.
       //
-      val isNewerData =
-        sierraTransformable.itemRecords.get(itemRecord.id) match {
+      val isNewerData = {
+        getRecords(t).get(record.id) match {
           case Some(existing) =>
-            itemRecord.modifiedDate.isAfter(existing.modifiedDate) ||
-              itemRecord.modifiedDate == existing.modifiedDate
+            record.modifiedDate.isAfter(existing.modifiedDate) ||
+              record.modifiedDate == existing.modifiedDate
           case None => true
         }
+      }
 
       if (isNewerData) {
-        val itemData = sierraTransformable.itemRecords + (itemRecord.id -> itemRecord)
-        Some(sierraTransformable.copy(itemRecords = itemData))
+        val newRecords = getRecords(t) ++ Map(record.id -> record)
+        Some(setRecords(t, newRecords))
       } else {
         None
       }
     }
 
-    override def remove(
-      sierraTransformable: SierraTransformable,
-      itemRecord: SierraItemRecord): Option[SierraTransformable] = {
-      if (!itemRecord.unlinkedBibIds.contains(sierraTransformable.sierraId)) {
+    override def remove(t: SierraTransformable, record: Record): Option[SierraTransformable] = {
+      if (!recordOps.getUnlinkedBibIds(record).contains(t.sierraId)) {
         throw new RuntimeException(
-          s"Non-matching bib id ${sierraTransformable.sierraId} in item unlink bibs ${itemRecord.unlinkedBibIds}")
+          s"Non-matching bib id ${t.sierraId} in ${recordOps.getUnlinkedBibIds(record)}")
       }
 
-      val itemRecords =
-        sierraTransformable.itemRecords
+      val newRecords =
+        getRecords(t)
           .filterNot {
-            case (id, currentItemRecord) =>
-              val matchesCurrentItemRecord = id == itemRecord.id
+            case (id, currentRecord) =>
+              val matchesCurrentRecord = id == record.id
 
-              val modifiedAfter = itemRecord.modifiedDate.isAfter(
-                currentItemRecord.modifiedDate
+              val modifiedAfter = record.modifiedDate.isAfter(
+                currentRecord.modifiedDate
               )
 
-              matchesCurrentItemRecord && modifiedAfter
+              matchesCurrentRecord && modifiedAfter
           }
 
-      if (sierraTransformable.itemRecords != itemRecords) {
-        Some(sierraTransformable.copy(itemRecords = itemRecords))
+      if (getRecords(t) != newRecords) {
+        Some(setRecords(t, newRecords))
       } else {
         None
       }
     }
   }
 
-  implicit val holdingsTransformableOps =
-    new TransformableOps[SierraHoldingsRecord] {
-      override def create(
-        sierraId: SierraBibNumber,
-        holdingsRecord: SierraHoldingsRecord): SierraTransformable =
-        SierraTransformable(
-          sierraId = sierraId,
-          holdingsRecords = Map(holdingsRecord.id -> holdingsRecord)
-        )
+  implicit val itemTransformableOps = new SubrecordTransformableOps[SierraItemNumber, SierraItemRecord] {
+    override implicit val recordOps: RecordOps[SierraItemRecord] = RecordOps.itemRecordOps
 
-      override def add(
-        sierraTransformable: SierraTransformable,
-        holdingsRecord: SierraHoldingsRecord): Option[SierraTransformable] = {
-        if (!holdingsRecord.bibIds.contains(sierraTransformable.sierraId)) {
-          throw new RuntimeException(
-            s"Non-matching bib id ${sierraTransformable.sierraId} in holdings bib ${holdingsRecord.bibIds}")
-        }
+    override def getRecords(t: SierraTransformable): Map[SierraItemNumber, SierraItemRecord] =
+      t.itemRecords
 
-        // We can decide whether to insert the new data in two steps:
-        //
-        //  - Do we already have any data for this item?  If not, we definitely
-        //    need to merge this record.
-        //  - If we have existing data, is it newer or older than the update we've
-        //    just received?  If the existing data is older, we need to merge the
-        //    new record.
-        //
-        val isNewerData =
-          sierraTransformable.holdingsRecords.get(holdingsRecord.id) match {
-            case Some(existing) =>
-              holdingsRecord.modifiedDate.isAfter(existing.modifiedDate) ||
-                holdingsRecord.modifiedDate == existing.modifiedDate
-            case None => true
-          }
+    override def setRecords(t: SierraTransformable, itemRecords: Map[SierraItemNumber, SierraItemRecord]): SierraTransformable =
+      t.copy(itemRecords = itemRecords)
+  }
 
-        if (isNewerData) {
-          Some(
-            sierraTransformable.copy(
-              holdingsRecords = sierraTransformable.holdingsRecords + (holdingsRecord.id -> holdingsRecord)
-            )
-          )
-        } else {
-          None
-        }
-      }
+  implicit val holdingsTransformableOps = new SubrecordTransformableOps[SierraHoldingsNumber, SierraHoldingsRecord] {
+    override implicit val recordOps: RecordOps[SierraHoldingsRecord] = RecordOps.holdingsRecordOps
 
-      override def remove(
-        sierraTransformable: SierraTransformable,
-        holdingsRecord: SierraHoldingsRecord): Option[SierraTransformable] = {
-        if (!holdingsRecord.unlinkedBibIds.contains(
-              sierraTransformable.sierraId)) {
-          throw new RuntimeException(
-            s"Non-matching bib id ${sierraTransformable.sierraId} in holdings unlink bibs ${holdingsRecord.unlinkedBibIds}")
-        }
+    override def getRecords(t: SierraTransformable): Map[SierraHoldingsNumber, SierraHoldingsRecord] =
+      t.holdingsRecords
 
-        val newHoldingsRecords =
-          sierraTransformable.holdingsRecords
-            .filterNot {
-              case (id, currentHoldingsRecord) =>
-                val matchesCurrentItemRecord = id == holdingsRecord.id
+    override def setRecords(t: SierraTransformable, holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord]): SierraTransformable =
+      t.copy(holdingsRecords = holdingsRecords)
+  }
 
-                val modifiedAfter = holdingsRecord.modifiedDate.isAfter(
-                  currentHoldingsRecord.modifiedDate
-                )
+  implicit val orderTransformableOps = new SubrecordTransformableOps[SierraOrderNumber, SierraOrderRecord] {
+    override implicit val recordOps: RecordOps[SierraOrderRecord] = RecordOps.orderRecordOps
 
-                matchesCurrentItemRecord && modifiedAfter
-            }
+    override def getRecords(t: SierraTransformable): Map[SierraOrderNumber, SierraOrderRecord] =
+      t.orderRecords
 
-        if (sierraTransformable.holdingsRecords != newHoldingsRecords) {
-          Some(sierraTransformable.copy(holdingsRecords = newHoldingsRecords))
-        } else {
-          None
-        }
-      }
-    }
+    override def setRecords(t: SierraTransformable, orderRecords: Map[SierraOrderNumber, SierraOrderRecord]): SierraTransformable =
+      t.copy(orderRecords = orderRecords)
+  }
 }

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
@@ -219,23 +219,22 @@ class SierraHoldingsRecordMergerFeatureTest
 }
 
 class SierraOrderRecordMergerFeatureTest
-  extends SierraRecordMergerFeatureTestCases[SierraOrderRecord]
+    extends SierraRecordMergerFeatureTestCases[SierraOrderRecord]
     with RecordMergerFixtures {
   override def withWorker[R](queue: Queue,
                              sourceVHS: SourceVHS[SierraTransformable])(
-                              testWith: TestWith[(Worker[SierraOrderRecord, String],
-                                MemoryMessageSender),
-                                R]): R =
+    testWith: TestWith[(Worker[SierraOrderRecord, String], MemoryMessageSender),
+                       R]): R =
     withRunningWorker[SierraOrderRecord, R](queue, sourceVHS) {
       testWith
     }
 
-  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraOrderRecord =
+  override def createRecordWith(
+    bibIds: List[SierraBibNumber]): SierraOrderRecord =
     createSierraOrderRecordWith(bibIds = bibIds)
 
   override implicit val encoder: Encoder[SierraOrderRecord] = deriveEncoder
 
-  override implicit val transformableOps
-  : TransformableOps[SierraOrderRecord] =
+  override implicit val transformableOps: TransformableOps[SierraOrderRecord] =
     TransformableOps.orderTransformableOps
 }

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/catalogue/sierra_merger/SierraRecordMergerFeatureTest.scala
@@ -217,3 +217,25 @@ class SierraHoldingsRecordMergerFeatureTest
     : TransformableOps[SierraHoldingsRecord] =
     TransformableOps.holdingsTransformableOps
 }
+
+class SierraOrderRecordMergerFeatureTest
+  extends SierraRecordMergerFeatureTestCases[SierraOrderRecord]
+    with RecordMergerFixtures {
+  override def withWorker[R](queue: Queue,
+                             sourceVHS: SourceVHS[SierraTransformable])(
+                              testWith: TestWith[(Worker[SierraOrderRecord, String],
+                                MemoryMessageSender),
+                                R]): R =
+    withRunningWorker[SierraOrderRecord, R](queue, sourceVHS) {
+      testWith
+    }
+
+  override def createRecordWith(bibIds: List[SierraBibNumber]): SierraOrderRecord =
+    createSierraOrderRecordWith(bibIds = bibIds)
+
+  override implicit val encoder: Encoder[SierraOrderRecord] = deriveEncoder
+
+  override implicit val transformableOps
+  : TransformableOps[SierraOrderRecord] =
+    TransformableOps.orderTransformableOps
+}

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.platform.sierra_reader.config.builders
 
 import com.typesafe.config.Config
 import uk.ac.wellcome.platform.sierra_reader.config.models.ReaderConfig
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes._
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import weco.catalogue.sierra_reader.models.SierraResourceTypes._
 
 object ReaderConfigBuilder {
   def buildReaderConfig(config: Config): ReaderConfig = {

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/builders/ReaderConfigBuilder.scala
@@ -11,6 +11,7 @@ object ReaderConfigBuilder {
       case s: String if s == bibs.toString     => bibs
       case s: String if s == items.toString    => items
       case s: String if s == holdings.toString => holdings
+      case s: String if s == orders.toString   => orders
       case s: String =>
         throw new IllegalArgumentException(
           s"$s is not a valid Sierra resource type")

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/models/ReaderConfig.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/config/models/ReaderConfig.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.sierra_reader.config.models
 
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
+import weco.catalogue.sierra_reader.models.SierraResourceTypes
 
 case class ReaderConfig(
   resourceType: SierraResourceTypes.Value,

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -20,10 +20,7 @@ import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.typesafe.Runnable
-import weco.catalogue.sierra_reader.models.{
-  SierraResourceTypes,
-  WindowStatus
-}
+import weco.catalogue.sierra_reader.models.{SierraResourceTypes, WindowStatus}
 import weco.catalogue.sierra_reader.source.{SierraSource, ThrottleRate}
 import weco.catalogue.source_model.sierra.Implicits._
 import weco.catalogue.source_model.sierra.{

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -15,15 +15,15 @@ import uk.ac.wellcome.platform.sierra_reader.config.models.{
   SierraAPIConfig
 }
 import uk.ac.wellcome.platform.sierra_reader.flow.SierraRecordWrapperFlow
-import uk.ac.wellcome.platform.sierra_reader.models.{
-  SierraResourceTypes,
-  WindowStatus
-}
 import uk.ac.wellcome.platform.sierra_reader.sink.SequentialS3Sink
 import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.s3.{S3Config, S3ObjectLocation}
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.sierra_reader.models.{
+  SierraResourceTypes,
+  WindowStatus
+}
 import weco.catalogue.sierra_reader.source.{SierraSource, ThrottleRate}
 import weco.catalogue.source_model.sierra.Implicits._
 import weco.catalogue.source_model.sierra.{

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManager.scala
@@ -7,7 +7,6 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.sierra_reader.config.models.ReaderConfig
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
-import uk.ac.wellcome.platform.sierra_reader.models.WindowStatus
 import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
 import uk.ac.wellcome.storage.s3.{
@@ -17,6 +16,7 @@ import uk.ac.wellcome.storage.s3.{
 }
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import weco.catalogue.source_model.sierra.Implicits._
+import weco.catalogue.sierra_reader.models.WindowStatus
 import weco.catalogue.source_model.sierra.UntypedSierraRecordNumber
 
 import scala.concurrent.Future

--- a/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/SierraResourceTypes.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/SierraResourceTypes.scala
@@ -1,5 +1,5 @@
 package weco.catalogue.sierra_reader.models
 
 object SierraResourceTypes extends Enumeration {
-  val bibs, items, holdings = Value
+  val bibs, items, holdings, orders = Value
 }

--- a/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/SierraResourceTypes.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/SierraResourceTypes.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.sierra_reader.models
+package weco.catalogue.sierra_reader.models
 
 object SierraResourceTypes extends Enumeration {
   val bibs, items, holdings = Value

--- a/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/WindowStatus.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/weco/catalogue/sierra_reader/models/WindowStatus.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.sierra_reader.models
+package weco.catalogue.sierra_reader.models
 
 import weco.catalogue.source_model.sierra.UntypedSierraRecordNumber
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -9,10 +9,10 @@ import uk.ac.wellcome.platform.sierra_reader.config.models.{
   ReaderConfig,
   SierraAPIConfig
 }
-import uk.ac.wellcome.platform.sierra_reader.models.SierraResourceTypes
 import uk.ac.wellcome.platform.sierra_reader.services.SierraReaderWorkerService
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import weco.catalogue.sierra_reader.models.SierraResourceTypes
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -7,13 +7,13 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.sierra_reader.config.models.ReaderConfig
 import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
-import uk.ac.wellcome.platform.sierra_reader.models.{
-  SierraResourceTypes,
-  WindowStatus
-}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import weco.catalogue.sierra_reader.models.{
+  SierraResourceTypes,
+  WindowStatus
+}
 import weco.catalogue.source_model.generators.SierraGenerators
 import weco.catalogue.source_model.sierra.Implicits._
 import weco.catalogue.source_model.sierra.SierraBibNumber

--- a/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/uk/ac/wellcome/platform/sierra_reader/services/WindowManagerTest.scala
@@ -10,10 +10,7 @@ import uk.ac.wellcome.platform.sierra_reader.exceptions.SierraReaderException
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import weco.catalogue.sierra_reader.models.{
-  SierraResourceTypes,
-  WindowStatus
-}
+import weco.catalogue.sierra_reader.models.{SierraResourceTypes, WindowStatus}
 import weco.catalogue.source_model.generators.SierraGenerators
 import weco.catalogue.source_model.sierra.Implicits._
 import weco.catalogue.source_model.sierra.SierraBibNumber


### PR DESCRIPTION
Nothing particularly fancy, just adding another record type alongside bibs/items/holdings.

For https://github.com/wellcomecollection/platform/issues/5137