### PR TITLE
Expose copies on order as an item with a new LocationType in the catalogue API

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/LocationType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/LocationType.scala
@@ -59,6 +59,11 @@ object LocationType extends Enum[LocationType] {
     val label = "On exhibition"
   }
 
+  case object OnOrder extends PhysicalLocationType {
+    val id = "on-order"
+    val label = "On order"
+  }
+
   case object IIIFPresentationAPI extends DigitalLocationType {
     val id = "iiif-presentation"
     val label = "IIIF Presentation API"

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -115,7 +115,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),
       items =
-        SierraItemsOnOrder(bibId, itemDataMap, orderDataMap) ++
+        SierraItemsOnOrder(bibId, hasItems = hasItems, orderDataMap) ++
           SierraItems(itemDataMap)(bibId, bibData) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap)
@@ -128,6 +128,9 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     ontologyType = "Work",
     value = bibId.withCheckDigit
   )
+
+  lazy val hasItems: Boolean =
+    sierraTransformable.itemRecords.nonEmpty
 
   lazy val itemDataMap: Map[SierraItemNumber, SierraItemData] =
     sierraTransformable.itemRecords

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -116,7 +116,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       duration = SierraDuration(bibData),
       items =
         SierraItemsOnOrder(bibId, hasItems = hasItems, orderDataMap) ++
-          SierraItems(itemDataMap)(bibId, bibData) ++
+          SierraItems(bibId, bibData, itemDataMap) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap)
     )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraOrderData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraOrderData.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.platform.transformer.sierra.source
