### PR TITLE
Fix the list of licenses available to filter in the Swagger docs

### DIFF
--- a/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
+++ b/api/api/src/main/scala/uk/ac/wellcome/platform/api/swagger/SwaggerDocs.scala
@@ -227,7 +227,12 @@ trait MultipleImagesSwagger {
             "cc-by-nc-nd",
             "cc-0",
             "pdm",
-            "copyright-not-cleared")),
+            "cc-by-nd",
+            "cc-by-sa",
+            "cc-by-nc-sa",
+            "ogl",
+            "opl",
+            "inc")),
         required = false
       ),
       new Parameter(
@@ -497,7 +502,12 @@ trait MultipleWorksSwagger {
             "cc-by-nc-nd",
             "cc-0",
             "pdm",
-            "copyright-not-cleared")),
+            "cc-by-nd",
+            "cc-by-sa",
+            "cc-by-nc-sa",
+            "ogl",
+            "opl",
+            "inc")),
         required = false
       ),
       new Parameter(

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -6,7 +6,11 @@ import io.circe.Json
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.display.models.{SingleImageIncludes, WorksIncludes}
 import uk.ac.wellcome.platform.api.fixtures.ReflectionHelpers
-import uk.ac.wellcome.platform.api.models.{DisplayWorkAggregations, SearchQueryType, WorkAggregations}
+import uk.ac.wellcome.platform.api.models.{
+  DisplayWorkAggregations,
+  SearchQueryType,
+  WorkAggregations
+}
 import uk.ac.wellcome.platform.api.rest._
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
 import weco.catalogue.internal_model.locations.License
@@ -174,7 +178,9 @@ class ApiSwaggerTest
   describe("includes all the options in enumerable filters") {
     describe("images endpoint") {
       it("locations.license") {
-        val actualValues = getParameterEnumValues(multipleImagesEndpoint, name = "locations.license")
+        val actualValues = getParameterEnumValues(
+          multipleImagesEndpoint,
+          name = "locations.license")
         val expectedValues = License.values.map { _.id }
 
         actualValues should contain theSameElementsAs expectedValues
@@ -191,7 +197,9 @@ class ApiSwaggerTest
       }
 
       it("items.locations.license") {
-        val actualValues = getParameterEnumValues(multipleWorksEndpoint, name = "items.locations.license")
+        val actualValues = getParameterEnumValues(
+          multipleWorksEndpoint,
+          name = "items.locations.license")
         val expectedValues = License.values.map { _.id }
 
         actualValues should contain theSameElementsAs expectedValues
@@ -201,7 +209,9 @@ class ApiSwaggerTest
     def getParameterEnumValues(endpoint: String, name: String): Seq[String] = {
       val lookup =
         getParameters(endpoint)
-          .map { json => getKey(json, "name") -> json }
+          .map { json =>
+            getKey(json, "name") -> json
+          }
           .collect { case (Some(key), json) => key -> json }
           .map { case (key, json) => key.asString.get -> json }
           .toMap

--- a/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -6,13 +6,10 @@ import io.circe.Json
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.display.models.{SingleImageIncludes, WorksIncludes}
 import uk.ac.wellcome.platform.api.fixtures.ReflectionHelpers
-import uk.ac.wellcome.platform.api.models.{
-  DisplayWorkAggregations,
-  SearchQueryType,
-  WorkAggregations
-}
+import uk.ac.wellcome.platform.api.models.{DisplayWorkAggregations, SearchQueryType, WorkAggregations}
 import uk.ac.wellcome.platform.api.rest._
 import uk.ac.wellcome.platform.api.works.ApiWorksTestBase
+import weco.catalogue.internal_model.locations.License
 
 class ApiSwaggerTest
     extends ApiWorksTestBase
@@ -171,6 +168,45 @@ class ApiSwaggerTest
         }.head
 
       getEnumValues(includeParam)
+    }
+  }
+
+  describe("includes all the options in enumerable filters") {
+    describe("images endpoint") {
+      it("locations.license") {
+        val actualValues = getParameterEnumValues(multipleImagesEndpoint, name = "locations.license")
+        val expectedValues = License.values.map { _.id }
+
+        actualValues should contain theSameElementsAs expectedValues
+      }
+    }
+
+    describe("works endpoint") {
+      ignore("items.locations.accessConditions.status") {
+        // TODO: This test can only be enabled when we bump the version of internal_model
+//        val actualValues = getParameterEnumValues(multipleWorksEndpoint, name = "items.locations.accessConditions.status")
+//        val expectedValues = AccessStatus.values.map { _.id }
+//
+//        actualValues should contain theSameElementsAs expectedValues
+      }
+
+      it("items.locations.license") {
+        val actualValues = getParameterEnumValues(multipleWorksEndpoint, name = "items.locations.license")
+        val expectedValues = License.values.map { _.id }
+
+        actualValues should contain theSameElementsAs expectedValues
+      }
+    }
+
+    def getParameterEnumValues(endpoint: String, name: String): Seq[String] = {
+      val lookup =
+        getParameters(endpoint)
+          .map { json => getKey(json, "name") -> json }
+          .collect { case (Some(key), json) => key -> json }
+          .map { case (key, json) => key.asString.get -> json }
+          .toMap
+
+      getEnumValues(lookup(name))
     }
   }
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -1,8 +1,10 @@
 package weco.catalogue.internal_model.locations
 
+import enumeratum.{Enum, EnumEntry}
+
 class UnknownAccessStatus(status: String) extends Exception(status)
 
-sealed trait AccessStatus { this: AccessStatus =>
+sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
 
   def name: String = this.getClass.getSimpleName.stripSuffix("$")
 
@@ -23,7 +25,12 @@ sealed trait AccessStatus { this: AccessStatus =>
   }
 }
 
-object AccessStatus {
+object AccessStatus extends Enum[License] {
+  val values = findValues
+  assert(
+    values.size == values.map { _.id }.toSet.size,
+    "IDs for AccessStatus are not unique!"
+  )
 
   // These types should reflect our collections access framework, as described in
   // Wellcome Collection's Access Policy.


### PR DESCRIPTION
The list was a bit out of date – quite a few licenses were missing, and one of the documented values (`copyright-not-cleared`) would never return any results.

Closes https://github.com/wellcomecollection/platform/issues/5145