### PR TITLE
Ignore suppressed items in the Sierra transformer

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraItemData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraItemData.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.platform.transformer.sierra.source.sierra.SierraSourceLoca
 
 case class SierraItemData(
   deleted: Boolean = false,
+  suppressed: Boolean = false,
   location: Option[SierraSourceLocation] = None,
   callNumber: Option[String] = None,
   fixedFields: Map[String, FixedField] = Map(),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -34,7 +34,9 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
             itemDataMap: Map[SierraItemNumber, SierraItemData]) = {
     val visibleItems =
       itemDataMap
-        .filterNot { case (_, itemData) => itemData.deleted || itemData.suppressed }
+        .filterNot {
+          case (_, itemData) => itemData.deleted || itemData.suppressed
+        }
 
     getPhysicalItems(bibId, visibleItems, bibData)
       .sortBy { item =>

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -25,13 +25,11 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
 
   def createSierraItemDataWith(
-    deleted: Boolean = false,
     location: Option[SierraSourceLocation] = None,
     callNumber: Option[String] = None,
     varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
-      deleted = deleted,
       location = location,
       callNumber = callNumber,
       varFields = varFields
@@ -40,13 +38,9 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraItemData: SierraItemData = createSierraItemDataWith()
 
   def createSierraOrderDataWith(
-    suppressed: Boolean = false,
-    deleted: Boolean = false,
     fixedFields: Map[String, FixedField] = Map()
   ): SierraOrderData =
     SierraOrderData(
-      deleted = deleted,
-      suppressed = suppressed,
       fixedFields = fixedFields
     )
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -135,16 +135,22 @@ class SierraItemsTest
     }
   }
 
-  it("removes items with deleted=true") {
-    val item1 = createSierraItemDataWith(deleted = true)
-    val item2 = createSierraItemDataWith(deleted = false)
+  it("skips deleted items") {
+    val itemDataMap = (1 to 3)
+      .map { _ => createSierraItemNumber -> createSierraItemData }
+      .toMap
 
-    val itemDataMap = Map(
-      createSierraItemNumber -> item1,
-      createSierraItemNumber -> item2
-    )
+    // First we transform the items without deleting them, to
+    // check they're not being skipped for a reason unrelated
+    // to deleted=true
+    getTransformedItems(itemDataMap = itemDataMap) should have size itemDataMap.size
 
-    getTransformedItems(itemDataMap = itemDataMap) should have size 1
+    // Then we mark them as deleted, and check they're all ignored.
+    val deletedItemDataMap =
+      itemDataMap
+        .map { case (id, itemData) => id -> itemData.copy(deleted = true) }
+
+    getTransformedItems(itemDataMap = deletedItemDataMap) shouldBe empty
   }
 
   it("ignores all digital locations - 'dlnk', 'digi'") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -136,9 +136,9 @@ class SierraItemsTest
   }
 
   it("skips deleted items") {
-    val itemDataMap = (1 to 3)
-      .map { _ => createSierraItemNumber -> createSierraItemData }
-      .toMap
+    val itemDataMap = (1 to 3).map { _ =>
+      createSierraItemNumber -> createSierraItemData
+    }.toMap
 
     // First we transform the items without deleting them, to
     // check they're not being skipped for a reason unrelated
@@ -154,9 +154,9 @@ class SierraItemsTest
   }
 
   it("skips suppressed items") {
-    val itemDataMap = (1 to 3)
-      .map { _ => createSierraItemNumber -> createSierraItemData }
-      .toMap
+    val itemDataMap = (1 to 3).map { _ =>
+      createSierraItemNumber -> createSierraItemData
+    }.toMap
 
     // First we transform the items without suppressing them, to
     // check they're not being skipped for a reason unrelated

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -153,6 +153,24 @@ class SierraItemsTest
     getTransformedItems(itemDataMap = deletedItemDataMap) shouldBe empty
   }
 
+  it("skips suppressed items") {
+    val itemDataMap = (1 to 3)
+      .map { _ => createSierraItemNumber -> createSierraItemData }
+      .toMap
+
+    // First we transform the items without suppressing them, to
+    // check they're not being skipped for a reason unrelated
+    // to suppressing=true
+    getTransformedItems(itemDataMap = itemDataMap) should have size itemDataMap.size
+
+    // Then we mark them as deleted, and check they're all ignored.
+    val suppressedItemDataMap =
+      itemDataMap
+        .map { case (id, itemData) => id -> itemData.copy(suppressed = true) }
+
+    getTransformedItems(itemDataMap = suppressedItemDataMap) shouldBe empty
+  }
+
   it("ignores all digital locations - 'dlnk', 'digi'") {
     val bibData = createSierraBibDataWith(
       locations = Some(


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/5144

There are suppressed items in Sierra, but currently we don't fetch that field in the adapter, so we'll expose those items in the API. This is wrong – we should be hiding those items.

This PR is the first step towards fixing that – it makes the Sierra transformer aware of this field, and gets it to skip creating catalogue Items for items that are suppressed in Sierra.