### PR TITLE
Add ECR deployment setup for stacks services

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -131,3 +131,12 @@ catalogue_api:
   account_id: '756629837203'
   role_arn: arn:aws:iam::756629837203:role/catalogue-ci
   aws_region_name: eu-west-1
+
+stacks:
+  image_repositories:
+    - id: items_api
+    - id: requests_api
+  name: Stacks API
+  account_id: '756629837203'
+  role_arn: arn:aws:iam::756629837203:role/catalogue-ci
+  aws_region_name: eu-west-1

--- a/api/terraform/shared/ecr.tf
+++ b/api/terraform/shared/ecr.tf
@@ -1,3 +1,19 @@
+resource "aws_ecr_repository" "items_api" {
+  name = "uk.ac.wellcome/items_api"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecr_repository" "requests_api" {
+  name = "uk.ac.wellcome/requests_api"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_ecr_repository" "api" {
   name = "uk.ac.wellcome/api"
 

--- a/api/terraform/shared/outputs.tf
+++ b/api/terraform/shared/outputs.tf
@@ -45,3 +45,11 @@ output "ecr_api_repository_url" {
 output "ecr_snapshot_generator_repository_url" {
   value = aws_ecr_repository.snapshot_generator.repository_url
 }
+
+output "ecr_items_api_repository_url" {
+  value = aws_ecr_repository.items_api.repository_url
+}
+
+output "ecr_requests_api_repository_url" {
+  value = aws_ecr_repository.requests_api.repository_url
+}


### PR DESCRIPTION
Without this the master build breaks (plus this gets the images into ECR for next steps).

Terraform plan:
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_repository.items_api will be created
  + resource "aws_ecr_repository" "items_api" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "uk.ac.wellcome/items_api"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
    }

  # aws_ecr_repository.requests_api will be created
  + resource "aws_ecr_repository" "requests_api" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "uk.ac.wellcome/requests_api"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ecr_items_api_repository_url    = (known after apply)
  + ecr_requests_api_repository_url = (known after apply)
```