### PR TITLE
Tidy up SierraItemsOnOrder

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -40,11 +40,12 @@ class AvailabilityTest
       val work = denormalisedWork()
         .items(
           List(
-            createIdentifiedItemWith(locations = List(
-              createPhysicalLocationWith(
-                locationType = LocationType.OnOrder
-              )
-            ))
+            createIdentifiedItemWith(
+              locations = List(
+                createPhysicalLocationWith(
+                  locationType = LocationType.OnOrder
+                )
+              ))
           )
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)
@@ -56,14 +57,15 @@ class AvailabilityTest
       val work = denormalisedWork()
         .items(
           List(
-            createIdentifiedItemWith(locations = List(
-              createPhysicalLocationWith(
-                locationType = LocationType.OnOrder
-              ),
-              createPhysicalLocationWith(
-                locationType = LocationType.OpenShelves
-              )
-            ))
+            createIdentifiedItemWith(
+              locations = List(
+                createPhysicalLocationWith(
+                  locationType = LocationType.OnOrder
+                ),
+                createPhysicalLocationWith(
+                  locationType = LocationType.OpenShelves
+                )
+              ))
           )
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -3,7 +3,7 @@ package weco.catalogue.internal_model.work
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.{ItemsGenerators, WorkGenerators}
-import weco.catalogue.internal_model.locations.AccessStatus
+import weco.catalogue.internal_model.locations.{AccessStatus, LocationType}
 
 class AvailabilityTest
     extends AnyFunSpec
@@ -31,6 +31,41 @@ class AvailabilityTest
     it(
       "adds Availability.InLibrary if there is an item with a physical location") {
       val work = denormalisedWork().items(List(createIdentifiedPhysicalItem))
+      val workAvailabilities = Availabilities.forWorkData(work.data)
+
+      workAvailabilities should contain only Availability.InLibrary
+    }
+
+    it("does not add Availability.InLibrary if the only location is OnOrder") {
+      val work = denormalisedWork()
+        .items(
+          List(
+            createIdentifiedItemWith(locations = List(
+              createPhysicalLocationWith(
+                locationType = LocationType.OnOrder
+              )
+            ))
+          )
+        )
+      val workAvailabilities = Availabilities.forWorkData(work.data)
+
+      workAvailabilities shouldBe empty
+    }
+
+    it("adds Availability.InLibrary if there are locations other than OnOrder") {
+      val work = denormalisedWork()
+        .items(
+          List(
+            createIdentifiedItemWith(locations = List(
+              createPhysicalLocationWith(
+                locationType = LocationType.OnOrder
+              ),
+              createPhysicalLocationWith(
+                locationType = LocationType.OpenShelves
+              )
+            ))
+          )
+        )
       val workAvailabilities = Availabilities.forWorkData(work.data)
 
       workAvailabilities should contain only Availability.InLibrary

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -60,9 +60,12 @@ object SierraItemsOnOrder extends Logging {
     (getStatus(order), getOrderDate(order), getReceivedDate(order)) match {
 
       // status 'o' = "On order"
+      // status 'c' = "Serial on order"
       //
       // We create an item with a message something like "Ordered for Wellcome Collection on 1 Jan 2001"
-      case (Some(status), orderedDate, _) if status == "o" =>
+      case (Some(status), orderedDate, receivedDate)
+          if (status == "o" || status == "c" || status == "a") &&
+            receivedDate.isEmpty=>
         Some(
           Item(
             title = None,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -49,6 +49,7 @@ object SierraItemsOnOrder extends Logging {
         }
         .sortBy { case (id, _) => id.withoutCheckDigit }
         .flatMap { case (_, orderData) => createItem(id, orderData) }
+        .distinct
     } else {
       List()
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -61,6 +61,7 @@ object SierraItemsOnOrder extends Logging {
 
       // status 'o' = "On order"
       // status 'c' = "Serial on order"
+      // status 'a' = "fully paid"
       //
       // We create an item with a message something like "Ordered for Wellcome Collection on 1 Jan 2001"
       case (Some(status), orderedDate, receivedDate)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -65,7 +65,7 @@ object SierraItemsOnOrder extends Logging {
       // We create an item with a message something like "Ordered for Wellcome Collection on 1 Jan 2001"
       case (Some(status), orderedDate, receivedDate)
           if (status == "o" || status == "c" || status == "a") &&
-            receivedDate.isEmpty=>
+            receivedDate.isEmpty =>
         Some(
           Item(
             title = None,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -63,6 +63,73 @@ class SierraItemsOnOrderTest
       )
     }
 
+    it("if there are orders with status 'a' and no RDATE") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "a")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "a")
+          )
+        )
+      )
+
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 1 January 2001"
+            )
+          )
+        ),
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 2 February 2002"
+            )
+          )
+        )
+      )
+    }
+
+    it("if there are orders with status 'c' and no RDATE") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "c")
+          )
+        )
+      )
+
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 1 January 2001"
+            )
+          )
+        )
+      )
+    }
+
     it("deduplicates the items it creates") {
       // Because we don't expose the number of copies in the API, duplicate
       // items are less useful.
@@ -273,7 +340,7 @@ class SierraItemsOnOrderTest
   }
 
   describe("returns 'awaiting cataloguing' items") {
-    it("if there are orders with status 'a'") {
+    it("if there are orders with status 'a' and an RDATE") {
       val orderData = List(
         createSierraOrderDataWith(
           fixedFields = Map(
@@ -352,26 +419,6 @@ class SierraItemsOnOrderTest
           )
         )
       )
-    }
-
-    it("unless the order has no RDATE") {
-      val orderData = List(
-        createSierraOrderDataWith(
-          fixedFields = Map(
-            "5" -> FixedField(label = "COPIES", value = "1"),
-            "20" -> FixedField(label = "STATUS", value = "a")
-          )
-        )
-      )
-
-      getOrders(hasItems = false, orderData = orderData) shouldBe empty
-
-      val orderWithRdate = orderData.map { od =>
-        od.copy(
-          fixedFields = od.fixedFields ++ Map(
-            "17" -> FixedField(label = "RDATE", value = "2008-08-08")))
-      }
-      getOrders(hasItems = false, orderData = orderWithRdate) should not be empty
     }
 
     it("unless the order is suppressed") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -63,6 +63,40 @@ class SierraItemsOnOrderTest
       )
     }
 
+    it("deduplicates the items it creates") {
+      // Because we don't expose the number of copies in the API, duplicate
+      // items are less useful.
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      getOrders(hasItems = false, orderData = orderData) shouldBe List(
+        Item(
+          id = Unidentifiable,
+          title = None,
+          locations = List(
+            PhysicalLocation(
+              locationType = LocationType.OnOrder,
+              label = "Ordered for Wellcome Collection on 1 January 2001"
+            )
+          )
+        )
+      )
+    }
+
     it("if the number of copies is missing") {
       val orderData = List(
         createSierraOrderDataWith(
@@ -258,16 +292,6 @@ class SierraItemsOnOrderTest
       )
 
       getOrders(hasItems = false, orderData = orderData) shouldBe List(
-        Item(
-          id = Unidentifiable,
-          title = None,
-          locations = List(
-            PhysicalLocation(
-              locationType = LocationType.OnOrder,
-              label = "Awaiting cataloguing for Wellcome Collection"
-            )
-          )
-        ),
         Item(
           id = Unidentifiable,
           title = None,


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5139

- De-duplicate the items when we have repeated information
- Tweak how we decide whether something is on order/awaiting cataloguing
- If an item is on order, it's not available in the library