### PR TITLE
Deploy the Sierra adapter with order records

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -33,15 +33,18 @@ sierra_adapter:
         - id: bibs-merger
         - id: items-merger
         - id: holdings-merger
+        - id: orders-merger
     - id: sierra_linker
       services:
         - id: items-linker
         - id: holdings-linker
+        - id: orders-linker
     - id: sierra_reader
       services:
         - id: items-reader
         - id: bibs-reader
         - id: holdings-reader
+        - id: orders-reader
     - id: sierra_indexer
       services:
         - id: sierra-indexer

--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     client = session.client("sns")
 
-    for resource_type in ("bibs", "items", "holdings"):
+    for resource_type in ("bibs", "items", "holdings", "orders"):
         report = build_report(
             s3_client=session.client("s3"), bucket=BUCKET, resource_type=resource_type
         )

--- a/sierra_adapter/get_sierra_transformable_record.py
+++ b/sierra_adapter/get_sierra_transformable_record.py
@@ -99,6 +99,9 @@ def main(bnumber, skip_decoding):
             for holdings_record in transformable.get("holdingsRecords", {}).values():
                 holdings_record["data"] = json.loads(holdings_record["data"])
 
+            for order_record in transformable.get("orderRecords", {}).values():
+                order_record["data"] = json.loads(order_record["data"])
+
         _, tmp_path = tempfile.mkstemp(suffix=".json", prefix=f"b{bnumber}_")
         with open(tmp_path, "w") as outfile:
             outfile.write(json.dumps(transformable, indent=2))

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
@@ -23,6 +23,8 @@ import weco.catalogue.source_model.sierra.{
   SierraHoldingsRecord,
   SierraItemNumber,
   SierraItemRecord,
+  SierraOrderNumber,
+  SierraOrderRecord,
   SierraRecordTypes,
   TypedSierraRecordNumber
 }
