### PR TITLE
Images query

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -13,82 +13,8 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   FieldWithOptionalBoost,
   MultiMatchQuery
 }
-import uk.ac.wellcome.models.index.WorksAnalysis.whitespaceAnalyzer
 
-case object ImagesMultiMatcher {
-  def apply(q: String): BoolQuery = {
-    val fields = Map(
-      Some(1000) -> Seq(
-        "data.contributors.agent.label"
-      ),
-      Some(100) -> Seq(
-        "data.title",
-        "data.title.english",
-        "data.title.shingles",
-        "data.alternativeTitles",
-      ),
-      Some(10) -> Seq(
-        "data.subjects.concepts.label",
-        "data.genres.concepts.label",
-        "data.production.*.label",
-      ),
-      None -> Seq(
-        "data.description",
-        "data.physicalDescription",
-        "data.language.label",
-        "data.edition",
-        "data.notes.content",
-        "data.lettering",
-        "data.collectionPath.path",
-        "data.collectionPath.label"
-      )
-    ) flatMap {
-      case (boost, fieldNames) =>
-        fieldNames.map { _ -> boost }
-    } flatMap {
-      case (fieldName, boost) =>
-        toWorkField(fieldName).map { workField =>
-          (workField, boost)
-        }
-    } map {
-      case (field, boost) =>
-        FieldWithOptionalBoost(field, boost.map(_.toDouble))
-    } toSeq
-
-    val sourceWorkIdFields = Seq(
-      "id.canonicalId",
-      "id.sourceIdentifier.value",
-      "data.otherIdentifiers.value"
-    )
-
-    val idFields = (Seq(
-      "state.canonicalId",
-      "state.sourceIdentifier.value",
-    ) ++ sourceWorkIdFields
-      .flatMap(toWorkField))
-      .map(fi => FieldWithOptionalBoost(fi, None))
-
-    should(
-      MultiMatchQuery(
-        text = q,
-        fields = fields,
-        `type` = Some(CROSS_FIELDS),
-        operator = Some(AND),
-      ),
-      prefixQuery("data.title.keyword", q).boost(1000),
-      MultiMatchQuery(
-        fields = idFields,
-        text = q,
-        `type` = Some(BEST_FIELDS),
-        operator = Some(OR),
-        analyzer = Some(whitespaceAnalyzer.name),
-      ).boost(1000)
-    ).minimumShouldMatch(1)
-  }
-
-  def toWorkField(field: String): Seq[String] =
-    Seq(s"source.canonicalWork.$field", s"source.redirectedWork.$field")
-}
+import uk.ac.wellcome.models.index.WorksAnalysis.{languages, whitespaceAnalyzer}
 
 case object ImageSimilarity {
   def blended: (String, Index) => Query =
@@ -111,5 +37,141 @@ case object ImageSimilarity {
         maxQueryTerms = Some(1000),
         minShouldMatch = Some("1")
       )
+  }
+}
+
+case object ImagesMultiMatcher {
+
+  def toWorkField(
+    field: String
+  ): Seq[String] =
+    Seq(s"source.canonicalWork.$field", s"source.redirectedWork.$field")
+
+  def boostedWorkFields(
+    boost: Option[Double] = None,
+    fields: Seq[String]
+  ): Seq[FieldWithOptionalBoost] =
+    fields.flatMap(toWorkField).map(FieldWithOptionalBoost(_, boost))
+
+  val titleFields = Seq(
+    "data.alternativeTitles",
+    "data.title.english",
+    "data.title.shingles",
+    "data.title"
+  )
+
+  val idFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
+    fields = Seq(
+      "id.canonicalId",
+      "id.sourceIdentifier.value",
+      "data.otherIdentifiers.value"
+    )
+  ) ++ Seq(
+    "state.canonicalId",
+    "state.sourceIdentifier.value"
+  ).map(FieldWithOptionalBoost(_, None))
+
+  val dataFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
+    boost = Some(1000.0),
+    fields = Seq("data.contributors.agent.label")
+  ) ++
+    boostedWorkFields(
+      boost = Some(10.0),
+      fields = Seq(
+        "data.subjects.concepts.label",
+        "data.genres.concepts.label",
+        "data.production.*.label"
+      )
+    ) ++
+    boostedWorkFields(
+      fields = Seq(
+        "data.description",
+        "data.physicalDescription",
+        "data.language.label",
+        "data.edition",
+        "data.collectionPath.path",
+        "data.collectionPath.label"
+      )
+    )
+
+  def apply(q: String): BoolQuery = {
+    boolQuery()
+      .should(
+        MultiMatchQuery(
+          fields = idFields,
+          queryName = Some("identifiers"),
+          text = q,
+          `type` = Some(BEST_FIELDS),
+          operator = Some(OR),
+          analyzer = Some(whitespaceAnalyzer.name)
+        ).boost(1000),
+        MultiMatchQuery(
+          q,
+          queryName = Some("data"),
+          `type` = Some(CROSS_FIELDS),
+          operator = Some(AND),
+          fields = dataFields
+        ),
+        dismax(
+          queries = Seq(
+            BoolQuery(
+              queryName = Some("redirected title prefix"),
+              boost = Some(1000.0),
+              must = List(
+                prefixQuery("source.redirectedWork.data.title.keyword", q),
+                matchPhraseQuery("source.redirectedWork.data.title", q)
+              )
+            ),
+            BoolQuery(
+              queryName = Some("canonical title prefix"),
+              boost = Some(1000.0),
+              must = List(
+                prefixQuery("source.canonicalWork.data.title.keyword", q),
+                matchPhraseQuery("source.canonicalWork.data.title", q)
+              )
+            ),
+            MultiMatchQuery(
+              q,
+              queryName = Some("title exact spellings"),
+              fields = boostedWorkFields(
+                boost = Some(100.0),
+                fields = titleFields
+              ),
+              `type` = Some(BEST_FIELDS),
+              operator = Some(AND)
+            ),
+            MultiMatchQuery(
+              q,
+              queryName = Some("title alternative spellings"),
+              fields = boostedWorkFields(
+                boost = Some(80.0),
+                fields = titleFields
+              ),
+              `type` = Some(BEST_FIELDS),
+              operator = Some(AND),
+              fuzziness = Some("AUTO")
+            ),
+            MultiMatchQuery(
+              q,
+              queryName = Some("non-english text"),
+              `type` = Some(BEST_FIELDS),
+              operator = Some(AND),
+              fields = boostedWorkFields(
+                boost = Some(100.0),
+                fields = languages
+                  .flatMap(
+                    language =>
+                      Seq(
+                        s"data.title.${language}",
+                        s"data.notes.${language}",
+                        s"data.lettering.${language}"
+                      )
+                  )
+              )
+            )
+          )
+        )
+      )
+      .minimumShouldMatch(1)
   }
 }