+
+case class SierraOrderData(
+  deleted: Boolean = false,
+  suppressed: Boolean = false,
+  fixedFields: Map[String, FixedField] = Map()
+)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -18,10 +18,7 @@ import weco.catalogue.internal_model.locations.{
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.sierra.{SierraBibNumber, SierraItemNumber}
 
-object SierraItems
-    extends Logging
-    with SierraLocation
-    with SierraQueryOps {
+object SierraItems extends Logging with SierraLocation with SierraQueryOps {
 
   type Output = List[Item[IdState.Unminted]]
 
@@ -32,7 +29,9 @@ object SierraItems
     * sierra-identifier.  We want to revisit this at some point.
     * See https://github.com/wellcomecollection/platform/issues/4993
     */
-  def apply(bibId: SierraBibNumber, bibData: SierraBibData, itemDataMap: Map[SierraItemNumber, SierraItemData]) =
+  def apply(bibId: SierraBibNumber,
+            bibData: SierraBibData,
+            itemDataMap: Map[SierraItemNumber, SierraItemData]) =
     getPhysicalItems(bibId, itemDataMap, bibData)
       .sortBy { item =>
         item.id match {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -18,9 +18,8 @@ import weco.catalogue.internal_model.locations.{
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.sierra.{SierraBibNumber, SierraItemNumber}
 
-case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
-    extends SierraIdentifiedDataTransformer
-    with Logging
+object SierraItems
+    extends Logging
     with SierraLocation
     with SierraQueryOps {
 
@@ -33,7 +32,7 @@ case class SierraItems(itemDataMap: Map[SierraItemNumber, SierraItemData])
     * sierra-identifier.  We want to revisit this at some point.
     * See https://github.com/wellcomecollection/platform/issues/4993
     */
-  def apply(bibId: SierraBibNumber, bibData: SierraBibData) =
+  def apply(bibId: SierraBibNumber, bibData: SierraBibData, itemDataMap: Map[SierraItemNumber, SierraItemData]) =
     getPhysicalItems(bibId, itemDataMap, bibData)
       .sortBy { item =>
         item.id match {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -1,15 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.source.{
-  SierraItemData,
-  SierraOrderData
-}
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraOrderData
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.sierra.{
-  SierraItemNumber,
   SierraOrderNumber,
   TypedSierraRecordNumber
 }
@@ -44,10 +40,10 @@ import scala.util.Try
 object SierraItemsOnOrder extends Logging {
   def apply(
     id: TypedSierraRecordNumber,
-    itemDataMap: Map[SierraItemNumber, SierraItemData],
+    hasItems: Boolean,
     orderDataMap: Map[SierraOrderNumber, SierraOrderData]
   ): List[Item[IdState.Unidentifiable.type]] =
-    if (itemDataMap.isEmpty) {
+    if (!hasItems) {
       orderDataMap
         .toList
         .filterNot { case (_, orderData) => orderData.suppressed || orderData.deleted }
@@ -81,7 +77,7 @@ object SierraItemsOnOrder extends Logging {
       // We create an item with a message like "Awaiting cataloguing for Wellcome Collection"
       // We don't expose the received date publicly (in case an item has been in the queue
       // for a long time) -- but we do expect it to be there for these records.
-      case (Some(status), _, receivedDate @ Some(_), copies) if status == "a" =>
+      case (Some(status), _, receivedDate, copies) if status == "a" && receivedDate.isDefined =>
         Some(
           Item(
             title = None,
@@ -97,7 +93,7 @@ object SierraItemsOnOrder extends Logging {
       // We're deliberately quite conservative here -- if we're not sure what an order
       // means, we ignore it.  I don't know how many orders this will affect, and how many
       // will be ignored because they're suppressed/there are other items.
-      case (Some(status), _, receivedDate @ None, _) if status == "a" =>
+      case (Some(status), _, receivedDate, _) if status == "a" && receivedDate.isEmpty =>
         warn(s"${id.withCheckDigit}: order has STATUS 'a' (fully paid) but no RDATE.  Where is this item?")
         None
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -81,7 +81,7 @@ object SierraItemsOnOrder extends Logging {
       // We create an item with a message like "Awaiting cataloguing for Wellcome Collection"
       // We don't expose the received date publicly (in case an item has been in the queue
       // for a long time) -- but we do expect it to be there for these records.
-      case (Some(status), _, Some(_), copies) if status == "a" =>
+      case (Some(status), _, receivedDate @ Some(_), copies) if status == "a" =>
         Some(
           Item(
             title = None,
@@ -97,7 +97,7 @@ object SierraItemsOnOrder extends Logging {
       // We're deliberately quite conservative here -- if we're not sure what an order
       // means, we ignore it.  I don't know how many orders this will affect, and how many
       // will be ignored because they're suppressed/there are other items.
-      case (Some(status), _, None, _) if status == "a" =>
+      case (Some(status), _, receivedDate @ None, _) if status == "a" =>
         warn(s"${id.withCheckDigit}: order has STATUS 'a' (fully paid) but no RDATE.  Where is this item?")
         None
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -4,13 +4,18 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraItemData,
   SierraOrderData
 }
-import weco.catalogue.internal_model.identifiers.DataState.Unidentified
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.sierra.{
   SierraItemNumber,
   SierraOrderNumber,
   TypedSierraRecordNumber
 }
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import scala.util.Try
 
 /** This transformer creates catalogue items that correspond to items that
   * are "on order" or "awaiting cataloguing" -- which don't have their own
@@ -31,13 +36,73 @@ import weco.catalogue.source_model.sierra.{
   *   3)  At some point after that, an item record is created.  This supercedes
   *       the order record.
   *
+  * The Sierra documentation for fixed fields on order records is useful reading:
+  * https://documentation.iii.com/sierrahelp/Default.htm#sril/sril_records_fixed_field_types_order.html%3FTocPath%3DSierra%2520Reference%7CHow%2520Innovative%2520Systems%2520Store%2520Information%7CFixed-length%2520Fields%7C_____11
+  *
   */
 object SierraItemsOnOrder {
   def apply(
     id: TypedSierraRecordNumber,
     itemDataMap: Map[SierraItemNumber, SierraItemData],
     orderDataMap: Map[SierraOrderNumber, SierraOrderData]
-  ): List[Item[Unidentified]] = {
-    List()
-  }
+  ): List[Item[IdState.Unidentifiable.type]] =
+    if (itemDataMap.isEmpty) {
+      orderDataMap
+        .toList
+        .filterNot { case (_, orderData) => orderData.suppressed || orderData.deleted }
+        .sortBy { case (id, _) => id.withoutCheckDigit }
+        .flatMap { case (_, orderData) => createItem(id, orderData) }
+    } else {
+      List()
+    }
+
+  private def createItem(id: TypedSierraRecordNumber, order: SierraOrderData): Option[Item[IdState.Unidentifiable.type]] =
+    (getStatus(order), getOrderDate(order), getCopies(order)) match {
+      // status 'o' = "On order"
+      case (status, orderedDate, copies) if status.contains("o") =>
+        Some(
+          Item(
+            title = None,
+            locations = List(
+              PhysicalLocation(
+                locationType = LocationType.OnOrder,
+                label = createOnOrderMessage(orderedDate, copies)
+              )
+            )
+          )
+        )
+    }
+
+  // Fixed field 20 = STATUS
+  private def getStatus(order: SierraOrderData): Option[String] =
+    order.fixedFields.get("20").map { _.value }
+
+  private val rdateFormat = new SimpleDateFormat("yyyy-MM-dd")
+
+  // Fixed field 13 = ODATE.  This is usually a date in the form YYYY-MM-DD.
+  private def getOrderDate(order: SierraOrderData): Option[Date] =
+    order.fixedFields.get("13").map { _.value }
+      .flatMap { d => Try(rdateFormat.parse(d)).toOption }
+
+  // Fixed field 5 = COPIES
+  private def getCopies(order: SierraOrderData): Option[Int] =
+    order.fixedFields.get("5").map { _.value }
+      .flatMap { c => Try(c.toInt).toOption }
+
+  private val displayFormat = new SimpleDateFormat("d MMMM yyyy")
+
+  private def createOnOrderMessage(maybeOrderedDate: Option[Date], maybeCopies: Option[Int]): String =
+    (maybeOrderedDate, maybeCopies) match {
+      case (Some(orderedDate), Some(copies)) =>
+        s"$copies ${if (copies == 1) "copy" else "copies"} ordered for Wellcome Collection on ${displayFormat.format(orderedDate)}"
+
+      case (None, Some(copies)) =>
+        s"$copies ${if (copies == 1) "copy" else "copies"} ordered for Wellcome Collection"
+
+      case (Some(orderedDate), None) =>
+        s"Ordered for Wellcome Collection on ${displayFormat.format(orderedDate)}"
+
+      case (None, None) =>
+        "Ordered for Wellcome Collection"
+    }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import weco.catalogue.internal_model.identifiers.DataState.Unidentified
+import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.sierra.SierraTransformable
+
+/** This transformer creates catalogue items that correspond to items that
+  * are "on order" or "awaiting cataloguing" -- which don't have their own
+  * item record yet.
+  *
+  */
+object SierraItemsOnOrder {
+  def apply(transformable: SierraTransformable): List[Item[Unidentified]] = {
+    List()
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -76,7 +76,11 @@ object SierraItemsOnOrder extends Logging {
           )
         )
 
-      // status 'a' = "Fully paid"
+      // status 'a' = "Fully paid", RDATE = "when we actually received the thing"
+      //
+      // We create an item with a message like "Awaiting cataloguing for Wellcome Collection"
+      // We don't expose the received date publicly (in case an item has been in the queue
+      // for a long time) -- but we do expect it to be there for these records.
       case (Some(status), _, Some(_), copies) if status == "a" =>
         Some(
           Item(
@@ -90,6 +94,9 @@ object SierraItemsOnOrder extends Logging {
           )
         )
 
+      // We're deliberately quite conservative here -- if we're not sure what an order
+      // means, we ignore it.  I don't know how many orders this will affect, and how many
+      // will be ignored because they're suppressed/there are other items.
       case (Some(status), _, None, _) if status == "a" =>
         warn(s"${id.withCheckDigit}: order has STATUS 'a' (fully paid) but no RDATE.  Where is this item?")
         None

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -44,17 +44,24 @@ object SierraItemsOnOrder extends Logging {
     orderDataMap: Map[SierraOrderNumber, SierraOrderData]
   ): List[Item[IdState.Unidentifiable.type]] =
     if (!hasItems) {
-      orderDataMap
-        .toList
-        .filterNot { case (_, orderData) => orderData.suppressed || orderData.deleted }
+      orderDataMap.toList
+        .filterNot {
+          case (_, orderData) => orderData.suppressed || orderData.deleted
+        }
         .sortBy { case (id, _) => id.withoutCheckDigit }
         .flatMap { case (_, orderData) => createItem(id, orderData) }
     } else {
       List()
     }
 
-  private def createItem(id: TypedSierraRecordNumber, order: SierraOrderData): Option[Item[IdState.Unidentifiable.type]] =
-    (getStatus(order), getOrderDate(order), getReceivedDate(order), getCopies(order)) match {
+  private def createItem(
+    id: TypedSierraRecordNumber,
+    order: SierraOrderData): Option[Item[IdState.Unidentifiable.type]] =
+    (
+      getStatus(order),
+      getOrderDate(order),
+      getReceivedDate(order),
+      getCopies(order)) match {
 
       // status 'o' = "On order"
       //
@@ -77,7 +84,8 @@ object SierraItemsOnOrder extends Logging {
       // We create an item with a message like "Awaiting cataloguing for Wellcome Collection"
       // We don't expose the received date publicly (in case an item has been in the queue
       // for a long time) -- but we do expect it to be there for these records.
-      case (Some(status), _, receivedDate, copies) if status == "a" && receivedDate.isDefined =>
+      case (Some(status), _, receivedDate, copies)
+          if status == "a" && receivedDate.isDefined =>
         Some(
           Item(
             title = None,
@@ -93,12 +101,15 @@ object SierraItemsOnOrder extends Logging {
       // We're deliberately quite conservative here -- if we're not sure what an order
       // means, we ignore it.  I don't know how many orders this will affect, and how many
       // will be ignored because they're suppressed/there are other items.
-      case (Some(status), _, receivedDate, _) if status == "a" && receivedDate.isEmpty =>
-        warn(s"${id.withCheckDigit}: order has STATUS 'a' (fully paid) but no RDATE.  Where is this item?")
+      case (Some(status), _, receivedDate, _)
+          if status == "a" && receivedDate.isEmpty =>
+        warn(
+          s"${id.withCheckDigit}: order has STATUS 'a' (fully paid) but no RDATE.  Where is this item?")
         None
 
       case (status, _, _, _) =>
-        warn(s"${id.withCheckDigit}: order has unrecognised STATUS $status.  How do we handle it?")
+        warn(
+          s"${id.withCheckDigit}: order has unrecognised STATUS $status.  How do we handle it?")
         None
     }
 
@@ -110,25 +121,39 @@ object SierraItemsOnOrder extends Logging {
 
   // Fixed field 13 = ODATE.  This is usually a date in the form YYYY-MM-DD.
   private def getOrderDate(order: SierraOrderData): Option[Date] =
-    order.fixedFields.get("13").map { _.value }
-      .flatMap { d => Try(marcDateFormat.parse(d)).toOption }
+    order.fixedFields
+      .get("13")
+      .map { _.value }
+      .flatMap { d =>
+        Try(marcDateFormat.parse(d)).toOption
+      }
 
   // Fixed field 17 = RDATE.  This is usually a date in the form YYYY-MM-DD.
   private def getReceivedDate(order: SierraOrderData): Option[Date] =
-    order.fixedFields.get("17").map { _.value }
-      .flatMap { d => Try(marcDateFormat.parse(d)).toOption }
+    order.fixedFields
+      .get("17")
+      .map { _.value }
+      .flatMap { d =>
+        Try(marcDateFormat.parse(d)).toOption
+      }
 
   // Fixed field 5 = COPIES
   private def getCopies(order: SierraOrderData): Option[Int] =
-    order.fixedFields.get("5").map { _.value }
-      .flatMap { c => Try(c.toInt).toOption }
+    order.fixedFields
+      .get("5")
+      .map { _.value }
+      .flatMap { c =>
+        Try(c.toInt).toOption
+      }
 
   private val displayFormat = new SimpleDateFormat("d MMMM yyyy")
 
-  private def createOnOrderMessage(maybeOrderedDate: Option[Date], maybeCopies: Option[Int]): String =
+  private def createOnOrderMessage(maybeOrderedDate: Option[Date],
+                                   maybeCopies: Option[Int]): String =
     (maybeOrderedDate, maybeCopies) match {
       case (Some(orderedDate), Some(copies)) =>
-        s"$copies ${if (copies == 1) "copy" else "copies"} ordered for Wellcome Collection on ${displayFormat.format(orderedDate)}"
+        s"$copies ${if (copies == 1) "copy" else "copies"} ordered for Wellcome Collection on ${displayFormat
+          .format(orderedDate)}"
 
       case (None, Some(copies)) =>
         s"$copies ${if (copies == 1) "copy" else "copies"} ordered for Wellcome Collection"
@@ -140,7 +165,8 @@ object SierraItemsOnOrder extends Logging {
         "Ordered for Wellcome Collection"
     }
 
-  private def createAwaitingCataloguingMessage(maybeCopies: Option[Int]): String =
+  private def createAwaitingCataloguingMessage(
+    maybeCopies: Option[Int]): String =
     maybeCopies match {
       case Some(copies) if copies == 1 =>
         "1 copy awaiting cataloguing for Wellcome Collection"

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -1,16 +1,43 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraItemData,
+  SierraOrderData
+}
 import weco.catalogue.internal_model.identifiers.DataState.Unidentified
 import weco.catalogue.internal_model.work.Item
-import weco.catalogue.source_model.sierra.SierraTransformable
+import weco.catalogue.source_model.sierra.{
+  SierraItemNumber,
+  SierraOrderNumber,
+  TypedSierraRecordNumber
+}
 
 /** This transformer creates catalogue items that correspond to items that
   * are "on order" or "awaiting cataloguing" -- which don't have their own
   * item record yet.
   *
+  *
+  * To understand how this works, it's useful to understand the ordering
+  * process:
+  *
+  *   1)  A staff member orders a book.  They create a skeleton bib record
+  *       in Sierra, which is linked to an order record with status 'o' ("on order").
+  *       At this point, there are no item records.
+  *
+  *   2)  When the book arrives, it's "received".  The RDATE on the order
+  *       record gets populated, the status is updated to 'a' ("fully paid"),
+  *       and invoice information gets attached to the order record.
+  *
+  *   3)  At some point after that, an item record is created.  This supercedes
+  *       the order record.
+  *
   */
 object SierraItemsOnOrder {
-  def apply(transformable: SierraTransformable): List[Item[Unidentified]] = {
+  def apply(
+    id: TypedSierraRecordNumber,
+    itemDataMap: Map[SierraItemNumber, SierraItemData],
+    orderDataMap: Map[SierraOrderNumber, SierraOrderData]
+  ): List[Item[Unidentified]] = {
     List()
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -38,4 +38,17 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
     )
 
   def createSierraItemData: SierraItemData = createSierraItemDataWith()
+
+  def createSierraOrderDataWith(
+    suppressed: Boolean = false,
+    deleted: Boolean = false,
+    fixedFields: Map[String, FixedField] = Map()
+  ): SierraOrderData =
+    SierraOrderData(
+      deleted = deleted,
+      suppressed = suppressed,
+      fixedFields = fixedFields
+    )
+
+  def createSierraOrderData: SierraOrderData = createSierraOrderDataWith()
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -2,14 +2,25 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 
-class SierraItemsOnOrderTest extends AnyFunSpec with Matchers {
+class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGenerators {
   it("returns nothing if there are no orders or items") {
-    true shouldBe false
+    val id = createSierraBibNumber
+
+    SierraItemsOnOrder(id, itemDataMap = Map(), orderDataMap = Map()) shouldBe empty
   }
 
   describe("returns 'on order' items") {
     it("if there are orders with status 'o' and no RDATE") {
+      true shouldBe false
+    }
+
+    it("unless the order is suppressed") {
+      true shouldBe false
+    }
+
+    it("unless the order is deleted") {
       true shouldBe false
     }
 
@@ -20,6 +31,14 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers {
 
   describe("returns 'awaiting cataloguing' items") {
     it("if there are orders with status 'a' and an RDATE") {
+      true shouldBe false
+    }
+
+    it("unless the order is suppressed") {
+      true shouldBe false
+    }
+
+    it("unless the order is deleted") {
       true shouldBe false
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class SierraItemsOnOrderTest extends AnyFunSpec with Matchers {
+  it("returns nothing if there are no orders or items") {
+    true shouldBe false
+  }
+
+  describe("returns 'on order' items") {
+    it("if there are orders with status 'o' and no RDATE") {
+      true shouldBe false
+    }
+
+    it("unless there are any items") {
+      true shouldBe false
+    }
+  }
+
+  describe("returns 'awaiting cataloguing' items") {
+    it("if there are orders with status 'a' and an RDATE") {
+      true shouldBe false
+    }
+
+    it("unless there are any items") {
+      true shouldBe false
+    }
+  }
+
+  describe("skips unrecognised order records") {
+    it("no RDATE, unrecognised status") {
+      true shouldBe false
+    }
+
+    it("RDATE, unrecognised status") {
+      true shouldBe false
+    }
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -12,7 +12,10 @@ import weco.catalogue.internal_model.identifiers.IdState.Unidentifiable
 import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
 import weco.catalogue.internal_model.work.Item
 
-class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGenerators {
+class SierraItemsOnOrderTest
+    extends AnyFunSpec
+    with Matchers
+    with SierraDataGenerators {
   it("returns nothing if there are no orders or items") {
     getOrders(hasItems = false, orderData = List()) shouldBe empty
   }
@@ -53,7 +56,8 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
           locations = List(
             PhysicalLocation(
               locationType = LocationType.OnOrder,
-              label = "2 copies ordered for Wellcome Collection on 2 February 2002"
+              label =
+                "2 copies ordered for Wellcome Collection on 2 February 2002"
             )
           )
         )
@@ -178,7 +182,9 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       getOrders(hasItems = false, orderData = orderData) should not be empty
 
-      val suppressedOrderData = orderData.map { od => od.copy(suppressed = true) }
+      val suppressedOrderData = orderData.map { od =>
+        od.copy(suppressed = true)
+      }
       getOrders(hasItems = false, orderData = suppressedOrderData) shouldBe empty
     }
 
@@ -202,7 +208,9 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       getOrders(hasItems = false, orderData = orderData) should not be empty
 
-      val deletedOrderData = orderData.map { od => od.copy(deleted = true) }
+      val deletedOrderData = orderData.map { od =>
+        od.copy(deleted = true)
+      }
       getOrders(hasItems = false, orderData = deletedOrderData) shouldBe empty
     }
 
@@ -335,7 +343,11 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       getOrders(hasItems = false, orderData = orderData) shouldBe empty
 
-      val orderWithRdate = orderData.map { od => od.copy(fixedFields = od.fixedFields ++ Map("17" -> FixedField(label = "RDATE", value = "2008-08-08"))) }
+      val orderWithRdate = orderData.map { od =>
+        od.copy(
+          fixedFields = od.fixedFields ++ Map(
+            "17" -> FixedField(label = "RDATE", value = "2008-08-08")))
+      }
       getOrders(hasItems = false, orderData = orderWithRdate) should not be empty
     }
 
@@ -352,7 +364,9 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       getOrders(hasItems = false, orderData = orderData) should not be empty
 
-      val suppressedOrderData = orderData.map { od => od.copy(suppressed = true) }
+      val suppressedOrderData = orderData.map { od =>
+        od.copy(suppressed = true)
+      }
       getOrders(hasItems = false, orderData = suppressedOrderData) shouldBe empty
     }
 
@@ -369,7 +383,9 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       getOrders(hasItems = false, orderData = orderData) should not be empty
 
-      val deletedOrderData = orderData.map { od => od.copy(deleted = true) }
+      val deletedOrderData = orderData.map { od =>
+        od.copy(deleted = true)
+      }
       getOrders(hasItems = false, orderData = deletedOrderData) shouldBe empty
     }
 
@@ -412,11 +428,14 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
     }
   }
 
-  def getOrders(hasItems: Boolean, orderData: List[SierraOrderData]): List[Item[IdState.Unidentifiable.type]] = {
+  def getOrders(hasItems: Boolean, orderData: List[SierraOrderData])
+    : List[Item[IdState.Unidentifiable.type]] = {
     val id = createSierraBibNumber
 
     val orderIds = (1 to orderData.size)
-      .map { _ => createSierraOrderNumber }
+      .map { _ =>
+        createSierraOrderNumber
+      }
       .sortBy { _.withoutCheckDigit }
 
     val orderDataMap = orderIds.zip(orderData).toMap

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   FixedField,
-  SierraItemData,
   SierraOrderData
 }
 import weco.catalogue.internal_model.identifiers.IdState
@@ -15,7 +14,7 @@ import weco.catalogue.internal_model.work.Item
 
 class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGenerators {
   it("returns nothing if there are no orders or items") {
-    getOrders(itemData = List(), orderData = List()) shouldBe empty
+    getOrders(hasItems = false, orderData = List()) shouldBe empty
   }
 
   describe("creates 'on order' items") {
@@ -37,7 +36,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -71,7 +70,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -96,7 +95,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -120,7 +119,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -145,7 +144,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -177,10 +176,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) should not be empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
 
       val suppressedOrderData = orderData.map { od => od.copy(suppressed = true) }
-      getOrders(itemData = List(), orderData = suppressedOrderData) shouldBe empty
+      getOrders(hasItems = false, orderData = suppressedOrderData) shouldBe empty
     }
 
     it("unless the order is deleted") {
@@ -201,10 +200,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) should not be empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
 
       val deletedOrderData = orderData.map { od => od.copy(deleted = true) }
-      getOrders(itemData = List(), orderData = deletedOrderData) shouldBe empty
+      getOrders(hasItems = false, orderData = deletedOrderData) shouldBe empty
     }
 
     it("unless there are any items") {
@@ -227,8 +226,8 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
 
       // Note: we test both with and without order data here, so we'll
       // spot if the lack of output is unrelated to the items.
-      getOrders(itemData = List(), orderData = orderData) should not be empty
-      getOrders(itemData = List(createSierraItemData), orderData = orderData) shouldBe empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
+      getOrders(hasItems = true, orderData = orderData) shouldBe empty
     }
   }
 
@@ -251,7 +250,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -285,7 +284,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -310,7 +309,7 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
         Item(
           id = Unidentifiable,
           title = None,
@@ -334,10 +333,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe empty
+      getOrders(hasItems = false, orderData = orderData) shouldBe empty
 
       val orderWithRdate = orderData.map { od => od.copy(fixedFields = od.fixedFields ++ Map("17" -> FixedField(label = "RDATE", value = "2008-08-08"))) }
-      getOrders(itemData = List(), orderData = orderWithRdate) should not be empty
+      getOrders(hasItems = false, orderData = orderWithRdate) should not be empty
     }
 
     it("unless the order is suppressed") {
@@ -351,10 +350,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) should not be empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
 
       val suppressedOrderData = orderData.map { od => od.copy(suppressed = true) }
-      getOrders(itemData = List(), orderData = suppressedOrderData) shouldBe empty
+      getOrders(hasItems = false, orderData = suppressedOrderData) shouldBe empty
     }
 
     it("unless the order is deleted") {
@@ -368,10 +367,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) should not be empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
 
       val deletedOrderData = orderData.map { od => od.copy(deleted = true) }
-      getOrders(itemData = List(), orderData = deletedOrderData) shouldBe empty
+      getOrders(hasItems = false, orderData = deletedOrderData) shouldBe empty
     }
 
     it("unless there are any items") {
@@ -385,10 +384,10 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      // Note: we test both with and without order data here, so we'll
+      // Note: we test both with and without items here, so we'll
       // spot if the lack of output is unrelated to the items.
-      getOrders(itemData = List(), orderData = orderData) should not be empty
-      getOrders(itemData = List(createSierraItemData), orderData = orderData) shouldBe empty
+      getOrders(hasItems = false, orderData = orderData) should not be empty
+      getOrders(hasItems = true, orderData = orderData) shouldBe empty
     }
   }
 
@@ -409,24 +408,19 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
         )
       )
 
-      getOrders(itemData = List(), orderData = orderData) shouldBe empty
+      getOrders(hasItems = false, orderData = orderData) shouldBe empty
     }
   }
 
-  def getOrders(itemData: List[SierraItemData], orderData: List[SierraOrderData]): List[Item[IdState.Unidentifiable.type]] = {
+  def getOrders(hasItems: Boolean, orderData: List[SierraOrderData]): List[Item[IdState.Unidentifiable.type]] = {
     val id = createSierraBibNumber
-
-    val itemIds = (1 to itemData.size)
-      .map { _ => createSierraItemNumber }
-      .sortBy { _.withoutCheckDigit }
 
     val orderIds = (1 to orderData.size)
       .map { _ => createSierraOrderNumber }
       .sortBy { _.withoutCheckDigit }
 
-    val itemDataMap = itemIds.zip(itemData).toMap
     val orderDataMap = orderIds.zip(orderData).toMap
 
-    SierraItemsOnOrder(id, itemDataMap, orderDataMap)
+    SierraItemsOnOrder(id, hasItems, orderDataMap)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -3,29 +3,250 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  FixedField,
+  SierraItemData,
+  SierraOrderData
+}
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.IdState.Unidentifiable
+import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
+import weco.catalogue.internal_model.work.Item
 
 class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGenerators {
   it("returns nothing if there are no orders or items") {
-    val id = createSierraBibNumber
-
-    SierraItemsOnOrder(id, itemDataMap = Map(), orderDataMap = Map()) shouldBe empty
+    getOrders(itemData = List(), orderData = List()) shouldBe empty
   }
 
-  describe("returns 'on order' items") {
+  describe("creates 'on order' items") {
     it("if there are orders with status 'o' and no RDATE") {
-      true shouldBe false
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "1 copy ordered for Wellcome Collection on 1 January 2001"
+            )
+          )
+        ),
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "2 copies ordered for Wellcome Collection on 2 February 2002"
+            )
+          )
+        )
+      )
+    }
+
+    it("if the number of copies is missing") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "13" -> FixedField(label = "ODATE", value = "2003-03-03"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 3 March 2003"
+            )
+          )
+        )
+      )
+    }
+
+    it("if the number of copies is not an integer") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "NaN"),
+            "13" -> FixedField(label = "ODATE", value = "2004-04-04"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 4 April 2004"
+            )
+          )
+        )
+      )
+    }
+
+    it("if the order date is missing") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "10"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "10 copies ordered for Wellcome Collection"
+            )
+          )
+        )
+      )
+    }
+
+    it("if the order date is unparseable") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "3"),
+            "13" -> FixedField(label = "ODATE", value = "tomorrow"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "3 copies ordered for Wellcome Collection"
+            )
+          )
+        )
+      )
     }
 
     it("unless the order is suppressed") {
-      true shouldBe false
+      val orderData = List(
+        createSierraOrderDataWith(
+          suppressed = true,
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "2 copies ordered for Wellcome Collection on 2 February 2002"
+            )
+          )
+        )
+      )
     }
 
     it("unless the order is deleted") {
-      true shouldBe false
+      val orderData = List(
+        createSierraOrderDataWith(
+          deleted = true,
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(itemData = List(), orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "2 copies ordered for Wellcome Collection on 2 February 2002"
+            )
+          )
+        )
+      )
     }
 
     it("unless there are any items") {
-      true shouldBe false
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      // Note: we test both with and without order data here, so we'll
+      // spot if the lack of output is unrelated to the items.
+      getOrders(itemData = List(), orderData = orderData) should not be empty
+      getOrders(itemData = List(createSierraItemData), orderData = orderData) shouldBe empty
     }
   }
 
