### PR TITLE
Use the British spelling of "Licence" for specific named licences in the API

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
@@ -79,16 +79,14 @@ object License extends Enum[License] {
 
   case object OGL extends License {
     val id = "ogl"
-    val label =
-      "Open Government License"
+    val label = "Open Government Licence"
     val url =
       "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
   }
 
   case object OPL extends License {
     val id = "opl"
-    val label =
-      "Open Parliament License"
+    val label = "Open Parliament Licence"
     val url =
       "https://www.parliament.uk/site-information/copyright-parliament/open-parliament-licence/"
   }


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/6409

If you follow the URLs, you see these licences both use the British spelling.