### PR TITLE
output elastic cluster values

### DIFF
--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -38,3 +38,16 @@ output "vhs_miro_inventory_table_name" {
 output "vhs_miro_inventory_assumable_read_role" {
   value = module.vhs_miro_migration.assumable_read_role
 }
+
+# Catalogue elastic cluster
+output "catalogue_ec_cluster_id" {
+  value = ec_deployment.catalogue.id
+}
+
+output "catalogue_ec_cluster_name" {
+  value = ec_deployment.catalogue.name
+}
+
+output "catalogue_ec_cluster_ref_id" {
+  value = ec_deployment.catalogue.elasticsearch.0.ref_id
+}


### PR DESCRIPTION
Outputs the cluster values to be used in reading the data from the [rank_eval cluster](https://github.com/wellcomecollection/rank/blob/master/terraform/main.tf).

As we are talking about moving this repo, and potentially having a cluster-per-pipeline, this seemed like the simplest option as I was thinking of moving it into it's own stack as it's odd to have to provision all critical infra to provision the cluster.

This is a no-op, so wasn't an issue.