@@ -55,5 +276,22 @@ class SierraItemsOnOrderTest extends AnyFunSpec with Matchers with SierraDataGen
     it("RDATE, unrecognised status") {
       true shouldBe false
     }
+  }
+
+  def getOrders(itemData: List[SierraItemData], orderData: List[SierraOrderData]): List[Item[IdState.Unidentifiable.type]] = {
+    val id = createSierraBibNumber
+
+    val itemIds = (1 to itemData.size)
+      .map { _ => createSierraItemNumber }
+      .sortBy { _.withoutCheckDigit }
+
+    val orderIds = (1 to orderData.size)
+      .map { _ => createSierraOrderNumber }
+      .sortBy { _.withoutCheckDigit }
+
+    val itemDataMap = itemIds.zip(itemData).toMap
+    val orderDataMap = orderIds.zip(orderData).toMap
+
+    SierraItemsOnOrder(id, itemDataMap, orderDataMap)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -349,5 +349,5 @@ class SierraItemsTest
     bibData: SierraBibData = createSierraBibData,
     itemDataMap: Map[SierraItemNumber, SierraItemData] = Map())
     : List[Item[IdState.Unminted]] =
-    SierraItems(itemDataMap)(createSierraBibNumber, bibData)
+    SierraItems(createSierraBibNumber, bibData, itemDataMap)
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1053,17 +1053,6 @@ class SierraTransformerTest
     }
   }
 