@@ -67,6 +69,14 @@ object Main extends WellcomeTypesafeApp {
           sqsStream = sqsStream,
           linkStore =
             createLinkStore[SierraHoldingsNumber, SierraHoldingsRecord](config),
+          messageSender = messageSender
+        )
+
+      case SierraRecordTypes.orders =>
+        new SierraLinkerWorker(
+          sqsStream = sqsStream,
+          linkStore =
+            createLinkStore[SierraOrderNumber, SierraOrderRecord](config),
           messageSender = messageSender
         )
 

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/Main.scala
@@ -45,6 +45,7 @@ object Main extends WellcomeTypesafeApp {
       case s: String if s == bibs.toString     => bibs
       case s: String if s == items.toString    => items
       case s: String if s == holdings.toString => holdings
+      case s: String if s == orders.toString   => orders
       case s: String =>
         throw new IllegalArgumentException(
           s"$s is not a valid Sierra resource type")

--- a/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/dynamo/Implicits.scala
+++ b/sierra_adapter/sierra_linker/src/main/scala/weco/catalogue/sierra_linker/dynamo/Implicits.scala
@@ -4,7 +4,8 @@ import org.scanamo.DynamoFormat
 import weco.catalogue.source_model.sierra.{
   SierraBibNumber,
   SierraHoldingsNumber,
-  SierraItemNumber
+  SierraItemNumber,
+  SierraOrderNumber
 }
 
 object Implicits {
@@ -26,6 +27,13 @@ object Implicits {
     DynamoFormat
       .coercedXmap[SierraHoldingsNumber, String, IllegalArgumentException](
         SierraHoldingsNumber(_),
+        _.withoutCheckDigit
+      )
+
+  implicit val formatOrderNumber: DynamoFormat[SierraOrderNumber] =
+    DynamoFormat
+      .coercedXmap[SierraOrderNumber, String, IllegalArgumentException](
+        SierraOrderNumber(_),
         _.withoutCheckDigit
       )
 }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
@@ -15,6 +15,7 @@ import weco.catalogue.source_model.sierra.{
   SierraBibRecord,
   SierraHoldingsRecord,
   SierraItemRecord,
+  SierraOrderRecord,
   SierraRecordTypes,
   SierraTransformable
 }
@@ -66,6 +67,13 @@ object Main extends WellcomeTypesafeApp {
         new Worker(
           sqsStream = sqsStream,
           updater = new Updater[SierraHoldingsRecord](sourceVHS),
+          messageSender = messageSender
+        )
+
+      case SierraRecordTypes.orders =>
+        new Worker(
+          sqsStream = sqsStream,
+          updater = new Updater[SierraOrderRecord](sourceVHS),
           messageSender = messageSender
         )
     }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/catalogue/sierra_merger/Main.scala
@@ -38,6 +38,7 @@ object Main extends WellcomeTypesafeApp {
       case s: String if s == bibs.toString     => bibs
       case s: String if s == items.toString    => items
       case s: String if s == holdings.toString => holdings
+      case s: String if s == orders.toString   => orders
       case s: String =>
         throw new IllegalArgumentException(
           s"$s is not a valid Sierra resource type")

--- a/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
+++ b/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
@@ -151,9 +151,7 @@ def main(event=None, _ctxt=None):
             errors.append(resource_type)
 
     if errors:
-        error_lines.insert(
-            0, "There are gaps in the %s data." % "/".join(errors)
-        )
+        error_lines.insert(0, "There are gaps in the %s data." % "/".join(errors))
 
         error_lines.append(
             "You can fix this by running `$ python sierra_adapter/build_missing_windows.py` in the root of the catalogue repo."

--- a/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
+++ b/sierra_adapter/sierra_progress_reporter/src/sierra_progress_reporter.py
@@ -137,7 +137,7 @@ def main(event=None, _ctxt=None):
     errors = []
     error_lines = []
 
-    for resource_type in ("bibs", "items"):
+    for resource_type in ("bibs", "items", "holdings", "orders"):
         try:
             process_report(
                 s3_client=s3_client, bucket=bucket, resource_type=resource_type
@@ -151,14 +151,9 @@ def main(event=None, _ctxt=None):
             errors.append(resource_type)
 
     if errors:
-        if errors == ["bibs"]:
-            message = "There are gaps in the bib data."
-        elif errors == ["items"]:
-            message = "There are gaps in the item data."
-        else:
-            message = "There are gaps in the bib and the item data."
-
-        error_lines.insert(0, message)
+        error_lines.insert(
+            0, "There are gaps in the %s data." % "/".join(errors)
+        )
 
         error_lines.append(
             "You can fix this by running `$ python sierra_adapter/build_missing_windows.py` in the root of the catalogue repo."

--- a/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
+++ b/sierra_adapter/sierra_reader/src/main/scala/uk/ac/wellcome/platform/sierra_reader/services/SierraReaderWorkerService.scala
@@ -27,7 +27,8 @@ import weco.catalogue.source_model.sierra.{
   AbstractSierraRecord,
   SierraBibRecord,
   SierraHoldingsRecord,
-  SierraItemRecord
+  SierraItemRecord,
+  SierraOrderRecord
 }
 
 import scala.concurrent.duration._
@@ -118,6 +119,7 @@ class SierraReaderWorkerService(
       case SierraResourceTypes.bibs     => SierraBibRecord.apply
       case SierraResourceTypes.items    => SierraItemRecord.apply
       case SierraResourceTypes.holdings => SierraHoldingsRecord.apply
+      case SierraResourceTypes.orders   => SierraOrderRecord.apply
     }
 
   private def toJson(records: Seq[AbstractSierraRecord[_]]): Json =
@@ -128,5 +130,7 @@ class SierraReaderWorkerService(
         records.asInstanceOf[Seq[SierraItemRecord]].asJson
       case SierraResourceTypes.holdings =>
         records.asInstanceOf[Seq[SierraHoldingsRecord]].asJson
+      case SierraResourceTypes.orders =>
+        records.asInstanceOf[Seq[SierraOrderRecord]].asJson
     }
 }

--- a/sierra_adapter/sierra_window_generator/src/build_windows.py
+++ b/sierra_adapter/sierra_window_generator/src/build_windows.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     minutes = int(args["--window_length"] or 30)
     resource = args["--resource"]
 
-    assert resource in ("bibs", "items", "holdings")
+    assert resource in ("bibs", "items", "holdings", "orders")
 
     client = boto3.client("sns")
 

--- a/sierra_adapter/terraform/main.tf
+++ b/sierra_adapter/terraform/main.tf
@@ -29,6 +29,11 @@ module "sierra-adapter-20200604" {
     module.holdings_reharvest_topic.arn,
   ]
 
+  orders_windows_topic_arns = [
+    module.orders_window_generator.topic_arn,
+    module.orders_reharvest_topic.arn,
+  ]
+
   reporting_reindex_topic_arn = local.reporting_reindex_topic_arn
 
   sierra_reader_image  = aws_ecr_repository.sierra_reader.repository_url

--- a/sierra_adapter/terraform/provider.tf
+++ b/sierra_adapter/terraform/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = var.aws_region
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
   }
 
   ignore_tags {

--- a/sierra_adapter/terraform/stack/bucket_notifications.tf
+++ b/sierra_adapter/terraform/stack/bucket_notifications.tf
@@ -21,4 +21,12 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_prefix       = "records_holdings/"
     filter_suffix       = ".json"
   }
+
+  lambda_function {
+    lambda_function_arn = module.orders_reader.demultiplexer_arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "records_orders/"
+    filter_suffix       = ".json"
+  }
+
 }

--- a/sierra_adapter/terraform/stack/indexer.tf
+++ b/sierra_adapter/terraform/stack/indexer.tf
@@ -9,6 +9,7 @@ module "sierra_indexer" {
     module.bibs_merger.topic_arn,
     module.items_merger.topic_arn,
     module.holdings_merger.topic_arn,
+    module.orders_merger.topic_arn,
     var.reporting_reindex_topic_arn,
   ]
 

--- a/sierra_adapter/terraform/stack/locals.tf
+++ b/sierra_adapter/terraform/stack/locals.tf
@@ -73,5 +73,23 @@ locals {
     "varFields",
   ])
 
+  # See https://techdocs.iii.com/sierraapi/Content/zReference/objects/orderObject.htm
+  sierra_orders_fields = join(",", [
+    "bibs",
+    "updatedDate",
+    "createdDate",
+    "deletedDate",
+    "deleted",
+    "suppressed",
+    "accountingUnit",
+    "estimatedPrice",
+    "vendorRecordCode",
+    "orderDate",
+    "chargedFunds",
+    "vendorTitles",
+    "fixedFields",
+    "varFields",
+  ])
+
   critical_slack_webhook = data.aws_ssm_parameter.critical_slack_webhook.value
 }

--- a/sierra_adapter/terraform/stack/pipeline_orders.tf
+++ b/sierra_adapter/terraform/stack/pipeline_orders.tf
@@ -1,0 +1,94 @@
+module "orders_reader" {
+  source = "./../sierra_reader"
+
+  resource_type = "orders"
+
+  bucket_name        = aws_s3_bucket.sierra_adapter.id
+  windows_topic_arns = var.orders_windows_topic_arns
+
+  sierra_fields = local.sierra_orders_fields
+
+  sierra_api_url = local.sierra_api_url
+
+  container_image = local.sierra_reader_image
+
+  cluster_name = aws_ecs_cluster.cluster.name
+  cluster_arn  = aws_ecs_cluster.cluster.arn
+  vpc_id       = var.vpc_id
+
+  dlq_alarm_arn          = var.dlq_alarm_arn
+  lambda_error_alarm_arn = var.lambda_error_alarm_arn
+
+  infra_bucket = var.infra_bucket
+
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  namespace    = local.namespace_hyphen
+  subnets      = var.private_subnets
+
+  service_egress_security_group_id = var.egress_security_group_id
+  interservice_security_group_id   = var.interservice_security_group_id
+  elastic_cloud_vpce_sg_id         = var.elastic_cloud_vpce_sg_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "orders-reader"
+  shared_logging_secrets  = var.shared_logging_secrets
+}
+
+module "orders_linker" {
+  source = "./../sierra_linker"
+
+  resource_type = "orders"
+
+  demultiplexer_topic_arn = module.orders_reader.topic_arn
+
+  container_image = local.sierra_linker_image
+
+  cluster_name = aws_ecs_cluster.cluster.name
+  cluster_arn  = aws_ecs_cluster.cluster.arn
+  vpc_id       = var.vpc_id
+
+  dlq_alarm_arn = var.dlq_alarm_arn
+
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  namespace    = local.namespace_hyphen
+  subnets      = var.private_subnets
+
+  service_egress_security_group_id = var.egress_security_group_id
+  interservice_security_group_id   = var.interservice_security_group_id
+  elastic_cloud_vpce_sg_id         = var.elastic_cloud_vpce_sg_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "orders-linker"
+  shared_logging_secrets  = var.shared_logging_secrets
+}
+
+module "orders_merger" {
+  source = "./../sierra_merger"
+
+  resource_type     = "orders"
+  updates_topic_arn = module.orders_linker.topic_arn
+
+  container_image = local.sierra_merger_image
+
+  vhs_table_name        = module.vhs_sierra.table_name
+  vhs_bucket_name       = module.vhs_sierra.bucket_name
+  vhs_read_write_policy = module.vhs_sierra.full_access_policy
+
+  cluster_name = aws_ecs_cluster.cluster.name
+  cluster_arn  = aws_ecs_cluster.cluster.arn
+  vpc_id       = var.vpc_id
+
+  dlq_alarm_arn = var.dlq_alarm_arn
+
+  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  namespace    = local.namespace_hyphen
+  subnets      = var.private_subnets
+
+  service_egress_security_group_id = var.egress_security_group_id
+  interservice_security_group_id   = var.interservice_security_group_id
+  elastic_cloud_vpce_sg_id         = var.elastic_cloud_vpce_sg_id
+
+  deployment_service_env  = var.deployment_env
+  deployment_service_name = "orders-merger"
+  shared_logging_secrets  = var.shared_logging_secrets
+}

--- a/sierra_adapter/terraform/stack/variables.tf
+++ b/sierra_adapter/terraform/stack/variables.tf
@@ -10,6 +10,11 @@ variable "interservice_security_group_id" {}
 variable "bibs_windows_topic_arns" {}
 variable "items_windows_topic_arns" {}
 variable "holdings_windows_topic_arns" {}
+
+variable "orders_windows_topic_arns" {
+  type = list(string)
+}
+
 variable "deployment_env" {}
 variable "shared_logging_secrets" {
   type = map(any)

--- a/sierra_adapter/terraform/topics.tf
+++ b/sierra_adapter/terraform/topics.tf
@@ -10,3 +10,8 @@ module "holdings_reharvest_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"
   name   = "sierra_holdings_reharvest_windows"
 }
+
+module "orders_reharvest_topic" {
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"
+  name   = "sierra_orders_reharvest_windows"
+}

--- a/sierra_adapter/terraform/window_generators.tf
+++ b/sierra_adapter/terraform/window_generators.tf
@@ -33,3 +33,15 @@ module "holdings_window_generator" {
   lambda_error_alarm_arn = local.lambda_error_alarm_arn
   infra_bucket           = var.infra_bucket
 }
+
+module "orders_window_generator" {
+  source = "./sierra_window_generator"
+
+  resource_type = "orders"
+
+  window_length_minutes    = 16
+  trigger_interval_minutes = 15
+
+  lambda_error_alarm_arn = local.lambda_error_alarm_arn
+  infra_bucket           = var.infra_bucket
+}


### PR DESCRIPTION
This adds the Terraform config, weco-deploy config, and some Scala fixes that weren't caught by the compiler previously. We've sucked all of the Sierra order records into the adapter.

For https://github.com/wellcomecollection/platform/issues/5137