--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesQuery.scala
@@ -165,7 +165,7 @@ case object ImagesMultiMatcher {
                         s"data.title.${language}",
                         s"data.notes.${language}",
                         s"data.lettering.${language}"
-                      )
+                    )
                   )
               )
             )

--- a/api/api/src/test/resources/ImagesMultiMatcherQuery.json
+++ b/api/api/src/test/resources/ImagesMultiMatcherQuery.json
@@ -1,0 +1,186 @@
+ {
+   "bool": {
+     "should": [{
+         "multi_match": {
+           "query": "{{query}}",
+           "_name": "identifiers",
+           "fields": [
+             "source.canonicalWork.id.canonicalId",
+             "source.redirectedWork.id.canonicalId",
+             "source.canonicalWork.id.sourceIdentifier.value",
+             "source.redirectedWork.id.sourceIdentifier.value",
+             "source.canonicalWork.data.otherIdentifiers.value",
+             "source.redirectedWork.data.otherIdentifiers.value",
+             "state.canonicalId",
+             "state.sourceIdentifier.value"
+           ],
+           "type": "best_fields",
+           "analyzer": "whitespace_analyzer",
+           "operator": "Or",
+           "boost": 1000.0
+         }
+       },
+       {
+         "multi_match": {
+          "_name": "data",
+           "query": "{{query}}",
+           "fields": [
+             "source.canonicalWork.data.contributors.agent.label^1000.0",
+             "source.redirectedWork.data.contributors.agent.label^1000.0",
+             "source.canonicalWork.data.subjects.concepts.label^10.0",
+             "source.redirectedWork.data.subjects.concepts.label^10.0",
+             "source.canonicalWork.data.genres.concepts.label^10.0",
+             "source.redirectedWork.data.genres.concepts.label^10.0",
+             "source.canonicalWork.data.production.*.label^10.0",
+             "source.redirectedWork.data.production.*.label^10.0",
+             "source.canonicalWork.data.description",
+             "source.redirectedWork.data.description",
+             "source.canonicalWork.data.physicalDescription",
+             "source.redirectedWork.data.physicalDescription",
+             "source.canonicalWork.data.language.label",
+             "source.redirectedWork.data.language.label",
+             "source.canonicalWork.data.edition",
+             "source.redirectedWork.data.edition",
+             "source.canonicalWork.data.collectionPath.path",
+             "source.redirectedWork.data.collectionPath.path",
+             "source.canonicalWork.data.collectionPath.label",
+             "source.redirectedWork.data.collectionPath.label"
+           ],
+           "type": "cross_fields",
+           "operator": "And"
+         }
+       },
+       {
+         "dis_max": {
+           "queries": [{
+               "bool": {
+                 "_name": "redirected title prefix",
+                 "boost": 1000.0,
+                 "must": [{
+                     "prefix": {
+                       "source.redirectedWork.data.title.keyword": {
+                         "value": "{{query}}"
+                       }
+                     }
+                   },
+                   {
+                     "match_phrase": {
+                       "source.redirectedWork.data.title": {
+                         "query": "{{query}}"
+                       }
+                     }
+                   }
+                 ]
+               }
+             },
+             {
+               "bool": {
+                 "_name": "canonical title prefix",
+                 "boost": 1000.0,
+                 "must": [{
+                     "prefix": {
+                       "source.canonicalWork.data.title.keyword": {
+                         "value": "{{query}}"
+                       }
+                     }
+                   },
+                   {
+                     "match_phrase": {
+                       "source.canonicalWork.data.title": {
+                         "query": "{{query}}"
+                       }
+                     }
+                   }
+                 ]
+               }
+             },
+             {
+               "multi_match": {
+                 "_name": "title exact spellings",
+                 "fields": [
+                   "source.canonicalWork.data.alternativeTitles^100.0",
+                   "source.redirectedWork.data.alternativeTitles^100.0",
+                   "source.canonicalWork.data.title.english^100.0",
+                   "source.redirectedWork.data.title.english^100.0",
+                   "source.canonicalWork.data.title.shingles^100.0",
+                   "source.redirectedWork.data.title.shingles^100.0",
+                   "source.canonicalWork.data.title^100.0",
+                   "source.redirectedWork.data.title^100.0"
+                 ],
+                 "operator": "And",
+                 "query": "{{query}}",
+                 "type": "best_fields"
+               }
+             },
+             {
+               "multi_match": {
+                 "_name": "title alternative spellings",
+                 "fields": [
+                   "source.canonicalWork.data.alternativeTitles^80.0",
+                   "source.redirectedWork.data.alternativeTitles^80.0",
+                   "source.canonicalWork.data.title.english^80.0",
+                   "source.redirectedWork.data.title.english^80.0",
+                   "source.canonicalWork.data.title.shingles^80.0",
+                   "source.redirectedWork.data.title.shingles^80.0",
+                   "source.canonicalWork.data.title^80.0",
+                   "source.redirectedWork.data.title^80.0"
+                 ],
+                 "fuzziness": "AUTO",
+                 "operator": "And",
+                 "query": "{{query}}",
+                 "type": "best_fields"
+               }
+             },
+             {
+               "multi_match": {
+                 "_name": "non-english text",
+                 "fields": [
+                   "source.canonicalWork.data.title.arabic^100.0",
+                   "source.redirectedWork.data.title.arabic^100.0",
+                   "source.canonicalWork.data.notes.arabic^100.0",
+                   "source.redirectedWork.data.notes.arabic^100.0",
+                   "source.canonicalWork.data.lettering.arabic^100.0",
+                   "source.redirectedWork.data.lettering.arabic^100.0",
+                   "source.canonicalWork.data.title.bengali^100.0",
+                   "source.redirectedWork.data.title.bengali^100.0",
+                   "source.canonicalWork.data.notes.bengali^100.0",
+                   "source.redirectedWork.data.notes.bengali^100.0",
+                   "source.canonicalWork.data.lettering.bengali^100.0",
+                   "source.redirectedWork.data.lettering.bengali^100.0",
+                   "source.canonicalWork.data.title.french^100.0",
+                   "source.redirectedWork.data.title.french^100.0",
+                   "source.canonicalWork.data.notes.french^100.0",
+                   "source.redirectedWork.data.notes.french^100.0",
+                   "source.canonicalWork.data.lettering.french^100.0",
+                   "source.redirectedWork.data.lettering.french^100.0",
+                   "source.canonicalWork.data.title.german^100.0",
+                   "source.redirectedWork.data.title.german^100.0",
+                   "source.canonicalWork.data.notes.german^100.0",
+                   "source.redirectedWork.data.notes.german^100.0",
+                   "source.canonicalWork.data.lettering.german^100.0",
+                   "source.redirectedWork.data.lettering.german^100.0",
+                   "source.canonicalWork.data.title.hindi^100.0",
+                   "source.redirectedWork.data.title.hindi^100.0",
+                   "source.canonicalWork.data.notes.hindi^100.0",
+                   "source.redirectedWork.data.notes.hindi^100.0",
+                   "source.canonicalWork.data.lettering.hindi^100.0",
+                   "source.redirectedWork.data.lettering.hindi^100.0",
+                   "source.canonicalWork.data.title.italian^100.0",
+                   "source.redirectedWork.data.title.italian^100.0",
+                   "source.canonicalWork.data.notes.italian^100.0",
+                   "source.redirectedWork.data.notes.italian^100.0",
+                   "source.canonicalWork.data.lettering.italian^100.0",
+                   "source.redirectedWork.data.lettering.italian^100.0"
+                 ],
+                 "query": "{{query}}",
+                 "operator": "And",
+                 "type": "best_fields"
+               }
+             }
+           ]
+         }
+       }
+     ],
+     "minimum_should_match": "1"
+   }
+ }

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesMultiMatcherQueryTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/elasticsearch/ImagesMultiMatcherQueryTest.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.api.elasticsearch
+
+import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+class ImagesMultiMatcherQueryTest
+    extends AnyFunSpec
+    with Matchers
+    with JsonAssertions {
+  it("matches the JSON version of the query") {
+    val fileJson =
+      Source
+        .fromResource("ImagesMultiMatcherQuery.json")
+        .getLines
+        .mkString
+
+    val queryJson = QueryBuilderFn(ImagesMultiMatcher("{{query}}")).string()
+    assertJsonStringsAreEqual(fileJson, queryJson)
+  }
+}


### PR DESCRIPTION
Applies some of what we've learned about catalogue search to image search like language analysis, exact vs approximate spelling, prefix matching, etc. 

Because image search is a different domain and its users have different intentions, the lessons are applied to a slightly different set of fields, though the structure is almost exactly the same.

Follows https://github.com/wellcomecollection/catalogue/pull/1549
Linked to https://github.com/wellcomecollection/rank/pull/35
Closes https://github.com/wellcomecollection/rank/issues/33