-  def defaultItemRecordData(id: SierraItemNumber,
-                            modifiedDate: Instant,
-                            bibIds: List[SierraBibNumber]) =
-    s"""
-      |{
-      |  "id": "$id",
-      |  "updatedDate": "${modifiedDate.toString}",
-      |  "bibIds": ${toJson(bibIds).get}
-      |}
-      |""".stripMargin
-
   private def transformDataToWork(
     id: SierraBibNumber,
     data: String,


### PR DESCRIPTION
This implements the rules described in https://github.com/wellcomecollection/platform/issues/5139

* If a bib has no items, but it has an order attached to the bib record with STATUS of `o` ("on order"), we create an item with LocationType `on-order` and label _"X copies ordered for Wellcome Collection on 20 April 2021"_
* If a bib has no items, but it has an associated order with STATUS of `a` ("fully paid") and a RDATE ("received date"), we create an item with LocationType `on-order` and label _"X copies awaiting cataloguing for Wellcome Collection"
* If a bib has any items, we ignore all the attached order records.

I haven't done too much planning for this patch – realistically it's only a few thousand items at most, so I just want to get _something_ into the API, and we can tweak it later if necessary.

I've run this code against the six examples @jtweed put in the original ticket, and it does the right thing for all of them. The only difference is that in Encore, one of them is labelled "Processing for the Asian Collections", whereas in this patch everything is "for Wellcome Collection".

Reviewers: @wellcomecollection/scala-devs for code, @jtweed to validate the approach.

